### PR TITLE
Translated dictionary to Finnish

### DIFF
--- a/blank.xml
+++ b/blank.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">TRANSLATE</column>
       <column name="definition_zh_HK">TRANSLATE</column>
       <column name="definition_pt">TRANSLATE</column>
+      <column name="definition_fi">TRANSLATE</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,5 +38,6 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>

--- a/call_google_translate.py
+++ b/call_google_translate.py
@@ -47,6 +47,7 @@ supported_languages_map = {
   "ru": "ru",
   "zh-HK": "zh-TW",
   "pt": "pt",
+  "fi": "fi",
 }
 
 # Check for balanced brackets.

--- a/commit_submissions.py
+++ b/commit_submissions.py
@@ -24,7 +24,7 @@ submissions = [Submission(*r) for r in reader]
 filenames = ['mem-01-b.xml', 'mem-02-ch.xml', 'mem-03-D.xml', 'mem-04-gh.xml', 'mem-05-H.xml', 'mem-06-j.xml', 'mem-07-l.xml', 'mem-08-m.xml', 'mem-09-n.xml', 'mem-10-ng.xml', 'mem-11-p.xml', 'mem-12-q.xml', 'mem-13-Q.xml', 'mem-14-r.xml', 'mem-15-S.xml', 'mem-16-t.xml', 'mem-17-tlh.xml', 'mem-18-v.xml', 'mem-19-w.xml', 'mem-20-y.xml', 'mem-21-a.xml', 'mem-22-e.xml', 'mem-23-I.xml', 'mem-24-o.xml', 'mem-25-u.xml', 'mem-26-suffixes.xml', 'mem-27-extra.xml', 'mem-28-examples.xml']
 
 # Keep count of how many submissions were made in each supported language.
-count = {"de":0, "fa":0, "sv":0, "ru":0, "zh-HK":0, "pt":0}
+count = {"de":0, "fa":0, "sv":0, "ru":0, "zh-HK":0, "pt":0, "fi":0}
 
 # Cycle through the database files and insert the submissions.
 for filename in filenames:

--- a/mem-01-b.xml
+++ b/mem-01-b.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {b:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{b:sen:nolink}</column>
       <column name="definition_pt">a consoante {b:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {b:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">Стрелять, вести огонь</column>
       <column name="definition_zh_HK">射擊</column>
       <column name="definition_pt">atirar</column>
+      <column name="definition_fi">ampua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bach:n}, {bachHa':v}, {Qeq:v:1}, {vI':n:1}</column>
@@ -72,6 +77,9 @@ Suffixet {-Daq:n} markerar målet. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra é usada quando se refere a disruptores ({nISwI':n}) e é distinta de {baH:v}. O objeto desse verbo é o "raio de energia" {tIH:n:1} que é acionado, por exemplo, {nISwI' tIH bach:sen@@nISwI':n, tIH:n:1, bach:v}. Na prática, a palavra {tIH:n:1,nolink} geralmente é descartada, e simplesmente se diz {nISwI 'bach:sen@@nISwI':n, bach:v}.[2]
 
 O sufixo {-Daq:n} marca o destino.</column>
+      <column name="notes_fi">Tätä sanaa käytetään viitattaessa häiriötekijöihin ({nISwI':n}), ja se eroaa {baH:v}-sanasta. Tämän verbin kohde on {tIH:n:1} "energiasäde", joka laukaistaan, esimerkiksi {nISwI' tIH bach:sen@@nISwI':n, tIH:n:1, bach:v}. Käytännössä sana {tIH:n:1,nolink} pudotetaan yleisesti, ja sanotaan yksinkertaisesti {nISwI' bach:sen@@nISwI':n, bach:v} sen sijaan.
+
+Pääte {-Daq:n} merkitsee kohteen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{baH:v:nolink} is pronounced like the name of the Terran composer "Bach" by speakers of American English.
 
 That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and a deleted line from {Star Trek V:src} (see under {vaj toDuj Daj ngeHbej DI vI'.:sen}).</column>
@@ -83,6 +91,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">disruptor, fire</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -90,6 +99,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="search_tags_ru">дизраптор, стрелять, вести огонь</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.56:src}</column>
     </table>
     <table name="mem">
@@ -103,6 +113,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="definition_ru">Выстрел</column>
       <column name="definition_zh_HK">射擊</column>
       <column name="definition_pt">tiro</column>
+      <column name="definition_fi">laukaus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bach:v}</column>
@@ -113,6 +124,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Botch".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -122,6 +134,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">beam, bullet, ray, target</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -129,6 +142,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="search_tags_ru">луч, пуля, цель</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt">feixe, bala, raio, alvo</column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -142,6 +156,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="definition_ru">Ошибаться, совершить ошибку</column>
       <column name="definition_zh_HK">弄錯、做錯</column>
       <column name="definition_pt">errar, cometer um erro</column>
+      <column name="definition_fi">erehtyä, tehdä virhe</column>
       <column name="synonyms">{Qagh:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{bach:v}</column>
@@ -152,6 +167,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="notes_ru">Смотрите {KGT p.145:src} для объяснения этого глагола. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關此動詞的說明，請參見{KGT p.145:src}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja {KGT p.145:src} para uma explicação deste verbo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {KGT p.145:src} saadaksesi selityksen tälle verbille. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is the first word in the Klingon-English side of the dictionary portion of {KGT:src}, where it is incorrectly listed as a noun as a joke.</column>
       <column name="components">{bach:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -161,6 +177,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">error, misfire, mistake</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -168,6 +185,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="search_tags_ru">Ошибка, осечка, недоразумение</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -181,6 +199,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="definition_ru">рабочий диапазон</column>
       <column name="definition_zh_HK">射擊有效範圍</column>
       <column name="definition_pt">alcance efetivo</column>
+      <column name="definition_fi">vaikuttava etäisyys [AUTOTRANSLATED]</column>
       <column name="synonyms">{Qapchu'meH chuq:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -191,6 +210,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bach:v}, {-lu':v}, {-meH:v}, {chuq:n}</column>
       <column name="examples">
@@ -208,6 +228,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
    Клингонская дизрапторная винтовка это стандартный ручной дизраптор, прикрепленный к расширенному источнику питания. Это помогает устойчивому прицеливанию для воина и увеличению эффективной дальности для дистанции прицеливания."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -215,6 +236,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="search_tags_ru">винтовка, ружьё</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 14:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -228,6 +250,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="definition_ru">Связывать веревкой</column>
       <column name="definition_zh_HK">綁</column>
       <column name="definition_pt">gravata</column>
+      <column name="definition_fi">solmia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QeymoH:v}, {QeyHa'moH:v}, {tay':v}, {meS:v:1}</column>
@@ -238,6 +261,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -247,6 +271,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">knot</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -254,6 +279,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -267,6 +293,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="definition_ru">взламывать код</column>
       <column name="definition_zh_HK">破解密碼</column>
       <column name="definition_pt">decifrar um código</column>
+      <column name="definition_fi">murtaa koodi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{So'Ha':v:2}, {meSHa':v:2}</column>
@@ -277,6 +304,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="notes_ru">Данное сленговое выражение использовано для понимания как декодировать зашифрованные данные(и успешно это сделать), без понимания того, как это сделать досрочно.[1]</column>
       <column name="notes_zh_HK">這個語是指弄清楚如何解密先前加密的數據（並成功解密），而又不知道如何提前解密。也就是說，它指的是未經授權的解密。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse termo de gíria é usado para descobrir como descriptografar dados criptografados anteriormente (e com êxito), sem saber como fazê-lo antes do tempo. Ou seja, refere-se à descriptografia não autorizada.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä slangitermiä käytetään selvittämään, kuinka purkaa aiemmin salattu tieto (ja onnistuneesti) tietämättä kuinka tehdä se etuajassa. Toisin sanoen se viittaa luvattomaan salauksen purkamiseen.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bagh:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -286,6 +314,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">decrypt, hack</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -293,6 +322,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="search_tags_ru">дешифровка, взлом</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -306,6 +336,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="definition_ru">Ложка</column>
       <column name="definition_zh_HK">匙羹</column>
       <column name="definition_pt">colher (utensílios de cozinha)</column>
+      <column name="definition_fi">lusikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puq chonnaQ:n}</column>
@@ -316,6 +347,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Spoonerism for {nagh beQ:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -325,6 +357,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">utensil</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -332,6 +365,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="search_tags_ru">Посуда</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.05.05:src} (reprinted in {HQ 7.2, p.9, Jun. 1998:src}), [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -345,6 +379,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="definition_ru">Вести огонь (торпедой, ракетой, реактивным снарядом)</column>
       <column name="definition_zh_HK">發射（魚雷、火箭、飛彈）</column>
       <column name="definition_pt">fogo (torpedo, foguete, míssil)</column>
+      <column name="definition_fi">ampua (torpedo, raketti, ohjus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bach:v}, {ghuS:v:1}, {vI':n:1}, {peng:n}, {cha:n}</column>
@@ -383,6 +418,11 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [AUTOTRAN
 O sufixo {-Daq:n} marca o destino.
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään torpedoihin viitattaessa, ja se eroaa sanasta {bach:v}.
+
+Pääte {-Daq:n} merkitsee kohteen.
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -392,6 +432,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shoot, torpedo</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -399,6 +440,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru">Стрелять, вести огонь, торпеда</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.57:src}</column>
     </table>
     <table name="mem">
@@ -412,6 +454,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Пусковое устройство, пусковая установка</column>
       <column name="definition_zh_HK">發射器、火箭筒</column>
       <column name="definition_pt">lançador</column>
+      <column name="definition_fi">sinko</column>
       <column name="synonyms">{tal:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -422,6 +465,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{baH:v} or {baH:n:hyp,nolink}, {jan:n:1}</column>
       <column name="examples"></column>
@@ -431,6 +475,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cannon, gun, missile</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -438,6 +483,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru">пушка, ружье, ракета</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -451,6 +497,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Стрелок</column>
       <column name="definition_zh_HK">砲手、炮兵</column>
       <column name="definition_pt">artilheiro</column>
+      <column name="definition_fi">ampuja</column>
       <column name="synonyms">{matHa':n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -461,6 +508,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{baH:v}, {-wI':v}</column>
       <column name="examples">{baHwI', DoS yIbuS. QuQ neH.:sen}</column>
@@ -470,6 +518,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shooter</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -477,6 +526,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -490,6 +540,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Зарабатывать, заслуживать, работать на кого-то</column>
       <column name="definition_zh_HK">賺</column>
       <column name="definition_pt">ganhar, trabalhar para (ativamente)</column>
+      <column name="definition_fi">ansaita, työskennellä (aktiivisesti) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIgh:n:2}, {Qap:v:1}, {Qu':n}, {vum:v}, {Qoyje':n}</column>
@@ -500,6 +551,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru">В одной традиционной форме поединка цель каждого из бойцов-мужчин состоит в том, чтобы «завоевать благосклонность женщины» ({vuv be' 'e' baj:sen@@vuv:v, be':n, 'e':n, baj:v}, буквально «заработать, чтобы женщина уважала его»). [1, p.69] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在一種傳統的對決形式中，每個男性戰鬥人員的目標都是“贏得女人的青睞”（{vuv be' 'e' baj:sen@@vuv:v, be':n, 'e':n, baj:v}，字面意思是“贏得女人的尊敬”）。[1, p.69] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Numa forma tradicional de duelo, o objetivo de cada um dos combatentes do sexo masculino é "conquistar o favor de uma mulher" ({vuv be' 'e' baj:sen@@vuv:v, be':n, 'e':n, baj:v}, literalmente, "fazer com que a mulher o respeite").[1, p.69] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yhdessä perinteisessä kaksintaistelumuodossa jokaisen miespuolisen taistelijan tavoitteena on "voittaa naisen suosio" ({vuv be' 'e' baj:sen@@vuv:v, be':n, 'e':n, baj:v}, kirjaimellisesti "ansaita, että nainen kunnioittaa häntä").[1, p.69] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A "badge" is something that has to be earned.</column>
       <column name="components"></column>
       <column name="examples">
@@ -511,6 +563,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -518,6 +571,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -531,6 +585,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Кувшин, банка, сосуд, бутылка</column>
       <column name="definition_zh_HK">罐、樽</column>
       <column name="definition_pt">jarro, jarra, garrafa</column>
+      <column name="definition_fi">kannu, purkki, pullo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaSwI':n}, {qorghwI':n}, {noq:n:2}</column>
@@ -541,6 +596,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Sounds like "bowl", or "bottle" in some accents where the middle consonant is a very short glottal stop.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -550,6 +606,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">container</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -557,6 +614,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru">Контейнер, ёмкость</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -570,6 +628,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Наталкиваться, иметь перспективу имения дела с</column>
       <column name="definition_zh_HK">面對</column>
       <column name="definition_pt">encarar, ter a perpectiva de enfrentar alguma coisa</column>
+      <column name="definition_fi">kohdata, joutua käsittelemään jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -580,6 +639,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -590,6 +650,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -597,6 +658,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -610,6 +672,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">бамбук [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">竹</column>
       <column name="definition_pt">bambu</column>
+      <column name="definition_fi">bambu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIyech:n}</column>
@@ -620,6 +683,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -629,6 +693,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -636,6 +701,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -649,6 +715,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">быть ушибленным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">受瘀、瘀傷</column>
       <column name="definition_pt">ser machucado</column>
+      <column name="definition_fi">olla mustelmilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moqtay':n}, {rIQ:v}, {Hampong:n}</column>
@@ -659,6 +726,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Bananas are known to bruise easily.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -668,6 +736,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -675,6 +744,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -688,6 +758,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">синяк [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">瘀傷</column>
       <column name="definition_pt">hematoma</column>
+      <column name="definition_fi">ruhjoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -698,6 +769,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ban:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -707,6 +779,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -714,6 +787,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -727,6 +801,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">любовь, тот, кого любят</column>
       <column name="definition_zh_HK">情人</column>
       <column name="definition_pt">amado, amada, quem é amado</column>
+      <column name="definition_fi">rakas, kulta</column>
       <column name="synonyms">{parmaqqay:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -737,6 +812,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -747,6 +823,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">companion, darling, dear, lover, mate, partner, romantic</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -754,6 +831,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru">компаньон, дорогой, дорогая, возлюбленный, пара, партнёр, романтический интерес</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -767,6 +845,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Любовная песнь</column>
       <column name="definition_zh_HK">情歌</column>
       <column name="definition_pt">canção de amor</column>
+      <column name="definition_fi">rakkauslaulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}</column>
@@ -777,6 +856,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bang:n}, {bom:n}</column>
       <column name="examples"></column>
@@ -786,6 +866,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -793,6 +874,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -806,6 +888,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Имя домашнего животного, ласка</column>
       <column name="definition_zh_HK">愛稱</column>
       <column name="definition_pt">apelido carinhoso</column>
+      <column name="definition_fi">hellittelynimi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -816,6 +899,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru">Они обычно характерны для пары, и почти никогда не произносятся, если пара не одинока. Имя питомца формируется добавлением суффикса {-oy:n:suff} к существительному. [1, p.199] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這些通常是一對夫婦特有的，除非一對夫婦獨自一人，否則幾乎不會說出來。寵物名是通過將名詞後綴{-oy:n:suff}添加到名詞而形成的.[1, p.199] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Geralmente são específicos para um casal e quase nunca são pronunciados, a menos que o casal esteja sozinho. Um apelido carinhoso é formado pela adição do sufixo {-oy:n:suff} a um substantivo.[1, p.199]</column>
+      <column name="notes_fi">Nämä ovat yleensä pariskunnalle ominaisia, ja melkein koskaan lausutaan, elleivät pariskunnat ole yksin. Lemmikkieläinten nimi muodostetaan lisäämällä substantiiviin loppuliite {-oy:n:suff}.[1, p.199] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bang:n}, {pong:n}</column>
       <column name="examples"></column>
@@ -825,6 +909,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nick, nickname</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -832,6 +917,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru">ник, никнейм</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -845,6 +931,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Прерывать, прекращать</column>
       <column name="definition_zh_HK">終結、終止</column>
       <column name="definition_pt">encerrar, descontinuar</column>
+      <column name="definition_fi">lopettaa, päättää, keskeyttää, lakkauttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hay':v}, {jegh:v}</column>
@@ -855,6 +942,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru">Это слово используется, чтобы подать сигнал о сдаче в поединке.</column>
       <column name="notes_zh_HK">這個詞用來表示決鬥中的投降。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada para sinalizar rendição em um duelo.</column>
+      <column name="notes_fi">Tätä sanaa käytetään ilmoittamaan antautumisesta kaksintaistelussa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Terminator says: "I'll be back."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -864,6 +952,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">surrender, defeat</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -871,6 +960,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -885,6 +975,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Тип ликёра, bahgol</column>
       <column name="definition_zh_HK">《bahgol》（酒類型）</column>
       <column name="definition_pt">tipo de licor, bahgol</column>
+      <column name="definition_fi">eräs alkoholijuoma, bahgol</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIq:n}</column>
@@ -895,6 +986,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{baq:v} means "terminate" and {ghol:n} means "opponent".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -904,6 +996,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">beer, wine</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -911,6 +1004,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru">пиво, вино</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -924,6 +1018,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Перекидывать батлет из одной руки в другую</column>
       <column name="definition_zh_HK">將bat'leth從一隻手扔向另一隻手 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atirar a bat'leth de uma mão para a outra</column>
+      <column name="definition_fi">vaihtaa bat'leth kädestä toiseen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{betleH:n}, {jop:v:1}, {way':v}, {chaQ:v}, {ngol:v}, {lev:v}, {DIj:v:1}, {jIrmoH:v:1}</column>
@@ -934,6 +1029,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru">Это также используется для смены хода (см. {baQ:v:3}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也用於輪流（請參閱{baQ:v:3}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é usado para se revezar (consulte {baQ:v:3}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään myös vuorotellen (katso {baQ:v:3}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -943,6 +1039,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">throw</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -950,6 +1047,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru">бросать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -963,6 +1061,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">быть свежим, быть только что собранным (фрукт, овощ)</column>
       <column name="definition_zh_HK">新鮮（水果、蔬菜）</column>
       <column name="definition_pt">ser fresco, apenas colhido (frutas, vegetais)</column>
+      <column name="definition_fi">olla tuore, olla juuri poimittu (hedelmä, vihannes)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{DeH:v:is}</column>
       <column name="see_also">{naH:n}, {Du' naH:n}, {non:v:is}</column>
@@ -973,6 +1072,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru">Это не является предпочтительным для {DeH:v:is}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不是{DeH:v:is}的首選。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não é preferido para {DeH:v:is}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä ei suositella {DeH:v:is}: lle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -982,6 +1082,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">unripe, raw, fruit</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -989,6 +1090,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru">незрелый, сырой, фрукт</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1002,6 +1104,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">по очереди [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">輪流</column>
       <column name="definition_pt">dar voltas</column>
+      <column name="definition_fi">vuorotella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1012,6 +1115,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru">Это расширение {baQ:v:1} для игр или других ситуаций, когда игроки и т. Д. Действуют в предопределенном порядке. Чтобы указать чей-то ход, используйте {jop:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{baQ:v:1}在遊戲或其他情況下的擴展，在這些情況下，玩家等按照預定的順序進行操作。要指定某人的轉身，請使用{jop:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é uma extensão do {baQ:v:1} para jogos ou outras situações em que jogadores etc. agem em uma ordem predefinida. Para especificar a vez de alguém, use {jop:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {baQ:v:1}: n laajennus pelaamiseen tai muihin tilanteisiin, joissa pelaajat jne. Toimivat ennalta määrätyssä järjestyksessä. Määritä jonkun vuoro käyttämällä {jop:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1022,6 +1126,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1029,6 +1134,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1042,6 +1148,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="definition_ru">Общее ругательство</column>
       <column name="definition_zh_HK">一般粗口</column>
       <column name="definition_pt">invectivo geral, vaia!, assobio!</column>
+      <column name="definition_fi">eräs kirosana, buu!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bep:v}, {ghughugh:v}</column>
@@ -1052,6 +1159,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/kWP0lgIYMBA} [A
       <column name="notes_ru">Данное ругательство не имеет прямого перевода.</column>
       <column name="notes_zh_HK">當用於噓聲時，通常會在抱怨或咆哮之前或之後。有時，僅僅抱怨和咆哮也可以表達這種情緒。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando usado para vaiar, geralmente é precedido ou seguido por resmungos e rosnados gerais. Às vezes, apenas resmungar e rosnar sozinho também pode expressar esse sentimento.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun sitä käytetään möykkyyn, sitä edeltää tai seuraa usein yleinen nurina ja murina. Joskus pelkkä murehtiminen ja röyhkeily yksin voi myös ilmaista tämän mielipiteen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined in {TKD:src} as "general invective". At {qep'a' 26 (2019):src}, it was explained that this could be used as the equivalent to the English "boo! hiss!"
 
 In Japanese, "baka" means "fool" or "idiot".</column>
@@ -1063,6 +1171,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">swear, curse</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1070,6 +1179,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1083,6 +1193,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">мигать, мигать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">眨、閃</column>
       <column name="definition_pt">piscar</column>
+      <column name="definition_fi">vilkkua, välähtää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pan:v:1}, {ghon:v}</column>
@@ -1093,6 +1204,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это значит загораться кратко или многократно [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著要短暫或反复點亮。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa acender brevemente ou repetidamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa, että syttyy lyhyesti tai toistuvasti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1102,6 +1214,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1109,6 +1222,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1122,6 +1236,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">плоскодонный горшок для приготовления еды</column>
       <column name="definition_zh_HK">用於食物準備的平底鍋</column>
       <column name="definition_pt">panela de fundo chato para preparação de alimentos</column>
+      <column name="definition_fi">litteäpohjainen kattila ruoanvalmistukseen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vut'un:n}, {mIv bargh:n}, {nevDagh:n}, {'Ib:n}</column>
@@ -1132,6 +1247,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Looks like a "barge".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1141,6 +1257,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pan, pot, dish</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1148,6 +1265,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">кастрюля, горшок, блюдо</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1161,6 +1279,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Бэрот</column>
       <column name="definition_zh_HK">「巴羅特」</column>
       <column name="definition_pt">Barot</column>
+      <column name="definition_fi">Barot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1171,6 +1290,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Отец Т'виса. Смотрите {tI'vIS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">T'vis的父親。參見{tI'vIS:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O pai de T'vis. Consulte {tI'vIS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">T'visin isä. Katso {tI'vIS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1180,6 +1300,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1187,6 +1308,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.182:src}</column>
     </table>
     <table name="mem">
@@ -1200,6 +1322,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Ветвь, ветка (дерево)</column>
       <column name="definition_zh_HK">樹枝</column>
       <column name="definition_pt">ramo (de uma árvore)</column>
+      <column name="definition_fi">(puun) haara</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sor:n}, {por:n}, {Qechjem'a':n}</column>
@@ -1210,6 +1333,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{tI:n} inside "bark".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1219,6 +1343,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1226,6 +1351,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1239,6 +1365,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Металл</column>
       <column name="definition_zh_HK">金屬</column>
       <column name="definition_pt">metal</column>
+      <column name="definition_fi">metalli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sor Hap:n}, {mep:n}, {'al'on:n}</column>
@@ -1277,6 +1404,21 @@ In Japanese, "baka" means "fool" or "idiot".</column>
 ▶ {'uSqan:n}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tunnettuja sanoja metalleille ovat:
+▶ {bettI':n}
+▶ {ghav 'uSqan:n}
+▶ {jey':n}
+▶ {jey' Sorpuq:n}
+▶ {letbIng:n}
+▶ {ngIDvoS:n}
+▶ {qol'om:n}
+▶ {SIrlIy:n}
+▶ {Sorpuq:n}
+▶ {velSo':n}
+▶ {velSo' 'uSqan:n}
+▶ {yuHSIQ:n}
+▶ {'apraQ:n}
+▶ {'uSqan:n}</column>
       <column name="hidden_notes">Something you "bash", or "base" metal. See {baS 'In:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1286,6 +1428,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">iron</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1293,6 +1436,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">Железо</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -1306,6 +1450,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="definition_ru">{Ha'on:n}</column>
           <column name="definition_zh_HK">{Ha'on:n}</column>
           <column name="definition_pt">{Ha'on:n}</column>
+      <column name="definition_fi">{Ha'on:n}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1316,6 +1461,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -1325,6 +1471,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1332,6 +1479,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
         </table>
         <table name="mem">
@@ -1345,6 +1493,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="definition_ru">Литейный завод</column>
           <column name="definition_zh_HK">煉鐵廠</column>
           <column name="definition_pt">fundição</column>
+      <column name="definition_fi">valimo</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{mItlh:v}, {Qu:v}, {vIncha':n}, {QumeH ngaSwI':n}</column>
@@ -1355,6 +1504,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{baS:n}, {laSvargh:n}</column>
           <column name="examples"></column>
@@ -1364,6 +1514,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1371,6 +1522,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -1384,6 +1536,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="definition_ru">Провод</column>
           <column name="definition_zh_HK">金屬線</column>
           <column name="definition_pt">fio</column>
+      <column name="definition_fi">johto</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1394,6 +1547,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{baS:n}, {SIrgh:n}</column>
           <column name="examples"></column>
@@ -1403,6 +1557,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1410,6 +1565,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -1423,6 +1579,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="definition_ru">Металлический барабан, колокол</column>
           <column name="definition_zh_HK">鐵鼓、鐵鐘</column>
           <column name="definition_pt">tambor metálico, sino</column>
+      <column name="definition_fi">metallirumpu, -kello</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{'In:n}</column>
@@ -1433,6 +1590,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">Something you "bash in".</column>
           <column name="components">{baS:n}, {'In:n}</column>
           <column name="examples"></column>
@@ -1442,6 +1600,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">gong</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1449,6 +1608,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
           <column name="search_tags_ru">гонг</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.75:src}</column>
         </table>
     <table name="mem">
@@ -1462,6 +1622,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">вектор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">向量</column>
       <column name="definition_pt">vetor</column>
+      <column name="definition_fi">vektori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quv:n}, {rober:n}, {roDSer:n}</column>
@@ -1472,6 +1633,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это математический термин. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個數學術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo matemático. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on matematiikan termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Victor Basta is a character in the movie "Airplane!" He is asked, "What's our vector, victor?"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1481,6 +1643,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1488,6 +1651,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1501,6 +1665,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Состязание Баткул</column>
       <column name="definition_zh_HK">《B'aht Qul》挑戰</column>
       <column name="definition_pt">Desafio B'aht Qul</column>
+      <column name="definition_fi">B'aht Qul -haaste</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1511,6 +1676,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это клингонская игра или состязание, очень похожее на армрестлинг.</column>
       <column name="notes_zh_HK">這是類似於手臂摔跤的克林崗遊戲或競賽。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um jogo ou concurso de Klingon semelhante à queda de braço. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on klingonipeli tai -kilpailu, joka on samanlainen kuin käsivarsi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1520,6 +1686,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">arm wrestling</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1527,6 +1694,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">армрестлинг</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNG - The Chase:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1540,6 +1708,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Честь (общее понятие, философское понятие, ассоциированное с целостностью)</column>
       <column name="definition_zh_HK">光榮、尊嚴（與人格相關的哲學概念）</column>
       <column name="definition_pt">honra (geral, conceito filosófico, associado à integridade)</column>
+      <column name="definition_fi">kunnia (filosofinen käsite, liittyy rehellisyyteen)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{DavHam:n}, {chIvo':n}</column>
       <column name="see_also">{quv:v}</column>
@@ -1550,6 +1719,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это слово относится к важному, более общему, философскому понятию, в сравнении с {quv:n}.[2]</column>
       <column name="notes_zh_HK">與{quv:n}.[2]相比，此詞指的是更宏大，更籠統的哲學概念。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se a um conceito filosófico mais grandioso, mais geral, em comparação com {quv:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa suurempaan, yleisempään filosofiseen käsitteeseen verrattuna {quv:n}: een.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Reverse of {tlhab:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1559,6 +1729,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1566,6 +1737,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 12.3, p.9, Sept. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1579,6 +1751,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Заслуженный, уважаемый, с честью</column>
       <column name="definition_zh_HK">光榮地、光明正大地</column>
       <column name="definition_pt">honrado, com honra</column>
+      <column name="definition_fi">kunniakkaasti, kunniallisesti, rehellisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{batlhHa':adv}</column>
       <column name="see_also">{quv:n}, {quv:v}</column>
@@ -1589,6 +1762,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1601,6 +1775,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">honoured, with honour, honorably, honourably</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1608,6 +1783,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">благородно</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1621,6 +1797,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Пусть ты умрешь с честью.</column>
       <column name="definition_zh_HK">願你死得有榮譽。</column>
       <column name="definition_pt">Que você morra bem.</column>
+      <column name="definition_fi">Kuole kunniakkaasti.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1631,6 +1808,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{batlh:adv}, {bI-:v}, {Hegh:v}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -1640,6 +1818,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1647,6 +1826,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.71:src}</column>
     </table>
     <table name="mem">
@@ -1660,6 +1840,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Тебя будут помнить с честью.</column>
       <column name="definition_zh_HK">你將會名垂千古。（你將會被光榮地銘記。）</column>
       <column name="definition_pt">Você será lembrado com honra.</column>
+      <column name="definition_fi">Sinut muistetaan kunnialla.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1670,6 +1851,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{batlh:adv}, {Da-:v}, {qaw:v}, {-lu':v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -1679,6 +1861,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1686,6 +1869,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">почитать, уважать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}, [2] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -1699,6 +1883,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Придерживайся добродетели с честью.</column>
       <column name="definition_zh_HK">光榮地堅持美德。</column>
       <column name="definition_pt">Aderir à virtude com honra.</column>
+      <column name="definition_fi">Noudata hyveitä kunniallisesti.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1709,6 +1894,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{batlh:adv}, {ghob:n}, {yI-:v}, {pab:v}</column>
       <column name="examples"></column>
@@ -1718,6 +1904,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Adhere to virtue honourably.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1725,6 +1912,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.47:src}</column>
     </table>
     <table name="mem">
@@ -1738,6 +1926,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Благородная смерть не требует отмщения.</column>
       <column name="definition_zh_HK">光榮的死亡是不需要復仇的。</column>
       <column name="definition_pt">Uma morte honrosa não exige vingança.</column>
+      <column name="definition_fi">Kunniallinen kuolema ei vaadi kostoa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1748,6 +1937,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{batlh:adv}, {Hegh:v}, {-lu':v}, {-chugh:v}, {noD:v}, {-nIS:v}, {-be':v}, {vay':n}</column>
       <column name="examples"></column>
@@ -1757,6 +1947,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">An honourable death requires no vengeance.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1764,6 +1955,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.129:src}</column>
     </table>
     <table name="mem">
@@ -1777,6 +1969,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Ты ведешь дела благородно.</column>
       <column name="definition_zh_HK">你光榮地交易業務。</column>
       <column name="definition_pt">Você realiza negócios com honra.</column>
+      <column name="definition_fi">Teet liiketoimintaa kunniallisesti.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1787,6 +1980,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{batlh:adv}, {malja':n}, {Da-:v}, {Huq:v}</column>
       <column name="examples"></column>
@@ -1796,6 +1990,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1803,6 +1998,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -1816,6 +2012,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Честь более важна, чем жизнь.</column>
       <column name="definition_zh_HK">榮譽比生命更重要。</column>
       <column name="definition_pt">A honra é mais importante que a vida.</column>
+      <column name="definition_fi">Kunnia on tärkeämpää kuin elämä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1826,6 +2023,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{batlh:n}, {potlh:v}, {... law':sen}, {yIn:n}, {potlh:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -1835,6 +2033,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Honour is more important than life.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1842,6 +2041,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.53:src}</column>
     </table>
     <table name="mem">
@@ -1855,6 +2055,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Клингон не откладывает дело чести.</column>
       <column name="definition_zh_HK">克林崗人不會推遲關於榮譽的問題。</column>
       <column name="definition_pt">Um Klingon não adia uma questão de honra.</column>
+      <column name="definition_fi">Klingoni ei lykkää kunnia-asiaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1865,6 +2066,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{batlh:n}, {qel:v:1}, {-DI':v}, {tlhIngan:n}, {lum:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -1874,6 +2076,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">A Klingon does not postpone a matter of honour.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1881,6 +2084,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.67:src}</column>
     </table>
     <table name="mem">
@@ -1894,6 +2098,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Защищай клингонскую расу с честью.</column>
       <column name="definition_zh_HK">光榮地捍衛克林崗人族。</column>
       <column name="definition_pt">Defenda a raça Klingon com honra.</column>
+      <column name="definition_fi">Puolusta klingonien rotua kunnialla.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1904,6 +2109,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This line was cut from {Star Trek V:src}.</column>
       <column name="components">{batlh:adv}, {tlhIngan:n}, {Segh:n}, {yI-:v}, {Hub:v}</column>
       <column name="examples"></column>
@@ -1913,6 +2119,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1920,6 +2127,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.11, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1934,6 +2142,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Бесчестно, подло</column>
       <column name="definition_zh_HK">不光彩地、不端地</column>
       <column name="definition_pt">desonrosamente</column>
+      <column name="definition_fi">häpeällisesti, epärehellisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{batlh:adv}</column>
       <column name="see_also">{-Ha':v:suff}</column>
@@ -1944,6 +2153,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1955,6 +2165,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dishonourably, dishonored, dishonoured, without honor, without honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1962,6 +2173,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">бесчестно, обесчещенный, без чести</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 4.4, p.11:src}</column>
     </table>
     <table name="mem">
@@ -1975,6 +2187,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Одиночка не достигнет чести, пока действует бесчестно.</column>
       <column name="definition_zh_HK">一個人在不光彩的行為中沒有獲得榮譽。</column>
       <column name="definition_pt">Não se conquista honra ao agir de forma desonrosa.</column>
+      <column name="definition_fi">Kunniaa ei saa toimimalla epärehellisesti.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1985,6 +2198,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{batlhHa':adv}, {vang:v}, {-lu':v}, {-taH:v}, {-vIS:v}, {quv:n}, {chav:v}, {-be':v}, {-lu':v}</column>
       <column name="examples"></column>
@@ -1994,6 +2208,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">One does not achieve honour while acting dishonourably.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2001,6 +2216,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.55:src}</column>
     </table>
     <table name="mem">
@@ -2014,6 +2230,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Орбита</column>
       <column name="definition_zh_HK">行軌道（天文學）</column>
       <column name="definition_pt">orbitar</column>
+      <column name="definition_fi">kiertää, olla kiertoradalla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIbDoH:n}, {maS:n}, {yuQ:n}, {jul:n}, {Hov:n}</column>
@@ -2024,6 +2241,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Объект - это то, что находится на орбите. {-Daq:n:suff} не требуется.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">物體是被繞行的物體。 {-Daq:n:suff}是不必要的。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é a coisa em órbita. {-Daq:n:suff} é desnecessário.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on kiertorata. {-Daq:n:suff} on tarpeeton.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2033,6 +2251,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">circle, encircle</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2040,6 +2259,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">круг, окружать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -2053,6 +2273,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">длина окружности [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">圓周</column>
       <column name="definition_pt">circunferência</column>
+      <column name="definition_fi">ympärysmitta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gho SubmaH:n}</column>
@@ -2063,6 +2284,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2072,6 +2294,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Umfang</column>
       <column name="search_tags_fa"></column>
@@ -2079,6 +2302,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2092,6 +2316,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">быть удобным, чуствовать себя готовым, быть уверенным в себе</column>
       <column name="definition_zh_HK">自信、篤定、有把炮</column>
       <column name="definition_pt">ser confortável, estar se sentindo preparado, confiante</column>
+      <column name="definition_fi">olla mukavasti, olla varma, tuntea olonsa valmistautuneeksi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{baw'Ha':v}</column>
       <column name="see_also"></column>
@@ -2102,6 +2327,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это может быть использовано, чтобы описать ощущение подготовленности к грядущему путеществию или битве.</column>
       <column name="notes_zh_HK">這可以用來描述為即將到來的旅程或戰鬥準備的感覺。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para descrever o sentimento de preparação para uma próxima jornada ou batalha. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää kuvaamaan tunne valmistautuneena tulevaan matkaan tai taisteluun. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2111,6 +2337,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2118,6 +2345,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -2131,6 +2359,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Быть неудобным, быть тревожным, быть озабоченным, быть неуверенным</column>
       <column name="definition_zh_HK">不舒服、擔心、猶豫不決 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desconfortável, ser preocupado, ser hesitante</column>
+      <column name="definition_fi">olla epämukavasti, olla huolissaan, olla epäröivä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{baw':v}</column>
       <column name="see_also"></column>
@@ -2141,6 +2370,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это может быть использовано, чтобы описать ощущение неподготовленности к грядущему путешествию или битве.</column>
       <column name="notes_zh_HK">這可以用來描述對即將到來的旅程或戰鬥沒有準備的感覺。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para descrever o sentimento de despreparo para uma próxima jornada ou batalha. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää kuvaamaan tuntemattomuutta tulevaan matkaan tai taisteluun. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{baw':v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -2150,6 +2380,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2157,6 +2388,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -2170,6 +2402,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">ломтик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">片</column>
       <column name="definition_pt">fatia</column>
+      <column name="definition_fi">viipale, siivu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ay':n}</column>
@@ -2180,6 +2413,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это относится к фрагменту, отрезанному в результате {quH:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指由於{quH:v}而切斷的塊。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao pedaço cortado como resultado do {quH:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kappaleeseen, joka on katkaistu {quH:v}: n seurauksena. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is {bay:n} "b" plus {laD:v} "read", a reference to sliced bread.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2189,6 +2423,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2196,6 +2431,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2209,6 +2445,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">подчиненный, подчиненный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">下級，下級 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inferior, subordinado</column>
+      <column name="definition_fi">alempiarvoinen, alainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{moch:n}</column>
       <column name="see_also">{QIv:v}</column>
@@ -2219,6 +2456,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{bay:n} "b" + {'eS:v} "low" = "below". Also "bias".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2228,6 +2466,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2235,6 +2474,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2248,6 +2488,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Сидеть</column>
       <column name="definition_zh_HK">坐</column>
       <column name="definition_pt">sentar</column>
+      <column name="definition_fi">istua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hu':v}, {Qam:v}, {Qot:v}, {'ung:v}, {tor:v:1}, {quS:n}, {Sa'Hut:n}</column>
@@ -2258,6 +2499,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2267,6 +2509,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2274,6 +2517,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2287,6 +2531,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">седло [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鞍</column>
       <column name="definition_pt">sela</column>
+      <column name="definition_fi">satula</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sargh:n}, {Hun:n}, {lIgh:v}</column>
@@ -2297,6 +2542,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это относится к сидению, привязанному к спине животного. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指綁在動物背部的座位。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao assento amarrado à parte de trás de um animal.</column>
+      <column name="notes_fi">Tämä viittaa eläimen takaosaan kiinnitettyyn istuimeen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Back in" the saddle.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2306,6 +2552,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2313,6 +2560,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2326,6 +2574,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Пузырь</column>
       <column name="definition_zh_HK">泡沫</column>
       <column name="definition_pt">bolha</column>
+      <column name="definition_fi">kupla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngon:v}, {jo':v}, {'o'nI':n}</column>
@@ -2336,6 +2585,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Bazooka" is a brand of bubble gum. {ba'Suq'a' jo':sen@@ba'Suq:n, -'a':n, jo':v} means "he blows a great bubble".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2345,6 +2595,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2352,6 +2603,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -2365,6 +2617,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Крыша, кровля</column>
       <column name="definition_zh_HK">屋頂</column>
       <column name="definition_pt">cobertura</column>
+      <column name="definition_fi">katto</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yav:n}</column>
       <column name="see_also">{qach:n}</column>
@@ -2375,6 +2628,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">{yor:n} {qach:n} и верхняя грань {pa' beb:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{qach:n}的{yor:n}和{pa' beb:n}的頂面。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {yor:n} de um {qach:n} e a face superior de um {pa' beb:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{qach:n}: n {yor:n} ja {pa' beb:n}: n yläpinta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Babe Ruth" was an American baseball player.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2384,6 +2638,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2391,6 +2646,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src}), [2] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -2404,6 +2660,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Кровельщик, укладчик крыши</column>
       <column name="definition_zh_HK">屋頂工人</column>
       <column name="definition_pt">telhador, aquele que constrói o telhado</column>
+      <column name="definition_fi">katontekijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2414,6 +2671,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это относится к человеку, который укладывает кровельные дранки,доски и т.д., когда сооружает крышу.</column>
       <column name="notes_zh_HK">這是指在建造屋頂時佈置木瓦，木板等的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa que estabelece as telhas, tábuas, etc., ao construir um telhado.</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, joka asentaa katon rakentamisen yhteydessä vyöruusut, lankut jne. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{majyang:n}, {mutlh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2423,6 +2681,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2430,6 +2689,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.10:src}</column>
     </table>
     <table name="mem">
@@ -2443,6 +2703,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Страдать</column>
       <column name="definition_zh_HK">受苦、遭受</column>
       <column name="definition_pt">sofrer</column>
+      <column name="definition_fi">kärsiä</column>
       <column name="synonyms">{SIQ:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{bep:v}, {vIng:v}</column>
@@ -2453,6 +2714,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Possibly from the expression "bitch and moan".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2462,6 +2724,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2469,6 +2732,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2482,6 +2746,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Дефлекторы</column>
       <column name="definition_zh_HK">偏轉盾</column>
       <column name="definition_pt">defletores</column>
+      <column name="definition_fi">kimmottimet</column>
       <column name="synonyms">{botjan:n}, {begh botjan:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2492,6 +2757,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rI'gheS:n:inhps}</column>
       <column name="examples"></column>
@@ -2501,6 +2767,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2508,6 +2775,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2521,6 +2789,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Отражатель(ли)</column>
       <column name="definition_zh_HK">偏轉防護罩</column>
       <column name="definition_pt">escudo (s) defletor (es)</column>
+      <column name="definition_fi">kimmotinlaatta</column>
       <column name="synonyms">{begh:n}, {botjan:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2531,6 +2800,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{begh:n}, {botjan:n}</column>
       <column name="examples"></column>
@@ -2540,6 +2810,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2547,6 +2818,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2560,6 +2832,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Дефлекторный массив</column>
       <column name="definition_zh_HK">偏轉器系列</column>
       <column name="definition_pt">matriz defletora</column>
+      <column name="definition_fi">kimmotinsarja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2570,6 +2843,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{begh:n}, {DaH:n}</column>
       <column name="examples"></column>
@@ -2579,6 +2853,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shield array</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2586,6 +2861,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">Массив щитов</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2599,6 +2875,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Винтовка</column>
       <column name="definition_zh_HK">步槍</column>
       <column name="definition_pt">rifle</column>
+      <column name="definition_fi">kivääri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIch:n}</column>
@@ -2609,6 +2886,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Два общих вида {beH:n} - это {nISwI' beH:n} и {pu'beH:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{beH:n}的兩種常見類型是{nISwI' beH:n}和{pu'beH:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Dois tipos comuns de {beH:n} são {nISwI' beH:n} e {pu'beH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kaksi yleistä {beH:n}-tyyppiä ovat {nISwI' beH:n} ja {pu'beH:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2618,6 +2896,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gun</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2625,6 +2904,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru">Ружье</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2638,6 +2918,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Смотреть, наблюдать, следить</column>
       <column name="definition_zh_HK">觀看、觀察</column>
       <column name="definition_pt">ver, observar com os olhos</column>
+      <column name="definition_fi">katsoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIH:v}, {qIm:v}, {buS:v}</column>
@@ -2648,6 +2929,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2658,6 +2940,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2665,6 +2948,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2678,6 +2962,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">быть уверенным, быть точным, быть достоверным, быть надежным</column>
       <column name="definition_zh_HK">確定、明確</column>
       <column name="definition_pt">ter certeza, ser definitivo, ser positivo, ter certeza</column>
+      <column name="definition_fi">olla varma (jostakin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-bej:v}, {DIch:n}, {na':v:2,slang}</column>
@@ -2688,6 +2973,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2697,6 +2983,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2704,6 +2991,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2717,6 +3005,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Быть довольным</column>
       <column name="definition_zh_HK">愜意、高興</column>
       <column name="definition_pt">estar satisfeito</column>
+      <column name="definition_fi">olla tyytyväinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{belHa':v}</column>
       <column name="see_also">{bel:n}, {yon:v}, {Quch:v}, {tIv:v}</column>
@@ -2727,6 +3016,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2736,6 +3026,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2743,6 +3034,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2756,6 +3048,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Удовольствие</column>
       <column name="definition_zh_HK">樂趣、高興</column>
       <column name="definition_pt">prazer</column>
+      <column name="definition_fi">ilo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bel:v}, {tIv:v}</column>
@@ -2766,6 +3059,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2775,6 +3069,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">entertainment</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2782,6 +3077,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2795,6 +3091,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Быть недовольным</column>
       <column name="definition_zh_HK">不高興</column>
       <column name="definition_pt">estar descontente</column>
+      <column name="definition_fi">olla tyytymätön</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bel:v}</column>
       <column name="see_also">{belHa'moH:v}</column>
@@ -2805,6 +3102,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bel:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -2814,6 +3112,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2821,6 +3120,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2834,6 +3134,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Сердить, быть неприятным, разочаровывать</column>
       <column name="definition_zh_HK">失望 、辜負</column>
       <column name="definition_pt">desagradar, decepcionar</column>
+      <column name="definition_fi">herättää tyytymättömyyttä jossakussa, tuottaa pettymys jollekulle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{belHa':v}</column>
@@ -2844,6 +3145,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The English translation of the sentence from {Star Trek Constellations:src} does not appear in the book, but in the author's annotations which was a separate document.</column>
       <column name="components">{belHa':v}, {-moH:v}</column>
       <column name="examples">
@@ -2855,6 +3157,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
 ▶ {chobelHa'moH, DI'qar. SajlIj 'oHbe' quvwIj'e'.:sen:nolink} "Ты разочаровал меня, Д'Кар. Моя честь не твоя игрушка."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2862,6 +3165,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek Constellations p.259:src}</column>
     </table>
     <table name="mem">
@@ -2875,6 +3179,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">хобби [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">娛樂、興趣</column>
       <column name="definition_pt">passatempo, hobby</column>
+      <column name="definition_fi">harrastus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2885,6 +3190,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru">Это буквально означает «задание на удовольствие». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從字面上看，這意味著“愉悅的任務”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso literalmente significa "tarefa de prazer". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "ilotehtävää". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bel:n}, {Qu':n}</column>
       <column name="examples"></column>
@@ -2894,6 +3200,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2901,6 +3208,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2914,6 +3222,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Подошва ноги</column>
       <column name="definition_zh_HK">腳板底</column>
       <column name="definition_pt">sola do pé, planta do pé</column>
+      <column name="definition_fi">jalkapohja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qam:n}, {ngIb:n:1}, {mov:n}, {toch:n}</column>
@@ -2924,6 +3233,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2933,6 +3243,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2940,6 +3251,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2953,6 +3265,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">Годы назад, лет назад</column>
       <column name="definition_zh_HK">（幾）年前</column>
       <column name="definition_pt">anos atrás</column>
+      <column name="definition_fi">... vuotta sitten</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nem:n}</column>
       <column name="see_also">{DIS:n:2}, {ret:n}, {ben:n:2}</column>
@@ -2963,6 +3276,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">How long has it "been"?</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2972,6 +3286,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2979,6 +3294,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2992,6 +3308,7 @@ In Japanese, "baka" means "fool" or "idiot".</column>
       <column name="definition_ru">лет</column>
       <column name="definition_zh_HK">歲</column>
       <column name="definition_pt">anos de idade</column>
+      <column name="definition_fi">... vuotta vanha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bogh:v}, {ben:n:1}, {qan:v:1}, {Qup:v}</column>
@@ -3006,6 +3323,9 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
 Чтобы сказать "Когда мне было X лет", можно, например использовать следующую конструкцию, {qaStaHvIS DISwIj javDIch...:sen@@qaS:v, -taH:v, -vIS:v, DIS:n:2, -wIj:n, jav:n:1, -DIch:n} "Когда мне было шесть лет...".[4]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonissa sen sijaan, että sanottaisiin "Olen X-vuotias", ihmisen ikä ilmaistaan ​​sanomalla "Olen syntynyt X vuotta sitten". [2]
+
+Sanoa "kun olin X-vuotias", rakennus on esimerkiksi {qaStaHvIS DISwIj javDIch...:sen@@qaS:v, -taH:v, -vIS:v, DIS:n:2, -wIj:n, jav:n:1, -DIch:n} "Kun olin kuusi vuotta vanha ...". Syntymäpäivän ja ensimmäisen syntymäpäivän välistä aikaa pidetään nolla-vuotena[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3018,6 +3338,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3025,6 +3346,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3038,6 +3360,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">Агония</column>
       <column name="definition_zh_HK">痛苦</column>
       <column name="definition_pt">agonia</column>
+      <column name="definition_fi">tuska</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bep:v}, {'oy':n}</column>
@@ -3048,6 +3371,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3057,6 +3381,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3064,6 +3389,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3077,6 +3403,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">жаловаться, возражать, схватить, зажать</column>
       <column name="definition_zh_HK">抱怨</column>
       <column name="definition_pt">reclamar, objeto, queixa</column>
+      <column name="definition_fi">valittaa, vastustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bep:n}, {vIng:v}, {boj:v}, {morgh:v}, {baQa':excl}</column>
@@ -3087,6 +3414,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3096,6 +3424,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3103,6 +3432,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3116,6 +3446,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">экипаж, член экипажа</column>
       <column name="definition_zh_HK">船員</column>
       <column name="definition_pt">tripulação</column>
+      <column name="definition_fi">miehistö; matruusi, miehistön jäsen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3126,6 +3457,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru">Звание, присвоенное военнослужащим в Силах обороны ({Hubbeq:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">國防軍中被徵募人員的等級。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma classificação dada ao pessoal alistado na Força de Defesa ({Hubbeq:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Puolustusvoimien värväytyneelle henkilöstölle annettu arvo ({Hubbeq:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A crewman is at "beck" and call.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3135,6 +3467,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3142,6 +3475,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3155,6 +3489,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">Сержантский член экипажа</column>
       <column name="definition_zh_HK">船員宿舍</column>
       <column name="definition_pt">quartos de tripulação não comissionados</column>
+      <column name="definition_fi">alipäällystön tilat?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa'mey:n:hyp}</column>
@@ -3165,6 +3500,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{beq:n}, {pa':n:1}, {-mey:n}</column>
       <column name="examples"></column>
@@ -3174,6 +3510,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3181,6 +3518,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3194,6 +3532,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">Тип минерала, bekpuj(оранжевого цвета)</column>
       <column name="definition_zh_HK">礦物類型《bekpuj》（橙色）</column>
       <column name="definition_pt">tipo de mineral, bekpuj (cor laranja)</column>
+      <column name="definition_fi">eräs oranssinvärinen mineraali, bekbuj</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Doq:v}</column>
@@ -3204,6 +3543,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru">Это слово может содержать элемент {puj:n:2,hyp} также найденный в {cha'puj:n}.</column>
       <column name="notes_zh_HK">該單詞可能包含在{cha'puj:n}中也找到的元素{puj:n:2,hyp}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra pode conter o elemento {puj:n:2,hyp} também encontrado em {cha'puj:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi sisältää elementin {puj:n:2,hyp}, joka löytyy myös {cha'puj:n}: sta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3213,6 +3553,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">colour, orange</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3220,6 +3561,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru">цвет, оранжевый</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3233,6 +3575,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">быть плоским</column>
       <column name="definition_zh_HK">平坦、扁</column>
       <column name="definition_pt">ser plano</column>
+      <column name="definition_fi">olla tasainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3243,6 +3586,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{puH beQ:n}</column>
@@ -3252,6 +3596,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3259,6 +3604,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3272,6 +3618,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">быть раздражительным, быть раздраженным</column>
       <column name="definition_zh_HK">煩躁、心躁、火起</column>
       <column name="definition_pt">ser irritado, ser irritável</column>
+      <column name="definition_fi">olla ärtyisä, olla ärtynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIt:v}, {jot:v:1}, {jotHa':v}, {nuQ:v}, {puQ:v}, {mogh:v}</column>
@@ -3282,6 +3629,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined in {TKD:src} only as "be irritable", but {berghmoH:v} "irritate" from {KGT:src} suggests that {bergh:v:nolink} can mean "be irritated".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3291,6 +3639,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3298,6 +3647,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3311,6 +3661,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">Раздражать</column>
       <column name="definition_zh_HK">惱怒、惹火</column>
       <column name="definition_pt">irritar</column>
+      <column name="definition_fi">ärsyttää</column>
       <column name="synonyms">{nuQ:v}, {yIv:v:2}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3321,6 +3672,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bergh:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -3330,6 +3682,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3337,6 +3690,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.167:src}</column>
     </table>
     <table name="mem">
@@ -3350,6 +3704,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">Бернардо</column>
       <column name="definition_zh_HK">「貝納多」</column>
       <column name="definition_pt">Bernardo</column>
+      <column name="definition_fi">Bernardo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -3360,6 +3715,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3369,6 +3725,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3376,6 +3733,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -3389,6 +3747,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">Конец, окончание( оперы, игры, истории, речи)</column>
       <column name="definition_zh_HK">結幕（歌劇、戲劇、故事、演講）</column>
       <column name="definition_pt">fim (de uma ópera, peça, história, discurso)</column>
+      <column name="definition_fi">(oopperan, näytelmän, tarunan, puheen) loppu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bI'reS:n}</column>
       <column name="see_also">{rIn:v}, {Dor:v:2}, {ghang:v}, {van:v:2}, {'o'megh:n}</column>
@@ -3399,6 +3758,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru">Это относится к финальной секции представления(последняя ария в опере, последняя речь в игре, последнее предложение в речи истории и т.д).</column>
       <column name="notes_zh_HK">這是指表演的最後部分（歌劇中的最後詠嘆調，戲劇中的最後講話，故事或演講中的最後一句話等）。對於一首歌（僅對於一首歌），最後一部分稱為{'o'megh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à seção final de uma performance (última ária de uma ópera, último discurso de uma peça, última frase ou mais de uma história ou discurso, etc.). Para uma música (e apenas para uma música), a parte final é chamada de {'o'megh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa esityksen viimeiseen osaan (oopperan viimeinen aaria, näytelmän viimeinen puhe, tarinan tai puheen viimeinen lause jne.). Kappaleen (ja vain kappaleen) loppuosaa kutsutaan sen {'o'megh:n}-kappaleeksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Bertram from Shakespeare's "All's Well That Ends Well".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3408,6 +3768,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3415,6 +3776,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -3428,6 +3790,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">Жидкий</column>
       <column name="definition_zh_HK">液體</column>
       <column name="definition_pt">líquido</column>
+      <column name="definition_fi">neste</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taS:n}, {lep:n}, {SIp:n}, {lI'choD:n}, {bum:v}</column>
@@ -3438,6 +3801,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="notes_ru">Это относится к состоянию материи.</column>
       <column name="notes_zh_HK">這是指物質狀態。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um estado da matéria. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa aineen tilaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Bette Graham was the inventor of liquid paper (correction fluid).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3447,6 +3811,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3454,6 +3819,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -3467,6 +3833,7 @@ To say "when I was X years old", the construction is, for example, {qaStaHvIS DI
       <column name="definition_ru">Батлет(тип ручного оружия)</column>
       <column name="definition_zh_HK">《bat'leth》（光榮聖劍）</column>
       <column name="definition_pt">tipo de arma de mão, bat'leth</column>
+      <column name="definition_fi">eräs käsiase, bat'leth</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yan:n}, {yan:v}, {chaQ:v}, {jop:v:1}, {way':v}, {ngol:v}, {lev:v}, {DIj:v:1}, {jIrmoH:v:1}, {baQ:v:1}, {Qach:v}, {ret'aq:n}</column>
@@ -3505,6 +3872,11 @@ I Klingon-legenden smiddes det ursprungliga Sword of Honor av {qeylIS'e' lIjlaHb
 Na lenda Klingon, a Espada de Honra original foi forjada por {qeylIS'e' lIjlaHbe'bogh vay':n:name} a partir de uma mecha de seu cabelo mergulhada na {qul ngeng:n} do vulcão {QIStaq:n}. A arma tem o formato de uma {maS'e' loQ So'be'bogh QIb:n}.[5]
 
 O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenciá-lo do {meqleH:n} de som semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän aseen nimen osat ovat arkaaisia, mutta se tarkoittaa "kunniamiekkaa". Nykyaikaisessa Klingonissa tietysti "kunniamiekka" olisi {batlh 'etlh:n:nolink}. Katso {paq'batlh:n}.
+
+Klingonin legendassa {qeylIS'e' lIjlaHbe'bogh vay':n:name} vääristi alkuperäisen kunniamiekan hiussaarnasta, joka oli kastettu {QIStaq:n}-tulivuoren {qul ngeng:n}-tulppaan. Ase on muotoiltu {maS'e' loQ So'be'bogh QIb:n}.[5]-muotoon
+
+{betleH:n:nolink}: ta kutsutaan myös {betleH quv:n:nolink}: ksi, jotta se erotettaisiin vastaavasta kuulostavasta {meqleH:n}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word is misspelled {batleH:n:hyp,nolink} on {SkyBox 8:src}.[3] A message on the {s.k:src} newsgroup gives a bit of history behind the various spellings used in English for this word.[4]</column>
       <column name="components">{batlh:n}, {'etlh:n}</column>
       <column name="examples">
@@ -3518,6 +3890,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
   "Батлет Ворфа находился в его семье вот уже десять поколений. Согласно клингонской легенде, этот меч чести нисходит ко временам Кейлеса Незабываемого".[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">batleth, bat'telh, sword of honor, sword of honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3525,6 +3898,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru">Батлет,бат'тел</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT:src}, [3] {SkyBox 8:src}, [4] {s.k 1998.10.20:src}, [5] {paq'batlh p.138-139:src}</column>
     </table>
         <table name="mem">
@@ -3538,6 +3912,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
           <column name="definition_ru">Демонстрация батлета</column>
           <column name="definition_zh_HK">《bat'leth》聖劍架</column>
           <column name="definition_pt">pé para bat'leth</column>
+      <column name="definition_fi">bat'leth-näyttely (?)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{quv bey':n}, {nuH bey':n}</column>
@@ -3548,6 +3923,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{betleH:n}, {bey':n}</column>
           <column name="examples"></column>
@@ -3557,6 +3933,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3564,6 +3941,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KCD:src}</column>
         </table>
         <table name="mem">
@@ -3577,6 +3955,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
           <column name="definition_ru">Орден Батлета</column>
           <column name="definition_zh_HK">《bat'leth》聖劍勳章</column>
           <column name="definition_pt">Ordem dos Bat'leth</column>
+      <column name="definition_fi">Bat'lethin ritarikunta</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -3587,6 +3966,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{betleH:n}, {'obe':n}</column>
           <column name="examples"></column>
@@ -3596,6 +3976,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3603,6 +3984,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.182:src}</column>
         </table>
     <table name="mem">
@@ -3616,6 +3998,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">алюминий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鋁</column>
       <column name="definition_pt">alumínio</column>
+      <column name="definition_fi">alumiini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baS:n}, {tamler:n}</column>
@@ -3626,6 +4009,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Это металлический химический элемент с символом А1 и атомным номером 13. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是金屬化學元素，符號為Al，原子序數為13。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o elemento químico metálico com o símbolo Al e o número atômico 13. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on metallinen kemiallinen alkuaine, jolla on symboli Al ja atominumero 13. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The chorus of the Paul Simon song "You Can Call Me Al" has the line "And Betty, when you call me, you can call me Al."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3635,6 +4019,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">aluminium</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3642,6 +4027,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3655,6 +4041,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Выть, завывать, стенать</column>
       <column name="definition_zh_HK">嚎叫、哀號</column>
       <column name="definition_pt">uivar, lamentar</column>
+      <column name="definition_fi">ulvonta, itku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jach:v}, {SaQ:v}, {Hegh bey:n}, {beyHom bey bey'a' jachtaH:sen}</column>
@@ -3665,6 +4052,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Bay" is an English word with the same meaning.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3682,6 +4070,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
    Когда клингонский воин умирает или его убивают, другие клингоны могут исполнять церемониальный вой или крик, как часть клингонского смертельного ритуала. Глаза павшего клингона открыты, и остальные рычат в нарастающем объеме. По природе этот вой скорее победоносный, нежели печальный. Также служит предупреждением другим умершим, что идет клингонский воин"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3689,6 +4078,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 31:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -3702,6 +4092,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Рычать в бурном темпе</column>
       <column name="definition_zh_HK">在漸強中咆哮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rugir em crescendo</column>
+      <column name="definition_fi">mölyä crescendossa [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hegh bey:n}</column>
@@ -3712,6 +4103,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Это выражение известно только через предложение от {SkyBox 31:src}, {beyHom bey bey'a' jachtaH latlh tlhInganpu'.:sen:nolink} "[Other Klingons] рев в большом крещендо".[1] Его точная грамматика неясна. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從{SkyBox 31:src}，{beyHom bey bey'a' jachtaH latlh tlhInganpu'.:sen:nolink}“ [Other Klingons]咆哮聲很高”這句話中，只能從句子中得知此表達式。[1]的確切語法尚不清楚。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão é conhecida apenas através da sentença, de {SkyBox 31:src}, {beyHom bey bey'a' jachtaH latlh tlhInganpu'.:sen:nolink} "[Other Klingons] rugem em um grande crescimento".[1] Sua gramática exata não é clara. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lauseke tunnetaan vain lauseesta {SkyBox 31:src}, {beyHom bey bey'a' jachtaH latlh tlhInganpu'.:sen:nolink} "[Other Klingons] karjuu suuressa crescendossa". [1] Sen tarkka kielioppi on epäselvä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3721,6 +4113,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3728,6 +4121,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 31:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -3741,6 +4135,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Б'Елана</column>
       <column name="definition_zh_HK">「貝拉娜」</column>
       <column name="definition_pt">B'Elanna</column>
+      <column name="definition_fi">B'Elanna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3751,6 +4146,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Именно так произносится имя Б'Эланны Торрес, которое не произносится по-клингонски. Клингонская версия названия, расшифрованного как «B'Elanna», будет {be'elanna:n:name,nolink} или {be'ela'na:n:name,nolink} или {bI'Ila'na:n:name,nolink} или что-то в этом роде [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">B'Elanna Torres的名字就是這樣發音的，但並不是以克林崗語的方式發音。轉錄為“ B'Elanna”的名稱的克林貢語版本為{be'elanna:n:name,nolink}或{be'ela'na:n:name,nolink}或{bI'Ila'na:n:name,nolink}或類似名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É assim que se pronuncia o nome de B'Elanna Torres, que não é pronunciado de maneira muito klingon. A versão klingon de um nome transcrito como "B'Elanna" seria {be'elanna:n:name,nolink} ou {be'ela'na:n:name,nolink} ou {bI'Ila'na:n:name,nolink} ou algo assim. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Näin B'Elanna Torresin nimi lausutaan, jota ei lausuta kovin klingonilaisella tavalla. "B'Elannaksi" kirjoitetun nimen klingoniversio olisi {be'elanna:n:name,nolink} tai {be'ela'na:n:name,nolink} tai {bI'Ila'na:n:name,nolink} tai jotain sellaista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3760,6 +4156,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3767,6 +4164,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.07.01:src}</column>
     </table>
     <table name="mem">
@@ -3780,6 +4178,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Банк</column>
       <column name="definition_zh_HK">銀行</column>
       <column name="definition_pt">banco</column>
+      <column name="definition_fi">pankki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Huch:n}, {ghunta:n}</column>
@@ -3790,6 +4189,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Это слово относится к финансовому учреждению. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞是指金融機構。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se a um estabelecimento financeiro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa rahoituslaitokseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the Bailey Bros. Building &amp; Loan Association, from the movie "It's a Wonderful Life". There is also a chain of jewellery stores called "Bailey Banks &amp; Biddle".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3799,6 +4199,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3806,6 +4207,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3819,6 +4221,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Церемониальный показ</column>
       <column name="definition_zh_HK">禮儀臺、武器架</column>
       <column name="definition_pt">exibição cerimonial</column>
+      <column name="definition_fi">seremoniallinen näyttely (?)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3829,6 +4232,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Известные типы {bey':n:nolink} включают {betleH bey':n}, {quv bey':n}, и {nuH bey':n}.</column>
       <column name="notes_zh_HK">{bey':n:nolink}的已知類型包括{betleH bey':n}，{quv bey':n}和{nuH bey':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os tipos conhecidos de {bey':n:nolink} incluem o {betleH bey':n}, o {quv bey':n} e o {nuH bey':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tunnettuja {bey':n:nolink}-tyyppejä ovat {betleH bey':n}, {quv bey':n} ja {nuH bey':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In architecture, a "bay" is an opening or hole, such as a recess in a wall where something may be displayed.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3838,6 +4242,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3845,6 +4250,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3858,6 +4264,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Самка, женщина, женский пол</column>
       <column name="definition_zh_HK">女性、女人</column>
       <column name="definition_pt">mulher, fêmea</column>
+      <column name="definition_fi">nainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loD:n}, {be'nal:n}</column>
@@ -3868,6 +4275,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Суффикс множественного числа этого слова зависит от того, используется ли оно для обозначения существ, способных к языку (см. {-pu':n:suff}) или нет (см. {-mey:n:suff}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此單詞的複數形式的後綴取決於它是否用於表示具有語言能力的人（請參閱{-pu':n:suff}）（請參見{-mey:n:suff}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O sufixo para o plural desta palavra depende se é usado para se referir a seres capazes de linguagem (veja {-pu':n:suff}) ou não (veja {-mey:n:suff}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan monikon loppuliite riippuu siitä, käytetäänkö sitä viittaamaan olentoja, jotka osaavat kieltä (katso {-pu':n:suff}) vai ei (katso {-mey:n:suff}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3877,6 +4285,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3884,6 +4293,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3897,6 +4307,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">БеТор</column>
       <column name="definition_zh_HK">B'Etor [AUTOTRANSLATED]</column>
       <column name="definition_pt">B'Etor</column>
+      <column name="definition_fi">B'Etor</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurSa':n:name}, {DuraS:n:name}</column>
@@ -3907,6 +4318,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Сестра Лурсы и Дюраса. Она сыграна актрисой {ghuwI'nItlh wa'lIS:n:name}.</column>
       <column name="notes_zh_HK">盧薩和杜拉斯的姐妹。她由女演員{ghuwI'nItlh wa'lIS:n:name}飾演。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Irmã de Lursa e Duras. Ela é interpretada pela atriz {ghuwI'nItlh wa'lIS:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sisar Lursasta ja Durasista. Näyttelijä {ghuwI'nItlh wa'lIS:n:name} kuvaa häntä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3920,6 +4332,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
   "Сёстры из дома Дюраса, Лурса и Бетор, постоянно ищут высокого положения для дома Дюраса внутри клингонского высшего совета. В конце, сёстры выступили против Гаурона, зайдя так далеко, что работали с ромуланскими группировками, чтобы усилить власть."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3927,6 +4340,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.3, Sept. 1996:src}, [2] {SkyBox 26:src}</column>
     </table>
     <table name="mem">
@@ -3940,6 +4354,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Девочка, девушка</column>
       <column name="definition_zh_HK">女孩</column>
       <column name="definition_pt">menina, garota</column>
+      <column name="definition_fi">tyttö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loDHom:n}, {puqbe':n}</column>
@@ -3950,6 +4365,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{be':n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -3959,6 +4375,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3966,6 +4383,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3979,6 +4397,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Жена</column>
       <column name="definition_zh_HK">妻子、太太、夫人</column>
       <column name="definition_pt">esposa</column>
+      <column name="definition_fi">vaimo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nay:v}, {loDnal:n}, {'e'nal:n}, {'Ipnal:n}</column>
@@ -3989,6 +4408,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{be':n}, {nal:n:hyp}</column>
       <column name="examples"></column>
@@ -3998,6 +4418,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4005,6 +4426,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4018,6 +4440,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">сестра</column>
       <column name="definition_zh_HK">姊妹</column>
       <column name="definition_pt">irmã</column>
+      <column name="definition_fi">sisar</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loDnI':n}</column>
@@ -4028,6 +4451,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Золовка будет {loDnI' be'nal:n@@loDnI':n, be'nal:n} или {be'nI' be'nal:n@@be'nI':n, be'nal:n}.</column>
       <column name="notes_zh_HK">“ s子”是{loDnI' be'nal:n@@loDnI':n, be'nal:n}或{be'nI' be'nal:n@@be'nI':n, be'nal:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma "cunhada" é {loDnI' be'nal:n@@loDnI':n, be'nal:n} ou {be'nI' be'nal:n@@be'nI':n, be'nal:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"Anoppi" on {loDnI' be'nal:n@@loDnI':n, be'nal:n} tai {be'nI' be'nal:n@@be'nI':n, be'nal:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4037,6 +4461,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4044,6 +4469,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4057,6 +4483,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Бетазед</column>
       <column name="definition_zh_HK">Betazed [AUTOTRANSLATED]</column>
       <column name="definition_pt">Betazed</column>
+      <column name="definition_fi">Betazed</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4067,6 +4494,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">Планета в составе Федерации. Населена телепатами.</column>
       <column name="notes_zh_HK">聯邦中的一顆行星。它的居民是心靈感應者。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta na Federação. Seus habitantes são telepatas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta federaatiossa. Sen asukkaat ovat telepaatteja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4076,6 +4504,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4083,6 +4512,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -4096,6 +4526,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Ты (делаешь что-либо)</column>
       <column name="definition_zh_HK">你：無</column>
       <column name="definition_pt">você-nenhum</column>
+      <column name="definition_fi">sinä-ei kukaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Su-:v:pref}, {Da-:v:pref}, {yI-:v:pref}</column>
@@ -4106,6 +4537,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SoH:n}: {pagh:n:1h} = {bI-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4115,6 +4547,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4122,6 +4555,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4135,6 +4569,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Половина</column>
       <column name="definition_zh_HK">半</column>
       <column name="definition_pt">metade</column>
+      <column name="definition_fi">puoli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dol:n}, {HochHom:n}</column>
@@ -4145,6 +4580,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The medical abbreviation "b.i.d.", short for the Latin "bis in die", means "twice a day".</column>
       <column name="components"></column>
       <column name="examples">
@@ -4157,6 +4593,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4164,6 +4601,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -4177,6 +4615,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Плати или умрёшь!</column>
       <column name="definition_zh_HK">不畀錢就受死！</column>
       <column name="definition_pt">Pague ou morra!</column>
+      <column name="definition_fi">Maksa tai kuole!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -4189,6 +4628,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru">К примечаниям для грамматики этого предложения, смотрите {bIjeghbe'chugh vaj bIHegh!:sen}</column>
       <column name="notes_zh_HK">有關此句子的語法的註釋，請參閱{bIjeghbe'chugh vaj bIHegh!:sen} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para notas sobre a gramática desta frase, consulte {bIjeghbe'chugh vaj bIHegh!:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso tämän lauseen kielioppia koskevia huomautuksia kohdasta {bIjeghbe'chugh vaj bIHegh!:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {DIl:v}, {-be':v}, {-chugh:v}, {vaj:adv}, {bI-:v}, {Hegh:v}</column>
       <column name="examples"></column>
@@ -4198,6 +4638,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4205,6 +4646,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -4218,6 +4660,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">Тюрьма</column>
       <column name="definition_zh_HK">監獄</column>
       <column name="definition_pt">prisão</column>
+      <column name="definition_fi">vankila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qama':n}, {jav:n:3,slang}, {'avwI':n}, {wegh:v}, {jon:v}, {mo':n:1}</column>
@@ -4228,6 +4671,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Jail is referred to in slang as the "big house".</column>
       <column name="components"></column>
       <column name="examples">
@@ -4241,6 +4685,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
 ▶ {bIghHa' yIjaH:sen:nolink} "Отправляйся в тюрьму"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gaol, holding cell, cell, brig</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4248,6 +4693,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -4261,6 +4707,7 @@ O {betleH:n:nolink} também é chamado de {betleH quv:n:nolink}, para diferenci�
       <column name="definition_ru">они, их, им</column>
       <column name="definition_zh_HK">它們、牠們</column>
       <column name="definition_pt">eles, eles (incapazes de linguagem)</column>
+      <column name="definition_fi">ne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaH:n:pro}, {-chaj:n}</column>
@@ -4307,6 +4754,25 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
 Глагольный префикс повелительной формы, когда {bIH:n:nolink} предмет, в отношении которого производится действие {tI-:v:pref}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on monikko {'oH:n:pro}.
+
+Verbien etuliitteet, kun aihe {bIH:n:nolink} on:
+▶ {bIH:n:nolink}: {pagh:n:1h} = {0:v:pref}
+▶ {bIH:n:nolink}: {jIH:n:1h} = {mu-:v:pref}
+▶ {bIH:n:nolink}: {maH:n:1h} = {nu-:v:pref}
+▶ {bIH:n:nolink}: {SoH:n} = {nI-:v:pref}
+▶ {bIH:n:nolink}: {tlhIH:n} = {lI-:v:pref}
+▶ {bIH:n:nolink}: {ghaH:n} / {'oH:n} = {lu-:v:pref}
+▶ {bIH:n:nolink}: {chaH:n} / {bIH:n:nolink} = {0:v:pref}
+
+Verbien etuliitteet, kun {bIH:n:nolink} on objekti:
+▶ {jIH:n:1h}: {bIH:n:nolink} = {vI-:v:pref}
+▶ {maH:n:1h}: {bIH:n:nolink} = {DI-:v:pref}
+▶ {SoH:n}: {bIH:n:nolink} = {Da-:v:pref}
+▶ {tlhIH:n}: {bIH:n:nolink} = {bo-:v:pref}
+▶ {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n:nolink}: {bIH:n:nolink} = {0:v:pref}
+
+Pakollinen verbin etuliite, kun kohde on {bIH:n:nolink}, on {tI-:v:pref}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4316,6 +4782,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4323,6 +4790,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4336,6 +4804,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="definition_ru">Если ты боишься умереть, ты уже умер.</column>
       <column name="definition_zh_HK">如果你害怕死，你就已經死咗了。</column>
       <column name="definition_pt">Se você tem medo de morrer, então você já morreu.</column>
+      <column name="definition_fi">Jos pelkäät kuolla, olet jo kuollut.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4346,6 +4815,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {Hegh:v}, {-vIp:v}, {-chugh:v}, {bI-:v}, {Hegh:v}, {-pu':v}</column>
       <column name="examples"></column>
@@ -4355,6 +4825,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4362,6 +4833,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.72:src}</column>
     </table>
     <table name="mem">
@@ -4375,6 +4847,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="definition_ru">Наказывать</column>
       <column name="definition_zh_HK">懲治</column>
       <column name="definition_pt">punir</column>
+      <column name="definition_fi">rangaista</column>
       <column name="synonyms">{Hup:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{bIj:n}, {jIb:v}, {rup:v}</column>
@@ -4385,6 +4858,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4394,6 +4868,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4401,6 +4876,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -4414,6 +4890,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="definition_ru">Наказание</column>
       <column name="definition_zh_HK">懲罰</column>
       <column name="definition_pt">punição</column>
+      <column name="definition_fi">rangaistus</column>
       <column name="synonyms">{jIp:n}</column>
       <column name="antonyms">{pop:n}</column>
       <column name="see_also">{bIj:v}, {Hup:v}</column>
@@ -4424,6 +4901,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4433,6 +4911,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4440,6 +4919,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -4453,6 +4933,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="definition_ru">Если ты скажешь, что-то не то, я тебя убью.</column>
       <column name="definition_zh_HK">如果你說錯事物，我會殺死你。</column>
       <column name="definition_pt">Se você disser a coisa errada, eu vou te matar.</column>
+      <column name="definition_fi">Jos sanot väärän asian, tapan sinut.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4463,6 +4944,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {jatlhHa':v}, {-chugh:v}, {qa-:v}, {HoH:v}</column>
       <column name="examples"></column>
@@ -4472,6 +4954,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4479,6 +4962,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.62:src}</column>
     </table>
     <table name="mem">
@@ -4492,6 +4976,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="definition_ru">Заткнись!</column>
       <column name="definition_zh_HK">收聲！</column>
       <column name="definition_pt">Cale-se!</column>
+      <column name="definition_fi">Turpa kiinni!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -4505,6 +4990,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined on {TKD p.172:src} as "Be quiet! (i.e., Stop speaking!)", and in {PK:src} as "Shut up!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4514,6 +5000,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be quiet, stop talking</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4521,6 +5008,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="search_tags_ru">Потише, прекратить разговаривать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -4534,6 +5022,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="definition_ru">Хватит болтать! Пей!</column>
       <column name="definition_zh_HK">收聲！乾杯！</column>
       <column name="definition_pt">Pare de falar! Beba!</column>
+      <column name="definition_fi">Älä puhu! Juo!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4544,6 +5033,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {jatlh:v}, {'e':n:pro}, {yI-:v}, {mev:v}, {yI-:v}, {tlhutlh:v}</column>
       <column name="examples"></column>
@@ -4553,6 +5043,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4560,6 +5051,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.87:src}</column>
     </table>
     <table name="mem">
@@ -4573,6 +5065,7 @@ The imperative verb prefix when {bIH:n:nolink} is the object is {tI-:v:pref}.</c
       <column name="definition_ru">Сдавайся или умрёшь!</column>
       <column name="definition_zh_HK">不投降就受死！</column>
       <column name="definition_pt">Renda-se ou morra!</column>
+      <column name="definition_fi">Antautu tai kuole!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -4599,6 +5092,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [AUTOTRAN
       <column name="notes_pt">Esta frase significa literalmente: "Se você não se render, você morrerá". Observe que, embora a tradução em inglês contenha "ou", a conjunção {pagh:conj} não é usada na frase Klingon. Em geral, frases em inglês da forma "X ou Y!" (exigindo que o ouvinte escolha uma das duas opções) deve ser reformulado como {bI-X-be'chugh vaj bI-Y:sen:nolink} "Se você não fizer X, você fará Y" em Klingon.
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lause tarkoittaa kirjaimellisesti: "Jos et anna periksi, kuolet". Huomaa, että vaikka englanninkielisessä käännöksessä on "tai", yhdistettä {pagh:conj} ei käytetä Klingon-lauseessa. Yleensä englanninkieliset lauseet muodossa "X or Y!" (vaaditaan, että kuuntelija valitsee yhden kahdesta vaihtoehdosta) on muotoiltava uudelleen nimellä {bI-X-be'chugh vaj bI-Y:sen:nolink} "Jos et ole X, tulet Y" Klingonissa.
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {jegh:v}, {-be':v}, {-chugh:v}, {vaj:adv}, {bI-:v}, {Hegh:v}</column>
       <column name="examples"></column>
@@ -4608,6 +5104,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4615,6 +5112,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}, [2] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -4628,6 +5126,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Покупай или умрёшь!</column>
       <column name="definition_zh_HK">不購買就受死！</column>
       <column name="definition_pt">Compre ou morra!</column>
+      <column name="definition_fi">Osta tai kuole!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4638,6 +5137,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru">Это часто говорят клингонские купцы своим покупателям. См анализ похожего предложения {bIjeghbe'chugh vaj bIHegh!:sen}</column>
       <column name="notes_zh_HK">克林崗商人經常向客戶說這句話。參見類似的{bIjeghbe'chugh vaj bIHegh!:sen}進行分析。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é frequentemente dito pelos comerciantes Klingon para seus clientes. Veja o {bIjeghbe'chugh vaj bIHegh!:sen} semelhante para análise. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin kauppiaat sanovat tämän usein asiakkailleen. Katso vastaava {bIjeghbe'chugh vaj bIHegh!:sen}-analyysi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {je':v:1}, {-be':v}, {-chugh:v}, {vaj:adv}, {bI-:v}, {Hegh:v}</column>
       <column name="examples"></column>
@@ -4647,6 +5147,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4654,6 +5155,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.213:src}</column>
     </table>
     <table name="mem">
@@ -4667,6 +5169,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Тебе нужно отдохнуть.</column>
       <column name="definition_zh_HK">你需要休息一下。</column>
       <column name="definition_pt">Você precisa descansar.</column>
+      <column name="definition_fi">Tarvitset lepoa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4677,6 +5180,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4686,6 +5190,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4693,6 +5198,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -4706,6 +5212,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Ты прав.</column>
       <column name="definition_zh_HK">你是對的。</column>
       <column name="definition_pt">Você está certo.</column>
+      <column name="definition_fi">Olet oikeassa.</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bIlughbe'.:sen}</column>
       <column name="see_also"></column>
@@ -4716,6 +5223,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4725,6 +5233,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4732,6 +5241,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -4745,6 +5255,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Ты неправ.</column>
       <column name="definition_zh_HK">你是錯的。</column>
       <column name="definition_pt">Você está errado.</column>
+      <column name="definition_fi">Olet väärässä.</column>
       <column name="synonyms">{bImuj.}</column>
       <column name="antonyms">{bIlugh.:sen}</column>
       <column name="see_also"></column>
@@ -4755,6 +5266,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4764,6 +5276,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4771,6 +5284,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -4784,6 +5298,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Если ты не можешь проиграть, ты не можешь преуспеть.</column>
       <column name="definition_zh_HK">如果你不能失敗，你就無法成功。</column>
       <column name="definition_pt">Se você não pode falhar, você não pode ter sucesso.</column>
+      <column name="definition_fi">Jos et voi epäonnistua, et voi menestyä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4794,6 +5309,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {luj:v}, {-laH:v}, {-be':v}, {-chugh:v}, {bI-:v}, {Qap:v:1}, {-laH:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -4803,6 +5319,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4810,6 +5327,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.56:src}</column>
     </table>
     <table name="mem">
@@ -4823,6 +5341,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Вторая интонация неатонической музыкальной шкалы</column>
       <column name="definition_zh_HK">非音階音階的第二音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">segundo tom de escala musical não-atônica</column>
+      <column name="definition_fi">nonatoonisen musiikkiasteikon toinen sävel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4833,6 +5352,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin musiikkiasteikon sävyt (katso {yutlhegh:n}) ovat: {yu:n}, {bIm:n:nolink}, {'egh:n}, {loS:n:2}, {vagh:n:2}, {jav:n:2}, {Soch:n:2}, {chorgh:n:2}, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DOT{yu:n:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Instead of "ray", which is "a drop of golden sun", this is a "beam".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4842,6 +5362,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4849,6 +5370,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4862,6 +5384,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Никогда не уходи без своего батлета.</column>
       <column name="definition_zh_HK">永遠不要離開你的蝙蝠。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Nunca saia sem a sua bat'leth.</column>
+      <column name="definition_fi">Älä koskaan lähde ilman bat'lethiasi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4872,6 +5395,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {mej:v}, {-DI':v}, {reH:adv}, {betleH:n}, {-lIj:n}, {yI-:v}, {tlhap:v}</column>
       <column name="examples"></column>
@@ -4881,6 +5405,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4888,6 +5413,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.79:src}</column>
     </table>
     <table name="mem">
@@ -4901,6 +5427,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Ты очень уродлив.</column>
       <column name="definition_zh_HK">你很難看。</column>
       <column name="definition_pt">Você é muito feia.</column>
+      <column name="definition_fi">Olet hyvin ruma.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bI'IHqu'.:sen}</column>
@@ -4911,6 +5438,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {moH:v:1}, {-qu':v}</column>
       <column name="examples"></column>
@@ -4920,6 +5448,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4927,6 +5456,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -4940,6 +5470,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Пусть ты увидишь Кейлеса в твоих снах.</column>
       <column name="definition_zh_HK">願你在夢中遇到「凱勒斯」。 </column>
       <column name="definition_pt">Que você encontre Kahless em seus sonhos.</column>
+      <column name="definition_fi">Toivon, että kohtaat Kahlessin unessasi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4950,6 +5481,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {naj:v}, {-taH:v}, {-vIS:v}, {qeylIS:n:name}, {Da-:v}, {ghom:v}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -4959,6 +5491,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4966,6 +5499,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -4979,6 +5513,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Территория внизу, территория ниже</column>
       <column name="definition_zh_HK">下面、下方</column>
       <column name="definition_pt">área abaixo, área sob</column>
+      <column name="definition_fi">alla, alapuoli</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Dung:n}</column>
       <column name="see_also">{joj:n}, {retlh:n}, {tlhop:n:1}, {'em:n}</column>
@@ -4989,6 +5524,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru">Посмотрите {bIS'ub:n} и {pIrmuS:n} для нижних частей объекта. Смотрите также {lurgh:n} для других слов, связанных с пространственными направлениями. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關對象底部的信息，請參見{bIS'ub:n}和{pIrmuS:n}。另請參見{lurgh:n}以獲取與空間方向有關的其他詞語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {bIS'ub:n} e {pIrmuS:n} para obter as partes inferiores de um objeto. Consulte também {lurgh:n} para outras palavras relacionadas a direções espaciais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohteen {bIS'ub:n} ja {pIrmuS:n} tiedot ovat kohteen alaosista. Katso myös {lurgh:n} muista paikkatietoihin liittyvistä sanoista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4998,6 +5534,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bottom, beneath, underneath, ventral</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5005,6 +5542,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru">внизу, под</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5018,6 +5556,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">гипотеза [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">假設 [AUTOTRANSLATED]</column>
       <column name="definition_pt">hipótese</column>
+      <column name="definition_fi">hypoteesi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngong:n}, {nger:n}</column>
@@ -5028,6 +5567,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Greek word "hypothesis" comes from roots meaning "under" ({bIng:n}) and "placing" ({lan:v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5037,6 +5577,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5044,6 +5585,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5057,6 +5599,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/NpFDKTzINH8} [A
       <column name="definition_ru">Сотня тысяч</column>
       <column name="definition_zh_HK">十萬</column>
       <column name="definition_pt">cem mil</column>
+      <column name="definition_fi">satatuhatta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI':n}, {netlh:n:num}, {'uy':n:num}</column>
@@ -5079,6 +5622,9 @@ För tiotals miljoner kunde man kombinera {maH:n:2,num} med {'uy':n:num,nolink} 
       <column name="notes_pt">Observe que a palavra klingon para "cem mil" é independente das palavras para "cem" ({vatlh:n:num}) e "mil" ({SaD:n:num}). O Klingon {bIp:n:num,nolink} é equivalente ao "lakh" usado nos sistemas de numeração do sul da Ásia na Terra.
 
 Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink} ou {vatlh:n:num} com {bIp:n:num}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että klingonilainen sana "sata tuhatta" on riippumaton sanoista "sata" ({vatlh:n:num}) ja "tuhat" ({SaD:n:num}). Klingon {bIp:n:num,nolink} on sama kuin "lakh", jota käytetään maan Aasian Aasian numerointijärjestelmissä.
+
+Kymmenien miljoonien kohdalla {maH:n:2,num} voidaan yhdistää {'uy':n:num,nolink}: een tai {vatlh:n:num} {bIp:n:num}: n kanssa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5088,6 +5634,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">lakh</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5095,6 +5642,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -5108,6 +5656,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="definition_ru">Ты выглядишь нездоровым.</column>
       <column name="definition_zh_HK">你似乎不健康。</column>
       <column name="definition_pt">Você parece doente.</column>
+      <column name="definition_fi">Näytät epäterveeltä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5118,6 +5667,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5127,6 +5677,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sick</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5134,6 +5685,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5147,6 +5699,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="definition_ru">вода</column>
       <column name="definition_zh_HK">水</column>
       <column name="definition_pt">água</column>
+      <column name="definition_fi">vesi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuch:n}, {SeS:n}, {taD:v}, {pub:v}, {yIQ:v}, {tlhepQe':n}, {taS:n}</column>
@@ -5157,6 +5710,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="notes_ru">Вода используется как символ слабости и презрения. Эта идея выражена в клингонском языке {puj; bIQ rur}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">水被用作軟弱和輕蔑的象徵。克林崗語{puj; bIQ rur}中表達了這一想法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A água é usada como símbolo de fraqueza e desdém. Essa idéia é expressa no idioma Klingon {puj; bIQ rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vettä käytetään heikkouden ja halveksun symbolina. Tämä ajatus ilmaistaan ​​Klingonin idioomissa {puj; bIQ rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5166,6 +5720,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5173,6 +5728,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -5186,6 +5742,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Кувшин для воды</column>
           <column name="definition_zh_HK">水壺</column>
           <column name="definition_pt">jarro de água</column>
+      <column name="definition_fi">vesikannu</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5196,6 +5753,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {bal:n}</column>
           <column name="examples"></column>
@@ -5205,6 +5763,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5212,6 +5771,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -5225,6 +5785,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">поверхность воды [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">水面</column>
           <column name="definition_pt">superfície da água</column>
+      <column name="definition_fi">veden pinta</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{ghor:n:1}</column>
@@ -5235,6 +5796,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Это буквально означает «водная крыша». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這字面意思是“水屋頂”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso significa literalmente "teto d'água". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "vesikattoa". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {beb:n}</column>
           <column name="examples"></column>
@@ -5244,6 +5806,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5251,6 +5814,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
         <table name="mem">
@@ -5264,6 +5828,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Лодка, корабль(для плавания по воде)</column>
           <column name="definition_zh_HK">船、舟</column>
           <column name="definition_pt">navio, barco</column>
+      <column name="definition_fi">laiva, vene</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Duj:n:1}, {vergh:n}, {vergh:v}, {SolDeS:n}, {mItlhon:n}</column>
@@ -5274,6 +5839,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Это слово используется для корабля, который путешествует по воде.</column>
           <column name="notes_zh_HK">這個詞用於在水上航行的船上。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esta palavra é usada para um navio que viaja na água. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään alukseen, joka kulkee vedellä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {Duj:n:1}</column>
           <column name="examples"></column>
@@ -5283,6 +5849,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">watercraft, ferry, barge</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5290,6 +5857,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru">гидроцикл, паром, баржа</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -5303,6 +5871,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Душевая комната</column>
           <column name="definition_zh_HK">沖涼房、淋浴房</column>
           <column name="definition_pt">banheiro</column>
+      <column name="definition_fi">suihkuhuone</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5313,6 +5882,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Это относится к комнате, в которой земляне обрызгивают себя водой. (Мерзость.)</column>
           <column name="notes_zh_HK">這是指人族在其中灑水的房間。 （好吧） [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso se refere à sala em que os terráqueos se pulverizam com água. (Que nojo.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa huoneeseen, jossa terraanit suihkuttavat itseään vedellä. (Yuck.) [AUTOTRANSLATED]</column>
           <column name="hidden_notes">This is defined in {TNK:src} as "shower", but it clearly refers to the room.</column>
           <column name="components">{bIQ:n}, {ghay:v}, {-wI':v}, {pa':n:1}</column>
           <column name="examples"></column>
@@ -5322,6 +5892,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5329,6 +5900,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -5342,6 +5914,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Фонтан</column>
           <column name="definition_zh_HK">噴泉</column>
           <column name="definition_pt">fonte (de água)</column>
+      <column name="definition_fi">suihkulähde</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5352,6 +5925,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {ghIt:v}, {-moH:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -5361,6 +5935,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5368,6 +5943,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -5381,6 +5957,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Солоноватая вода</column>
           <column name="definition_zh_HK">鹹淡水</column>
           <column name="definition_pt">água salobra</column>
+      <column name="definition_fi">murtovesi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Dargh:n}</column>
@@ -5391,6 +5968,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Солоноватая вода - лучшая вода для чая. [1, p.96] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">苦鹹水是最好的茶水。[1, p.96] [AUTOTRANSLATED]</column>
           <column name="notes_pt">A água salobra é a melhor água para o chá.[1, p.96] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Suolainen vesi on paras teetä varten tarkoitettu vesi[1, p.96] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {na':v:1}</column>
           <column name="examples"></column>
@@ -5400,6 +5978,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5407,6 +5986,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -5420,6 +6000,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">водопад [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">瀑布</column>
           <column name="definition_pt">cascata</column>
+      <column name="definition_fi">vesiputous</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nayeghra:n}</column>
@@ -5430,6 +6011,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {notron:n}</column>
           <column name="examples"></column>
@@ -5439,6 +6021,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5446,6 +6029,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
         </table>
         <table name="mem">
@@ -5459,6 +6043,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Быть очень неправым, быть абсолютно неправым</column>
           <column name="definition_zh_HK">完全錯了</column>
           <column name="definition_pt">estar completamente enganado, estar totalmente errado</column>
+      <column name="definition_fi">olla hyvin erehtynyt, olla täysin väärässä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{muj:v}, {Qagh:v}</column>
@@ -5469,6 +6054,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Это буквально означает «Чашка содержит воду». Это достаточно сильное выражение, и не удивительно, если после этого произойдет драка. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">字面意思是“杯子裡有水。”這是一種相當有力的表達，如果說完之後爆發戰鬥，也就不足為奇了。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso literalmente significa "O copo contém água". É uma expressão razoavelmente forte e não seria de surpreender se uma briga eclodisse depois que ela fosse proferida. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "Kuppi sisältää vettä". Se on kohtuullisen vahva ilmaus, eikä olisi yllättävää, jos taistelu puhkeaisi tämän jälkeen. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples">
@@ -5480,6 +6066,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
 ▶ {bIQ ngaS HIvje'lIj.:sen:nolink} "Вы все неправы."</column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5487,6 +6074,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.120:src}</column>
         </table>
         <table name="mem">
@@ -5501,6 +6089,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Рыба, морское существо</column>
           <column name="definition_zh_HK">魚、海洋生物</column>
           <column name="definition_pt">peixe, criatura do mar</column>
+      <column name="definition_fi">kala, meriolento</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5511,6 +6100,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Охватывает большинство животных, что живут в море, таких как дельфины, киты, рыба, а также осьминоги, но не животных поменьше таких как креветки или водяные жуки, или амфибии. Каждый {ghotI':n} является {bIQDep:n:nolink}, но не каждый {bIQDep:n:nolink} является {ghotI':n:nolink}.[2]</column>
           <column name="notes_zh_HK">它涵蓋了大多數生活在海洋中的動物，例如海豚，鯨魚，魚類和章魚，但不包括較小的動物，例如蝦或水蟲或兩棲動物。每個{ghotI':n}都是{bIQDep:n:nolink}，但不是每個{bIQDep:n:nolink}都是{ghotI':n:nolink}.[2] [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso abrange a maioria dos animais que vivem no mar, como golfinhos, baleias, peixes e polvos, mas não animais menores, como camarões ou insetos aquáticos, ou anfíbios. Todo {ghotI':n} é um {bIQDep:n:nolink}, mas nem todo {bIQDep:n:nolink} é um {ghotI':n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä koskee useimpia meressä eläviä eläimiä, kuten delfiinejä, valaita, kaloja ja mustekaloja, mutta ei pienempiä eläimiä, kuten katkarapuja, vesibugeja tai sammakkoeläimiä. Jokainen {ghotI':n} on {bIQDep:n:nolink}, mutta jokainen {bIQDep:n:nolink} ei ole {ghotI':n:nolink}.[2] [AUTOTRANSLATED]</column>
           <column name="hidden_notes">This was defined as "fish" in {KGT:src}[1], but was clarified to refer to any sea or water-based creature later.[2]</column>
           <column name="components">{bIQ:n}, {Dep:n}</column>
           <column name="examples"></column>
@@ -5520,6 +6110,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5527,6 +6118,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
         </table>
         <table name="mem">
@@ -5540,6 +6132,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">кран [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">水龍頭</column>
           <column name="definition_pt">torneira</column>
+      <column name="definition_fi">hana</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5550,6 +6143,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Исторически или этимологически, это, без сомнения, было сформировано из {bIQ SeHmeH jan:n} путем удаления {-meH:v}. Это может произойти для других слов (например, {voD jan:n}), но это не продуктивный процесс. За исключением некоторого набора, принятых выражений, отбрасывание {-meH:v:nolink} считается странным, но люди могут делать это в любом случае в повседневной беседе. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">從歷史或詞源上看，這無疑是由{bIQ SeHmeH jan:n}刪除{-meH:v}形成的。換句話說，這可能會發生（例如{voD jan:n}），但這不是有效的過程。除了某些可以接受的固定表達方式外，丟棄{-meH:v:nolink}被認為是很奇怪的，但是人們仍然可以在日常對話中這樣做。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Historicamente ou etimologicamente, isso foi sem dúvida formado a partir de {bIQ SeHmeH jan:n}, eliminando o {-meH:v}. Isso pode acontecer com outras palavras (por exemplo, {voD jan:n}), mas não é um processo produtivo. Exceto por algumas expressões definidas e aceitas, descartar o {-meH:v:nolink} é considerado estranho, mas as pessoas podem fazer isso de qualquer maneira na conversa diária. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Historiallisesti tai etymologisesti tämä epäilemättä muodostui {bIQ SeHmeH jan:n}: stä pudottamalla {-meH:v}. Näin voi käydä muilla sanoilla (esim. {voD jan:n}), mutta se ei ole tuottava prosessi. Joitakin asetettuja, hyväksyttyjä lausekkeita lukuun ottamatta {-meH:v:nolink}: n pudottamista pidetään parittomana, mutta ihmiset voivat tehdä tämän joka tapauksessa jokapäiväisessä keskustelussa. [AUTOTRANSLATED]</column>
           <column name="hidden_notes">The grammar was discussed during the Q &amp; A session, and afterwards MO released a document providing further details. MO originally replied to the request for "faucet" by suggesting {bIQ SeH jan:sen@@bIQ:n, SeH:v, jan:n:1}, which is a sentence meaning "the device controls the water", which led to some confusion as it was interpreted as a noun.</column>
           <column name="components">{bIQ:n}, {SeHjan:n}</column>
           <column name="examples"></column>
@@ -5559,6 +6153,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5566,6 +6161,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -5579,6 +6175,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">{bIQ SeHjan:n}</column>
           <column name="definition_zh_HK">{bIQ SeHjan:n}</column>
           <column name="definition_pt">{bIQ SeHjan:n}</column>
+      <column name="definition_fi">{bIQ SeHjan:n}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5589,6 +6186,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Обычно это {bIQ SeHjan:n:nolink}, но это тоже нормально. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">常見的說法是{bIQ SeHjan:n:nolink}，但這也很好。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">A maneira comum de dizer isso é {bIQ SeHjan:n:nolink}, mas também não tem problema. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yleinen tapa sanoa tämä on {bIQ SeHjan:n:nolink}, mutta tämä on myös hieno. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {SeH:v}, {-meH:v}, {jan:n:1}</column>
           <column name="examples"></column>
@@ -5598,6 +6196,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5605,6 +6204,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -5618,6 +6218,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Водород</column>
           <column name="definition_zh_HK">氫氣</column>
           <column name="definition_pt">hidrogênio</column>
+      <column name="definition_fi">vety</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{SIp:n}, {tamler:n}, {bIQSIp 'ugh:n}, {rugh bIQSIp:n}</column>
@@ -5628,6 +6229,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Дословное значение "водный газ".</column>
           <column name="notes_zh_HK">這字面意思是“水氣”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso literalmente significa "gás de água". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "vesikaasua". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {SIp:n}</column>
           <column name="examples"></column>
@@ -5637,6 +6239,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5644,6 +6247,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -5657,6 +6261,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Изотоп дейтерия</column>
           <column name="definition_zh_HK">重氫、氘同位素</column>
           <column name="definition_pt">isótopo de deutério</column>
+      <column name="definition_fi">deuterium-isotooppi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{rugh bIQSIp:n}, {choH lISbogh Hap'e':n}</column>
@@ -5667,6 +6272,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQSIp:n}, {'ugh:v}</column>
           <column name="examples"></column>
@@ -5676,6 +6282,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5683,6 +6290,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -5696,6 +6304,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Река</column>
           <column name="definition_zh_HK">河</column>
           <column name="definition_pt">rio</column>
+      <column name="definition_fi">joki</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{bIQ'a':n}</column>
@@ -5706,6 +6315,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {tIq:v} or {tIq:n} or a homophonous element</column>
           <column name="examples">
@@ -5720,6 +6330,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">stream</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5727,6 +6338,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}, [2] {paq'batlh p.76-77:src}</column>
         </table>
         <table name="mem">
@@ -5740,6 +6352,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Океан</column>
           <column name="definition_zh_HK">海洋</column>
           <column name="definition_pt">oceano</column>
+      <column name="definition_fi">meri</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{yu'egh:n}, {vI'Ir:n}, {bIQtIq:n}, {bIQ'a' HeH:n}, {tlher'aq:n}</column>
@@ -5750,6 +6363,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ:n}, {-'a':n}</column>
           <column name="examples">
@@ -5760,6 +6374,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5767,6 +6382,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -5780,6 +6396,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Меч находится в океане.</column>
           <column name="definition_zh_HK">劍在海洋中。</column>
           <column name="definition_pt">A espada está no oceano.</column>
+      <column name="definition_fi">Miekka on meressä.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{rIntaH:v}</column>
@@ -5790,6 +6407,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Эта идиома означает, что что-либо закончилось, и это невозможно вернуть в предыдущее состояние.</column>
           <column name="notes_zh_HK">這個成語意味著某些事情已經結束，並且不可能返回到先前的狀態。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esse idioma significa que algo terminou e é impossível retornar à condição anterior. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sanonta tarkoittaa, että jokin on päättynyt, ja on mahdotonta palata edelliseen tilaan. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -5799,6 +6417,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5806,6 +6425,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.121:src}</column>
         </table>
         <table name="mem">
@@ -5819,6 +6439,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="definition_ru">Пляж, берег моря</column>
           <column name="definition_zh_HK">海灘</column>
           <column name="definition_pt">praia</column>
+      <column name="definition_fi">ranta</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5829,6 +6450,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="notes_ru">Дословно это означает край ({HeH:n}) океана ({bIQ'a':n}). Пляж у озера можно будет назван {ngeng HeH:n}, и так далее.</column>
           <column name="notes_zh_HK">字面意思是海洋（{bIQ'a':n}）的邊緣（{HeH:n}）。湖邊的海灘將被稱為{ngeng HeH:n}，依此類推。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso significa literalmente a borda ({HeH:n}) do oceano ({bIQ'a':n}). Uma praia à beira de um lago seria chamada {ngeng HeH:n}, e assim por diante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti meren reunaa ({HeH:n}) ({bIQ'a':n}). Järven rannalla sijaitsevaa rantaa kutsutaan nimellä {ngeng HeH:n} ja niin edelleen. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{bIQ'a':n}, {HeH:n}</column>
           <column name="examples"></column>
@@ -5838,6 +6460,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5845,6 +6468,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
     <table name="mem">
@@ -5858,6 +6482,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="definition_ru">Чтобы преуспеть по настоящему, вы должны наслаждаться поеданием яда.</column>
       <column name="definition_zh_HK">要真正成功，你必須享受吃毒藥。</column>
       <column name="definition_pt">Para realmente ter sucesso, você deve gostar de comer veneno.</column>
+      <column name="definition_fi">Menestyäksesi sinun pitää nauttia myrkyn juomisesta.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5868,6 +6493,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {Qap:v:1}, {-qu':v}, {-meH:v}, {tar:n}, {Da-:v}, {Sop:v}, {'e':n:pro}, {Da-:v}, {tIv:v}, {-nIS:v}</column>
       <column name="examples"></column>
@@ -5877,6 +6503,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5884,6 +6511,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.73:src}</column>
     </table>
     <table name="mem">
@@ -5897,6 +6525,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="definition_ru">Если ты спишь с таргами, ты проснешься в кругу мух.</column>
       <column name="definition_zh_HK">如果你和塔格斯一起睡覺，你會被全身蒼蠅喚醒。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Se você dorme com targs, acorda com moscas globulares.</column>
+      <column name="definition_fi">Jos nukkuu targien kanssa, herää glob-kärpästen kanssa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5907,6 +6536,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {Qong:v}, {-taH:v}, {-vIS:v}, {nI-:v}, {tlhej:v}, {-chugh:v}, {targh:n}, {-mey:n}, {bI-:v}, {vem:v}, {-DI':v}, {nI-:v}, {tlhej:v}, {ghIlab ghew:n}, {-mey:n}</column>
       <column name="examples"></column>
@@ -5916,6 +6546,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5923,6 +6554,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.173:src}</column>
     </table>
     <table name="mem">
@@ -5936,6 +6568,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="definition_ru">Сэндвич с печеньем</column>
       <column name="definition_zh_HK">餅乾三明治</column>
       <column name="definition_pt">sanduíche de biscoito</column>
+      <column name="definition_fi">kerroskeksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5946,6 +6579,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="notes_ru">Это особый тип {chabHom:n}, который похож на два {chabHommey:n:nolink}, склеенные вместе, как бутерброд. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{chabHom:n}的一種特定類型，類似於兩個三明治一樣粘在一起的兩個{chabHommey:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse é um tipo específico de {chabHom:n} que é uma espécie de dois {chabHommey:n:nolink} presos juntos como um sanduíche. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tietyntyyppinen {chabHom:n}, joka on tavallaan kaksi {chabHommey:n:nolink}: ta, jotka ovat tarttuneet toisiinsa kuin voileipä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Hydrox" is a brand of cookie sandwich which derives its name from the components of water, hydrogen ({bIQSIp:n}) and oxygen ({yInSIp:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5955,6 +6589,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5962,6 +6597,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5975,6 +6611,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="definition_ru">Быть холодным</column>
       <column name="definition_zh_HK">冷、凍</column>
       <column name="definition_pt">ser frio</column>
+      <column name="definition_fi">olla kylmä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tuj:v}, {ghun:v:2}</column>
       <column name="see_also">{Qey':v}, {chuch:n}, {peD:v}, {buj:v}, {Hat:n}</column>
@@ -5985,6 +6622,7 @@ Para dezenas de milhões, pode-se combinar {maH:n:2,num} com {'uy':n:num,nolink}
       <column name="notes_ru">Существует идиома {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A cold "beer", or alternatively, "brrrr" is the sound one makes when one is cold.
 
 It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the temperature words really are about temperature and not about effect or perception, so that clothing, for example, is not said to be "hot" or "cold" in Klingon.</column>
@@ -5997,6 +6635,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6004,6 +6643,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6017,6 +6657,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">brak'lul (дублирование в частях тела)</column>
       <column name="definition_zh_HK">brak'lul（身體部位冗餘） [AUTOTRANSLATED]</column>
       <column name="definition_pt">brak'lul (redundância em partes do corpo)</column>
+      <column name="definition_fi">brak'lul (ruumiinosien redundanssi) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{raq:v}</column>
@@ -6027,6 +6668,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6036,6 +6678,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">two, double, backup, redundacy, redundant</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6043,6 +6686,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6056,6 +6700,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Кровь воина становится холодной.</column>
       <column name="definition_zh_HK">戰士的鮮血變冷了。</column>
       <column name="definition_pt">O sangue do guerreiro se esfria.</column>
+      <column name="definition_fi">Soturin veri virtaa kylmänä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6066,6 +6711,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru">Чтобы отбить у кого-то романтическое внимание, поверните к нему свою сторону и произнесите это предложение. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了阻止某個人對浪漫的關注，請轉身對他們說這句話。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para desencorajar a atenção romântica de alguém, vire o lado para ele e diga esta frase. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat estää jonkun romanttisen huomion, käänny puolellesi heille ja sano tämä lause. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bIr:v}, {-choH:v}, {SuvwI':n}, {'Iw:n}</column>
       <column name="examples"></column>
@@ -6075,6 +6721,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6082,6 +6729,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -6095,6 +6743,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Если Кивон холодный, кровь горяча.</column>
       <column name="definition_zh_HK">如果qIvon很冷，血就很熱。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Se o qIvon estiver frio, o sangue está quente.</column>
+      <column name="definition_fi">Jos qIvon on kylmä, veri on kuumaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6105,6 +6754,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bIr:v}, {-chugh:v}, {qIvon:n}, {tuj:v}, {'Iw:n}</column>
       <column name="examples"></column>
@@ -6114,6 +6764,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6121,6 +6772,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.174:src}</column>
     </table>
     <table name="mem">
@@ -6134,6 +6786,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Ритуал Бректал</column>
       <column name="definition_zh_HK">Brek'tal儀式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ritual de Brek'tal</column>
+      <column name="definition_fi">Brek'tal-rituaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6144,6 +6797,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru">Это церемония, в которой убийца главы клингонского дома женится на вдове и сам становится главой дома. Язык взаимодействует с этой церемонией в виде {no' Hol:n}.[1, p.11]</column>
       <column name="notes_zh_HK">這是一個儀式，克林崗一家之主的殺人犯與寡婦結婚並親自成為該家的首領。與此儀式相關的語言為{no' Hol:n}.[1, p.11] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma cerimônia em que o assassino do chefe de uma casa klingon casa com a viúva e se torna o chefe da casa. O idioma associado a esta cerimônia está na forma de {no' Hol:n}.[1, p.11] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on seremonia, jossa Klingonin talon pään tappaja menee naimisiin lesken kanssa ja tulee itse talon päämieheksi. Tähän seremoniaan liittyvä kieli on muodossa {no' Hol:n}.[1, p.11] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6153,6 +6807,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6160,6 +6815,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6173,6 +6829,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Брегит</column>
       <column name="definition_zh_HK">bregit [AUTOTRANSLATED]</column>
       <column name="definition_pt">bregit</column>
+      <column name="definition_fi">bregit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIreQtagh:n}</column>
@@ -6183,6 +6840,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru">Неизвестно, что данное слово означает.</column>
       <column name="notes_zh_HK">未知“ bregit”是什麼意思。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não se sabe o que "bregit" significa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei tiedetä, mitä "bregit" tarkoittaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word does not appear in canon by itself, but can be inferred from {bIreQtagh:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6192,6 +6850,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6199,6 +6858,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -6212,6 +6872,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Легкое Брегита</column>
       <column name="definition_zh_HK">bregit肺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pulmão bregit</column>
+      <column name="definition_fi">bregitin keuhko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6222,6 +6883,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru">Это блюдо может быть сделано из дыхательного органа любого из множества животных. Несмотря на то, что это блюдо может состоять из кусочков легкого из более чем одного брегита, его никогда не называют «бредит легкими».[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這道菜可以用許多野獸的呼吸器官製成。即使這道菜可能由來自多個布雷吉特的肺碎片組成，也從未被稱為“布雷吉特肺”。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este prato pode ser feito a partir do órgão respiratório de qualquer um dos vários animais. Mesmo que esse prato possa consistir em pedaços de pulmão de mais de um bregit, nunca é chamado de "pulmão bregit".[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ruokalaji voidaan valmistaa minkä tahansa pedon hengityselimestä. Vaikka tämä ruokalaji voi koostua useamman kuin yhden bregitin keuhkopaloista, sitä ei koskaan kutsutaan "bregit-keuhkoiksi".[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bIreQ:n}, {tagh:n}</column>
       <column name="examples"></column>
@@ -6231,6 +6893,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6238,6 +6901,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {Diplomatic Implausibility:src}, [3] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -6251,6 +6915,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Когда сомневаешься, удиви их.</column>
       <column name="definition_zh_HK">如有疑問，震驚他們。</column>
       <column name="definition_pt">Na dúvida, surpreenda-os.</column>
+      <column name="definition_fi">Jos olet epävarma, yllätä heidät.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6261,6 +6926,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {Sov:v}, {-bej:v}, {-be':v}, {-DI':v}, {tI-:v}, {mer:v}</column>
       <column name="examples"></column>
@@ -6270,6 +6936,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6277,6 +6944,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.25:src}</column>
     </table>
     <table name="mem">
@@ -6290,6 +6958,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Если ты должен вести переговоры, наблюдай за глазами своего врага.</column>
       <column name="definition_zh_HK">如果你必須談判，密切注視敵人的眼睛。</column>
       <column name="definition_pt">Se você precisar negociar, observe os olhos do seu inimigo.</column>
+      <column name="definition_fi">Jos sinun on neuvoteltava, tarkkaile vihollisen silmiä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -6301,6 +6970,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {Sutlh:v}, {-nIS:v}, {-chugh:v}, {jagh:n}, {-lI':n}, {mIn:n}, {-Du':n}, {tI-:v}, {bej:v:1}</column>
       <column name="examples"></column>
@@ -6310,6 +6980,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6317,6 +6988,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.19:src}</column>
     </table>
     <table name="mem">
@@ -6330,6 +7002,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Выбирай сражение, а не переговоры.</column>
       <column name="definition_zh_HK">選擇戰鬥，而不選擇談判。</column>
       <column name="definition_pt">Escolha lutar, não negociar.</column>
+      <column name="definition_fi">Valitse taistelu, älä neuvottelua.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -6341,6 +7014,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {Suv:v}, {'e':n:pro}, {yI-:v}, {wIv:v}, {bI-:v}, {Sutlh:v}, {'e':n:pro}, {yI-:v}, {wIv:v}, {-Qo':v}</column>
       <column name="examples"></column>
@@ -6350,6 +7024,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6357,6 +7032,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.19:src}</column>
     </table>
     <table name="mem">
@@ -6370,6 +7046,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Пусть ты умрешь в битве!</column>
       <column name="definition_zh_HK">願你在戰鬥中死亡！</column>
       <column name="definition_pt">Que você morra em batalha!</column>
+      <column name="definition_fi">Kuole taistelussa!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6380,6 +7057,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {Suv:v}, {-taH:v}, {-vIS:v}, {bI-:v}, {Hegh:v}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -6389,6 +7067,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6396,6 +7075,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -6410,6 +7090,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Низ(внутри)</column>
       <column name="definition_zh_HK">底部（內）</column>
       <column name="definition_pt">parte inferior (interior)</column>
+      <column name="definition_fi">pohja (sisäpuolella)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'aqroS:n:1}</column>
       <column name="see_also">{bIng:n}, {rav:n:1}, {yor:n}</column>
@@ -6420,6 +7101,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru">Например, это слово будет использоваться для описания внутреннего дна коробки. Другое лицо {bIS'ub:n:nolink} на коробке - это {pIrmuS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">例如，該詞將用於描述盒子的內部底部。盒子的{bIS'ub:n:nolink}的另一面是{pIrmuS:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Por exemplo, esta palavra seria usada para descrever o fundo interno de uma caixa. A outra face da caixa {bIS'ub:n:nolink} é seu {pIrmuS:n}.</column>
+      <column name="notes_fi">Tätä sanaa käytetään esimerkiksi kuvaamaan laatikon sisäosaa. Laatikon {bIS'ub:n:nolink} toinen puoli on sen {pIrmuS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6429,6 +7111,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">interior, inside bottom</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6436,6 +7119,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru">внутри</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -6449,6 +7133,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">Быть нервным, быть беспокойным</column>
       <column name="definition_zh_HK">緊張、不安</column>
       <column name="definition_pt">ser nervoso, ser inquieto</column>
+      <column name="definition_fi">ole hermostunut, levoton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bergh:v}, {lIm:v}, {jot:v:1}, {jotHa':v}, {tI'qa' vIghro':n}, {ghIj:v}, {Haj:v}, {Qep:v}</column>
@@ -6459,6 +7144,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru">Является идиомой, {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}.[2]</column>
       <column name="notes_zh_HK">有一個成語{bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">As the saying goes: once bitten, twice shy.
 
 On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:nolink}, but this is clearly a typo.</column>
@@ -6470,6 +7156,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6477,6 +7164,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.132:src}</column>
     </table>
     <table name="mem">
@@ -6490,6 +7178,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Если тебя нельзя посрамить, тебя нельзя почтить.</column>
       <column name="definition_zh_HK">如果你不能被羞辱，你就不能被尊重。</column>
       <column name="definition_pt">Se você não pode ser envergonhado, não pode ser honrado.</column>
+      <column name="definition_fi">Jos sinua ei voi häpäistä, sinua ei voi kunnioittaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6500,6 +7189,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {tuH:v}, {-laH:v}, {-be':v}, {-chugh:v}, {bI-:v}, {quv:v}, {-laH:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -6509,6 +7199,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">If you cannot be shamed, you cannot be honoured.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6516,6 +7207,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.57:src}</column>
     </table>
     <table name="mem">
@@ -6529,6 +7221,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Смерть перед бесчестием.</column>
       <column name="definition_zh_HK">願你被羞辱之前死亡。</column>
       <column name="definition_pt">Morte antes da vergonha.</column>
+      <column name="definition_fi">Kuolema ennen häpeää.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6539,6 +7232,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {tuH:v}, {-pa':v}, {bI-:v}, {Hegh:v}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -6548,6 +7242,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6555,6 +7250,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -6568,6 +7264,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">адаптироваться, привыкать, акклиматизироваться, соответствовать, приспосабливаться к [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">因應、調適</column>
       <column name="definition_pt">adaptar-se, acostumar-se, ajustar-se a</column>
+      <column name="definition_fi">sopeutua, tottua, mukautua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6578,6 +7275,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6587,6 +7285,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6594,6 +7293,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -6607,6 +7307,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Нарушать правила</column>
       <column name="definition_zh_HK">違章、違紀</column>
       <column name="definition_pt">quebrar (regras)</column>
+      <column name="definition_fi">rikkoa (sääntöjä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pab:v}</column>
       <column name="see_also">{wem:v}, {chut:n}, {HeQ:v}</column>
@@ -6617,6 +7318,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6626,6 +7328,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rules</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6633,6 +7336,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6646,6 +7350,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Ты понимаешь?</column>
       <column name="definition_zh_HK">你明白嗎？</column>
       <column name="definition_pt">você entende?</column>
+      <column name="definition_fi">Ymmärrätkö?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -6659,6 +7364,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru">Смотрите, как это говорит Гаурон: {YouTube video:url:http://youtu.be/DRVZd0L-hzo}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/DRVZd0L-hzo} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/DRVZd0L-hzo} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/DRVZd0L-hzo} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {yaj:v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -6668,6 +7374,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6675,6 +7382,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -6688,6 +7396,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Ты грешишь?</column>
       <column name="definition_zh_HK">你會造孽嗎？</column>
       <column name="definition_pt">Você vai pecar?</column>
+      <column name="definition_fi">Teetkö syntiä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6698,6 +7407,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru">Смотрите, как это говорит Гаурон: {YouTube video:url:http://youtu.be/AcgPCgDUYwI}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/AcgPCgDUYwI} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/AcgPCgDUYwI} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/AcgPCgDUYwI} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {yem:v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -6707,6 +7417,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6714,6 +7425,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -6727,6 +7439,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Ты не заслуживаешь жизни.</column>
       <column name="definition_zh_HK">你不值得活下去。</column>
       <column name="definition_pt">Você não merece viver.</column>
+      <column name="definition_fi">Et ansaitse elää.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6737,6 +7450,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence is spoken in Klingon in the opening sequence to {PK:src}, but no English translation is provided.</column>
       <column name="components">{bI-:v}, {yIn:v}, {-taH:v}, {'e':n:pro}, {Da-:v}, {qotlh:v:2}, {-be':v}</column>
       <column name="examples"></column>
@@ -6746,6 +7460,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6753,6 +7468,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -6766,6 +7482,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Отметать, выметать (прочь)</column>
       <column name="definition_zh_HK">掃走</column>
       <column name="definition_pt">varrer (para longe)</column>
+      <column name="definition_fi">lakaista (pois)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6776,6 +7493,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru">Идиоматическое выражение, {pe'vIl bI'chu':sen} "мощно вымести", которое означает сделать что-либо однажды, как единичное событие.[1, p.112]</column>
       <column name="notes_zh_HK">有一個慣用的表達方式{pe'vIl bI'chu':sen}“強制掃開”，這意味著一次將所有操作一次完成。[1, p.112] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Há uma expressão idiomática, {pe'vIl bI'chu':sen} "varrer à força", o que significa fazer algo de uma só vez, como um único evento.[1, p.112]</column>
+      <column name="notes_fi">On olemassa idiomaattinen ilmaisu, {pe'vIl bI'chu':sen} "pakottaa voimakkaasti pois", mikä tarkoittaa tehdä jotain kerralla, yhtenä tapahtumana.[1, p.112] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6787,6 +7505,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
 ▶ {romuluSnganpu' Dujmey DIQaw'pu'; pe'vIl DIbI'chu'pu'.:sen@@romuluSngan:n, -pu':n, Duj:n:1, -mey:n, DI-:v, Qaw':v, -pu':v, pe'vIl:adv, DI-:v, bI':v, -chu':v, -pu':v} "Мы уничтожили ромуланские корабли все разом."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">broom</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6794,6 +7513,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6807,6 +7527,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Если ты грустный, действуй!</column>
       <column name="definition_zh_HK">如果你很傷心，那就行動吧！</column>
       <column name="definition_pt">Se você está triste, aja!</column>
+      <column name="definition_fi">Jos olet surullinen, toimi!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6817,6 +7538,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bI-:v}, {'IQ:v}, {-chugh:v}, {yI-:v}, {vang:v}</column>
       <column name="examples"></column>
@@ -6826,6 +7548,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6833,6 +7556,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.8:src}</column>
     </table>
     <table name="mem">
@@ -6846,6 +7570,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Разведывательный корабль, класса Бирэл</column>
       <column name="definition_zh_HK">《B'rel》偵察艦</column>
       <column name="definition_pt">B'rel klasse Scout</column>
+      <column name="definition_fi">B'rel-tiedustelija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlharghDuj:n}, {toQDuj:n}, {rotarran:n:name}</column>
@@ -6856,6 +7581,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6865,6 +7591,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6872,6 +7599,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6885,6 +7613,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Начало (оперы, игры, истории, речи)</column>
       <column name="definition_zh_HK">開始（歌劇、戲劇、故事、演講） [AUTOTRANSLATED]</column>
       <column name="definition_pt">começo (de uma ópera, peça, história, discurso)</column>
+      <column name="definition_fi">(oopperan, näytelmän, tarinan, puheen) alku</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bertlham:n}</column>
       <column name="see_also">{tagh:v}, {qa'vam:n}</column>
@@ -6895,6 +7624,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru">Это относится к начальному разделу представления (первый акт, сцена, предложение, и т.д.).</column>
       <column name="notes_zh_HK">這是指表演的開頭部分（第一幕，場景，句子等）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à seção de abertura de uma performance (primeiro ato, cena, frase, etc.). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa esityksen alkuosaan (ensimmäinen näytös, kohtaus, lause jne.). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">These are the first two syllables of the Torah.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6906,6 +7636,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
 ▶ {bI'reS qeylIS vaq molor:sen:nolink} "Сначала Молор насмехается над Кейлесом"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">start</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6913,6 +7644,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}, [2] {paq'batlh p.140-141:src}</column>
     </table>
     <table name="mem">
@@ -6926,6 +7658,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Перо, оперение</column>
       <column name="definition_zh_HK">羽毛</column>
       <column name="definition_pt">pena, pluma</column>
+      <column name="definition_fi">sulka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -6936,6 +7669,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Feather boa".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6945,6 +7679,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6952,6 +7687,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -6965,6 +7701,7 @@ On {KGT p.132:src}, the word is written as {tIb:v:nolink} instead of {bIt:v:noli
       <column name="definition_ru">Вы(множественное число) (некое действие) ему/ей/этому/им</column>
       <column name="definition_zh_HK">你們：他、它、他們、它們</column>
       <column name="definition_pt">você (plural) - ele/ela/elas/eles</column>
+      <column name="definition_fi">te-häntä/sitä/heitä/niitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lI-:v:pref}</column>
       <column name="see_also">{Da-:v:pref}, {Su-:v:pref}, {yI-:v:pref}, {tI-:v:pref}</column>
@@ -6979,6 +7716,9 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
 Использование префикса совместно с {-lu':v}, означает "Кто-то (неопределенный) делает что-то вам (множственное число)".</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{tlhIH:n}: {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n} = {bo-:v:pref,nolink}
+
+Kun sitä käytetään {-lu':v}:n kanssa, tämä etuliite tarkoittaa "Joku (määrittelemätön) tekee teille jotain".</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6988,6 +7728,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">you-him, you-her, you-it, you-them</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6995,6 +7736,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru">вы-ему,вы-ей,вы-этому,вы-им</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7008,6 +7750,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Модуль</column>
       <column name="definition_zh_HK">模 [AUTOTRANSLATED]</column>
       <column name="definition_pt">módulo</column>
+      <column name="definition_fi">moduuli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7018,6 +7761,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">matches lip movement</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7027,6 +7771,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7034,6 +7779,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7047,6 +7793,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Сиять, быть блестящим</column>
       <column name="definition_zh_HK">閃耀、閃光</column>
       <column name="definition_pt">brilhante, ser brilhante</column>
+      <column name="definition_fi">kiiltää, olla kiiltävä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIch:n}, {bochmoHwI':n}, {wov:v}, {chorgh:v}</column>
@@ -7057,6 +7804,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это идиома, {boch; ghIch rur@@boch:v, ghIch:n, rur:v}.[2, p.133]</column>
       <column name="notes_zh_HK">有一個成語{boch; ghIch rur@@boch:v, ghIch:n, rur:v}.[2, p.133] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {boch; ghIch rur@@boch:v, ghIch:n, rur:v}.[2, p.133] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {boch; ghIch rur@@boch:v, ghIch:n, rur:v}.[2, p.133] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7067,6 +7815,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7074,6 +7823,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7087,6 +7837,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">подхалим, льстец, </column>
       <column name="definition_zh_HK">sy媚的、flat媚的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bajulador, adulador</column>
+      <column name="definition_fi">hännystelijä, imartelija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIchwIj DabochmoHchugh ghIchlIj qanob.:sen:phr}</column>
@@ -7097,6 +7848,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Получено из более раннего выражения {'etlh bochmoHwI':n:nolink}.</column>
       <column name="notes_zh_HK">這是從較早的表達式{'etlh bochmoHwI':n:nolink}派生的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é derivado de uma expressão anterior {'etlh bochmoHwI':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on johdettu aikaisemmasta lausekkeesta {'etlh bochmoHwI':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{boch:v}, {-moH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7106,6 +7858,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7113,6 +7866,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.146-7:src}</column>
     </table>
     <table name="mem">
@@ -7126,6 +7880,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Лоб</column>
       <column name="definition_zh_HK">額頭</column>
       <column name="definition_pt">testa</column>
+      <column name="definition_fi">otsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quch:n}</column>
@@ -7136,6 +7891,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Fore"bode".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7145,6 +7901,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7152,6 +7909,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7165,6 +7923,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Быть рожденным</column>
       <column name="definition_zh_HK">出生</column>
       <column name="definition_pt">nascer</column>
+      <column name="definition_fi">syntyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ben:n:2}, {Hegh:v}, {qoS:n}</column>
@@ -7175,6 +7934,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7187,6 +7947,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7194,6 +7955,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7207,6 +7969,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Клингоны рождаются, живут как воины, а затем умирают.</column>
       <column name="definition_zh_HK">克林崗人出生，作為戰士生活，然後死去。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Os klingons nascem, vivem como guerreiros e depois morrem.</column>
+      <column name="definition_fi">Klingonit syntyvät, elävät sotureija, kuolevat.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7217,6 +7980,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bogh:v}, {tlhIngan:n}, {-pu':n}, {SuvwI':n}, {moj:v}, {Hegh:v}</column>
       <column name="examples"></column>
@@ -7226,6 +7990,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7233,6 +7998,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.5:src}</column>
     </table>
     <table name="mem">
@@ -7246,6 +8012,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">шествие, парад, марш [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">遊行遊行遊行 [AUTOTRANSLATED]</column>
       <column name="definition_pt">procissão, desfile, marcha</column>
+      <column name="definition_fi">kulkue, paraati, marssi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhaj:v}</column>
@@ -7256,6 +8023,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to the Colonel Bogey March.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7265,6 +8033,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7272,6 +8041,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7285,6 +8055,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Быть нетерпеливым</column>
       <column name="definition_zh_HK">急切、心急、不耐煩</column>
       <column name="definition_pt">ser impaciente</column>
+      <column name="definition_fi">ole kärsimätön</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tuv:v}</column>
       <column name="see_also">{loS:v}</column>
@@ -7295,6 +8066,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {Hob:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7304,6 +8076,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7311,6 +8084,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7324,6 +8098,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">ворчать, придираться, изводить</column>
       <column name="definition_zh_HK">嘮叨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">incomodar</column>
+      <column name="definition_fi">nalkuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bep:v}, {vIng:v}</column>
@@ -7334,6 +8109,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7343,6 +8119,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7350,6 +8127,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7363,6 +8141,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">сочиться, течь</column>
       <column name="definition_zh_HK">流口水</column>
       <column name="definition_pt">babar</column>
+      <column name="definition_fi">kuolata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIl:v}, {tlhepQe':n}, {bolwI':n}, {bol:v:2}</column>
@@ -7373,6 +8152,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It is explicitly stated on {KGT p.147:src} that the non-slang meaning of this verb does not take an object.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7382,6 +8162,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7389,6 +8170,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7402,6 +8184,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Предавать</column>
       <column name="definition_zh_HK">背叛</column>
       <column name="definition_pt">trair</column>
+      <column name="definition_fi">pettää</column>
       <column name="synonyms">{magh:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{bol:v:1}</column>
@@ -7412,6 +8195,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The slang definition of this verb appears in the discussion on {bolwI':n} on {KGT p.147:src}, but is not found in the word lists in that book. This is the reverse of {lob:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7421,6 +8205,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7428,6 +8213,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.147:src}</column>
     </table>
     <table name="mem">
@@ -7441,6 +8227,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Предатель</column>
       <column name="definition_zh_HK">叛徒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">traidor</column>
+      <column name="definition_fi">petturi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maghwI':n}, {'urwI':n}</column>
@@ -7451,6 +8238,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Possibly from "boll weevil", from American Civil War history.</column>
       <column name="components">{bol:v:2}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7460,6 +8248,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7467,6 +8256,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7480,6 +8270,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Песня, песнопение</column>
       <column name="definition_zh_HK">歌曲</column>
       <column name="definition_pt">música, canto</column>
+      <column name="definition_fi">laulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom mu':n}, {ghuQ:n}, {gha'tlhIq:n}, {wup:v}, {bom:v}, {'ISQIm:n}, {'IngSav:n}, {jaghIv:n}, {romta':n}, {Savvanwer:n}</column>
@@ -7490,6 +8281,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Виды {bom:n:nolink} включают: {bang bom:n}, {HIvje' bom:n}, {van bom:n}, {chon bom:n}, {Dap bom:n}, {ghe'naQ:n}, {may' bom:n}, {najmoHwI':n}.</column>
       <column name="notes_zh_HK">{bom:n:nolink}的類型包括：{bang bom:n}、{HIvje' bom:n}、{van bom:n}、{chon bom:n}、{Dap bom:n}、{ghe'naQ:n}、{may' bom:n}、{najmoHwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os tipos de {bom:n:nolink} incluem: {bang bom:n}, {HIvje' bom:n}, {van bom:n}, {chon bom:n}, {Dap bom:n}, {ghe'naQ:n}, {may' bom:n}, {najmoHwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{bom:n:nolink}-tyypit sisältävät: {bang bom:n}, {HIvje' bom:n}, {van bom:n}, {chon bom:n}, {Dap bom:n}, {ghe'naQ:n}, {may' bom:n}, {najmoHwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7500,6 +8292,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7507,6 +8300,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
     </table>
     <table name="mem">
@@ -7520,6 +8314,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Петь, воспевать</column>
       <column name="definition_zh_HK">唱歌、吟唱</column>
       <column name="definition_pt">cantar</column>
+      <column name="definition_fi">laulaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}, {much:v:2}, {wup:v}, {QoQ:n}, {'uq:v}, {Huy:v:1}</column>
@@ -7530,6 +8325,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7541,6 +8337,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">falsetto</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7548,6 +8345,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}, [3] {qep'a' 27 (2020):src}</column>
     </table>
         <table name="mem">
@@ -7561,6 +8359,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="definition_ru">Лирика, текст песни</column>
           <column name="definition_zh_HK">歌詞</column>
           <column name="definition_pt">letra de música</column>
+      <column name="definition_fi">sanoitus, lyriikka</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7571,6 +8370,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bom:n}, {mu':n}</column>
           <column name="examples"></column>
@@ -7580,6 +8380,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7587,6 +8388,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
         </table>
         <table name="mem">
@@ -7600,6 +8402,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="definition_ru">Память о том, как ты поёшь, в моей крови.</column>
           <column name="definition_zh_HK">你的記憶在我的血液中唱歌。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">A lembrança de você canta no meu sangue.</column>
+      <column name="definition_fi">Kun vereni laulaa, muistan sinut.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7610,6 +8413,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -7619,6 +8423,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7626,6 +8431,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.17:src}</column>
         </table>
         <table name="mem">
@@ -7639,6 +8445,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="definition_ru">Певец</column>
           <column name="definition_zh_HK">歌手</column>
           <column name="definition_pt">cantor</column>
+      <column name="definition_fi">laulaja</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7649,6 +8456,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="notes_ru">Клингонская идиома, {'oj; bomwI' rur@@'oj:v, bomwI':n, rur:v}.</column>
           <column name="notes_zh_HK">有一個克林崗語，{'oj; bomwI' rur@@'oj:v, bomwI':n, rur:v}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Existe um idioma Klingon, {'oj; bomwI' rur@@'oj:v, bomwI':n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On olemassa klingonin idioomi {'oj; bomwI' rur@@'oj:v, bomwI':n, rur:v}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{bom:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -7658,6 +8466,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7665,6 +8474,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.71:src}</column>
         </table>
     <table name="mem">
@@ -7678,6 +8488,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Поделиться с кем-то</column>
       <column name="definition_zh_HK">與某人分享 [AUTOTRANSLATED]</column>
       <column name="definition_pt">compartilhar com</column>
+      <column name="definition_fi">jakaa jotain (jollekulle)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIn:v:1}</column>
@@ -7688,6 +8499,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Когда {A:sen:nolink} делит {C:sen:nolink} с {B:sen:nolink}, конструкция следующая {B-vaD C bon A:sen:nolink} (с подходящими глагольными префиксами, зависящими от {A:sen:nolink} и {C:sen:nolink}). В этом случае, {C:sen:nolink} принадлежит к {A:sen:nolink} и {A:sen:nolink} решает поделиться этим с {B:sen:nolink}.</column>
       <column name="notes_zh_HK">當{A:sen:nolink}與{B:sen:nolink}共享{C:sen:nolink}時，其結構為{B-vaD C bon A:sen:nolink}（具有適當的動詞前綴，具體取決於{A:sen:nolink}和{C:sen:nolink}）。在這種情況下，{C:sen:nolink}屬於{A:sen:nolink}，而{A:sen:nolink}選擇與{B:sen:nolink}共享。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando {A:sen:nolink} compartilha {C:sen:nolink} com {B:sen:nolink}, a construção é {B-vaD C bon A:sen:nolink} (com prefixos verbais apropriados, dependendo de {A:sen:nolink} e {C:sen:nolink}). Nesse caso, {C:sen:nolink} pertence a {A:sen:nolink} e {A:sen:nolink} escolhe compartilhá-lo com {B:sen:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun {A:sen:nolink} jakaa {C:sen:nolink}: n {B:sen:nolink}: n kanssa, rakenne on {B-vaD C bon A:sen:nolink} (sopivilla verbien etuliitteillä {A:sen:nolink} ja {C:sen:nolink} mukaan). Tällöin {C:sen:nolink} kuuluu {A:sen:nolink}: een ja {A:sen:nolink} päättää jakaa sen {B:sen:nolink}: n kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Share a "bond".
 
 Reverse of {nob:v}. This was apparently not intentional.</column>
@@ -7699,6 +8511,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7706,6 +8519,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7719,6 +8533,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">Случайно, нечаянно </column>
       <column name="definition_zh_HK">意外、偶然</column>
       <column name="definition_pt">acidentalmente, por acidente</column>
+      <column name="definition_fi">vahingossa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chIch:adv}</column>
       <column name="see_also"></column>
@@ -7729,6 +8544,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7738,6 +8554,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">by chance</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7745,6 +8562,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7758,6 +8576,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">Быть о чём-то(о ком-то), быть обеспокоенным</column>
       <column name="definition_zh_HK">關於</column>
       <column name="definition_pt">estar preocupado com</column>
+      <column name="definition_fi">koskea jotain, käsitellä jotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIch:v}</column>
@@ -7768,6 +8587,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The refrain to the Hokey Pokey, "that's what it's all about", is {'e' bop:sen:nolink} in Klingon.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7779,6 +8599,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
 ▶ {HolQeD bopbe' paqvam.:sen@@HolQeD:n, bop:v, -be':v, paq:n:1h, -vam:n} "Эта книга не о лингвистике."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7786,6 +8607,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 12 (2005):src}</column>
     </table>
     <table name="mem">
@@ -7799,6 +8621,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">Альянс, блок, коалиция</column>
       <column name="definition_zh_HK">聯合、聯盟、同盟、集團</column>
       <column name="definition_pt">aliança, bloco, coalizão</column>
+      <column name="definition_fi">liitto, ryhmä, koalitio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhoQ:n}, {DIvI':n}, {ghom:n}, {qev:n}, {tlhach:n}, {boq:v:1}, {boq:n:2}</column>
@@ -7809,6 +8632,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7818,6 +8642,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7825,6 +8650,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7838,6 +8664,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">Слияние, сплав, объединение</column>
       <column name="definition_zh_HK">聚變</column>
       <column name="definition_pt">fusão</column>
+      <column name="definition_fi">fuusio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hong boq chuyDaH:n}, {boq:n:1}, {butnat:n}</column>
@@ -7848,6 +8675,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru">Это физический термин.</column>
       <column name="notes_zh_HK">這是一個物理術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo da física. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on fysiikan termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7857,6 +8685,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7864,6 +8693,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7877,6 +8707,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">Вступать в союз с, заключать альянс с</column>
       <column name="definition_zh_HK">結盟</column>
       <column name="definition_pt">aliado com, formar uma aliança com</column>
+      <column name="definition_fi">liittoutua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boq:n:1}</column>
@@ -7887,6 +8718,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru">Это слово также используется в математике для сложения (см. {boq:v:2}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞在數學中也用於加法（請參閱{boq:v:2}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra também é usada em matemática para adição (consulte {boq:v:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään myös matematiikassa lisäykseen (katso {boq:v:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7896,6 +8728,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7903,6 +8736,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -7916,6 +8750,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">добавлять(используется в математике)</column>
       <column name="definition_zh_HK">加（數學）</column>
       <column name="definition_pt">adição (usado em matemática)</column>
+      <column name="definition_fi">laskea yhteen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boq:v:1}, {chen:v}, {chel:v}</column>
@@ -7926,6 +8761,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru">4 базовые арифеметические операции: + {boq:v:2,nolink}, - {boqHa':v}, × {boq'egh:v}, ÷ {boqHa''egh:v}. В этих операциях числа трактуются так, как если бы они были в единственном числе.</column>
       <column name="notes_zh_HK">四個基本算術運算是：+ {boq:v:2,nolink}，-{boqHa':v}，×{boq'egh:v}，÷{boqHa''egh:v}。在這些運算中，將數字視為在語法上是單數的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">As quatro operações aritméticas básicas são: + {boq:v:2,nolink}, - {boqHa':v}, × {boq'egh:v}, ÷ {boqHa''egh:v}. Nessas operações, os números são tratados como se fossem gramaticalmente singulares. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Aritmeettiset neljä perusoperaatiota ovat: + {boq:v:2,nolink}, - {boqHa':v}, × {boq'egh:v}, ÷ {boqHa''egh:v}. Näissä operaatioissa numeroita käsitellään ikään kuin ne olisivat kieliopillisesti yksikköisiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7936,6 +8772,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">plus, addition</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7943,6 +8780,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru">плюс, сложение</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
         <table name="mem">
@@ -7956,6 +8794,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="definition_ru">Вычитание (используется в математике)</column>
           <column name="definition_zh_HK">減（數學）</column>
           <column name="definition_pt">subtrair (usado em matemática)</column>
+      <column name="definition_fi">vähentää (matematiikassa)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{boq:v:2}, {chen:v}, {Dop:v:2}</column>
@@ -7966,6 +8805,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{boq:v:2}, {-Ha':v}</column>
           <column name="examples">
@@ -7976,6 +8816,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">minus, subtraction</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7983,6 +8824,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="search_tags_ru">минус, вычитание</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
         </table>
         <table name="mem">
@@ -7996,6 +8838,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="definition_ru">Умножение (используется в математике)</column>
           <column name="definition_zh_HK">乘（數學）</column>
           <column name="definition_pt">multiplicar (usado em matemática)</column>
+      <column name="definition_fi">kertoa (matematiikassa)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{boq:v:2}, {chen:v}, {-logh:n:num,suff}</column>
@@ -8006,6 +8849,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{boq:v:2}, {-'egh:v}</column>
           <column name="examples">
@@ -8017,6 +8861,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">times, multiplication</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8024,6 +8869,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
         </table>
         <table name="mem">
@@ -8037,6 +8883,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="definition_ru">Деление (используется в математике)</column>
           <column name="definition_zh_HK">除（數學）</column>
           <column name="definition_pt">dividir (usado em matemática)</column>
+      <column name="definition_fi">jakaa (matematiikassa)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{boq:v:2}, {chen:v}, {wav:v}, {loch:v}</column>
@@ -8047,6 +8894,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{boq:v:2}, {-Ha':v}, {-'egh:v}</column>
           <column name="examples">
@@ -8057,6 +8905,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">over, division</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8064,6 +8913,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
         </table>
         <table name="mem">
@@ -8077,6 +8927,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="definition_ru">Коалиция</column>
           <column name="definition_zh_HK">聯盟（暫時）</column>
           <column name="definition_pt">coalizão</column>
+      <column name="definition_fi">koalitio</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -8087,6 +8938,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{boq:n:1}, {ru':v:1}</column>
           <column name="examples"></column>
@@ -8096,6 +8948,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8103,6 +8956,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
     <table name="mem">
@@ -8116,6 +8970,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">чудо, чудо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">奇蹟、奇蹟 [AUTOTRANSLATED]</column>
       <column name="definition_pt">milagre, maravilha</column>
+      <column name="definition_fi">ihme</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IDnar:n}, {ngar:v}</column>
@@ -8126,6 +8981,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8136,6 +8992,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8143,6 +9000,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -8156,6 +9014,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">тип животного, Бократ</column>
       <column name="definition_zh_HK">動物類型、bokrat [AUTOTRANSLATED]</column>
       <column name="definition_pt">bokrat (tipo de animal)</column>
+      <column name="definition_fi">eräs eläin, bokrat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chej:n}, {Qev:v}</column>
@@ -8166,6 +9025,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru">Его печень едят как {boqrat chej Qevlu'pu'bogh:n@@boqrat:n, chej:n, Qev:v, -lu':v, -pu':v, -bogh:v} "тушеная печень бократ". [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它的肝臟被當作{boqrat chej Qevlu'pu'bogh:n@@boqrat:n, chej:n, Qev:v, -lu':v, -pu':v, -bogh:v}“燉的牛肝”食用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Seus fígados são comidos como {boqrat chej Qevlu'pu'bogh:n@@boqrat:n, chej:n, Qev:v, -lu':v, -pu':v, -bogh:v} "fígado cozido de bokrat". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen maksa syö {boqrat chej Qevlu'pu'bogh:n@@boqrat:n, chej:n, Qev:v, -lu':v, -pu':v, -bogh:v}-haudutettua bokrat-maksaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{boqrat chej:n:nolink} is listed in the glossary to {Diplomatic Implausibility:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8175,6 +9035,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8182,6 +9043,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8195,6 +9057,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">симбионт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">共生體</column>
       <column name="definition_pt">simbionte</column>
+      <column name="definition_fi">symbiontti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tI'rIl:n}, {nungmaH:n}</column>
@@ -8205,6 +9068,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru">Какой суффикс множественного числа это принимает, зависит от типа симбионта. В случае симбионтов Trill (см. {tI'rIlngan:n}) используется суффикс {-pu':n:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這採用哪個後綴取決於共生體的類型。對於Trill（請參見{tI'rIlngan:n}）共鳴符，將使用後綴{-pu':n:suff}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O sufixo plural usado depende do tipo de simbionte. No caso dos simbiontes Trill (consulte {tI'rIlngan:n}), o sufixo {-pu':n:suff} é usado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Se, minkä monikkomuodon tämä tarvitsee, riippuu symbiontin tyypistä. Trill-symbiontien (katso {tI'rIlngan:n}) tapauksessa käytetään loppuliitettä {-pu':n:suff}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The plural suffix this word takes was clarified during the Q &amp; A session.</column>
       <column name="components">{boq:n:1}, {yIn:n}</column>
       <column name="examples"></column>
@@ -8214,6 +9078,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8221,6 +9086,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -8234,6 +9100,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="definition_ru">Помощник</column>
       <column name="definition_zh_HK">助手 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colaborador</column>
+      <column name="definition_fi">avustaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'DIch:n:2}, {boQ:n:2}</column>
@@ -8244,6 +9111,7 @@ Reverse of {nob:v}. This was apparently not intentional.</column>
       <column name="notes_ru">Это относится к человеку, который помогает кому-то.</column>
       <column name="notes_zh_HK">這是指協助某人的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa que ajuda alguém. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, joka avustaa jotakuta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Boq" is the name of a character in The Wizard of Oz who assists Dorothy.
 
 Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated as {chenmoHwI' boQ@@chenmoHwI':n, boQ:n:1}, in the film {Conlanging:src}.</column>
@@ -8255,6 +9123,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">assistant</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8262,6 +9131,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="search_tags_ru">помощник</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8275,6 +9145,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="definition_ru">Помощь, содействие</column>
       <column name="definition_zh_HK">援助</column>
       <column name="definition_pt">ajuda, assistência</column>
+      <column name="definition_fi">apu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QaH:n}, {boQ:n:1}</column>
@@ -8285,6 +9156,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Boq" is the name of a character in The Wizard of Oz who assists Dorothy.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8294,6 +9166,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8301,6 +9174,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8314,6 +9188,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="definition_ru">Помогать, содействовать</column>
       <column name="definition_zh_HK">助攻</column>
       <column name="definition_pt">ajudar</column>
+      <column name="definition_fi">avustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sot:v}, {boQ:n:2}, {vuy:v}</column>
@@ -8324,6 +9199,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="notes_ru">Это следует использовать в ситуациях, когда кто-то может сделать задание в одиночку, но проще или лучше или более эффективно, если кто-то поможет. Объект {boQ:v:nolink} сохраняет ответственность за оказанную помощь. Это контрастирует с {QaH:v}.[2]</column>
       <column name="notes_zh_HK">這將用於某些人可能獨自完成某項任務的情況，但如果有人幫助，它會變得更輕鬆，更好或更有效。 {boQ:v:nolink}的對象保留了所協助活動的責任。這與{QaH:v}.[2]相反 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso seria usado em situações em que alguém seria capaz de executar uma tarefa sozinho, mas é mais fácil ou melhor ou mais eficiente se alguém ajudar. O objeto de {boQ:v:nolink} mantém a responsabilidade pela atividade que está sendo auxiliada. Isso contrasta com {QaH:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään tilanteissa, joissa joku voi pystyä tekemään tehtävän yksin, mutta se on helpompaa, parempaa tai tehokkaampaa, jos joku auttaa. {boQ:v:nolink}-objekti säilyttää vastuun tuettavasta toiminnasta. Tämä on päinvastoin kuin {QaH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Boq" is the name of a character in The Wizard of Oz who assists Dorothy.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8333,6 +9209,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8340,6 +9217,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2017.10.10:src}</column>
     </table>
     <table name="mem">
@@ -8353,6 +9231,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="definition_ru">Адъютант</column>
       <column name="definition_zh_HK">副官 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ajudante</column>
+      <column name="definition_fi">adjutantti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8363,6 +9242,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8372,6 +9252,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8379,6 +9260,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8392,6 +9274,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="definition_ru">Бульканье</column>
       <column name="definition_zh_HK">汩汩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gorgolejo</column>
+      <column name="definition_fi">lorista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghung:v}</column>
@@ -8402,6 +9285,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="notes_ru">Относится к звукам, которые издаёт живот.</column>
       <column name="notes_zh_HK">特別是指胃發出的聲音。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere especificamente ao som que o estômago produz. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa erityisesti vatsaan kuuluvaan ääniin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Borborygmus" is an onomatopoetic word referring to the rumbling sound made by intestinal gas.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8411,6 +9295,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8418,6 +9303,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -8431,6 +9317,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="definition_ru">Гром</column>
       <column name="definition_zh_HK">行雷</column>
       <column name="definition_pt">trovão</column>
+      <column name="definition_fi">ukkonen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8441,6 +9328,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="notes_ru">Безсленговый способ сказать "гром", это {tuD:v}.</column>
       <column name="notes_zh_HK">說“雷聲”的非-語方式是{tuD:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A maneira não gíria de dizer "trovão" é {tuD:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei-slangi tapa sanoa "ukkonen" on {tuD:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bor:v}, {-qu':v}</column>
       <column name="examples"></column>
@@ -8450,6 +9338,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">knallen, rumsen, Gewitter</column>
       <column name="search_tags_fa"></column>
@@ -8457,6 +9346,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -8470,6 +9360,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="definition_ru">Название очень маленькой птицы, чьи яйца считаются довольно вкусными</column>
       <column name="definition_zh_HK">一隻非常小的鳥、它的雞蛋被認為非常好吃 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro muito pequeno cujos ovos são considerados bastante saborosos</column>
+      <column name="definition_fi">eräs hyvin pieni lintu, jonka munia pidetään melko maukkaina</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}, {QIm:n}</column>
@@ -8480,6 +9371,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8489,6 +9381,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8496,6 +9389,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -8509,6 +9403,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="definition_ru">Месть</column>
       <column name="definition_zh_HK">報復</column>
       <column name="definition_pt">vingança</column>
+      <column name="definition_fi">kosto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noD:v}, {bortaS DIb:n}</column>
@@ -8519,6 +9414,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="notes_ru">Есть идиома, {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}.</column>
       <column name="notes_zh_HK">有一個成語，{bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8530,6 +9426,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8537,6 +9434,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.127:src}, [3] {TKW p.133:src}</column>
     </table>
     <table name="mem">
@@ -8550,6 +9448,7 @@ Marc Okrand ({marq 'oqranD:n:name}) is billed as Associate Producer, translated 
       <column name="definition_ru">Месть это блюдо, которое подают холодным.</column>
       <column name="definition_zh_HK">復仇是一道最好的冷盤。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A vingança é um prato que é melhor servido frio.</column>
+      <column name="definition_fi">Kosto maistuu parhaalta tarjoiltuna kylmänä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8574,6 +9473,9 @@ Det finns också ett relaterat formspråk {bIr; bortaS rur@@bIr:v, bortaS:n, rur
       <column name="notes_pt">Este é um provérbio Klingon muito famoso.
 
 Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on hyvin kuuluisa Klingonin sananlasku.
+
+On myös siihen liittyvä idioomi {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bortaS:n}, {bIr:v}, {jab:v}, {-lu':v}, {-DI':v}, {reH:adv}, {QaQ:v}, {-qu':v}, {nay':n}</column>
       <column name="examples"></column>
@@ -8583,6 +9485,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8590,6 +9493,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.133:src}</column>
     </table>
     <table name="mem">
@@ -8603,6 +9507,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="definition_ru">Право на месть</column>
       <column name="definition_zh_HK">報仇權</column>
       <column name="definition_pt">Direito de Vingança</column>
+      <column name="definition_fi">kosto-oikeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8613,6 +9518,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bortaS:n}, {DIb:n}</column>
       <column name="examples"></column>
@@ -8622,6 +9528,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8629,6 +9536,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8642,6 +9550,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="definition_ru">Месть это лучшая месть.</column>
       <column name="definition_zh_HK">報仇是最好的報復。</column>
       <column name="definition_pt">A vingança é a melhor vingança.</column>
+      <column name="definition_fi">Kosto on paras kosto.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8652,6 +9561,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8661,6 +9571,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8668,6 +9579,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.121:src}</column>
     </table>
     <table name="mem">
@@ -8681,6 +9593,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="definition_ru">Собирать, коллекционировать</column>
       <column name="definition_zh_HK">收集</column>
       <column name="definition_pt">coletar</column>
+      <column name="definition_fi">kerätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIq:v}, {yIr:v}, {pol:v}</column>
@@ -8691,6 +9604,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8700,6 +9614,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8707,6 +9622,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8720,6 +9636,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="definition_ru">предотвращать, блокировать, запрещать, препятствовать</column>
       <column name="definition_zh_HK">防止、阻止、禁止</column>
       <column name="definition_pt">impedir, bloquear, proibir</column>
+      <column name="definition_fi">estää, kieltää</column>
       <column name="synonyms">{tuch:v}</column>
       <column name="antonyms">{chaw':v}</column>
       <column name="see_also">{le'mIS:n}, {waQ:v}</column>
@@ -8730,6 +9647,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The German word for "forbidden" is ver"bot"en.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8741,6 +9659,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">intercept</column>
       <column name="search_tags_de">stoppen, abfangen</column>
       <column name="search_tags_fa"></column>
@@ -8748,6 +9667,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="search_tags_ru">перехват</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -8761,6 +9681,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="definition_ru">щиты (силовое поле на корабле)</column>
       <column name="definition_zh_HK">護盾、防護罩（力場）</column>
       <column name="definition_pt">escudos (campo de força na nave)</column>
+      <column name="definition_fi">kilpi (alusta suojaava voimakenttä)</column>
       <column name="synonyms">{begh:n}, {begh botjan:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{Som:n}, {Duj:n:1}, {Surchem:n}, {chu':v:2}</column>
@@ -8771,6 +9692,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="notes_ru">Это слово относится к силовому полю ({Surchem:n}) окружающему корабль. Для щитов, которые держат в руке, смотрите {yoD:n}.</column>
       <column name="notes_zh_HK">這個詞是指圍繞飛船的力場（{Surchem:n}）。有關手持式防護罩，請參閱{yoD:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se ao campo de força ({Surchem:n}) ao redor de uma nave espacial. Para escudos de mão, consulte {yoD:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa avaruusalusta ympäröivään voimakenttään ({Surchem:n}). Katso kädessä pidettävät kilvet kohdasta {yoD:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bot:n:hyp,nolink} or {bot:v}, {jan:n:1}</column>
       <column name="examples">
@@ -8781,6 +9703,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">force field</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8788,6 +9711,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8801,6 +9725,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="definition_ru">Поднять щиты!</column>
       <column name="definition_zh_HK">升起護盾！</column>
       <column name="definition_pt">Levantar escudos!</column>
+      <column name="definition_fi">Nosta kilvet!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8811,6 +9736,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="notes_ru">Смотрите, как Гаурон говорит это: {YouTube video:url:http://youtu.be/BhNqW6yOnZU}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/BhNqW6yOnZU} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/BhNqW6yOnZU} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/BhNqW6yOnZU} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{botjan:n}, {yI-:v}, {chu':v:2}</column>
       <column name="examples"></column>
@@ -8820,6 +9746,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8827,6 +9754,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -8840,6 +9768,7 @@ Há também um idioma relacionado {bIr; bortaS rur@@bIr:v, bortaS:n, rur:v}. [AU
       <column name="definition_ru">центр, середина</column>
       <column name="definition_zh_HK">中心</column>
       <column name="definition_pt">centro, meio</column>
+      <column name="definition_fi">keskus, keskiosa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joj:n}, {qoD:n}, {bIng:n}, {Dung:n}, {retlh:n}, {tlhop:n:1}, {'em:n}</column>
@@ -8862,6 +9791,9 @@ Detta ord används också i matematik (se {botlh:n:2}). [AUTOTRANSLATED]</column
       <column name="notes_pt">Para a área entre dois (ou mais) objetos, consulte {joj:n}. Para o interior de um objeto em geral, consulte {qoD:n}.
 
 Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso kahden (tai useamman) objektin välinen alue kohdasta {joj:n}. Kohteen sisustus yleensä, katso {qoD:n}.
+
+Tätä sanaa käytetään myös matematiikassa (katso {botlh:n:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8871,6 +9803,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">centre, central</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8878,6 +9811,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8891,6 +9825,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="definition_ru">Медиана (используется в математике) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">中位數（用於數學） [AUTOTRANSLATED]</column>
       <column name="definition_pt">mediana (usada em matemática)</column>
+      <column name="definition_fi">mediaani (käytetään matematiikassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIl:v}</column>
@@ -8901,6 +9836,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="notes_ru">Это «среднее» значение группы чисел. Это просто приложение {botlh:n:1} в контексте математики. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一組數字的“中間”值。它只是{botlh:n:1}在數學中的應用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o valor "intermediário" de um grupo de números. É apenas a aplicação do {botlh:n:1} no contexto da matemática. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on numeroryhmän "keskiarvo". Se on vain {botlh:n:1}: n soveltamista matematiikan yhteydessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8910,6 +9846,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8917,6 +9854,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8930,6 +9868,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="definition_ru">Эра, эпоха</column>
       <column name="definition_zh_HK">時代</column>
       <column name="definition_pt">era</column>
+      <column name="definition_fi">aikakausi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{poH:n}, {qeylIS bov:n}, {qeylIS bov nubwI':n}</column>
@@ -8940,6 +9879,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8949,6 +9889,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8956,6 +9897,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8969,6 +9911,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="definition_ru">древняя эпоха [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">古代時代 [AUTOTRANSLATED]</column>
       <column name="definition_pt">era antiga</column>
+      <column name="definition_fi">muinaiset ajat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{no' bov:n}</column>
@@ -8979,6 +9922,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="notes_ru">Это может быть использовано для обозначения древнего периода в палеонтологии. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以用來指古生物學。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso poderia ser usado para se referir a um período antigo na paleontologia. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voitaisiin käyttää viitaten muinaisiin aikoihin paleontologiassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bov:n}, {tIQ:v}</column>
       <column name="examples"></column>
@@ -8988,6 +9932,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8995,6 +9940,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -9008,6 +9954,7 @@ Essa palavra também é usada em matemática (consulte {botlh:n:2}). [AUTOTRANSL
       <column name="definition_ru">черпак, зачерпывать (еда)</column>
       <column name="definition_zh_HK">殼子、勺子（用來端上食物）</column>
       <column name="definition_pt">Espátula (ferramenta de pá, semelhante a uma espátula de jardim para levar comida de uma panela)</column>
+      <column name="definition_fi">kauha (ruokaa varten)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9032,6 +9979,9 @@ Detta ord används i idiomen {bo'Dagh'a' lo':sen} och {bo'DaghHom lo':sen}. [AUT
       <column name="notes_pt">Isso é usado para remover alimentos do {'un:n}.
 
 Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään ruoan poistamiseen {'un:n}: stä.
+
+Tätä sanaa käytetään sanastoissa {bo'Dagh'a' lo':sen} ja {bo'DaghHom lo':sen}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9041,6 +9991,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9048,6 +9999,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9061,6 +10013,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="definition_ru">преувеличивать, утрировать</column>
       <column name="definition_zh_HK">誇大、作大</column>
       <column name="definition_pt">exagerar</column>
+      <column name="definition_fi">liioitella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'DaghHom lo':sen}, {lach:v}</column>
@@ -9071,6 +10024,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="notes_ru">Это выражение имеет негативное сопутствующее значение для преувеличения, когда так делать неуместно.</column>
       <column name="notes_zh_HK">當不適合這樣做時，該表述具有誇大其詞的負面含義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão tem a conotação negativa de exagerar quando é inapropriado fazê-lo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä ilmaisulla on negatiivinen merkitys liioittelusta, kun se ei ole asianmukaista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bo'Dagh:n}, {-'a':n}, {lo':v}</column>
       <column name="examples"></column>
@@ -9080,6 +10034,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9087,6 +10042,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.125:src}</column>
     </table>
     <table name="mem">
@@ -9100,6 +10056,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="definition_ru">Минимизация важности чего-либо</column>
       <column name="definition_zh_HK">低調某事的重要性</column>
       <column name="definition_pt">minimizar a importância de algo</column>
+      <column name="definition_fi">vähätellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Dagh'a' lo':sen}</column>
@@ -9110,6 +10067,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="notes_ru">Это выражение имеет негативное сопутствующее значение для преуменьшения, когда так делать неуместно.</column>
       <column name="notes_zh_HK">這種表達的負面含義是在不合適的情況下將某事物的重要性降至最低。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão tem a conotação negativa de minimizar a importância de algo quando é inapropriado fazer isso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä ilmaisulla on negatiivinen merkitys minimoida jonkin tärkeys, kun se ei ole asianmukaista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{bo'Dagh:n}, {-Hom:n}, {lo':v}</column>
       <column name="examples"></column>
@@ -9119,6 +10077,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">trivialize, trivialise, minimise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9126,6 +10085,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.125:src}</column>
     </table>
     <table name="mem">
@@ -9139,6 +10099,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="definition_ru">птица, наиболее общее слово для птицеподобного существа</column>
       <column name="definition_zh_HK">鳥、鳥類生物最常用的詞</column>
       <column name="definition_pt">pássaro, a palavra mais geral para uma criatura parecida com um pássaro</column>
+      <column name="definition_fi">lintu, yleisin sana lintumaista olentoa varten</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo:n}, {tel:n}, {neb:n:1}, {pach:n}, {laq:v:1}, {puv:v}, {ngun:v}, {Saq:v}, {tlhot:v}, {wom:v}, {'uq:v}, {yanwo':n}</column>
@@ -9149,6 +10110,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="notes_ru">Типы птиц включают: {borghel:n}, {cha'bIp:n}, {cha'Do':n}, {cha'naS:n}, {cha'par:n}, {cha'qu':n}, {Da'nal:n}, {Da'vI':n}, {jentu':n}, {lIr:n}, {lotlhmoq:n}, {notqa':n}, {parbIng:n}, {qanraD:n}, {qaryoq:n}, {qaryoq'a':n}, {qa'rol:n}, {ramjep:n:2}, {raw':n}, {toQ:n}, {vem'eq:n}, {vIlInHoD:n}, {waqboch:n}, {yatqap:n}, {'apuStoQ:n}, {'uSgheb:n}, [and possibly] {qISa'ruj:n}.</column>
       <column name="notes_zh_HK">鳥的種類包括：{borghel:n}、{cha'bIp:n}、{cha'Do':n}、{cha'naS:n}、{cha'par:n}、{cha'qu':n}、{Da'nal:n}、{Da'vI':n}、{jentu':n}、{lIr:n}、{lotlhmoq:n}、{notqa':n}、{parbIng:n}、{qanraD:n}、{qaryoq:n}、{qaryoq'a':n}、{qa'rol:n}、{ramjep:n:2}、{raw':n}、{toQ:n}、{vem'eq:n}、{vIlInHoD:n}、{waqboch:n}、{yatqap:n}、{'apuStoQ:n}、{'uSgheb:n}以及可能的{qISa'ruj:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Tipos de aves incluem: {borghel:n}, {cha'bIp:n}, {cha'Do':n}, {cha'naS:n}, {cha'par:n}, {cha'qu':n}, {Da'nal:n}, {Da'vI':n}, {jentu':n}, {lIr:n}, {lotlhmoq:n}, {notqa':n}, {parbIng:n}, {qanraD:n}, {qaryoq:n}, {qaryoq'a':n}, {qa'rol:n}, {ramjep:n:2}, {raw':n}, {toQ:n}, {vem'eq:n}, {vIlInHoD:n}, {waqboch:n} , {yatqap:n}, {'apuStoQ:n}, {'uSgheb:n} e possivelmente {qISa'ruj:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tyypit linnut ovat: {borghel:n}, {cha'bIp:n}, {cha'Do':n}, {cha'naS:n}, {cha'par:n}, {cha'qu':n}, {Da'nal:n}, {Da'vI':n}, {jentu':n}, {lIr:n}, {lotlhmoq:n}, {notqa':n}, {parbIng:n}, {qanraD:n}, {qaryoq:n}, {qaryoq'a':n}, {qa'rol:n}, {ramjep:n:2}, {raw':n}, {toQ:n}, {vem'eq:n}, {vIlInHoD:n}, {waqboch:n} , {yatqap:n}, {'apuStoQ:n}, {'uSgheb:n} ja mahdollisesti {qISa'ruj:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Alfred Hitchcock movie "The Birds" takes place in Bodega Bay.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9158,6 +10120,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9165,6 +10128,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -9178,6 +10142,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="definition_ru">Суд</column>
       <column name="definition_zh_HK">法庭</column>
       <column name="definition_pt">corte (justiça)</column>
+      <column name="definition_fi">tuomioistuin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIpDIj:v}, {bo'DIj pa':n}, {bo'DIj qach:n}, {bo'DIj qaD:n}</column>
@@ -9188,6 +10153,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="notes_ru">Это относится к институту суда, судебной организации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指法院機構，司法組織。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à instituição do tribunal, uma organização judicial. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tuomioistuimen instituutioon, oikeusorganisaatioon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9197,6 +10163,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9204,6 +10171,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
         <table name="mem">
@@ -9217,6 +10185,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="definition_ru">судебные доказательства [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">法醫證據</column>
           <column name="definition_pt">evidência forense</column>
+      <column name="definition_fi">rikostekniset todisteet</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nItlh Su'nIm vem:n}</column>
@@ -9227,6 +10196,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="notes_ru">Это буквально означает «судебные доказательства». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這字面意思是“法庭證據”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso literalmente significa "evidência da corte". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "tuomioistuimen todisteita". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{bo'DIj:n}, {nompuq:n}</column>
           <column name="examples"></column>
@@ -9236,6 +10206,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9243,6 +10214,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
         <table name="mem">
@@ -9256,6 +10228,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="definition_ru">зал суда [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">法庭</column>
           <column name="definition_pt">sala de audiências</column>
+      <column name="definition_fi">oikeussali</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9266,6 +10239,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bo'DIj:n}, {pa':n:1}</column>
           <column name="examples"></column>
@@ -9275,6 +10249,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9282,6 +10257,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
         </table>
         <table name="mem">
@@ -9295,6 +10271,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="definition_ru">здание суда [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">法院</column>
           <column name="definition_pt">tribunal</column>
+      <column name="definition_fi">oikeustalo</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9305,6 +10282,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bo'DIj:n}, {qach:n}</column>
           <column name="examples"></column>
@@ -9314,6 +10292,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9321,6 +10300,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
         </table>
         <table name="mem">
@@ -9334,6 +10314,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="definition_ru">судебный процесс [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">訴訟案件</column>
           <column name="definition_pt">ação judicial</column>
+      <column name="definition_fi">oikeusjuttu</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9344,6 +10325,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{bo'DIj}, {qaD:n}</column>
           <column name="examples"></column>
@@ -9353,6 +10335,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9360,6 +10343,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -9373,6 +10357,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="definition_ru">склон (горы) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">山坡、山陂</column>
       <column name="definition_pt">declive (de uma montanha)</column>
+      <column name="definition_fi">(vuoren) rinne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HuD:n:1}, {janbI':n}, {lav:v}</column>
@@ -9383,6 +10368,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A golf course has a "slope rating" which is used to measure its difficulty for "bogey golfers".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9392,6 +10378,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9399,6 +10386,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -9412,6 +10400,7 @@ Esta palavra é usada nos idiomas {bo'Dagh'a' lo':sen} e {bo'DaghHom lo':sen}. [
       <column name="definition_ru">Борет</column>
       <column name="definition_zh_HK">「布拉斯」星</column>
       <column name="definition_pt">Boreth</column>
+      <column name="definition_fi">Boreth</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghochwI':n}, {poH qut:n}</column>
@@ -9443,6 +10432,10 @@ Story of the Promise säger att:
 
 A história da promessa afirma que:
 ▶ {ghIq chalDaq HovDaq SIq qeylIS 'ej jatlh pa' DaqHomvetlh wovDaq HInej.:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Klingonin imperiumissa. Klingonin mytologian mukaan {qeylIS'e' lIjlaHbe'bogh vay':n:name} palaa tänne.
+
+Lupauksen tarinassa todetaan, että:
+▶ {ghIq chalDaq HovDaq SIq qeylIS 'ej jatlh pa' DaqHomvetlh wovDaq HInej.:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9452,6 +10445,7 @@ A história da promessa afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9459,6 +10453,7 @@ A história da promessa afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -9472,6 +10467,7 @@ A história da promessa afirma que:
       <column name="definition_ru">Выдвижной ящик</column>
       <column name="definition_zh_HK">抽屜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gaveta</column>
+      <column name="definition_fi">laatikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DeSwar:n}, {'ut'at:n}</column>
@@ -9482,6 +10478,7 @@ A história da promessa afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Drawer" is slang for "underwear", and "BVD" is a brand of men's underwear.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9491,6 +10488,7 @@ A história da promessa afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9498,6 +10496,7 @@ A história da promessa afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -9511,6 +10510,7 @@ A história da promessa afirma que:
       <column name="definition_ru">Быть ленивым</column>
       <column name="definition_zh_HK">懶</column>
       <column name="definition_pt">ser preguiçoso</column>
+      <column name="definition_fi">olla laiska</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9521,6 +10521,7 @@ A história da promessa afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9530,6 +10531,7 @@ A história da promessa afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9537,6 +10539,7 @@ A história da promessa afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9550,6 +10553,7 @@ A história da promessa afirma que:
       <column name="definition_ru">не быть ни теплым, ни прохладным (температура) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不冷不熱（溫度） [AUTOTRANSLATED]</column>
       <column name="definition_pt">não ser nem quente nem frio (temperatura)</column>
+      <column name="definition_fi">olla neutraalin lämpöinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIr:v}, {Qey':v}, {ghun:v:2}, {tuj:v}, {Hat:n}</column>
@@ -9560,6 +10564,7 @@ A história da promessa afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a combination of {bIr:v} and {tuj:v}.
 
 It was clarified during the Q &amp; A session that the temperature words really are about temperature and not about effect or perception, so that clothing, for example, is not said to be "hot" or "cold" in Klingon.</column>
@@ -9571,6 +10576,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mild, lukewarm</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9578,6 +10584,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -9591,6 +10598,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="definition_ru">монах, монахиня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">修女修女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">monge, freira</column>
+      <column name="definition_fi">munkki, nunna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIn:n}, {ghIn pIn:n}, {maqlegh:n}</column>
@@ -9601,6 +10609,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="notes_ru">Это слово нейтрально в гендерном отношении. Если требуется различие, добавьте {loD:n} или {be':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞不分性別。如果需要區分，請添加{loD:n}或{be':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é neutra em termos de gênero. Se for necessária uma distinção, adicione {loD:n} ou {be':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on sukupuolineutraali. Jos tarvitaan eroa, lisää {loD:n} tai {be':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Monk Boulevard is a major street in Montreal.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9610,6 +10619,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9617,6 +10627,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9630,6 +10641,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="definition_ru">абсорбировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吸收 [AUTOTRANSLATED]</column>
       <column name="definition_pt">absorver</column>
+      <column name="definition_fi">imeä, imeytyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{betgham:n}, {Hal:v}</column>
@@ -9640,6 +10652,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="notes_ru">Это относится к ощущению жидкости, поглощающей полотенце. Он не используется в смысле поглощения информации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指毛巾吸收液體的感覺。它不是在吸收信息的意義上使用的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à sensação de um líquido absorvente de toalha. Não é usado no sentido de absorver informações. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa siihen, että pyyhe absorboi nestettä. Sitä ei käytetä tiedon absorboimisessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Boom"s are used to absorb oil and other substances.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9649,6 +10662,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9656,6 +10670,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -9669,6 +10684,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="definition_ru">выходить, прекращать, оставлять</column>
       <column name="definition_zh_HK">退出、放棄、辭職</column>
       <column name="definition_pt">sair</column>
+      <column name="definition_fi">lopettaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mev:v}, {yev:v}, {qIl:v}, {jegh:v}, {luj:v}</column>
@@ -9679,6 +10695,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A line which was cut from {Star Trek Into Darkness:src} reveals that this can mean to end a relationship: {'ej jIHvo' nIHDI' jIbup:sen@@'ej:conj, jIH:n:1h, -vo':n, nIH:v, -DI':v, jI-:v, bup:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9688,6 +10705,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9695,6 +10713,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9708,6 +10727,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="definition_ru">Угрожать</column>
       <column name="definition_zh_HK">威脅</column>
       <column name="definition_pt">ameaçar</column>
+      <column name="definition_fi">uhata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIj:v}, {lech:v}, {ghIchwIj DabochmoHchugh ghIchlIj qanob.:sen}</column>
@@ -9718,6 +10738,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9728,6 +10749,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9735,6 +10757,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9748,6 +10771,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="definition_ru">Сумка, мешок, кошелек, карман</column>
       <column name="definition_zh_HK">袋、麻袋、小袋、口袋</column>
       <column name="definition_pt">saco, sacola, bolsa, bolso</column>
+      <column name="definition_fi">laukku, säkki, pussi, tasku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qem:v}, {QIq:v}, {vaH:n}</column>
@@ -9758,6 +10782,7 @@ It was clarified during the Q &amp; A session that the temperature words really 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Klingon Dictionary was published by Pocket Books. See also {paq:n:1h}.
 
 The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq DIvI' De' pu'jInmey... 'ach pu'jInmeylIj bIHbe'.:sen:nolink}</column>
@@ -9772,6 +10797,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9779,6 +10805,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2010:src}</column>
     </table>
     <table name="mem">
@@ -9792,6 +10819,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Пятница</column>
       <column name="definition_zh_HK">星期五</column>
       <column name="definition_pt">Sexta-feira</column>
+      <column name="definition_fi">perjantai</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hogh:n}</column>
@@ -9802,6 +10830,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This refers to a line in "Lady Madonna" by The Beatles: "Friday night arrives without a suitcase."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9811,6 +10840,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9818,6 +10848,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -9831,6 +10862,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Куб(геометрическая фигура)</column>
       <column name="definition_zh_HK">立方體</column>
       <column name="definition_pt">cubo (geometria)</column>
+      <column name="definition_fi">kuutio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meyrI':n}, {moQ:n}</column>
@@ -9841,6 +10873,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to "Rubik's Cube". It is, of course, scrambled.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9850,6 +10883,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9857,6 +10891,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -9870,6 +10905,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Икота</column>
       <column name="definition_zh_HK">嗝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">soluço</column>
+      <column name="definition_fi">hikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9880,6 +10916,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9889,6 +10926,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hiccough</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9896,6 +10934,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -9909,6 +10948,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Живот</column>
       <column name="definition_zh_HK">胃</column>
       <column name="definition_pt">estômago</column>
+      <column name="definition_fi">vatsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{luH:n}, {rID:v}</column>
@@ -9919,6 +10959,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru">Это слово относится ко внутреннему органу, коих у Клингонов два (see {bIraqlul:n}). Чтобы сослаться на внешнюю сторону тела, используйте {chor:n:1} вместо этого.</column>
       <column name="notes_zh_HK">這個詞指的是一個內部器官，克林崗人有兩個（見{bIraqlul:n}）。要引用身體的外部中央部分，請改用{chor:n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra se refere a um órgão interno, do qual os klingons têm dois (consulte {bIraqlul:n}). Para se referir à seção externa do corpo, use {chor:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa sisäiseen elimeen, josta klingoneilla on kaksi (katso {bIraqlul:n}). Jos haluat viitata rungon ulkoiseen keskiosaan, käytä sen sijaan {chor:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9928,6 +10969,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9935,6 +10977,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9948,6 +10991,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Произведено естественным путем</column>
       <column name="definition_zh_HK">自然產生的《qud》</column>
       <column name="definition_pt">produzido naturalmente [qud]</column>
+      <column name="definition_fi">luonnollisesti tuotettu [qud]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quD:n}, {'un quD:n}</column>
@@ -9958,6 +11002,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru">{Su'lop:n} скармливают животному и {Suqqa':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{Su'lop:n}以動物為食，{Suqqa':v}為動物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">{Su'lop:n} alimentado a um animal e {Suqqa':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Su'lop:n} syötetään eläimelle ja {Suqqa':v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The K-E side says [kud] instead of [qud].</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9967,6 +11012,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9974,6 +11020,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9987,6 +11034,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Сконцентрироваться на чём-то(ком-то), думать только об</column>
       <column name="definition_zh_HK">注視、專注、只注意</column>
       <column name="definition_pt">concentrar-se, focar-se, pensar apenas em</column>
+      <column name="definition_fi">keskittyä, ajatella vain yhtä asiaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{buSHa':v}</column>
       <column name="see_also">{qIm:v}, {paQ:v}, {Dugh:v}, {'uch:v:2}</column>
@@ -9997,6 +11045,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10010,6 +11059,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10017,6 +11067,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -10030,6 +11081,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
           <column name="definition_ru">Игнорировать</column>
           <column name="definition_zh_HK">忽視</column>
           <column name="definition_pt">ignorar</column>
+      <column name="definition_fi">jättää huomiotta</column>
           <column name="synonyms"></column>
           <column name="antonyms">{buS:v}</column>
           <column name="see_also"></column>
@@ -10040,6 +11092,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{buS:v}, {-Ha':v}</column>
           <column name="examples">
@@ -10050,6 +11103,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10057,6 +11111,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
     <table name="mem">
@@ -10070,6 +11125,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">мысль, понятие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">思想，觀念 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pensamento, noção</column>
+      <column name="definition_fi">ajatus, käsitys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qub:v}</column>
@@ -10080,6 +11136,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru">Это относится к индивидуальной мысли, чему-то, о чем думают или о чем-то, о чем-то задуманном, о ментальном объекте или конструкции. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是個人的思想，關於某事的思想，關於某事的思想，構想的事物或構想。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um pensamento individual, algo pensado ou sobre, algo concebido, um objeto ou construção mental. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa yksilön ajatukseen, johonkin ajateltuun tai siitä käsitellyyn, johonkin ajateltuun, henkiseen esineeseen tai rakenteeseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confirmed at {qep'a' 27 (2020):src} during the Q &amp; A session.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10089,6 +11146,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10096,6 +11154,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -10109,6 +11168,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Быть натуральным, быть естественным</column>
       <column name="definition_zh_HK">自然</column>
       <column name="definition_pt">seja natural</column>
+      <column name="definition_fi">ole luonnollinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pargh:v}</column>
       <column name="see_also">{ngar:v}, {'umber:n}</column>
@@ -10119,6 +11179,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Butter", as opposed to margarine.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10128,6 +11189,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10135,6 +11197,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Si Vis Pacem, Para Bellum:src}</column>
     </table>
     <table name="mem">
@@ -10148,6 +11211,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">плутоний [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">钚</column>
       <column name="definition_pt">plutônio</column>
+      <column name="definition_fi">plutonium</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boq:n:2}, {tamler:n}, {woj:n}, {tlhuD:v}</column>
@@ -10158,6 +11222,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru">Это радиоактивный химический элемент с символом Pu и атомным номером 94. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是放射性化學元素，符號為Pu，原子序數為94。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o elemento químico radioativo com o símbolo Pu e o número atômico 94. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on radioaktiivinen kemiallinen alkuaine, jolla on symboli Pu ja atominumero 94. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10167,6 +11232,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10174,6 +11240,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -10187,6 +11254,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Грязь под ногтями</column>
       <column name="definition_zh_HK">指甲下的污垢</column>
       <column name="definition_pt">sujeira sob as unhas</column>
+      <column name="definition_fi">lika kynsien alla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlhpach:n:1}, {butlh:n:2}</column>
@@ -10197,6 +11265,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10207,6 +11276,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10214,6 +11284,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10227,6 +11298,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Качество, что очень похоже на то, что люди называют "желчь"</column>
       <column name="definition_zh_HK">質量類似於人類所謂的“膽” [AUTOTRANSLATED]</column>
       <column name="definition_pt">qualidade semelhante à que os humanos chamam de "fel"</column>
+      <column name="definition_fi">julkeus, röyhkeys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{butlh:n:1}</column>
@@ -10237,6 +11309,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru">Это замечательная черта. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是令人欽佩的特質。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma característica admirável de se ter. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ihailtava piirre. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10246,6 +11319,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10253,6 +11327,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -10266,6 +11341,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Восхищайся человеком, с грязью под ногтями.</column>
       <column name="definition_zh_HK">在他的指甲下面塗抹污垢的人。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Admire a pessoa com sujeira nas unhas.</column>
+      <column name="definition_fi">Ihailla henkilöä, jolla on likaa kynsiensä alla.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{butlh:n:1}, {butlh:n:2}</column>
@@ -10276,6 +11352,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10285,6 +11362,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10292,6 +11370,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.142:src}</column>
     </table>
     <table name="mem">
@@ -10305,6 +11384,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="definition_ru">Классификация</column>
       <column name="definition_zh_HK">分類</column>
       <column name="definition_pt">classificação</column>
+      <column name="definition_fi">luokittelu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Segh:n}, {mut:n}, {tetlh:n}, {HIDjolev:n}, {mem:n}, {buv:v}</column>
@@ -10329,6 +11409,9 @@ Detta kan hänvisa till en "kategori" (dvs en relaterad grupp) av {DuH:n} i en {
       <column name="notes_pt">Consulte {Hung buv rav:n} para obter um exemplo de como falar sobre informações classificadas.
 
 Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n} em uma {SeHlaw:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {Hung buv rav:n}-esimerkki siitä, miten puhutaan turvaluokitellusta tiedosta.
+
+Tämä voi viitata {DuH:n}: n "luokkaan" (eli siihen liittyvään ryhmään) {SeHlaw:n}: ssa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10339,6 +11422,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">category</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10346,6 +11430,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.17:src}, [3] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -10359,6 +11444,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="definition_ru">Классифицировать</column>
       <column name="definition_zh_HK">分門別類</column>
       <column name="definition_pt">classificar</column>
+      <column name="definition_fi">luokitella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gher:v}, {buv:n}</column>
@@ -10369,6 +11455,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="notes_ru">Для засекреченной информации смотрите {pegh:v:2}. Смотрите также {rav:n:2} для примера того, как говорить о классифицированной информации.</column>
       <column name="notes_zh_HK">有關“機密信息”的“分類”含義，請參閱{pegh:v:2}。另請參閱{rav:n:2}，以獲取有關如何談論機密信息的示例。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para o sentido "informações secretas" de "classificados", consulte {pegh:v:2}. Consulte também {rav:n:2} para obter um exemplo de como falar sobre informações classificadas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso "salaisen tiedon" käsite "luokiteltu", katso {pegh:v:2}. Katso myös {rav:n:2}-esimerkki siitä, miten puhutaan turvaluokitellusta tiedosta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10378,6 +11465,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10385,6 +11473,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10398,6 +11487,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="definition_ru">Быть наполненным, быть заполненным</column>
       <column name="definition_zh_HK">滿、充滿</column>
       <column name="definition_pt">estar cheio, estar recheado</column>
+      <column name="definition_fi">olla täynnä, täysi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chIm:v}</column>
       <column name="see_also">{teb:v}, {loj:v}, {buy' ngop:excl}, {ghoD:v}, {Qoy':v}</column>
@@ -10408,6 +11498,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="notes_ru">Это нельзя использовать, чтобы сказать человек "полон"(т.е., не голоден).[2]</column>
       <column name="notes_zh_HK">這不能用來說一個人“飽”（即不餓）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não pode ser usado para dizer que uma pessoa está "cheia" (ou seja, sem fome).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä ei voida käyttää sanomaan, että henkilö on "täynnä" (eli ei nälkäinen).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Cantonese Chinese for "cup" (杯).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10417,6 +11508,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10424,6 +11516,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[11] {KGT:src}, [2] {KLI mailing list 1998.05.28:src}</column>
     </table>
     <table name="mem">
@@ -10437,6 +11530,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="definition_ru">Хорошие новости, прекрасно такое слышать</column>
       <column name="definition_zh_HK">好消息、很高興聽到這個消息</column>
       <column name="definition_pt">boas notícias, é bom ouvir isso</column>
+      <column name="definition_fi">hyviä uutisia, onpa hyvä kuulla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{buy':v}, {ngop:n}</column>
@@ -10447,6 +11541,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10456,6 +11551,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10463,6 +11559,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10476,6 +11573,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="definition_ru">Сержант (воинское звание)</column>
       <column name="definition_zh_HK">軍士 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sargento</column>
+      <column name="definition_fi">kersantti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10486,6 +11584,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="notes_ru">Это высший ранг {QaS:n:1h}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{QaS:n:1h}的最高等級。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a classificação mais alta de {QaS:n:1h}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {QaS:n:1h}: n korkein sijoitus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10495,6 +11594,7 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10502,5 +11602,6 @@ Isso pode se referir a uma "categoria" (ou seja, um grupo relacionado) de {DuH:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>

--- a/mem-01-b.xml
+++ b/mem-01-b.xml
@@ -199,7 +199,7 @@ That the target is marked with {-Daq:n:nolink} is known from {SkyBox 14:src} and
       <column name="definition_ru">рабочий диапазон</column>
       <column name="definition_zh_HK">射擊有效範圍</column>
       <column name="definition_pt">alcance efetivo</column>
-      <column name="definition_fi">vaikuttava etäisyys [AUTOTRANSLATED]</column>
+      <column name="definition_fi">(aseen) kantama, kantomatka</column>
       <column name="synonyms">{Qapchu'meH chuq:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -454,7 +454,7 @@ Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/kWP0lgIYM
       <column name="definition_ru">Пусковое устройство, пусковая установка</column>
       <column name="definition_zh_HK">發射器、火箭筒</column>
       <column name="definition_pt">lançador</column>
-      <column name="definition_fi">sinko</column>
+      <column name="definition_fi">raketinheitin, sinko</column>
       <column name="synonyms">{tal:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>

--- a/mem-02-ch.xml
+++ b/mem-02-ch.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {ch:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{ch:sen:nolink}</column>
       <column name="definition_pt">a consoante {ch:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {ch:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">Торпеды</column>
       <column name="definition_zh_HK">魚雷（眾數）</column>
       <column name="definition_pt">torpedos</column>
+      <column name="definition_fi">torpedot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuS:v:1}, {baH:v}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word or a homophone appears to be a component of {lolSeHcha:n} and {'eDSeHcha:n}, which suggests that perhaps {cha:n:nolink} can mean "rockets" in some contexts, or used to in the past.</column>
       <column name="components">{peng:n:inhps}</column>
       <column name="examples">
@@ -68,6 +74,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">missiles</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -75,6 +82,7 @@
       <column name="search_tags_ru">ракеты, торпеды</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek I:src}</column>
     </table>
     <table name="mem">
@@ -88,6 +96,7 @@
       <column name="definition_ru">Приготовить торпеды!</column>
       <column name="definition_zh_HK">魚雷待命！</column>
       <column name="definition_pt">Aguarde torpedos!</column>
+      <column name="definition_fi">Odota torpedojen kanssa!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qara'DI' cha yIbaH!:sen}</column>
@@ -98,6 +107,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{cha:n}, {yI-:v}, {ghuS:v:1}</column>
       <column name="examples"></column>
@@ -107,6 +117,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -114,6 +125,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek I:src}</column>
     </table>
     <table name="mem">
@@ -127,6 +139,7 @@
       <column name="definition_ru">пирог, фруктовое пирожное, торт, клецка</column>
       <column name="definition_zh_HK">餡餅、餡餅、餃子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">torta, bolo, bolinho de massa</column>
+      <column name="definition_fi">piirakka, torttu, myky?, pasteija?, patee?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chab:n:2}, {chabHom:n}</column>
@@ -137,6 +150,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -146,6 +160,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -153,6 +168,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -166,6 +182,7 @@
       <column name="definition_ru">Изобретение, инновация</column>
       <column name="definition_zh_HK">發明、創新</column>
       <column name="definition_pt">invenção, inovação</column>
+      <column name="definition_fi">keksintö, innovaatio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chab chu':n}</column>
@@ -176,6 +193,7 @@
       <column name="notes_ru">Этот сленговый термин происходит от подобного в {Qotmagh Sep:n} диалект от {chab:n:1} к {cham:n}.</column>
       <column name="notes_zh_HK">這個語是源於{chab:n:1}的{Qotmagh Sep:n}方言與{cham:n}的相似性。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo de gíria deriva da semelhança no dialeto {Qotmagh Sep:n} de {chab:n:1} para {cham:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä slangitermi johtuu {chab:n:1}: n {Qotmagh Sep:n}-murteen samankaltaisuudesta {cham:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -185,6 +203,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -192,6 +211,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -205,6 +225,7 @@
       <column name="definition_ru">Новое изобретение, последняя инновация</column>
       <column name="definition_zh_HK">新發明、最新創新</column>
       <column name="definition_pt">nova invenção, mais recente inovação</column>
+      <column name="definition_fi">uusi keksintö, viimeisin innovaatio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chab:n:2}</column>
@@ -215,6 +236,7 @@
       <column name="notes_ru">Это дословно означает "новый пирог". Этот сленговый термин происходит от подобного в {Qotmagh Sep:n} диалект от {chab:n:1} к {cham:n}.</column>
       <column name="notes_zh_HK">這字面意思是“新派”。這個語是源於{chab:n:1}的{Qotmagh Sep:n}方言與{cham:n}的相似性。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "nova torta". Este termo de gíria deriva da semelhança no dialeto {Qotmagh Sep:n} de {chab:n:1} para {cham:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "uutta piirakkaa". Tämä slangitermi johtuu {chab:n:1}: n {Qotmagh Sep:n}-murteen samankaltaisuudesta {cham:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chab:n:2,slang}, {chu':v:1,i}</column>
       <column name="examples"></column>
@@ -224,6 +246,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -231,6 +254,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -244,6 +268,7 @@
       <column name="definition_ru">что-то желаемое или запрошенное</column>
       <column name="definition_zh_HK">心願（期望或要求的東西）</column>
       <column name="definition_pt">algo desejado ou solicitado</column>
+      <column name="definition_fi">toivomus, pyyntö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIn:v}, {chabal tetlh:n}</column>
@@ -254,6 +279,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The expression "pie ({chab:n:1}) in the sky ({chal:n})" refers to something that one hopes for but is unlikely to happen.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -263,6 +289,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">wish, desideratum</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -270,6 +297,7 @@
       <column name="search_tags_ru">желание, что-либо желаемое</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -283,6 +311,7 @@
       <column name="definition_ru">Список желаний</column>
       <column name="definition_zh_HK">心願單</column>
       <column name="definition_pt">Lista de Desejos</column>
+      <column name="definition_fi">toivomuslista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -293,6 +322,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chabal:n}, {tetlh:n}</column>
       <column name="examples"></column>
@@ -302,6 +332,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -309,6 +340,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -322,6 +354,7 @@
       <column name="definition_ru">Печенье</column>
       <column name="definition_zh_HK">餅乾</column>
       <column name="definition_pt">biscoito, bolacha</column>
+      <column name="definition_fi">keksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIQyIn:n}</column>
@@ -332,6 +365,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chab:n:1}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -341,6 +375,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -348,6 +383,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -362,6 +398,7 @@
       <column name="definition_ru">крайняя необходимость, помощник, подкрепление</column>
       <column name="definition_zh_HK">緊急、輔助、備份 [AUTOTRANSLATED]</column>
       <column name="definition_pt">emergência, auxiliar, backup</column>
+      <column name="definition_fi">hätätilanne, hätä-, apu-, vara-</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pav:v}</column>
@@ -372,6 +409,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was originally defined as "emergency" in {TKD:src}, and its meaning was then expanded to include "auxiliary, backup" in a vocabulary list first published in {veS QonoS:src} then reprinted in {HQ 1.3, Sept. 1992:src}. Note that a noun-noun construction containing {chach:n:nolink} might have a different meaning depending on whether {chach:n:nolink} is the first or second noun in the compound.</column>
       <column name="components"></column>
       <column name="examples">
@@ -383,6 +421,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -390,6 +429,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 1.3, Sept. 1992:src}</column>
     </table>
     <table name="mem">
@@ -403,6 +443,7 @@
       <column name="definition_ru">скорая помощь, спасательный транспорт</column>
       <column name="definition_zh_HK">救護車、急救車</column>
       <column name="definition_pt">ambulância, veículo de emergência</column>
+      <column name="definition_fi">ambulanssi, hälytysajoneuvo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -413,6 +454,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chach:n}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -422,6 +464,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -429,6 +472,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -442,6 +486,7 @@
       <column name="definition_ru">радио частота, Герц(единица измерения)</column>
       <column name="definition_zh_HK">射頻、赫茲（頻率） [AUTOTRANSLATED]</column>
       <column name="definition_pt">radiofrequência, Hertz (frequência)</column>
+      <column name="definition_fi">radiotaajuus, hertsi (taajuus)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lup:n}</column>
       <column name="see_also">{Se':n}, {rI'Se':n}, {wab HevwI':n}, {HoS:n:2}</column>
@@ -452,6 +497,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -461,6 +507,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Hz, frequency</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -468,6 +515,7 @@
       <column name="search_tags_ru">Гц, частота</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 1.3, Sept. 1992:src}</column>
     </table>
     <table name="mem">
@@ -481,6 +529,7 @@
       <column name="definition_ru">Бросать</column>
       <column name="definition_zh_HK">下降 [AUTOTRANSLATED]</column>
       <column name="definition_pt">soltar</column>
+      <column name="definition_fi">pudottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{woH:v}, {roQ:v}</column>
@@ -491,6 +540,7 @@
       <column name="notes_ru">Этот глагол подразумевает, что субъект держит объект, а затем (случайно или намеренно) позволяет ему упасть. Если кошка сбивает стекло со стола, вместо этого правильным глаголом будет {pummoH:v@@pum:v:2, -moH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個動詞意味著主體握住了物體，然後（偶然地或故意地）讓其掉落。如果貓將玻璃杯從桌子上摔下來，則使用的正確動詞應是{pummoH:v@@pum:v:2, -moH:v}。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse verbo implica que o sujeito está segurando o objeto e, em seguida (acidentalmente ou de propósito), deixa-o cair. Se um gato bate um copo em uma mesa, o verbo apropriado a ser usado será {pummoH:v@@pum:v:2, -moH:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi implikoi, että subjekti pitää objektia kädessään ja sitten (vahingossa tai tahallaan) pudottaa sen. Jos kissa kaataa lasin pöydällä ja se putoaa maahan, verbi {pummoH:v@@pum:v:2, -moH:v} on sopivampi.[2]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -506,6 +556,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -513,6 +564,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2018:src}, [3] {paq'batlh p.78-79:src}</column>
     </table>
     <table name="mem">
@@ -526,6 +578,7 @@
       <column name="definition_ru">Они, им (допустимо к использованию в языке)</column>
       <column name="definition_zh_HK">他們、她們</column>
       <column name="definition_pt">eles, elas (capazes de usar a linguagem)</column>
+      <column name="definition_fi">he</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIH:n}, {-chaj:n}</column>
@@ -554,6 +607,25 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on monikko {ghaH:n:pro}.
+
+Verbien etuliitteet, kun aihe {chaH:n:nolink} on:
+▶ {chaH:n:nolink}: {pagh:n:1h} = {0:v:pref}
+▶ {chaH:n:nolink}: {jIH:n:1h} = {mu-:v:pref}
+▶ {chaH:n:nolink}: {maH:n:1h} = {nu-:v:pref}
+▶ {chaH:n:nolink}: {SoH:n} = {nI-:v:pref}
+▶ {chaH:n:nolink}: {tlhIH:n} = {lI-:v:pref}
+▶ {chaH:n:nolink}: {ghaH:n} / {'oH:n} = {lu-:v:pref}
+▶ {chaH:n:nolink}: {chaH:n:nolink} / {bIH:n} = {0:v:pref}
+
+Verbien etuliitteet, kun {chaH:n:nolink} on objekti:
+▶ {jIH:n:1h}: {chaH:n:nolink} = {vI-:v:pref}
+▶ {maH:n:1h}: {chaH:n:nolink} = {DI-:v:pref}
+▶ {SoH:n}: {chaH:n:nolink} = {Da-:v:pref}
+▶ {tlhIH:n}: {chaH:n:nolink} = {bo-:v:pref}
+▶ {ghaH:n} / {'oH:n} / {chaH:n:nolink} / {bIH:n}: {chaH:n:nolink} = {0:v:pref}
+
+Pakollinen verbin etuliite, kun kohde on {chaH:n:nolink}, on {tI-:v:pref}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -563,6 +635,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -570,6 +643,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -583,6 +657,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">близкая подруга женского пола [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一位女性的親密女性朋友 [AUTOTRANSLATED]</column>
       <column name="definition_pt">amiga íntima de uma mulher</column>
+      <column name="definition_fi">ystävätär (naisen naispuolinen ystävä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maqoch:n}, {jup:n}, {ruS:n}</column>
@@ -593,6 +668,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Женщина, являющаяся близким другом женщины</column>
       <column name="notes_zh_HK">一個女性使用這個詞來稱呼另一個是密友的女性。在其他情況下使用此詞可能會被視為侮辱性或冒犯性的。克林崗人的母親稱呼女兒為{chaj:n:nolink}並不少見，但反之亦然。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada por uma mulher para se dirigir a outra mulher que é uma amiga íntima. O uso dessa palavra em outros contextos pode ser considerado ofensivo ou ofensivo. Não é incomum uma mãe klingon se dirigir à filha como {chaj:n:nolink}, mas não o contrário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksi nainen käyttää tätä sanaa puhuessaan toiselle naiselle, joka on läheinen ystävä. Tämän sanan käyttöä muissa yhteyksissä voidaan pitää loukkaavana tai loukkaavana. Ei ole harvinaista, että klingonilainen äiti kääntyy tyttärensä puoleen {chaj:n:nolink}, mutta ei päinvastoin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -602,6 +678,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">buddy, bff</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -609,6 +686,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru">приятель</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -622,6 +700,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">небо</column>
       <column name="definition_zh_HK">天空</column>
       <column name="definition_pt">céu</column>
+      <column name="definition_fi">taivas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eng:n}, {muD:n:0}, {yav:n}</column>
@@ -632,6 +711,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In the novel {Sarek:src}, {chal:n:nolink} is also the name of a type of flower.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -641,6 +721,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -648,6 +729,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -661,6 +743,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Дождь</column>
       <column name="definition_zh_HK">雨</column>
       <column name="definition_pt">chuva</column>
+      <column name="definition_fi">sade</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIS:v}</column>
@@ -671,6 +754,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Это может быть использовано, к примеру, чтобы сослаться на лужу на земле и это было необходимо, чтобы пояснить, что лужа появилась из-за дождя. Тем не менее вода будет просто {bIQ:n} (возможно с каким-то модификатором).</column>
       <column name="notes_zh_HK">例如，將其用於指代地面上的水坑，必須弄清楚該水坑是由雨引起的。否則，水就只能是{bIQ:n}（也許帶有某些修飾劑或其他）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso seria usado, por exemplo, para se referir a uma poça no chão e era necessário deixar claro que a poça resultou da chuva. Caso contrário, a água seria apenas {bIQ:n} (talvez com algum modificador ou outro). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytettäisiin esimerkiksi viittaamaan lätäkköön maassa, ja oli välttämätöntä olla selvää, että lätäkkö johtui sateesta. Muuten vesi olisi vain {bIQ:n} (ehkä jollakin muokkaimella tai muulla). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chal:n}, {bIQ:n}</column>
       <column name="examples"></column>
@@ -680,6 +764,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rainwater</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -687,6 +772,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -700,6 +786,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Снег</column>
       <column name="definition_zh_HK">雪</column>
       <column name="definition_pt">neve</column>
+      <column name="definition_fi">lumi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peD:v}</column>
@@ -710,6 +797,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chal:n}, {chuch:n}</column>
       <column name="examples"></column>
@@ -719,6 +807,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -726,6 +815,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -739,6 +829,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Башня</column>
       <column name="definition_zh_HK">塔</column>
       <column name="definition_pt">torre</column>
+      <column name="definition_fi">torni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -749,6 +840,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chal:n}, {qach:n}</column>
       <column name="examples">
@@ -760,6 +852,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
 ▶ {chalqach rachlu'ta'bogh:n:nolink} "укрепленная башня"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">skyscraper, building</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -767,6 +860,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru">небоскреб, здание</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 17 (2010):src}, [2] {paq'batlh p.159:src}</column>
     </table>
     <table name="mem">
@@ -780,6 +874,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Чалток IV</column>
       <column name="definition_zh_HK">Chaltok IV [AUTOTRANSLATED]</column>
       <column name="definition_pt">Chaltok IV</column>
+      <column name="definition_fi">Chaltok IV</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -790,6 +885,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Планета в составе Ромуланской звёздной империи.</column>
       <column name="notes_zh_HK">羅慕蘭星空帝國中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta no Império Estelar Romulano. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Romulan-tähtien imperiumissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The fact that the name of this planet appears to be "inhabited sky" in Klingon (see {chal:n}, {toq:v}) seems to be a coincidence.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -799,6 +895,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -806,6 +903,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -819,6 +917,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Технология</column>
       <column name="definition_zh_HK">技術</column>
       <column name="definition_pt">tecnologia</column>
+      <column name="definition_fi">teknologia, tekniikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chab:n:2,slang}, {QeD:n}, {Hov leng QeD:n}</column>
@@ -829,6 +928,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Для конкретных частей технологии, в отличие от абстрактной идеи технологии, рассмотрим {luch:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於與抽象技術概念相對的具體技術，請考慮{luch:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para peças de tecnologia concretas, em oposição à idéia abstrata de tecnologia, considere {luch:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Harkitse {luch:n} konkreettisten tekniikkakappaleiden ja tekniikan abstraktin ajatuksen sijaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -838,6 +938,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -845,6 +946,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -859,6 +961,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Техник</column>
       <column name="definition_zh_HK">技術員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">técnico</column>
+      <column name="definition_fi">teknikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -869,6 +972,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{cham:v:hyp,nolink}, {-wI':v}</column>
       <column name="examples"></column>
@@ -878,6 +982,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -885,6 +990,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -898,6 +1004,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">область на восток, область на восток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">東面、東方</column>
       <column name="definition_pt">leste, área para leste</column>
+      <column name="definition_fi">itä, alue idässä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurgh:n}, {'ev:n}, {tIng:n}, {SInan:n}</column>
@@ -908,6 +1015,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Это в направлении восхода солнца.[1] На терранском компасе это 90 градусов, если север равен 0 и градусы отсчитываются по часовой стрелке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是朝日出的方向。[1]如果north為0，並且順時針計數角度，則在Terran羅盤上為90度。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso está na direção do nascer do sol.[1] É 90 graus em uma bússola terráquea, se o norte for 0 e os graus forem contados no sentido horário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on auringonnousun suuntaan.[1] Terran-kompassilla on 90 astetta, jos pohjoinen on 0 ja astetta lasketaan myötäpäivään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">China is in the east (from the perspective of Europe or America).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -917,6 +1025,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -924,6 +1033,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.21:src} (reprinted in {HQ 8.4, p.6, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -937,6 +1047,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">маринад [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">醃泡汁 [AUTOTRANSLATED]</column>
       <column name="definition_pt">marinado</column>
+      <column name="definition_fi">marinadi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaH:v:2}, {Se'tu':n}</column>
@@ -947,6 +1058,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Это хранится в большом {bal:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">將其保存在大的{bal:n}中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é mantido em um grande {bal:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä pidetään suuressa {bal:n}-tiedostossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{nach:n} is "head", and {qoD:sen:nolink} sounds like "cold".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -956,6 +1068,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -963,6 +1076,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -977,6 +1091,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">густой маринад [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">番茄醬</column>
       <column name="definition_pt">marinada grossa</column>
+      <column name="definition_fi">paksu marinadi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -987,6 +1102,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Это региональное слово для {qettlhup:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{qettlhup:n}的區域詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra regional para {qettlhup:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on alueellinen sana sanalle {qettlhup:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This parallels the fact that there are some regions in the English-speaking world where "ketchup" is called "catsup".</column>
       <column name="components">{chanDoq:n}, {jeD:v}</column>
       <column name="examples"></column>
@@ -996,6 +1112,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">catsup</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1003,6 +1120,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1016,6 +1134,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">быть желатиновым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">膠狀、膠質</column>
       <column name="definition_pt">ser gelatinoso</column>
+      <column name="definition_fi">olla hyytelömäinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1026,6 +1145,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Possibly a reference to the gelatinous substance found by the Chang'e 4 lunar mission.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1035,6 +1155,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">jelly</column>
       <column name="search_tags_de">glibberig</column>
       <column name="search_tags_fa"></column>
@@ -1042,6 +1163,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1055,6 +1177,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">пара [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一對</column>
       <column name="definition_pt">par</column>
+      <column name="definition_fi">pari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1065,6 +1188,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Chang and Eng Bunker were a famous pair of Siamese twins.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1076,6 +1200,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Zwilling</column>
       <column name="search_tags_fa"></column>
@@ -1083,6 +1208,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1096,6 +1222,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Задняя сторона (руки)</column>
       <column name="definition_zh_HK">手背</column>
       <column name="definition_pt">costas (da mão)</column>
+      <column name="definition_fi">kädenselkä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghop:n}, {toch:n}, {mov:n}</column>
@@ -1106,6 +1233,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Удар кого-либо тыльной стороной руки означает вызов вызова на смертельный поединок (см. {Hay':v} и {Hay'chu':v}). Чтобы ударить кого-то по какой-либо другой причине, например, от удовольствия, используйте кулак ({ro':n}) .[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">用手背擊打某人意味著向死亡決鬥發起挑戰（請參閱{Hay':v}和{Hay'chu':v}）。要以某些其他原因（例如娛樂）擊中某人，請使用拳頭（{ro':n}）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Bater em alguém com as costas da mão significa desafiar um duelo até a morte (veja {Hay':v} e {Hay'chu':v}). Para bater em alguém por algum outro motivo, como diversão, use o punho ({ro':n}).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jonkun lyöminen käden takaosaan tarkoittaa haastetta kaksintaisteluun kuolemaan asti (katso {Hay':v} ja {Hay'chu':v}). Jos haluat lyödä jotakuta muusta syystä, kuten nautinnosta, käytä nyrkkiä ({ro':n}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's quite common for the backs of one's hands to become "chap"ped.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1115,6 +1243,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1122,6 +1251,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.69:src}</column>
     </table>
     <table name="mem">
@@ -1135,6 +1265,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Возможно</column>
       <column name="definition_zh_HK">或者、也許</column>
       <column name="definition_pt">possivelmente</column>
+      <column name="definition_fi">kenties, ehkä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghaytan:adv}, {ghaytanHa':adv}</column>
@@ -1145,6 +1276,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1154,6 +1286,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">maybe</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1161,6 +1294,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1174,6 +1308,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">тянуть вверх с конца батлета</column>
       <column name="definition_zh_HK">隨著蝙蝠的結束向上推 [AUTOTRANSLATED]</column>
       <column name="definition_pt">empurrado para cima com o fim do bat'leth</column>
+      <column name="definition_fi">iskeä bat'lethin päällä ylöspäin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qach:v}</column>
       <column name="see_also">{betleH:n}, {jop:v:1}, {way':v}, {ngol:v}, {lev:v}, {DIj:v:1}, {jIrmoH:v:1}, {baQ:v:1}</column>
@@ -1184,6 +1319,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1193,6 +1329,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1200,6 +1337,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1213,6 +1351,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">быть слизистым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">粘糊糊的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser viscoso</column>
+      <column name="definition_fi">olla limainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HuH:n}, {yIQ:v}, {Hum:v}, {QaD:v:1}</column>
@@ -1223,6 +1362,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1232,6 +1372,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1239,6 +1380,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1252,6 +1394,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Завоевывать, завоевать</column>
       <column name="definition_zh_HK">征服、勝利</column>
       <column name="definition_pt">conquistar</column>
+      <column name="definition_fi">valloittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jey:v}, {yay:n:2}</column>
@@ -1262,6 +1405,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
         <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
         <column name="hidden_notes">There have been a number of conquerors named Charles. Also, "Charge!" is a common battle cry.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1276,6 +1420,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1283,6 +1428,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1296,6 +1442,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Истина победит. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">真理將征服。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A verdade vencerá.</column>
+      <column name="definition_fi">Totuus voittaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1306,6 +1453,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/8Rg12lJheMc} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/8Rg12lJheMc} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/8Rg12lJheMc} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/8Rg12lJheMc} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1315,6 +1463,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1322,6 +1471,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -1335,6 +1485,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">победитель, победитель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勝利者、征服者</column>
       <column name="definition_pt">vencedor, conquistador</column>
+      <column name="definition_fi">voittaja, valloittaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1345,6 +1496,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chargh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1354,6 +1506,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1361,6 +1514,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1374,6 +1528,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">верх трости или церемониальная трость [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手杖或禮儀手杖的頂部 [AUTOTRANSLATED]</column>
       <column name="definition_pt">topo da bengala ou cana cerimonial</column>
+      <column name="definition_fi">kepin tai sauvan yläosa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQ:n:1}</column>
@@ -1384,6 +1539,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1393,6 +1549,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1400,6 +1557,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1413,6 +1571,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">суп (густой) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">湯（厚） [AUTOTRANSLATED]</column>
       <column name="definition_pt">sopa (grossa)</column>
+      <column name="definition_fi">keitto (paksu)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ep:v:1}, {tlhIq:n}, {Qev:v}, {chatlh:n:2}</column>
@@ -1423,6 +1582,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru">Это содержит меньше жидкости, чем найдено в том, что терран может идентифицировать как суп. Его подают в {maHpIn:n}, а едят в {Duq:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它所含的液體少於人族可能識別為湯的液體。將其放在{maHpIn:n}中食用，然後在{Duq:n}中食用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso contém menos líquido do que o encontrado no que um terráqueo pode identificar como sopa. É servido em um {maHpIn:n} e consumido em um {Duq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sisältää vähemmän nestettä kuin mitä Terran saattaa tunnistaa keitoksi. Se tarjoillaan {maHpIn:n}-muodossa ja syödään {Duq:n}-muodossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The fact that this is eaten in a {Duq:n:nolink} may be a reference to the Marx Brothers film "Duck Soup".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1432,6 +1592,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">thick</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1439,6 +1600,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1452,6 +1614,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">ерунда, балдердаш [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">廢話、balderdash [AUTOTRANSLATED]</column>
       <column name="definition_pt">sem sentido, absurdo</column>
+      <column name="definition_fi">hölynpöly, puppu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dap:n}, {jat Hol:n}, {laq:v:2}, {laqlaq:n}, {chatlh:n:1}, {chatlh!:excl}</column>
@@ -1462,6 +1625,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The slang meaning may be a reference to the Marx Brothers film "Duck Soup".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1471,6 +1635,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1478,6 +1643,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1491,6 +1657,7 @@ The imperative verb prefix when {chaH:n:nolink} is the object is {tI-:v:pref}.</
       <column name="definition_ru">Это глупо! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">那太蠢了！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Isso é estupido!</column>
+      <column name="definition_fi">Tuo on typerää!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chatlh:n:2}, {QIp:v}</column>
@@ -1536,6 +1703,12 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
 ▶ {vuvpu' SuS neH vay'!:sen:nolink} "Isso é estúpido!", "Alguém queria que o vento o respeitasse"
 ▶ {vogh tIghla' tu'lu':sen:nolink} "há um t'gla em algum lugar"
 ▶ {HIv tIghla'!:sen:nolink} "a / os ataques t'gla" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on huutomerkki, joka on annettu vastauksena lausuntoon, jonka puhuja pitää tyhmänä tai tyhmänä. (Huutomerkki {Dap!:sen:nolink}, jossa käytetään ei-slangia sanaa {Dap:n}, on myös mahdollista, vaikkakin vähemmän todennäköistä.)
+
+Jos puhuja viittaa johonkin tapahtuneeseen, mikä on typerys, mitä on tapahtunut (mutta todella tapahtui, niin että se ei ole järjetön lausunto), {chatlh:sen:nolink}- tai {Dap:sen:nolink}-tiedostoja ei käytetä. Sen sijaan saatetaan kuulla versio idiomaattisista lausekkeista {ghaH vuv SuS neH:sen} tai {Dogh; tIghla' rur:sen@@Dogh:v, tIghla':n, rur:v}:
+▶ {vuvpu' SuS neH vay'!:sen:nolink} "Se on tyhmää!", "Joku halusi tuulen kunnioittavan häntä"
+▶ {vogh tIghla' tu'lu':sen:nolink} "jossain on t'gla"
+▶ {HIv tIghla'!:sen:nolink} "a / t'gla hyökkää" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1545,6 +1718,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1552,6 +1726,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1565,6 +1740,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="definition_ru">достигать, добиваться</column>
       <column name="definition_zh_HK">實現 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alcançar</column>
+      <column name="definition_fi">saavuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ta':v}, {chav:n}, {DIgh:v}</column>
@@ -1575,6 +1751,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1596,6 +1773,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
 ▶ {Hegh neH chav qoH.:sen}</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1603,6 +1781,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1616,6 +1795,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="definition_ru">Достижение</column>
       <column name="definition_zh_HK">成果、成就</column>
       <column name="definition_pt">realização</column>
+      <column name="definition_fi">saavutus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ta':n:1}, {chav:v}</column>
@@ -1626,6 +1806,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1635,6 +1816,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1642,6 +1824,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1655,6 +1838,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="definition_ru">разрешать, позволять, давать разрешение</column>
       <column name="definition_zh_HK">允許、許可</column>
       <column name="definition_pt">autorizar, permitir</column>
+      <column name="definition_fi">sallia</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bot:v}, {tuch:v}</column>
       <column name="see_also">{ghIb:v}, {ruch:v}</column>
@@ -1665,6 +1849,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1676,6 +1861,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
 ▶ {QaghwIj vIQIj 'e' yIchaw'neS.} "Разрешите мне объяснить свою ошибку ваша честь."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1683,6 +1869,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -1696,6 +1883,7 @@ Se o falante estiver se referindo a algo que aconteceu que é uma coisa estúpid
       <column name="definition_ru">Разрешать, давать разрешение</column>
       <column name="definition_zh_HK">許可證</column>
       <column name="definition_pt">permitir</column>
+      <column name="definition_fi">lupa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qoyje':n}</column>
@@ -1720,6 +1908,9 @@ En {chaw':n:nolink} visar att du officiellt eller lagligt har rätt att göra el
       <column name="notes_pt">Esta palavra é usada para uma gama mais ampla de objetos do que a tradução "permitir" sugere. Os tipos de {chaw':n:nolink} incluem {HIjmeH chaw':n}, {Huch chaw':n}, {leng chaw':n}, {lojmIt chaw':n:nolink}, {yer ghajwI' chaw':n} e {'elmeH chaw':n}. Assim, {chaw':n:nolink} também pode significar "passagem", "aprovação" ou "licença".
 
 UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado a fazer, obter ou possuir algo, enquanto um {Qoyje':n} serve como prova ou verificação de algum tipo de realização ou realização.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään laajemmalle objektijoukolle kuin käännös "lupa" ehdottaa. {chaw':n:nolink}-tyypit sisältävät {HIjmeH chaw':n}, {Huch chaw':n}, {leng chaw':n}, {lojmIt chaw':n:nolink}, {yer ghajwI' chaw':n} ja {'elmeH chaw':n}. Täten {chaw':n:nolink} voi tarkoittaa myös "lippua", "passia" tai "lisenssiä".
+
+{chaw':n:nolink} osoittaa, että sinulla on virallisesti tai laillisesti oikeus tehdä, hankkia tai omistaa jotain, kun taas {Qoyje':n} toimii todisteena tai todisteeksi jonkinlaisesta saavutuksesta tai suorituksesta.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the K-E side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1741,6 +1932,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
 ▶ {'elmeH chaw':n}</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ticket, deed, pass, license</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1748,6 +1940,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {PK:src}, [3] {KLI mailing list 2015.05.29:src}</column>
     </table>
     <table name="mem">
@@ -1761,6 +1954,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">пароль</column>
       <column name="definition_zh_HK">密碼</column>
       <column name="definition_pt">senha, código</column>
+      <column name="definition_fi">salasana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pegh:n}, {Durghang:n}</column>
@@ -1771,6 +1965,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chaw':n}, {ngoq:n}</column>
       <column name="examples"></column>
@@ -1780,6 +1975,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1787,6 +1983,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1800,6 +1997,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">пищевод [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食管</column>
       <column name="definition_pt">esôfago</column>
+      <column name="definition_fi">ruokatorvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mong:n}, {Hugh:n}, {ghup:v}</column>
@@ -1810,6 +2008,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1819,6 +2018,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1826,6 +2026,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1839,6 +2040,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">Как? Каким образом?</column>
       <column name="definition_zh_HK">怎麼樣</column>
       <column name="definition_pt">como?</column>
+      <column name="definition_fi">miten?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chay'?:excl}</column>
@@ -1849,6 +2051,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1859,6 +2062,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1866,6 +2070,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.4:src}</column>
     </table>
     <table name="mem">
@@ -1879,6 +2084,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">Как это случилось? Что происходит?</column>
       <column name="definition_zh_HK">這怎麼發生的？這是怎麼回事？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Como isso aconteceu? O que está acontecendo?</column>
+      <column name="definition_fi">Kuinka tämä tapahtui? Mitä tapahtuu?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chay':ques}</column>
@@ -1889,6 +2095,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1898,6 +2105,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1905,6 +2113,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -1918,6 +2127,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">Как мне это использовать? Что я буду с этим делать?</column>
       <column name="definition_zh_HK">我該如何使用它？我該怎麼辦？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Como eu uso isso? O que eu faço com isso?</column>
+      <column name="definition_fi">Kuinka käytän tätä? Mitä teen tämän kanssa?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuqDaq Dochvam vIlan?:sen}</column>
@@ -1928,6 +2138,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chay':ques}, {Doch:n}, {-vam:n}, {vI-:v}, {lo':v}</column>
       <column name="examples"></column>
@@ -1937,6 +2148,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1944,6 +2156,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -1957,6 +2170,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">Каковы ваши заказы? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你有什麼命令？</column>
       <column name="definition_pt">Quais são os seus pedidos?</column>
+      <column name="definition_fi">Mitkä ovat käskysi?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1967,6 +2181,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru">Это буквально означает «Как вы (поете) командуете нами?» [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“您（唱歌）如何命令我們？” [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso literalmente significa "Como você (cantar) nos comanda?" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "Kuinka (laulat) käsket meitä?" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chay':ques}, {ju-:v}, {ra':v:1}</column>
       <column name="examples"></column>
@@ -1976,6 +2191,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1983,6 +2199,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -1996,6 +2213,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">Как произносится это слово? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">這個詞怎麼發音？</column>
       <column name="definition_pt">Como esta palavra é pronunciada?</column>
+      <column name="definition_fi">Kuinka tämä sana lausutaan?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2006,6 +2224,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2015,6 +2234,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2022,6 +2242,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.01.16:src}</column>
     </table>
     <table name="mem">
@@ -2035,6 +2256,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">показывать, отображать (картинку, изображение)</column>
       <column name="definition_zh_HK">顯示、顯示（圖片） [AUTOTRANSLATED]</column>
       <column name="definition_pt">mostrar, exibir (imagem)</column>
+      <column name="definition_fi">näytä (kuva)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaSta:n}, {wIy:n}, {'ang:v}</column>
@@ -2045,6 +2267,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The first ever line of Klingon spoken on-screen was {wIy cha':sen@@wIy:n, cha':v}, in {Star Trek I:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2058,6 +2281,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
 ▶ {tlhIngan Dujmey law'qu' SommeyDaq batlh cha'lu'.@@tlhIngan:n, Duj:n:1, -mey:n, law':v, -qu':v, Som:n, -mey:n, -Daq:n, batlh:adv, cha':v, -lu':v} "[Это] было начертано на обшивках бесчисленных Клингонских кораблей."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">emblazon</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2065,6 +2289,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek I:src}, [3] {SkyBox 1:src}</column>
     </table>
     <table name="mem">
@@ -2078,6 +2303,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">два</column>
       <column name="definition_zh_HK">二</column>
       <column name="definition_pt">dois</column>
+      <column name="definition_fi">kaksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2088,6 +2314,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2097,6 +2324,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2104,6 +2332,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -2117,6 +2346,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="definition_ru">второй [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">第二</column>
           <column name="definition_pt">segundo</column>
+      <column name="definition_fi">toinen</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{cha'DIch:n:2}</column>
@@ -2127,6 +2357,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{cha':n:num}, {-DIch:n:num}</column>
           <column name="examples"></column>
@@ -2136,6 +2367,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">2nd</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2143,6 +2375,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -2156,6 +2389,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="definition_ru">во-вторых, помощник [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">第二、助手 [AUTOTRANSLATED]</column>
           <column name="definition_pt">segundo, assessor</column>
+      <column name="definition_fi">neuvonantaja, puolustaja</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{boQ:n:1}, {cha'DIch:n:1}</column>
@@ -2166,6 +2400,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="notes_ru">Во время некоторых судебных разбирательств обвиняемый должен иметь секунду, чтобы защитить его или ее. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">在一些法律程序中，被告必須有一秒鐘的時間為他或她辯護。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Durante alguns procedimentos legais, o acusado deve ter um segundo para defendê-lo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Joidenkin oikeudenkäyntien aikana syytetyllä on oltava toinen hetki puolustaa häntä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -2175,6 +2410,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2182,6 +2418,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW:src}</column>
         </table>
         <table name="mem">
@@ -2195,6 +2432,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="definition_ru">Позавчера (день перед вчера)</column>
           <column name="definition_zh_HK">前日、前天</column>
           <column name="definition_pt">anteontem</column>
+      <column name="definition_fi">toissa päivä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2205,6 +2443,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{cha':n:num}, {Hu':n}</column>
           <column name="examples"></column>
@@ -2214,6 +2453,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2221,6 +2461,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -2234,6 +2475,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="definition_ru">Послезавтра (день после завтрашнего дня)</column>
           <column name="definition_zh_HK">後日、後天</column>
           <column name="definition_pt">dia depois de Amanhã</column>
+      <column name="definition_fi">ylihuomen</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2244,6 +2486,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{cha':n:num}, {leS:n}</column>
           <column name="examples"></column>
@@ -2253,6 +2496,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2260,6 +2504,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -2273,6 +2518,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="definition_ru">Дважды</column>
           <column name="definition_zh_HK">兩次</column>
           <column name="definition_pt">duas vezes</column>
+      <column name="definition_fi">kahdesti</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2283,6 +2529,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{cha':n:num}, {-logh:n:num,suff}</column>
           <column name="examples"></column>
@@ -2292,6 +2539,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2299,6 +2547,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -2312,6 +2561,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="definition_ru">20 [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">二十</column>
           <column name="definition_pt">vinte</column>
+      <column name="definition_fi">kaksikymmentä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2322,6 +2572,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{cha':n:num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -2331,6 +2582,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2338,6 +2590,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -2351,6 +2604,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">птица, известная своей скоростью [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一隻以速度聞名的鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro conhecido por sua velocidade</column>
+      <column name="definition_fi">eräs nopeudestaan tunnettu lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -2361,6 +2615,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Road Runner says "beep beep".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2370,6 +2625,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2377,6 +2633,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2390,6 +2647,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">вид клингонской птицы, о которой мало что известно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種克林崗鳥、鮮為人知 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma espécie de ave Klingon sobre a qual pouco se sabe</column>
+      <column name="definition_fi">eräs lintulaji (josta tiedetään vähän)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -2400,6 +2658,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "dodo".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2409,6 +2668,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2416,6 +2676,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2429,6 +2690,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">двадцать два ребра [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">二十二個肋骨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vinte e duas costelas</column>
+      <column name="definition_fi">22 kylkiluuta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qagh Sopbe'!:sen}</column>
@@ -2439,6 +2701,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru">У клингонов двадцать три ребра ({joQ:n:1,body}). Это выражение означает, что что-то не совсем правильно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗人有23根肋骨（{joQ:n:1,body}）。這種表述意味著有些不對勁。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os klingons têm vinte e três costelas ({joQ:n:1,body}). Essa expressão significa que algo não está certo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingoneilla on 23 kylkiluuta ({joQ:n:1,body}). Tämä ilmaisu tarkoittaa, että jokin ei ole aivan oikein. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cha'maH:n:num}, {cha':n:num}, {joQ:n:1}, {-Du':n}</column>
       <column name="examples">
@@ -2450,6 +2713,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2457,6 +2721,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.126:src}</column>
     </table>
     <table name="mem">
@@ -2471,6 +2736,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">маленькая птица, копающая в поисках съедобных жуков</column>
       <column name="definition_zh_HK">一隻小鳥挖了蟲子吃 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pequeno pássaro que desenterra insetos para comer</column>
+      <column name="definition_fi">eräs lintulaji (pieni, kaivaa maasta hyönteisiä syödäkseen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -2481,6 +2747,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2490,6 +2757,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2497,6 +2765,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2510,6 +2779,7 @@ UM {chaw':n:nolink} mostra que você está oficialmente ou legalmente autorizado
       <column name="definition_ru">предплечье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">前臂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">antebraço</column>
+      <column name="definition_fi">kyynärvarsi</column>
       <column name="synonyms">{DeS reStav:n@@DeS:n:1, reStav:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{nev'ob:n}, {reStav:n}, {qIv:n}, {DeSqIv:n}, {Do'ghI':n}</column>
@@ -2532,6 +2802,9 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
 
 可以將{DeS cha'neH:n@@DeS:n:1, cha'neH:n}表示為“ forearm”，但這可能僅在有人同時談論前臂和小腿並且需要區分它們的情況下使用。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Yksin käytettynä tämä tarkoittaa "käsivartta", mutta kun sitä edeltää {'uS:n}, se tarkoittaa "jalan alaosaa". (Säären etuosa on {reStav:n}.)
+
+On mahdollista sanoa {DeS cha'neH:n@@DeS:n:1, cha'neH:n} käsivarrelle, mutta tätä todennäköisesti käytettäisiin vain tilanteessa, jossa puhuttiin sekä kyynärvarresta että säärestä ja tarvittiin niiden erottamiseksi.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Pun: "forearms" sounds like "four arms", but there are only two ({cha':n:num}, {neH:adv}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2541,6 +2814,7 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2548,6 +2822,7 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, via {'ISqu':n:name}, [2] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -2561,6 +2836,7 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
       <column name="definition_ru">ритуальные подарки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">儀式禮物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">presentes de rituais</column>
+      <column name="definition_fi">rituaalilahjat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nob:n}</column>
@@ -2571,6 +2847,7 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2580,6 +2857,7 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2587,6 +2865,7 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2600,6 +2879,7 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
       <column name="definition_ru">птица, известная своей песней [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一隻以它的歌而聞名的鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro conhecido por sua música</column>
+      <column name="definition_fi">eräs laulustaan tunnettu lintulaji</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -2610,6 +2890,7 @@ Det är möjligt att säga {DeS cha'neH:n@@DeS:n:1, cha'neH:n} för "underarm", 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to Charlie Parker, an American Jazz musician known by the nickname "Yardbird", or "Bird" for short.
 
 Also, in Spanish, "parpar" is the sound made by a duck.</column>
@@ -2621,6 +2902,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2628,6 +2910,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2641,6 +2924,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">Дилитий</column>
       <column name="definition_zh_HK">二鋰</column>
       <column name="definition_pt">dilítio</column>
+      <column name="definition_fi">dilitium</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dom:n}, {cha'pujqut:n}</column>
@@ -2651,6 +2935,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{cha':n:num}, {puj:n:2,hyp}</column>
       <column name="examples">
@@ -2666,6 +2951,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
 ▶ {yuQ SumDaq cha'puj law' Datu'.:sen@@yuQ:n, Sum:v, -Daq:n, cha'puj:n, law':v, Da-:v, tu':v} "Обнаружено большое количество дилития на ближайшей планете."[4]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2673,6 +2959,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}, [3] {PK:src}, [4] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2686,6 +2973,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">Кристалл дилития</column>
       <column name="definition_zh_HK">二鋰晶體</column>
       <column name="definition_pt">cristal de dilítio</column>
+      <column name="definition_fi">dilitiumkide</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2696,6 +2984,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Неочищенный кристалл дилития называется {Dom:n}.[1]. Кристаллический дилитий используется в качестве замедляющего реакцию элемента ({choH lISbogh Hap'e':n}) в хищной птице клингона.[2] Глагол {chIm:v} используется для осушенного кристалла дилития.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">粗製的二鋰晶體被稱為{Dom:n}.[1]晶體二鋰被用作克林崗猛禽中的反應緩和元素（{choH lISbogh Hap'e':n}）.[2]動詞{chIm:v}用於排水的二鋰晶體.[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O cristal de dilítio bruto é denominado {Dom:n}.[1] O dilítio cristalino é usado como elemento moderador da reação ({choH lISbogh Hap'e':n}) em uma ave de rapina Klingon.[2] O verbo {chIm:v} é usado para um cristal de dilítio drenado.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Raakaa dilitiumkidettä kutsutaan {Dom:n}.[1] Kiteistä dilitiumia käytetään reaktion hillitsevänä elementtinä ({choH lISbogh Hap'e':n}) Klingonin petolinnussa.[2]{chIm:v}[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cha'puj:n}, {qut:n}</column>
       <column name="examples">
@@ -2709,6 +2998,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
 ▶ {cha'pujqutmey chIm lutamlu'.:sen@@cha'pujqut:n, -mey:n, chIm:v, lu-:v, tam:v:2, -lu':v} "Дренированные кристаллы дилития перемещены."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2716,6 +3006,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {BoP:src}, [3] {Klingon Monopoly:src}, [4] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2729,6 +3020,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">дилитиевая камера [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">二鋰室 [AUTOTRANSLATED]</column>
       <column name="definition_pt">câmara de dilítio</column>
+      <column name="definition_fi">dilitiumkammio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2739,6 +3031,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{cha'puj:n}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -2748,6 +3041,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2755,6 +3049,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2768,6 +3063,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">птица с шумным, повторяющимся криком [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一隻吵鬧、重複哭泣的小鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro com um grito barulhento e repetitivo</column>
+      <column name="definition_fi">eräs äänekkäästä kirkumisesta tunnettu lintulaji</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -2778,6 +3074,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "cuckoo", as in a cuckoo clock.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2787,6 +3084,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2794,6 +3092,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2807,6 +3106,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">Двухсотлетний эль</column>
       <column name="definition_zh_HK">二百年老的麥酒</column>
       <column name="definition_pt">cerveja de dois séculos de idade</column>
+      <column name="definition_fi">kaksi vuosisataa vanha olut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2817,6 +3117,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Хотя это не влияет на {romuluS HIq:n}, оно все же впечатляет. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">儘管這沒有{romuluS HIq:n}的影響，但仍然令人印象深刻。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Embora isso não tenha o impacto de {romuluS HIq:n}, ainda é impressionante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikka tällä ei ole {romuluS HIq:n}: n vaikutusta, se on silti vaikuttava. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cha':n:num}, {vatlh:n:num}, {ben:n:2}, {HIq:n}</column>
       <column name="examples"></column>
@@ -2826,6 +3127,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2833,6 +3135,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2846,6 +3149,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">выщипывать пинцетом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鑷子</column>
       <column name="definition_pt">pinça</column>
+      <column name="definition_fi">pinsetti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2856,6 +3160,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Это считается единственным (то есть несколько пар пинцетов - {cha''etlh DaSwI'mey:n@@cha''etlh DaSwI':n, -mey:n}). Слово было сформировано по аналогии с {cha''etlh pe'wI':n} «ножницами», с {DaS:v} «щепоткой», заменяющим {pe':v} «порез». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這被認為是單數的（也就是說，多對鑷子是{cha''etlh DaSwI'mey:n@@cha''etlh DaSwI':n, -mey:n}）。這個詞是通過類似於{cha''etlh pe'wI':n}“ scissors”的形式形成的，用{DaS:v}“ pinch”代替{pe':v}“ cut”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é considerado singular (ou seja, vários pares de pinças são {cha''etlh DaSwI'mey:n@@cha''etlh DaSwI':n, -mey:n}). A palavra foi formada por analogia com {cha''etlh pe'wI':n} "tesoura", com {DaS:v} "pinch" substituindo {pe':v} "cut". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä pidetään yksinäisenä (toisin sanoen useat pinsettiparit ovat {cha''etlh DaSwI'mey:n@@cha''etlh DaSwI':n, -mey:n}). Sana muodostettiin analogisesti {cha''etlh pe'wI':n} "sakset" kanssa {DaS:v} "nipistys" korvaa {pe':v} "leikkaus". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cha':n:num}, {'etlh:n}, {DaS:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2865,6 +3170,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tongs, pincers</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2872,6 +3178,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK">夾剪,眉毛鉗</column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2885,6 +3192,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">ножницы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鉸剪</column>
       <column name="definition_pt">tesouras</column>
+      <column name="definition_fi">sakset</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha''etlh DaSwI':n}</column>
@@ -2895,6 +3203,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Обратите внимание, что это слово в единственном числе, в отличие от английского слова «ножницы». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，該單詞是單數形式，與英語單詞“ scissors”不同。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que essa palavra é singular, diferente da palavra em inglês "tesoura". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä sana on yksikkö, toisin kuin englanninkielinen sana "sakset". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cha':n:num}, {'etlh:n}, {pe':v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2904,6 +3213,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2911,6 +3221,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -2924,6 +3235,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">Мы не согласны. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我們不同意。</column>
       <column name="definition_pt">Nós discordamos.</column>
+      <column name="definition_fi">Olemme eri mieltä.</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wa' DoS wIqIp.:sen}</column>
       <column name="see_also">{Qoch:v}, {Qochbe':v}</column>
@@ -2934,6 +3246,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Это буквально означает «мы поражаем цели». Обратите внимание, что должен использоваться {DoSmey:n:nolink}, а не множественно по своей сути {ray':n}. Эта идиома может быть сокращена до просто {DoSmey DIqIp.:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“我們擊中了目標”。請注意，必須使用{DoSmey:n:nolink}，而不是固有的複數{ray':n}。這個習語可以簡化為{DoSmey DIqIp.:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "atingimos alvos". Observe que {DoSmey:n:nolink} deve ser usado, não o {ray':n} inerentemente plural. Esse idioma pode ser reduzido para apenas {DoSmey DIqIp.:sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "osumme kohteisiin". Huomaa, että on käytettävä {DoSmey:n:nolink}, ei luontaisesti monikon {ray':n}. Tämä sanasto voidaan lyhentää vain {DoSmey DIqIp.:sen:nolink}: ksi [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cha':n}, {DoS:n}, {-mey:n}, {DI-:v}, {qIp:v}</column>
       <column name="examples"></column>
@@ -2943,6 +3256,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2950,6 +3264,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.106:src}</column>
     </table>
     <table name="mem">
@@ -2963,6 +3278,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">два лица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雙面人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">duas caras</column>
+      <column name="definition_fi">kahdet kasvot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hay':v}, {qabDu' law':n}</column>
@@ -2973,6 +3289,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Это идиоматическое выражение означает, что два человека участвуют в одной деятельности, а никто другой - нет. Например, дуэль можно описать словами {Suv cha' qabDu':sen:nolink} «Два человека сражаются», «Два человека сражаются один на один». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語表示兩個人參與一項活動，沒有其他人參與。例如，對決可以通過說{Suv cha' qabDu':sen:nolink}“兩個面孔在戰鬥”，“兩個人一對一戰鬥”來描述。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa que duas pessoas estão envolvidas em uma única atividade e ninguém mais está. Por exemplo, um duelo pode ser descrito dizendo {Suv cha' qabDu':sen:nolink} "Duas caras estão brigando", "Duas pessoas estão brigando uma a uma". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa, että kaksi ihmistä on mukana yhdessä toiminnassa eikä kukaan muu ole. Esimerkiksi kaksintaistelu voidaan kuvata sanomalla {Suv cha' qabDu':sen:nolink} "Kaksi kasvot taistelevat", "Kaksi ihmistä taistelee yksi kerrallaan". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cha':n:num}, {qab:n}, {-Du':n}</column>
       <column name="examples"></column>
@@ -2982,6 +3299,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">one on one, one-on-one, face to face, face-to-face</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2989,6 +3307,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.124:src}</column>
     </table>
     <table name="mem">
@@ -3002,6 +3321,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">Вы(множественное число) (действие)-нам</column>
       <column name="definition_zh_HK">你們：我們</column>
       <column name="definition_pt">vocês (plural) - nós</column>
+      <column name="definition_fi">te-meitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{re-:v:pref}</column>
       <column name="see_also">{ju-:v:pref}, {tu-:v:pref}, {gho-:v:pref}</column>
@@ -3012,6 +3332,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{tlhIH:n}: {maH:n:1h} = {che-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3021,6 +3342,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">you-us</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3028,6 +3350,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru">вы-нам</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3041,6 +3364,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">единица веса, масса (около 5 фунтов или 2,25 кг) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">重量單位、質量（約5磅或2.25千克） [AUTOTRANSLATED]</column>
       <column name="definition_pt">unidade de peso, massa (aprox. 5 lbs ou 2,25 kg)</column>
+      <column name="definition_fi">eräs massan yksikkö (n. 2,25 kg)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngI':v}, {tIS:v}, {'ugh:v}, {cheb'a':n}</column>
@@ -3051,6 +3375,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Since gravity on Kronos is different than that on Earth, it's not really clear what the exact value of this unit is, or whether it measures weight or mass.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3060,6 +3385,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pound, kilogram, mass</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3067,6 +3393,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {msn 1997.10.22:src}</column>
     </table>
     <table name="mem">
@@ -3080,6 +3407,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">единица веса, масса [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">重量單位、質量 [AUTOTRANSLATED]</column>
       <column name="definition_pt">unidade de peso, massa</column>
+      <column name="definition_fi">eräs massan yksikkö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cheb:n}</column>
@@ -3090,6 +3418,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Согласно постеру {BoP:src}, 8,7KT = 375 000 {cheb'a':n:nolink}. Вероятно, что один {cheb'a':n:nolink} равен девяти {cheb:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據{BoP:src}的海報，8.7KT = 37.5萬{cheb'a':n:nolink}。一個{cheb'a':n:nolink}可能等於九個{cheb:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o pôster {BoP:src}, 8,7KT = 375 000 {cheb'a':n:nolink}. É provável que um {cheb'a':n:nolink} seja igual a nove {cheb:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{BoP:src}-julisteen mukaan 8,7 kt = 375 000 {cheb'a':n:nolink}. On todennäköistä, että yksi {cheb'a':n:nolink} on yhtä suuri kuin yhdeksän {cheb:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cheb:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -3099,6 +3428,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3106,6 +3436,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3119,6 +3450,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">быть пьяным, быть одурманенным, страдать от интоксикации</column>
       <column name="definition_zh_HK">醉酒</column>
       <column name="definition_pt">estar bêbado, embriagado</column>
+      <column name="definition_fi">olla humalassa, päihtynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uH:v}, {HIq:n}</column>
@@ -3129,6 +3461,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3138,6 +3471,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3145,6 +3479,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3158,6 +3493,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">Тип ликёра, Чеч'лют</column>
       <column name="definition_zh_HK">《chech'tluth》（酒類型）</column>
       <column name="definition_pt">tipo de licor, chech'tluth</column>
+      <column name="definition_fi">eräs viinilaji, chech'tluth</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIq:n}</column>
@@ -3168,6 +3504,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Алкогольный напиток, который лучше всего подавать нагретым и дымящимся.[1] Это имя составлено из {chech:v} и {tlhutlh:v}.[2]</column>
       <column name="notes_zh_HK">酒精飲料最適合加熱和蒸煮.[1]它的名稱似乎由{chech:v}和{tlhutlh:v}.[2]組成 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma bebida alcoólica melhor servida aquecida e cozida no vapor.[1] Seu nome parece ser composto por {chech:v} e {tlhutlh:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Alkoholijuomaa tarjoillaan parhaiten kuumennettuna ja höyryssä.[1] Sen nimi näyttää koostuvan {chech:v}: sta ja {tlhutlh:v}: sta.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the K-E side, this is given as "baceh'tluth". This is commonly assumed to be a typo, or perhaps a joke.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3177,6 +3514,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3184,6 +3522,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -3197,6 +3536,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="definition_ru">Возвращаться (куда-то)</column>
       <column name="definition_zh_HK">回來</column>
       <column name="definition_pt">voltar (para)</column>
+      <column name="definition_fi">palata jonnekin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jaH:v}, {tatlh'egh:v}</column>
@@ -3207,6 +3547,7 @@ Also, in Spanish, "parpar" is the sound made by a duck.</column>
       <column name="notes_ru">Объектом является место, куда субъект возвращается (если оно не упомянуто, глагол принимает префикс, который не указывает на объект). Если возвращение вынужденное, используйте {tatlh'egh:v} вместо этого.[5]</column>
       <column name="notes_zh_HK">賓語是主語返回的地方（如果未提及，則動詞使用前綴表示沒有賓語）。如果強制退貨，請改用{tatlh'egh:v}。[5] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é o local para o qual o sujeito retorna (se não for mencionado, o verbo usa um prefixo indicando nenhum objeto). Se o retorno for forçado, use {tatlh'egh:v}.[5] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on paikka, johon kohde palaa (jos sitä ei mainita, verbi ottaa etuliitteen, joka ei osoita kohdetta). Jos palautus pakotetaan, käytä sen sijaan {tatlh'egh:v}[5] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3234,6 +3575,7 @@ The following four examples illustrate the role of the object(s) and how to use 
 ▶ {tera'vo' Qo'noS vIchegh.:sen:nolink} "Я возвращаюсь на Кронос с Земли"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3241,6 +3583,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}, [3] {KGT:src}, [4] {Star Trek VI:src}, [5] {KLI mailing list 1999.07.19:src}</column>
     </table>
     <table name="mem">
@@ -3255,6 +3598,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">отступиться, нарушить долг</column>
       <column name="definition_zh_HK">缺陷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">defeito</column>
+      <column name="definition_fi">loikata (vihollismaahan)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choS:v}</column>
@@ -3265,6 +3609,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3276,6 +3621,7 @@ The following four examples illustrate the role of the object(s) and how to use 
 ▶ {wa'leS jIcheH.:sen:nolink} "Завтра я нарушу долг."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3283,6 +3629,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.192:src}</column>
     </table>
     <table name="mem">
@@ -3296,6 +3643,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">печень [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肝臟</column>
       <column name="definition_pt">fígado</column>
+      <column name="definition_fi">maksa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mavje':n}, {HuH:n}, {boqrat:n}</column>
@@ -3306,6 +3654,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru">У клингонов есть две печени. [1, p.28] (см. Также {bIraqlul:n}.) [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗人有兩個肝臟.[1, p.28]（另見{bIraqlul:n}。） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os klingons têm dois fígados.[1, p.28] (Veja também {bIraqlul:n}.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingoneilla on kaksi maksa.[1, p.28] (Katso myös {bIraqlul:n}.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3315,6 +3664,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3322,6 +3672,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3335,6 +3686,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">Добавлять, приплюсовывать</column>
       <column name="definition_zh_HK">加</column>
       <column name="definition_pt">adicionar</column>
+      <column name="definition_fi">lisätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boq:v:2}, {SIm:v}, {togh:v}, {chelwI':n}</column>
@@ -3345,6 +3697,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru">Для математической операции добавления, смотрите {boq:v:2}.</column>
       <column name="notes_zh_HK">有關加法的數學運算，請參見{boq:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para a operação matemática de adição, consulte {boq:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso lisäyksen matemaattinen toiminta kohdasta {boq:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example Klingon sentence was not written by Marc Okrand, but by an unknown staffer at Decipher. Only the Klingon sentence was published in the {HolQeD:src} article. The English translation comes from the card deck's rulebook.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3356,6 +3709,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3363,6 +3717,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek Customizable Card Game - Fajo Collection:src} (reprinted in {HQ 9.4, p.16, Dec. 2000:src})</column>
     </table>
     <table name="mem">
@@ -3376,6 +3731,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">бухгалтер, счетовод, финансист</column>
       <column name="definition_zh_HK">會計師、金融家 [AUTOTRANSLATED]</column>
       <column name="definition_pt">contador, financista</column>
+      <column name="definition_fi">kirjanpitäjä, raha-asiantuntija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chel:v}</column>
@@ -3386,6 +3742,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chel:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3395,6 +3752,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3402,6 +3760,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3415,6 +3774,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">шалость [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">開玩笑、做惡作劇</column>
       <column name="definition_pt">pegadinha</column>
+      <column name="definition_fi">tehdä pila jollekulle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toj:v}, {qID:v}</column>
@@ -3425,6 +3785,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru">Жертва розыгрыша - объект. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">惡作劇的受害者是對象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A vítima da brincadeira é o objeto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Keppon uhri on esine. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The object was confirmed during the Q &amp; A session.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3434,6 +3795,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Streich, narren, scherzen</column>
       <column name="search_tags_fa"></column>
@@ -3441,6 +3803,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3454,6 +3817,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">тип животного, чемва [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《chemvah》（動物類型）</column>
       <column name="definition_pt">tipo de animal, chemvah</column>
+      <column name="definition_fi">eräs eläin, chemvah</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3464,6 +3828,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru">Женщины-клингоны издают звуки, похожие на {chemvaH:n:nolink}, чтобы обозначить интерес к потенциальному партнеру.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗婦女聽起來像{chemvaH:n:nolink}，表明對潛在伴侶的興趣。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">As mulheres klingon emitem sons como um {chemvaH:n:nolink} para indicar interesse em um parceiro em potencial.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingon-naiset kuulostavat {chemvaH:n:nolink}: ltä osoittamaan kiinnostusta potentiaalista kaveria kohtaan.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3473,6 +3838,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3480,6 +3846,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -3493,6 +3860,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">воздвигать, принимать форму</column>
       <column name="definition_zh_HK">積累、形成 [AUTOTRANSLATED]</column>
       <column name="definition_pt">construir, tomar forma</column>
+      <column name="definition_fi">rakentua, muotoutua, muodostua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boq:v:2}, {vI':v}</column>
@@ -3503,6 +3871,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru">Этот глагол также используется, чтобы указать на результат математических операций.[2]</column>
       <column name="notes_zh_HK">此動詞也用於表示數學運算的結果。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado para indicar o resultado de operações matemáticas.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös osoittamaan matemaattisten operaatioiden tulos.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3512,6 +3881,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">equals</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3519,6 +3889,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -3532,6 +3903,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">формировать, создавать, создавать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">製造、創造</column>
       <column name="definition_pt">formar, fazer, criar</column>
+      <column name="definition_fi">muodostaa, tehdä, luoda</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lagh:v}</column>
       <column name="see_also">{mutlh:v}, {cher:v}</column>
@@ -3542,6 +3914,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru">Это глагол {chen:v} с суффиксом {-moH:v}, поэтому суффиксы глаголов типов с 1 по 3 должны идти перед {-moH:v}, тип 4.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是帶後綴{-moH:v}的動詞{chen:v}，因此類型1到3的動詞後綴需要放在{-moH:v}（即類型4）之前。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse é o verbo {chen:v} com o sufixo {-moH:v}, portanto, os sufixos verbais dos tipos 1 a 3 precisam ir antes de {-moH:v}, que é do tipo 4.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on verbi {chen:v}, jonka pääte on {-moH:v}, joten tyyppien 1–3 verbiliitteiden on mentävä ennen {-moH:v}: ta, joka on tyyppi 4.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chen:v}, {-moH:v}</column>
       <column name="examples">
@@ -3552,6 +3925,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3559,6 +3933,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.11.30:src} (repeated in {s.k 1998.02.23:src})</column>
     </table>
     <table name="mem">
@@ -3572,6 +3947,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">строительная площадка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">建築工地</column>
       <column name="definition_pt">local de construção</column>
+      <column name="definition_fi">työmaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3582,6 +3958,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chenmoH:v}, {-lu':v}, {-meH:v}, {Daq:n}</column>
       <column name="examples">
@@ -3592,6 +3969,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3599,6 +3977,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3612,6 +3991,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">создатель, создатель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">創作者、製造者</column>
       <column name="definition_pt">criador</column>
+      <column name="definition_fi">luoja, valmistaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3622,6 +4002,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chen:v}, {-moH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3631,6 +4012,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3638,6 +4020,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3651,6 +4034,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">лабиринт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">迷宮、迷陣</column>
       <column name="definition_pt">Labirinto</column>
+      <column name="definition_fi">sokkelo, labyrintti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3661,6 +4045,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3670,6 +4055,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">labyrinth</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3677,6 +4063,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -3690,6 +4077,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">Чанг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">「常」（將軍）</column>
       <column name="definition_pt">Chang</column>
+      <column name="definition_fi">Chang</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3700,6 +4088,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru">Генерал Чанг ({cheng Sa':n:nolink}) служил под началом канцлера Горкона (см. {ghorqon:n:name}) и предал его, когда он пытался заключить мир с Федерацией. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">張將軍（{cheng Sa':n:nolink}）在Gorkon總理（見{ghorqon:n:name}）的領導下服役，並在他試圖與聯邦和解時背叛了他。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O general Chang ({cheng Sa':n:nolink}) serviu sob o chanceler Gorkon (ver {ghorqon:n:name}) e o traiu quando ele tentou fazer as pazes com a Federação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kenraali Chang ({cheng Sa':n:nolink}) palveli liittokansleri Gorkonin alaisuudessa (katso {ghorqon:n:name}) ja petti hänet, kun hän yritti tehdä rauhan federaation kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">He appeared in {Star Trek VI:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3709,6 +4098,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3716,6 +4106,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3729,6 +4120,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">Процветать, быть процветающим</column>
       <column name="definition_zh_HK">繁榮昌盛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prosperar, ser próspero</column>
+      <column name="definition_fi">menestyä, olla menestyksekäs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIp:v}, {Huch:n}</column>
@@ -3739,6 +4131,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="notes_ru">Этот глагол не используется для роста растений.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞不用於植物生長。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo não é usado para o crescimento das plantas.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä ei käytetä kasvien kasvuun.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3749,6 +4142,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3756,6 +4150,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.01:src}</column>
     </table>
     <table name="mem">
@@ -3769,6 +4164,7 @@ The following four examples illustrate the role of the object(s) and how to use 
       <column name="definition_ru">Торнадо</column>
       <column name="definition_zh_HK">龍捲風</column>
       <column name="definition_pt">tornado</column>
+      <column name="definition_fi">tornado, trombi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vung:v}, {SuS:n}, {jev:v:1}, {muD Dotlh:n}</column>
@@ -3791,6 +4187,9 @@ Verbetet {ver:v:1} kan också användas för att prata om tornado och virvelvind
       <column name="notes_pt">Observe que este é um verbo em Klingon. Em Klingon, diz-se "it tornadoes", semelhante a como se diz "it rains" em inglês.
 
 O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä on verbi klingonissa. Klingonissa sanotaan "se tornadot", samalla tavalla kuin sanotaan "sataa" englanniksi.
+
+Verbillä {ver:v:1} voidaan myös puhua tornadoista ja pyörremyrskyistä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3800,6 +4199,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">wirbeln</column>
       <column name="search_tags_fa"></column>
@@ -3807,6 +4207,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3820,6 +4221,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="definition_ru">Щекотать нас, мы не смеемся? Укол нас, мы не истекаем кровью? Неправда ли нам, не будем ли мы искать мести? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">癢癢我們、我們不笑嗎？刺破我們、我們不流血嗎？我們錯了、我們不應該報復嗎？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Agrade-nos, não rimos? Nos picou, não sangramos? Errado nós, não devemos procurar vingança?</column>
+      <column name="definition_fi">Jos kutitat meitä, emmekö me naura? Jos pistät meitä, emmekö me vuoda verta? Jos teet vääryyttä meille, emmekö me kostaisi?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3830,6 +4232,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="notes_ru">Это парафраз знаменитого отрывка из пьесы Шекспира «{The Merchant of Venice:src}», акт III, сцена i. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是莎士比亞的《唐納西大道》第三幕第一幕的一段著名段落的解釋。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma paráfrase de uma passagem famosa da cena {The Merchant of Venice:src}, Ato III, de Shakespeare. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on parafraasi kuuluisasta kohdasta Shakespearen {The Merchant of Venice:src}, Act III, kohtauksesta i. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{che-:v}, {qotlh:v:1}, {-chugh:v}, {ma-:v}, {Hagh:v}, {-be':v}, {-'a':v}, {che-:v}, {DuQ:v:1}, {-chugh:v}, {ma-:v}, {regh:v}, {-be':v}, {-'a':v}, {che-:v}, {QIH:v:2}, {-chugh:v}, {ma-:v}, {noD:v}, {-be':v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -3839,6 +4242,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3846,6 +4250,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.131:src}</column>
     </table>
     <table name="mem">
@@ -3859,6 +4264,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="definition_ru">устанавливать</column>
       <column name="definition_zh_HK">建立</column>
       <column name="definition_pt">estabelecer, configurar</column>
+      <column name="definition_fi">perustaa, pystyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{che':v}, {chenmoH:v}</column>
@@ -3869,6 +4275,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word sounds like "chair", but {che':v} is closer in meaning to "chair".</column>
       <column name="components"></column>
       <column name="examples">
@@ -3892,6 +4299,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
    Связь жизни."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">found</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3899,6 +4307,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 25:src}, [3] {paq'batlh p.136-137:src}</column>
     </table>
     <table name="mem">
@@ -3912,6 +4321,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="definition_ru">Терпеть, относиться терпимо</column>
       <column name="definition_zh_HK">容忍、耐煩</column>
       <column name="definition_pt">tolerar</column>
+      <column name="definition_fi">sietää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{laj:v}, {SIQ:v}</column>
@@ -3922,6 +4332,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3931,6 +4342,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3938,6 +4350,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3951,6 +4364,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="definition_ru">мята, ментоидное растение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">薄荷，薄荷類植物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">menta, hortelã, planta mentóide</column>
+      <column name="definition_fi">minttu, mentolikasvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3961,6 +4375,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on Klingonsin viljellyn kasvin alkuperäinen nimi sen maun ja aromin vuoksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3970,6 +4385,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Pfefferminz</column>
       <column name="search_tags_fa"></column>
@@ -3977,6 +4393,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3990,6 +4407,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="definition_ru">кролик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">兔子</column>
       <column name="definition_pt">coelho</column>
+      <column name="definition_fi">kani</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4000,6 +4418,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="notes_ru">Это животное с длинными ушами, похожее на земного кролика. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種長耳朵的動物，類似於地球兔子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um animal com orelhas compridas, semelhante a um coelho da Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eläin, jolla on pitkät korvat, samanlainen kuin maapallon kani. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4009,6 +4428,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bunny, hare</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4016,6 +4436,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4029,6 +4450,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="definition_ru">тип пальто [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">外套類型</column>
       <column name="definition_pt">tipo de casaco</column>
+      <column name="definition_fi">eräänlainen takki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cheSvel:n:2}</column>
@@ -4039,6 +4461,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4048,6 +4471,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4055,6 +4479,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4068,6 +4493,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="definition_ru">пальто, куртка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">外套、上衣、夾克</column>
       <column name="definition_pt">casaco, jaqueta</column>
+      <column name="definition_fi">takki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cheSvel:n:1}, {wep:n:1}</column>
@@ -4078,6 +4504,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="notes_ru">На диалекте {voSpegh Sep:n} это относится к любому пальто или куртке (то, что другие клингоны назвали бы {wep:n:1}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{voSpegh Sep:n}的方言中，它指的是任何外套或夾克（其他克林崗人將其稱為{wep:n:1}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No dialeto de {voSpegh Sep:n}, isso se refere a qualquer casaco ou jaqueta (o que outros klingons chamariam de {wep:n:1}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{voSpegh Sep:n}: n murteessa tämä viittaa mihin tahansa takkiin tai takkiin (mitä muut klingonit kutsuisivat {wep:n:1}: ksi). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4087,6 +4514,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4094,6 +4522,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4107,6 +4536,7 @@ O verbo {ver:v:1} também pode ser usado para falar sobre tornados e redemoinhos
       <column name="definition_ru">Торпедная труба</column>
       <column name="definition_zh_HK">魚雷發射管</column>
       <column name="definition_pt">tubo de torpedo</column>
+      <column name="definition_fi">torpedoputki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chetvI':n:2}, {DuS:n}</column>
@@ -4137,6 +4567,10 @@ Skillnaden mellan en {chetvI':n:nolink} och en {DuS:n} har att göra med hur pro
 
 
 A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o projétil é carregado.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {lo'laHbe'; chetvI' chIm rur@@lo'laHbe':v, chetvI':n:1, chIm:v, rur:v}.
+
+
+{chetvI':n:nolink}: n ja {DuS:n}: n välinen ero liittyy ammuksen lataamiseen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4146,6 +4580,7 @@ A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o proj
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4153,6 +4588,7 @@ A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o proj
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.57:src}</column>
     </table>
     <table name="mem">
@@ -4166,6 +4602,7 @@ A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o proj
       <column name="definition_ru">метательное устройство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">投擲矛的裝置 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dispositivo de lança</column>
+      <column name="definition_fi">keihäänheittolaite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chetvI':n:1}</column>
@@ -4176,6 +4613,7 @@ A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o proj
       <column name="notes_ru">Это палка с крючком на конце, которая используется для помощи в броске (см. {wob:v}) {tlhevjaQ:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個在末端帶有鉤子的棍子，用於幫助扔（參見{wob:v}）和{tlhevjaQ:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um bastão com um gancho no final, que é usado como auxílio no arremesso (consulte {wob:v}) um {tlhevjaQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tikku, jonka päässä on koukku, jota käytetään apuna heittäessä (katso {wob:v}) {tlhevjaQ:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This item, as described in {KGT:src}, would seem to be an "atlatl".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4185,6 +4623,7 @@ A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o proj
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4192,6 +4631,7 @@ A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o proj
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4205,6 +4645,7 @@ A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o proj
       <column name="definition_ru">Разделять</column>
       <column name="definition_zh_HK">分開、分離</column>
       <column name="definition_pt">separado</column>
+      <column name="definition_fi">erottaa, erotella, jakaa, irrottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4215,6 +4656,7 @@ A distinção entre um {chetvI':n:nolink} e um {DuS:n} tem a ver com como o proj
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Separate the wheat from the "chaff".
 
 Reverse of {vech:v}.</column>
@@ -4228,6 +4670,7 @@ Reverse of {vech:v}.</column>
 ▶ {'uSDaj chop, chev!:sen:nolink} "Откуси его/её ногу!"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4235,6 +4678,7 @@ Reverse of {vech:v}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -4248,6 +4692,7 @@ Reverse of {vech:v}.</column>
       <column name="definition_ru">территориальная стена (например, Берлинская стена) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">領土牆（例如柏林牆） [AUTOTRANSLATED]</column>
       <column name="definition_pt">muro territorial (por exemplo, muro de Berlim)</column>
+      <column name="definition_fi">rajamuuri (esim. Berliinin muuri)</column>
       <column name="synonyms">{pIn tlhoy':n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4258,6 +4703,7 @@ Reverse of {vech:v}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chev:v}, {-wI':v}, {tlhoy':n}</column>
       <column name="examples"></column>
@@ -4267,6 +4713,7 @@ Reverse of {vech:v}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4274,6 +4721,7 @@ Reverse of {vech:v}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -4287,6 +4735,7 @@ Reverse of {vech:v}.</column>
       <column name="definition_ru">править, господствовать, председательствовать</column>
       <column name="definition_zh_HK">統治、統治、奔跑、主持 [AUTOTRANSLATED]</column>
       <column name="definition_pt">governar, reinar, presidir</column>
+      <column name="definition_fi">hallita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loH:v}, {cher:v}, {ghatlh:v}, {cho':v}</column>
@@ -4297,6 +4746,7 @@ Reverse of {vech:v}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This almost sounds like "chair".
 
 This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT:src} as "preside".</column>
@@ -4312,6 +4762,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
 "В родном мире, есть великий зал, где лидеры Клингонского высшего совета встречаются, чтобы определить политику, задать курс и решить судьбу империи. Сейчас председательствует Гаурон, лидер Высшего совета, назначенный капитаном Жаном-Люком Пикардом, который был Арбитром посвящения."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">chair</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4319,6 +4770,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {SkyBox 25:src}</column>
     </table>
     <table name="mem">
@@ -4332,6 +4784,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="definition_ru">Поле боя</column>
       <column name="definition_zh_HK">戰場</column>
       <column name="definition_pt">campo de batalha</column>
+      <column name="definition_fi">taistelukenttä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yotlh:n}, {may':n}</column>
@@ -4342,6 +4795,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Cheron" was the name of the planet in {TOS - Let That Be Your Last Battlefield:src}. </column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4351,6 +4805,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4358,6 +4813,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4371,6 +4827,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="definition_ru">умышленно, с целью, намеренно</column>
       <column name="definition_zh_HK">特登、故意、有心</column>
       <column name="definition_pt">propositalmente, intencionalmente</column>
+      <column name="definition_fi">tahallaan, tarkoituksella</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bong:adv}</column>
       <column name="see_also">{ngoQ:n}</column>
@@ -4381,6 +4838,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4390,6 +4848,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">deliberately</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4397,6 +4856,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4410,6 +4870,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="definition_ru">Признавать</column>
       <column name="definition_zh_HK">承認</column>
       <column name="definition_pt">Admitem</column>
+      <column name="definition_fi">myöntää, tunnustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tem:v}</column>
       <column name="see_also"></column>
@@ -4420,6 +4881,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4430,6 +4892,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4437,6 +4900,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4450,6 +4914,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="definition_ru">Управлять(судном)</column>
       <column name="definition_zh_HK">導航</column>
       <column name="definition_pt">navegar, seguir um curso</column>
+      <column name="definition_fi">navigoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}, {vaj Duj chIj:sen:idiom}, {'or:v}</column>
@@ -4460,6 +4925,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="notes_ru">Выражение {Dujmey law' chIjpu':sen:idiom} означает, что кто-то являтся опытным.</column>
       <column name="notes_zh_HK">{Dujmey law' chIjpu':sen:idiom}表示有經驗的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A expressão {Dujmey law' chIjpu':sen:idiom} significa que alguém é experiente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ilmaisu {Dujmey law' chIjpu':sen:idiom} tarkoittaa, että joku on kokenut. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4470,6 +4936,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4477,6 +4944,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.113:src}</column>
     </table>
     <table name="mem">
@@ -4490,6 +4958,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="definition_ru">Навигатор</column>
       <column name="definition_zh_HK">導航員</column>
       <column name="definition_pt">navegador</column>
+      <column name="definition_fi">navigaattori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4500,6 +4969,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chIj:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4509,6 +4979,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4516,6 +4987,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4529,6 +5001,7 @@ This word is defined in {TKD:src} as "rule, reign, run" and additionally in {KGT
       <column name="definition_ru">терять, положить не на место, невозможно отыскать, потреять чей-то след</column>
       <column name="definition_zh_HK">失敗、錯位、無法找到、失去踪跡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">perder, extraviar, não conseguir encontrar, perder o controle</column>
+      <column name="definition_fi">kadottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DoS:n}, {nej:v}, {Sam:v}, {lan:v}, {weS:v}</column>
@@ -4543,6 +5016,9 @@ This verb can be used for misplacing your keys, but also for things like losing 
 Этот глагол может быть использован для описания потери ваших ключей, но также для вещей, подобных потери сигнала чего-то, что вы отслеживали.[3]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Idiomaattinen ilmaus {DoS chIl:sen:idiom} tarkoittaa "poikkeamaan", esim. {DoS vIchIl:sen:nolink} tarkoittaa "poikkeamaan".
+
+Tätä verbiä voidaan käyttää avainten väärään sijoittamiseen, mutta myös esimerkiksi seuraamasi signaalin menettämiseen.[3][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined in {TKDA:src} as "lose, misplace". The other definitions were added at {Saarbrücken qepHom'a' 2017:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4552,6 +5028,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">lost, forget</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4559,6 +5036,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru">потерянный</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {qep'a' 15 (2008):src}, [3] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -4572,6 +5050,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">Быть пустым, быть опустевшим, быть необитаемым</column>
       <column name="definition_zh_HK">空虛、冷清、無人居住 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser vazio, deserto, desabitado</column>
+      <column name="definition_fi">olla tyhjä, autio, asumaton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{toq:v}, {buy':v}</column>
       <column name="see_also">{choS:v}, {qeD:v}, {woD:v:2}, {'achghej:n}</column>
@@ -4582,6 +5061,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">Глагол {chIm:v:nolink} используется для опустевшего дилитиевого кристалла.</column>
       <column name="notes_zh_HK">動詞{chIm:v:nolink}用於排幹的二鋰晶體。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O verbo {chIm:v:nolink} é usado para um cristal de dilítio drenado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbiä {chIm:v:nolink} käytetään valutettuun dilitiumkiteeseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4593,6 +5073,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
 ▶ {cha'pujqutmey chIm lutamlu'.:sen@@cha'pujqut:n, -mey:n, chIm:v, lu-:v, tam:v:2, -lu':v} "Дренированные кристаллы дилития перемещены."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">drained</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4600,6 +5081,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru">опустевший</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -4613,6 +5095,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">обрезать, остригать (волосы)</column>
       <column name="definition_zh_HK">剪裁、修剪（頭髮） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cortar, aparar (cabelo)</column>
+      <column name="definition_fi">leikata (hiukset)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIb:n}, {pob:n}, {pe':v}, {magh:n}</column>
@@ -4623,6 +5106,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">Это слово может использоваться, чтобы резать или подстригать другие вещи, такие как трава, полоски на одежде, ногти и т. Д.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此詞可用於剪切或修剪其他事物，例如草，衣服上的條紋，指甲等。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra pode ser usada para cortar ou aparar outras coisas, como grama, franjas na roupa, unhas, etc.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää leikkaamaan tai leikkaamaan muita asioita, kuten ruohoa, hapsut vaatteissa, kynnet jne.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">One "chip"s away at hair.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4632,6 +5116,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shave</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4639,6 +5124,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -4652,6 +5138,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">крест, траверс [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">橫越</column>
       <column name="definition_pt">atravessar</column>
+      <column name="definition_fi">ylittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taw:n}, {vech:v}, {leng:v}</column>
@@ -4662,6 +5149,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Why did the "chick"en cross the road?</column>
       <column name="components"></column>
       <column name="examples">
@@ -4672,6 +5160,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4679,6 +5168,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Smithsonian GO FLIGHT app:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4692,6 +5182,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">Храм (строение)</column>
       <column name="definition_zh_HK">寺廟</column>
       <column name="definition_pt">templo (estrutura)</column>
+      <column name="definition_fi">temppeli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIn:n}, {lat:n}</column>
@@ -4702,6 +5193,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It's basically "church".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4711,6 +5203,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">church</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4718,6 +5211,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru">церковь, храм</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4731,6 +5225,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">быть белым</column>
       <column name="definition_zh_HK">白色</column>
       <column name="definition_pt">ser branco</column>
+      <column name="definition_fi">olla valkoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qIj:v}</column>
       <column name="see_also">{wov:v}</column>
@@ -4741,6 +5236,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4750,6 +5246,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4757,6 +5254,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4770,6 +5268,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">быть симметричным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">對稱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser simétrico</column>
+      <column name="definition_fi">olla symmetrinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rober:n}, {nar:v}</column>
@@ -4780,6 +5279,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4789,6 +5289,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">gespiegelt</column>
       <column name="search_tags_fa"></column>
@@ -4796,6 +5297,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4809,6 +5311,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">Полное бесчестие, абсолютное отсутствие чести</column>
       <column name="definition_zh_HK">總恥辱、絕對缺乏榮譽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desonra total, absoluta falta de honra</column>
+      <column name="definition_fi">täydellinen häpeä, kunniattomuus</column>
       <column name="synonyms"></column>
       <column name="antonyms">{batlh:n}, {quv:n}</column>
       <column name="see_also">{DavHam:n}, {jIvvo':n}</column>
@@ -4819,6 +5322,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The first part of the example sentence was a lip-match for {mughojmoH parmaqqaywI':sen@@mu-:v, ghojmoH:v, parmaqqay:n, -wI':n}. The second part was a lip-match for {'ej jIHvo' nIHDI' jIbup:sen@@'ej:conj, jIH:n:1h, -vo':n, nIH:v, -DI':v, jI-:v, bup:v}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4830,6 +5334,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
 ▶ {potlhmo' batlh, vIqawba', 'ej chIvo' neH chIw vum'e'.@@potlh:v, -mo':v, batlh:n, vI-:v, qaw:v, -ba':v, 'ej:conj, chIvo':n, neH:adv, chIw:v, vum:n, -'e':n} "Потому что ты заботишься о чести. А этот человек нет."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">total dishonour, absolute lack of honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4837,6 +5342,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru">Полное бесчестие, абсолютное отсутствие чести</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -4850,6 +5356,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">выражать, воплощать, источать, воплощать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">表達、體現、散發、集中體現 [AUTOTRANSLATED]</column>
       <column name="definition_pt">expressar, incorporar, exalar, epitomizar</column>
+      <column name="definition_fi">ilmaista, ilmentää, esittää, olla jonkin ruumiillistuma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'agh:v}</column>
@@ -4860,6 +5367,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4871,6 +5379,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
 ▶ {potlhmo' batlh, vIqawba', 'ej chIvo' neH chIw vum'e'.@@potlh:v, -mo':v, batlh:n, vI-:v, qaw:v, -ba':v, 'ej:conj, chIvo':n, neH:adv, chIw:v, vum:n, -'e':n} "Потому что ты заботишься о чести. А этот человек нет."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">epitomise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4878,6 +5387,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -4891,6 +5401,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">матка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">子宮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">útero</column>
+      <column name="definition_fi">kohtu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qey'Hav:n}, {yatlh:v}, {ghu:n}</column>
@@ -4901,6 +5412,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4910,6 +5422,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4917,6 +5430,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4930,6 +5444,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">ты(какое-то действие)-мне, вы(единственное число)(какое-то действие)-мне</column>
       <column name="definition_zh_HK">你：我</column>
       <column name="definition_pt">você-eu</column>
+      <column name="definition_fi">sinä-minua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qa-:v:pref}</column>
       <column name="see_also">{tu-:v:pref}, {ju-:v:pref}, {HI-:v:pref}</column>
@@ -4940,6 +5455,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SoH:n}: {jIH:n:1h} = {cho-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4949,6 +5465,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4956,6 +5473,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4969,6 +5487,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">коридор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">走廊</column>
       <column name="definition_pt">corredor</column>
+      <column name="definition_fi">käytävä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'och:n}, {qa'rI':n}, {DIn:n}, {lojmIt:n}, {vegh:v}</column>
@@ -4979,6 +5498,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4988,6 +5508,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4995,6 +5516,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5008,6 +5530,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">главный коридор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">主要走廊</column>
       <column name="definition_pt">corredor principal</column>
+      <column name="definition_fi">pääkäytävä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5018,6 +5541,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chob:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -5027,6 +5551,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5034,6 +5559,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5047,6 +5573,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">лестница, ведущая к двери корабля, трап [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通往船門、跳板的樓梯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">escada que leva a uma porta de um navio, prancha</column>
+      <column name="definition_fi">kulkusilta, portaikko aluksen ovelle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{letlh:n:1}, {letlh:n:2}</column>
@@ -5057,6 +5584,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5066,6 +5594,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">stairs, steps, escalator</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5073,6 +5602,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5086,6 +5616,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">крыльцо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">門廊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">varanda</column>
+      <column name="definition_fi">kuisti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5096,6 +5627,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">Это относится к проектированию архитектурного сооружения, в котором находится вход в здание. Иногда это {qach choghvat:n:nolink}, а иногда {choghvat pa':n:nolink}. Это слово (которое на самом деле является словом «трап», см. {choghvat:n:1}) используется для этой части конструкции, даже если там нет ступеней или пандусов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指容納建築物入口的凸出建築結構。有時是{qach choghvat:n:nolink}，有時是{choghvat pa':n:nolink}。即使沒有樓梯或坡道，該詞（實際上是“跳板”的詞，請參見{choghvat:n:1}）也用於該結構的這一部分。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à estrutura arquitetônica projetada que abriga uma entrada para um edifício. Às vezes, isso é {qach choghvat:n:nolink} e, às vezes, {choghvat pa':n:nolink}. Essa palavra (que é realmente a palavra para "gangplank", consulte {choghvat:n:1}) é usada para essa parte de uma estrutura, mesmo que não haja escadas ou rampas envolvidas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ulkonevaan arkkitehtoniseen rakenteeseen, johon on rakennuksen sisäänkäynti. Tämä on joskus {qach choghvat:n:nolink} ja joskus {choghvat pa':n:nolink}. Tätä sanaa (joka on oikeastaan ​​sana "gangplank", katso {choghvat:n:1}) käytetään rakennuksen tähän osaan, vaikka siihen ei olisi portaita tai luiskia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It was clarified during the Q &amp; A session that this has to be attached to the building.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5105,6 +5637,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5112,6 +5645,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
         <table name="mem">
@@ -5125,6 +5659,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
           <column name="definition_ru">{choghvat:n:2}</column>
           <column name="definition_zh_HK">{choghvat:n:2}</column>
           <column name="definition_pt">{choghvat:n:2}</column>
+      <column name="definition_fi">{choghvat:n:2}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5135,6 +5670,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{choghvat:n:2}, {pa':n:1}</column>
           <column name="examples"></column>
@@ -5144,6 +5680,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5151,6 +5688,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -5164,6 +5702,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">изменить(состояние), преобразовать</column>
       <column name="definition_zh_HK">改變</column>
       <column name="definition_pt">alterar, mudar</column>
+      <column name="definition_fi">muuttaa, muuttua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choH:n}, {ngaD:v}, {ratlh:v}, {-choH:v}, {ghe':v}</column>
@@ -5174,6 +5713,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was used to translate "update" (change the value of a variable) in Klingon Blockly.[2]</column>
       <column name="components"></column>
       <column name="examples">
@@ -5188,6 +5728,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">update</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5195,6 +5736,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru">обновить</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <table name="mem">
@@ -5208,6 +5750,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">Изменить, преобразовать</column>
       <column name="definition_zh_HK">變化</column>
       <column name="definition_pt">mudança</column>
+      <column name="definition_fi">muutos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choH:v}, {ghe':v}</column>
@@ -5218,6 +5761,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">Это может также относиться к химической или ядерной реакции.</column>
       <column name="notes_zh_HK">這也可以指化學或核反應。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode se referir a uma reação química ou nuclear. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata myös kemialliseen tai ydinreaktioon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5228,6 +5772,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">reaction, metamorphosis</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5235,6 +5780,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru">реакция, метаморфоза</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5248,6 +5794,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">замедляющий реакцию элемент [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">反應調節元素 [AUTOTRANSLATED]</column>
       <column name="definition_pt">elemento moderador da reação</column>
+      <column name="definition_fi">reaktiota hillitsevä aine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'pujqut:n}, {bIQSIp 'ugh:n}</column>
@@ -5258,6 +5805,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">Это показано на плакате {BoP:src} в спецификации: {choH lISbogh Hap'e':sen:nolink}: {cha'pujqut:sen:nolink} «Элемент, регулирующий реакцию - кристаллический дилитий». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在規範的{BoP:src}海報上顯示：{choH lISbogh Hap'e':sen:nolink}：{cha'pujqut:sen:nolink}“反應調節元素-結晶雙鋰”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso aparece no pôster {BoP:src} na especificação: {choH lISbogh Hap'e':sen:nolink}: {cha'pujqut:sen:nolink} "Elemento moderador da reação - dilítio cristalino". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä näkyy {BoP:src}-julisteessa eritelmässä: {choH lISbogh Hap'e':sen:nolink}: {cha'pujqut:sen:nolink} "Reaktion moderaatioelementti - kiteinen dilitium". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{choH:n}, {lIS:v}, {-bogh:v}, {Hap:n}, {-'e':n}</column>
       <column name="examples"></column>
@@ -5267,6 +5815,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5274,6 +5823,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5287,6 +5837,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">приближаться, подходить ближе</column>
       <column name="definition_zh_HK">靠近</column>
       <column name="definition_pt">aproximar, aproximar-se</column>
+      <column name="definition_fi">lähestyä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{DoH:v}</column>
       <column name="see_also">{ghoS:v:1}, {Duv:v}, {HeD:v}, {Sum:v}</column>
@@ -5297,6 +5848,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">Объект этого глагола - это то, к чему приближается субъект. {-Daq:n:suff} не нужен. Это иногда используется, но это избыточно (хотя и не неправильно) .[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個動詞的賓語是主語越來越接近的東西。不需要{-Daq:n:suff}。有時會使用它，但它是多餘的（儘管沒有錯）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto desse verbo é o assunto em que o assunto está se aproximando. {-Daq:n:suff} não é necessário. Às vezes é usado, mas é redundante (embora não esteja errado).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde on asia, johon aihe on lähempänä. {-Daq:n:suff}-tiedostoa ei tarvita. Sitä käytetään joskus, mutta se on tarpeeton (vaikkakaan ei väärin)[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5306,6 +5858,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5313,6 +5866,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -5326,6 +5880,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">Держатель "конского хвоста"(вида прически)</column>
       <column name="definition_zh_HK">馬尾辮髮帶</column>
       <column name="definition_pt">suporte de rabo de cavalo</column>
+      <column name="definition_fi">ponnari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qeb:n:2}, {DaQ:n}, {naQ:n:2}</column>
@@ -5336,6 +5891,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It is unknown why this word appears to combine {chol:v} and {jaH:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5345,6 +5901,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5352,6 +5909,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5365,6 +5923,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">Бармен</column>
       <column name="definition_zh_HK">調酒師、酒保</column>
       <column name="definition_pt">barman</column>
+      <column name="definition_fi">baarimikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tach:n}, {jabwI':n}, {tebwI':n}</column>
@@ -5375,6 +5934,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">В Клингонском баре, бармен кричит {'eb Qav:n} для "последнего заказа".[2]</column>
       <column name="notes_zh_HK">在克林崗酒吧，酒保喊{'eb Qav:n}表示“最後通話”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em uma barra de Klingon, o barman grita {'eb Qav:n} para "última chamada" .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Baarimikko huutaa Klingon-baarissa {'eb Qav:n} "viimeisestä puhelusta".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The bartender is your "chum".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5384,6 +5944,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5391,6 +5952,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -5404,6 +5966,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">охота [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">獵</column>
       <column name="definition_pt">caçar</column>
+      <column name="definition_fi">metsästys, jahti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wam:v}, {chontay:n}, {gheD:n}</column>
@@ -5414,6 +5977,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5423,6 +5987,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5430,6 +5995,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5443,6 +6009,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">охотничья песня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">狩獵歌</column>
       <column name="definition_pt">música de caça</column>
+      <column name="definition_fi">metsästyslaulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}</column>
@@ -5453,6 +6020,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chon:n}, {bom:n}</column>
       <column name="examples"></column>
@@ -5462,6 +6030,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5469,6 +6038,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5482,6 +6052,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">охотничье копье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">狩獵矛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lança de caça</column>
+      <column name="definition_fi">metsästyskeihäs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQjej:n}</column>
@@ -5492,6 +6063,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chon:n}, {naQ:n:1}</column>
       <column name="examples"></column>
@@ -5501,6 +6073,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5508,6 +6081,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5521,6 +6095,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">ритуальная охота [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">儀式追捕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">caça ritual</column>
+      <column name="definition_fi">rituaalimetsästys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chon:n}, {tay:n:2}</column>
@@ -5531,6 +6106,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chon:n}, {tay:n:2}</column>
       <column name="examples"></column>
@@ -5540,6 +6116,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5547,6 +6124,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5560,6 +6138,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">Быть вертикальным</column>
       <column name="definition_zh_HK">垂直</column>
       <column name="definition_pt">ser vertical</column>
+      <column name="definition_fi">olla pystysuora</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SaS:v:1}</column>
       <column name="see_also">{chong:v:2}</column>
@@ -5570,6 +6149,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">В типографии шрифт «курсив» может быть описан как {chongHa':v@@chong:v:1, -Ha':v}. Смотрите {ngutlh tu'qom:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在排版中，“斜體”字體可以描述為{chongHa':v@@chong:v:1, -Ha':v}。參見{ngutlh tu'qom:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Na tipografia, uma fonte "itálico" pode ser descrita como {chongHa':v@@chong:v:1, -Ha':v}. Consulte {ngutlh tu'qom:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Typografiassa "kursivoitu" fontti voidaan kuvata nimellä {chongHa':v@@chong:v:1, -Ha':v}. Katso {ngutlh tu'qom:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5579,6 +6159,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5586,6 +6167,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5599,6 +6181,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">будь глубоким, будь тщательным, будь осторожен; будь хорошим, будь превосходным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要深刻、要徹底、要小心;要善良、要善良 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser profundo, ser cuidadoso, ter cuidado; ser bom, ser excelente</column>
+      <column name="definition_fi">olla perusteellinen, olla huolellinen; olla hyvä, olla erinomainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SaS:v:2,slang}</column>
       <column name="see_also">{pov:v}, {qu':v:2}, {chong:v:1}</column>
@@ -5609,6 +6192,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="notes_ru">Это слово применяется к интеллекту человека и выражает значение, эквивалентное {Qubchu'}. Он также используется как выражение одобрения, аналогично {maj:excl}.[1, p.148] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此詞適用於人的智力，表示與{Qubchu'}等效的含義。它也單獨用作批准的表達方式，類似於{maj:excl}.[1, p.148] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é aplicada ao intelecto de uma pessoa e expressa um significado equivalente a {Qubchu'}. Também é usado por si só como uma expressão de aprovação, semelhante ao {maj:excl}.[1, p.148] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään henkilön älyyn, ja se ilmaisee vastaavan merkityksen kuin {Qubchu'}. Sitä käytetään myös itsessään hyväksynnän ilmaisuna, samanlainen kuin {maj:excl}.[1, p.148] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Cantonese Chinese for "clever" (聰).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5618,6 +6202,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5625,6 +6210,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5638,6 +6224,7 @@ This verb can be used for misplacing your keys, but also for things like losing 
       <column name="definition_ru">Кусать, откусить</column>
       <column name="definition_zh_HK">咬</column>
       <column name="definition_pt">mordida</column>
+      <column name="definition_fi">purra, suudella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noS:v}, {ngal:v}, {yIv:v:1}, {ghew:n}, {choptaH:v}, {'ep:v:2}</column>
@@ -5662,6 +6249,9 @@ Se en föreställning av {HIchop!:sen:lyr} av Jen Usellis: {YouTube video:url:ht
       <column name="notes_pt">Esta palavra também pode denotar um beijo no estilo klingon.[4]
 
 Assista a uma performance de {HIchop!:sen:lyr} de Jen Usellis: {YouTube video:url:http://youtu.be/v2bjc6U0tjI} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi merkitä myös klingonityylistä suudelmaa.[4]
+
+Katso Jen Usellisin {HIchop!:sen:lyr}-esitys: {YouTube video:url:http://youtu.be/v2bjc6U0tjI} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is almost a "chomp".
 
 In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expression "Give us a kiss, love." was translated as {HIchop, bang.:sen:nolink}[3]</column>
@@ -5677,6 +6267,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
 ▶ {'uSDaj chop, chev!:sen:nolink} "Откуси его/её ногу!"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">kiss</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5684,6 +6275,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {PK:src}, [3] {Radio Times Star Trek 30th Anniversary Special Issue:src}, [4] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -5697,6 +6289,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">грызть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">啃、咬住</column>
       <column name="definition_pt">roer</column>
+      <column name="definition_fi">jyrsiä, kaluta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIv:v:1}, {ngal:v}</column>
@@ -5707,6 +6300,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chop:v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -5716,6 +6310,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5723,6 +6318,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5736,6 +6332,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">Оно кусается?</column>
       <column name="definition_zh_HK">它會咬嗎？</column>
       <column name="definition_pt">Isso morde?</column>
+      <column name="definition_fi">Pureeko se?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5746,6 +6343,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5755,6 +6353,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5762,6 +6361,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -5775,6 +6375,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">сохранять, спасать</column>
       <column name="definition_zh_HK">保存</column>
       <column name="definition_pt">preservar, salvar</column>
+      <column name="definition_fi">säilöä, suojella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pol:v}, {toD:v}</column>
@@ -5785,6 +6386,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This has a different meaning of "save" than {pol:v}, as in {nuqDaq yuch Dapol?:sen} "where do you keep the 'choc'olate?"</column>
       <column name="components"></column>
       <column name="examples">
@@ -5796,6 +6398,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5805,6 +6408,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
 ▶ {wo' ngay' bochoqmeH bowIvlu'pu'!:sen:nolink} "Вы все были выбраны, чтобы сохранить славу империи!"[3].</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW p.211:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -5818,6 +6422,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">палуба (на корабле) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">甲板（船上）</column>
       <column name="definition_pt">convés (em um navio)</column>
+      <column name="definition_fi">kansi (aluksella)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meH:n}, {rav:n:1}</column>
@@ -5828,6 +6433,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5839,6 +6445,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">level, floor</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5846,6 +6453,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5859,6 +6467,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">живот</column>
       <column name="definition_zh_HK">肚、腹部</column>
       <column name="definition_pt">barriga</column>
+      <column name="definition_fi">vatsa, keskiruumis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eQway:n}, {luH:n}, {porgh:n}, {ro:n}, {logh'ob:n}</column>
@@ -5869,6 +6478,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Это слово относится к внешней секции тела. Чтобы упомянуть живот (внутренний орган), используйте {burgh:n} вместо этого.</column>
       <column name="notes_zh_HK">這個詞是指身體的外部中央部分。要提及胃（內部器官），請改用{burgh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se à parte externa do corpo. Para se referir a um estômago (um órgão interno), use {burgh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa kehon ulkoiseen keskiosaan. Käytä mahaa (sisäinen elin) käyttämällä {burgh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined in {TKD:src} as "belly".[1] The gloss "midsection" comes from {FTG:src}.[2]</column>
       <column name="components"></column>
       <column name="examples">
@@ -5880,6 +6490,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
 ▶ {tajwIj 'oHbe' chorlIj jeqbogh Dochvetlh'e'.:sen:nolink} "Это не мой кинжал торчит из твоего живота."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5887,6 +6498,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {FTG:src}</column>
     </table>
     <table name="mem">
@@ -5900,6 +6512,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">{chor bargh:n}</column>
       <column name="definition_zh_HK">{chor bargh:n}</column>
       <column name="definition_pt">{chor bargh:n}</column>
+      <column name="definition_fi">{chor bargh:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5910,6 +6523,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5919,6 +6533,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5926,6 +6541,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5939,6 +6555,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">керамический горшок с плоским дном [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陶瓷平底鍋</column>
       <column name="definition_pt">vaso de cerâmica com fundo plano</column>
+      <column name="definition_fi">keraaminen tasapohjainen kulho</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5949,6 +6566,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Это {bargh:n} из керамики. Это слово также может быть сокращено до {chor:n:2,nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是由陶瓷製成的{bargh:n}。這個詞也可以縮寫為{chor:n:2,nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um {bargh:n} feito de cerâmica. Esta palavra também pode ser reduzida para {chor:n:2,nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {bargh:n}, joka on valmistettu keraamisesta. Tämä sana voidaan myös lyhentää sanaksi {chor:n:2,nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5958,6 +6576,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5965,6 +6584,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5978,6 +6598,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">восемь</column>
       <column name="definition_zh_HK">八</column>
       <column name="definition_pt">oito</column>
+      <column name="definition_fi">kahdeksan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chorgh:n:2} (musical tone)</column>
@@ -5988,6 +6609,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5997,6 +6619,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">8th</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6004,6 +6627,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -6017,6 +6641,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
           <column name="definition_ru">восьмой(ая)</column>
           <column name="definition_zh_HK">第八</column>
           <column name="definition_pt">oitavo</column>
+      <column name="definition_fi">kahdeksas</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -6027,6 +6652,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{chorgh:n:1,num}, {-DIch:n:num,suff}</column>
           <column name="examples"></column>
@@ -6036,6 +6662,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6043,6 +6670,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -6056,6 +6684,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
           <column name="definition_ru">восемьдесят [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">八十</column>
           <column name="definition_pt">oitenta</column>
+      <column name="definition_fi">kahdeksankymmentä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -6066,6 +6695,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{chorgh:n:1,num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -6075,6 +6705,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6082,6 +6713,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -6095,6 +6727,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">восьмой тон нонатонической музыки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">第八音非音樂音階 [AUTOTRANSLATED]</column>
       <column name="definition_pt">oitavo tom da escala musical não-atônica</column>
+      <column name="definition_fi">nonatoonisen musiikkiasteikon kahdeksas sävel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chorgh:n:1} (number)</column>
@@ -6105,6 +6738,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin musiikkiasteikon sävyt (katso {yutlhegh:n}) ovat: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}, {vagh:n:2}, {jav:n:2}, {Soch:n:2}, {chorgh:n:2,nolink}, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DOT{yu:n:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6114,6 +6748,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6121,6 +6756,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6134,6 +6770,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">быть глянцевым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有光澤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser brilhante, ser polido, ser lustroso, ser liso</column>
+      <column name="definition_fi">olla kiiltävä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boch:v}</column>
@@ -6144,6 +6781,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Это значит иметь гладкую, шелковистую, отражающую поверхность. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著要具有光滑的絲狀反射表面。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa ter uma superfície refletora lisa, semelhante a seda. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa, että sillä on sileä, silkkimainen, heijastava pinta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The lyrics to "Alice's Restaurant Massacree" has several repetitions of the phrase "twenty seven eight-by-ten color glossy pictures". Glossy paper used in professional photos are often 8" ({chorgh:n:1}) by 10".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6153,6 +6791,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6160,6 +6799,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6173,6 +6813,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">дезертировать</column>
       <column name="definition_zh_HK">背棄、叛逃</column>
       <column name="definition_pt">deserto</column>
+      <column name="definition_fi">hylätä (kylä, rakennus tms.), jättää autioksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cheH:v}, {chIm:v}, {lon:v}, {qeD:v}</column>
@@ -6183,6 +6824,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6204,6 +6846,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6211,6 +6854,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -6224,6 +6868,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">сумерки</column>
       <column name="definition_zh_HK">暮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">crepúsculo</column>
+      <column name="definition_fi">iltahämärä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jajlo':n}, {tlhom:n}, {ram:n}</column>
@@ -6234,6 +6879,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Заметьте, что есть двое сумерек в дне ({jaj:n}), одни утром и одни вечером.</column>
       <column name="notes_zh_HK">請注意，一天中有兩個暮色（{jaj:n}），一個在早晨，一個在晚上。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que existem duas luzes crepusculares em um dia ({jaj:n}), uma pela manhã e outra à noite. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että päivässä on kaksi hämärää ({jaj:n}), yksi aamulla ja toinen illalla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined in {TKD:src} as "twilight" only. However, in {TNK:src}, the Terran expression "Good evening" is translated into Klingon as {maj choS:excl:nolink} (see {maj:excl}), suggesting that this word can also mean "evening" to a Klingon, at least in context.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6243,6 +6889,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">evening</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6250,6 +6897,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6263,6 +6911,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">убивать</column>
       <column name="definition_zh_HK">謀殺</column>
       <column name="definition_pt">assassinato</column>
+      <column name="definition_fi">murhata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoH:v}</column>
@@ -6273,6 +6922,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6282,6 +6932,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6289,6 +6940,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6302,6 +6954,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">убийца [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">兇手、殺人犯</column>
       <column name="definition_pt">assassino</column>
+      <column name="definition_fi">murhaaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6312,6 +6965,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chot:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -6321,6 +6975,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6328,6 +6983,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.25:src}</column>
     </table>
     <table name="mem">
@@ -6341,6 +6997,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">оценивать</column>
       <column name="definition_zh_HK">評估</column>
       <column name="definition_pt">avaliar, estimar</column>
+      <column name="definition_fi">arvioida, määrittää arvo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noH:v}, {yoj:n}, {nuD:v}, {chovnatlh:n}, {poj:v}, {waH:v:1}, {qaD:v}</column>
@@ -6351,6 +7008,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6360,6 +7018,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6367,6 +7026,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -6380,6 +7040,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">образец</column>
       <column name="definition_zh_HK">標本</column>
       <column name="definition_pt">espécime</column>
+      <column name="definition_fi">näyte</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghantoH:n}, {chov:v}, {natlh:v:1}, {Segh:n}</column>
@@ -6390,6 +7051,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6399,6 +7061,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">example</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6406,6 +7069,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru">пример, образец</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6419,6 +7083,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">преемственность, посвящение</column>
       <column name="definition_zh_HK">演替 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sucessão</column>
+      <column name="definition_fi">vallanperimys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nubwI':n}, {'ISyar:n}</column>
@@ -6429,6 +7094,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6438,6 +7104,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6445,6 +7112,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -6458,6 +7126,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">преуспеть (во власти)</column>
       <column name="definition_zh_HK">繼承</column>
       <column name="definition_pt">ter sucesso (no poder)</column>
+      <column name="definition_fi">seurata (virassa), tulla seuraajaksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gheS:v}, {Sugh:v}, {che':v}, {woQ:n}, {nubwI':n}, {ngup:n:2,slang}</column>
@@ -6468,6 +7137,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6477,6 +7147,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6484,6 +7155,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -6497,6 +7169,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">Арбитр наследования [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">繼承仲裁者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Árbitro de Sucessão</column>
+      <column name="definition_fi">vallanperimysneuvottelija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6507,6 +7180,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{cho':n}, {'oDwI':n}</column>
       <column name="examples">
@@ -6520,6 +7194,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
 "В родном мире, есть великий зал, где лидеры Клингонского высшего совета встречаются, чтобы определить политику, задать курс и решить судьбу империи. Сейчас председательствует Гаурон, лидер Высшего совета, назначенный капитаном Жаном-Люком Пикардом, который был Арбитром посвящения."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6527,6 +7202,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 25:src}</column>
     </table>
     <table name="mem">
@@ -6540,6 +7216,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">Лёд</column>
       <column name="definition_zh_HK">冰</column>
       <column name="definition_pt">gelo</column>
+      <column name="definition_fi">jää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIr:v}, {taD:v}, {bIQ:n}, {peD:v}</column>
@@ -6550,6 +7227,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Для строганного льда или вида льда в смузи, {chuch:n:nolink} обычно достаточно. Твердая глыба льда или ледяной куб будут звучать {chuch ngogh:n}.[2]</column>
       <column name="notes_zh_HK">對於刨冰或細冰錐或冰沙中的某種冰塊，{chuch:n:nolink}通常就足夠了。一塊堅實的冰塊或一塊冰塊將是{chuch ngogh:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para gelo raspado ou o tipo de gelo em um cone ou smoothie, geralmente o {chuch:n:nolink} é suficiente. Um bloco sólido de gelo ou um cubo de gelo seria {chuch ngogh:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ajeltuun jäähän tai sno-kartion tai smoothietyyppiseen jäähän {chuch:n:nolink} riittää yleensä. Kiinteä jääpalo tai jääkuutio olisi {chuch ngogh:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6559,6 +7237,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6566,6 +7245,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -6579,6 +7259,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">сплошная глыба льда, кубик льда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">堅固的冰塊、冰塊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bloco sólido de gelo, cubo de gelo</column>
+      <column name="definition_fi">kiinteä lohko jäätä, jääkuutio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6589,6 +7270,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chuch:n}, {ngogh:n}</column>
       <column name="examples"></column>
@@ -6598,6 +7280,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6605,6 +7288,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -6618,6 +7302,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">градина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">冰雹</column>
       <column name="definition_pt">pedra de granizo</column>
+      <column name="definition_fi">rae</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6628,6 +7313,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Эквивалентный способ сказать, что это {'aplom chuch:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{'aplom chuch:n}是等效的說法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma maneira equivalente de dizer isso é {'aplom chuch:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vastaava tapa sanoa tämä on {'aplom chuch:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chuch:n}, {'aplom:n}</column>
       <column name="examples"></column>
@@ -6637,6 +7323,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6644,6 +7331,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -6657,6 +7345,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">люди, родственники, члены одной группы, племени или клана [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">人、親屬、同一群體或部落或氏族的成員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pessoas, parentes, membros do mesmo grupo ou tribo ou clã</column>
+      <column name="definition_fi">sukulaiset, saman ryhmän/heimon/klaanin jäsenet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vInDa':n}, {tuq:n}</column>
@@ -6667,6 +7356,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This may have been a back-fit for a mispronunciation of {jup:n}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6677,6 +7367,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6684,6 +7375,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -6697,6 +7389,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">метать (копье) в, метать (копье) в [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">扔（長矛）、投擲（長矛） [AUTOTRANSLATED]</column>
       <column name="definition_pt">arremessar (lançar) em</column>
+      <column name="definition_fi">heittää keihäs jotakuta kohti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQjej:n}, {ghuS:v:2}, {wob:v}, {tlhevjaQ:n}, {chuH:v:2}</column>
@@ -6707,6 +7400,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Этот глагол можно использовать только в том случае, если снаряд является копьем или напоминает его. Объект этого глагола является предполагаемой целью. Суффикс {-chu':v:suff} используется с этим глаголом, чтобы указать, что цель действительно поражена. [1, p.64] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">僅當射彈為或類似於長矛時才能使用此動詞。該動詞的賓語是預期的目標。此動詞使用後綴{-chu':v:suff}表示實際上已命中目標。 [1, p.64] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo só pode ser usado se o projétil for ou se assemelhar a uma lança. O objeto desse verbo é o destino pretendido. O sufixo {-chu':v:suff} é usado com esse verbo para indicar que o destino é realmente atingido. [1, p.64] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä voidaan käyttää vain, jos ammus on tai muistuttaa keihästä. Tämän verbin kohde on tarkoitettu kohde. Tämän verbin kanssa käytetään päätettä {-chu':v:suff} osoittamaan, että kohde on todella osunut. [1, p.64] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Chuck".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6716,6 +7410,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6723,6 +7418,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6736,6 +7432,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">объяснить четко, уточнить для, указать для [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">清楚地解釋、澄清、指明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">explicar claramente, esclarecer, especificar para</column>
+      <column name="definition_fi">selittää jollekulle, selventää jollekulle, täsmentää jollekulle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIj:v}, {chuH:v:1}</column>
@@ -6746,6 +7443,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6755,6 +7453,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6762,6 +7461,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6775,6 +7475,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">будь мудр [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聰明點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser sábio</column>
+      <column name="definition_fi">olla viisas</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Dogh:v}</column>
       <column name="see_also">{qoH:n}, {val:v}</column>
@@ -6785,6 +7486,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Это относится к демонстрации здравого смысла, основанного на опыте, а не только на интеллекте или на изучении книг. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指根據經驗而不是智力或書本知識來證明自己的判斷力。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a demonstrar bom senso com base na experiência, não apenas em inteligência ou aprendizado de livros. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa hyvän arvostelukyvyn osoittamiseen kokemuksen perusteella, ei vain älykkyydestä tai kirjaoppimisesta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6794,6 +7496,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6801,6 +7504,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6814,6 +7518,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">быть красочным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">多彩</column>
       <column name="definition_pt">ser colorido</column>
+      <column name="definition_fi">olla värikäs</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Dem:v}</column>
       <column name="see_also">{nguv:v}, {rItlh:n}</column>
@@ -6824,6 +7529,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word was awarded to {Qov:n:name} as a Friend of Maltz, hence the Canadian spelling in the definition.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6833,6 +7539,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">colorful</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6840,6 +7547,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -6854,6 +7562,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">быть невинным</column>
       <column name="definition_zh_HK">無辜</column>
       <column name="definition_pt">ser inocente</column>
+      <column name="definition_fi">olla viaton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{DIv:v}</column>
       <column name="see_also"></column>
@@ -6864,6 +7573,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6873,6 +7583,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6880,6 +7591,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6893,6 +7605,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">Метеор</column>
       <column name="definition_zh_HK">流星</column>
       <column name="definition_pt">meteoro</column>
+      <column name="definition_fi">meteori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghopDap:n}, {lIy:n}, {joSraD:n}</column>
@@ -6903,6 +7616,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6912,6 +7626,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6919,6 +7634,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6933,6 +7649,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">ускорять, ускоряться, разгонять</column>
       <column name="definition_zh_HK">加速、加快、加油</column>
       <column name="definition_pt">acelerar</column>
+      <column name="definition_fi">kiihdyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Do:n}</column>
@@ -6943,6 +7660,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Cantonese Chinese for "charge ahead" (衝).</column>
       <column name="components"></column>
       <column name="examples">
@@ -6953,6 +7671,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6960,6 +7679,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6973,6 +7693,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">Тормоз</column>
       <column name="definition_zh_HK">制動器</column>
       <column name="definition_pt">freio</column>
+      <column name="definition_fi">jarru</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6983,6 +7704,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chung:v}, {-Ha':v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -6992,6 +7714,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6999,6 +7722,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7012,6 +7736,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">рекомендовать, предлагать</column>
       <column name="definition_zh_HK">推薦、建議、提議</column>
       <column name="definition_pt">recomendar, sugerir</column>
+      <column name="definition_fi">suositella, ehdottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeS:v}, {qeS:n}</column>
@@ -7022,6 +7747,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Слово {ghu':n} может быть использовано, чтобы упомянуть предложение (предлагаемая ситуация); что что-то может {chup:v} быть {ghu':n}.[2]</column>
       <column name="notes_zh_HK">{ghu':n}這個詞可以用來指一個提議（一種提議的情況）。也就是說，一個人可以{chup:v}一個{ghu':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra {ghu':n} pode ser usada para se referir a uma proposta (uma situação proposta); ou seja, é possível {chup:v} a {ghu':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sanaa {ghu':n} voidaan käyttää viittaamaan ehdotukseen (ehdotettu tilanne); toisin sanoen voi {chup:v} a {ghu':n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7032,6 +7758,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">propose</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7039,6 +7766,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.144-145:src}</column>
     </table>
     <table name="mem">
@@ -7052,6 +7780,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">расстояние, дистанция</column>
       <column name="definition_zh_HK">範圍、距離、射程</column>
       <column name="definition_pt">alcance, distância</column>
+      <column name="definition_fi">kantomatka, toimintasäde, etäisyys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{juv:v}, {chuq'a':n}, {Sum:v}, {Hop:v}, {loghqam:n}</column>
@@ -7062,6 +7791,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7071,6 +7801,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7078,6 +7809,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7091,6 +7823,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">дальний [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">長距離</column>
       <column name="definition_pt">longo alcance</column>
+      <column name="definition_fi">pitkä kantomatka, pitkä toimintasäde, pitkä etäisyys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noch:n}</column>
@@ -7101,6 +7834,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chuq:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -7110,6 +7844,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7117,6 +7852,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7130,6 +7866,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">космический телескоп [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">太空望遠鏡</column>
       <column name="definition_pt">telescópio espacial</column>
+      <column name="definition_fi">avaruusteleskooppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hov tut:n}</column>
@@ -7140,6 +7877,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Это относится к телескопу в космосе, как Хаббл. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指太空望遠鏡，例如哈勃望遠鏡。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um telescópio no espaço, como o Hubble. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa avaruudessa olevaan kaukoputkeen, kuten Hubble. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chuq'a':n}, {legh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7149,6 +7887,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7156,6 +7895,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -7169,6 +7909,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">знать (сословие)</column>
       <column name="definition_zh_HK">貴族 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nobreza</column>
+      <column name="definition_fi">aatelisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qun:n}, {tuq:n}, {joH:n}</column>
@@ -7179,6 +7920,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Это слово упоминает класс людей.</column>
       <column name="notes_zh_HK">這個詞指的是一類人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se refere a uma classe de pessoas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa ihmisryhmään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">That this word refers to a class of people, rather than to an abstract concept, is supported by the script of {TOS - Elaan of Troyius:src}, the only TOS episode with both Klingons and dialogue referring to nobility. The words {Doy'yuS:n}, {'elaS:n}, {telun Hovtay':n}, and {Dom:n} likewise appear only in this episode.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7188,6 +7930,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7195,6 +7938,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7208,6 +7952,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">быть некомфортным (физически)</column>
       <column name="definition_zh_HK">不舒服（身體上） [AUTOTRANSLATED]</column>
       <column name="definition_pt">desconfortável (fisicamente)</column>
+      <column name="definition_fi">olla epämiellyttävä (fyysisesti)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{churHa':v}</column>
       <column name="see_also"></column>
@@ -7218,6 +7963,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Это используется для физического дискомфорта, такого как с одеждой, комнатной температурой, и т. Д. Предметом является то, что чувствует себя некомфортно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於身體不適，例如衣服，室溫等。對像是感到不舒服的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É usado para desconforto físico, como roupas, temperatura ambiente, etc. O assunto é o ser que se sente desconfortável. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään fyysiseen epämukavuuteen, kuten vaatteiden, huoneen lämpötilan tms. Kanssa. Kohde on olo, joka tuntuu epämukavalta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In German, virgin wool is called Schurwolle, and clothes made of it are very scratchy.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7227,6 +7973,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7234,6 +7981,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -7247,6 +7995,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">быть комфортно (физически) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">舒服（身體上） [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar confortável (fisicamente)</column>
+      <column name="definition_fi">olla miellyttävä (fyysisesti)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chur:v}</column>
       <column name="see_also"></column>
@@ -7257,6 +8006,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Это используется для физического комфорта, например, при одежде, комнатной температуре и т. Д. Субъект - это существо, которое чувствует себя комфортно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">用於身體上的舒適，例如衣服，室溫等。對像是感覺舒適的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para o conforto físico, como roupas, temperatura ambiente, etc. O assunto é o ser que se sente confortável. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään fyysiseen mukavuuteen, kuten vaatteiden, huoneen lämpötilan jne. Kanssa. Kohde on olo, joka tuntuu mukavalta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chur:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -7266,6 +8016,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7273,6 +8024,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -7286,6 +8038,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">Быть шумным</column>
       <column name="definition_zh_HK">嘈雜</column>
       <column name="definition_pt">ser barulhento</column>
+      <column name="definition_fi">olla äänekäs</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tam:v:1}</column>
       <column name="see_also">{wab:n}</column>
@@ -7296,6 +8049,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7305,6 +8059,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">loud</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7312,6 +8067,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7325,6 +8081,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">тип грызуна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">囓齒動物的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de roedor</column>
+      <column name="definition_fi">eräs jyrsijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qorvIt:n}, {HaS:v}</column>
@@ -7335,6 +8092,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru">Согласно глоссарию {A Burning House:src}, это грызун, который в основном живет под землей и издает раздражающий шум. Его название буквально означает «тот, который шумит». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據{A Burning House:src}的詞彙表，這是一種囓齒類動物，主要生活在地下並發出令人討厭的聲音。它的名字字面意思是“嘈雜的一個”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o glossário do {A Burning House:src}, este é um roedor que vive principalmente no subsolo e produz um ruído irritante. Seu nome significa literalmente "um que é barulhento". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{A Burning House:src}-sanaston mukaan tämä on jyrsijä, joka elää enimmäkseen maan alla ja tuottaa ärsyttävää melua. Sen nimi tarkoittaa kirjaimellisesti "meluisaa". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chuS:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7344,6 +8102,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mouse</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7351,6 +8110,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -7364,6 +8124,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="definition_ru">Тип музыкального инструмента</column>
       <column name="definition_zh_HK">樂器的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de instrumento musical</column>
+      <column name="definition_fi">eräs soitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7374,6 +8135,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", the British expre
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This seems to be composed of {chuS:v} and {'ugh:v}.
 
 In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed instrument, pear-shaped, about two feet high, and played with a bow while it rests on the knee.</column>
@@ -7385,6 +8147,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cello</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7392,6 +8155,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7405,6 +8169,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="definition_ru">Закон</column>
       <column name="definition_zh_HK">法</column>
       <column name="definition_pt">lei</column>
+      <column name="definition_fi">laki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pab:v}, {bIv:v}, {HeQ:v}, {ngoch:n}, {pab:n}, {Hung:n}, {ghan'Iq:n}, {qop:v}, {rIchwIn:n}</column>
@@ -7415,6 +8180,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {tuch:v}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7430,6 +8196,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rule</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7437,6 +8204,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.178-179:src}</column>
     </table>
     <table name="mem">
@@ -7450,6 +8218,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="definition_ru">адвокат [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">律師</column>
       <column name="definition_pt">advogado</column>
+      <column name="definition_fi">lakimies, juristi, asianajaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7460,6 +8229,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chut:n}, {qeS:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7469,6 +8239,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7476,6 +8247,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -7489,6 +8261,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="definition_ru">быть оставленным</column>
       <column name="definition_zh_HK">剩下 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sobrar</column>
+      <column name="definition_fi">jäädä yli, jäädä jäljelle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuv:n}</column>
@@ -7499,6 +8272,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7508,6 +8282,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7515,6 +8290,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7528,6 +8304,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="definition_ru">пережиток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">剩落</column>
       <column name="definition_pt">sobras</column>
+      <column name="definition_fi">ylijäänyt, (monikossa) muut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuv:v}</column>
@@ -7538,6 +8315,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="notes_ru">Это может быть использовано для остатка пищи. Тем не менее, ядро ​​яблока, которое не съедено, - {SuqSIv:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以用於剩菜。但是，沒有吃的蘋果的核心是{SuqSIv:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para restos de comida. No entanto, o núcleo de uma maçã, que não é consumido, é o {SuqSIv:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää ruokajäämiin. Omenan ydin, jota ei syö, on kuitenkin {SuqSIv:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7547,6 +8325,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7554,6 +8333,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -7567,6 +8347,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="definition_ru">объедки (грамматический термин)</column>
       <column name="definition_zh_HK">剩落（語法術語）</column>
       <column name="definition_pt">sobras (termo gramatical)</column>
+      <column name="definition_fi">ylijääneet-sanaluokka (muut kuin verbit ja substantiivit)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7577,6 +8358,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="notes_ru">{chuvmey:n:nolink} включает в себя местоимения, числительные, объединения, обстоятельства и восклицания.</column>
       <column name="notes_zh_HK">{chuvmey:n:nolink}包括代詞，數字，連詞，狀語和感嘆詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {chuvmey:n:nolink} inclui pronomes, números, conjunções, adverbiais e exclamações. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{chuvmey:n:nolink} sisältää pronominit, numerot, konjunktiot, adverbiaalit ja huutomerkit. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{chuv:n}, {-mey:n}</column>
       <column name="examples"></column>
@@ -7586,6 +8368,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7593,6 +8376,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7606,6 +8390,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="definition_ru">чих [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">噴嚏 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espirrar</column>
+      <column name="definition_fi">aivastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IqnaH:n}, {'IqnaH QaD:n}, {tlhov:v}, {jev:v:2}, {tlhar:v}</column>
@@ -7616,6 +8401,7 @@ In the {TNG:src} novel {Power Hungry:src}, this was described as a four-stringed
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Achoo!"
 
 The noun {chuyDaH:n} seems to imply that this verb, or a homophone, can be used to describe the expulsion of gas at a high velocity.</column>
@@ -7627,6 +8413,7 @@ The noun {chuyDaH:n} seems to imply that this verb, or a homophone, can be used 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7634,6 +8421,7 @@ The noun {chuyDaH:n} seems to imply that this verb, or a homophone, can be used 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -7647,6 +8435,7 @@ The noun {chuyDaH:n} seems to imply that this verb, or a homophone, can be used 
       <column name="definition_ru">ускорители, двигатели</column>
       <column name="definition_zh_HK">火箭推進器（眾數）</column>
       <column name="definition_pt">propulsores</column>
+      <column name="definition_fi">(työntö)moottorit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{laQ:v}</column>
@@ -7661,6 +8450,9 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
 Смотрите, как Гаурон говорит это {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be/KKZoYsbxUjY}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Potkurityyppejä ovat {'eDSeHcha:n}, {lolSeHcha:n}, {muDDaq 'eDSeHcha lulaQlu'bogh:n}, {Hong boq chuyDaH:n} ja {'o' chuyDaH:n}.
+
+Katso Gowronin sanovan {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be/KKZoYsbxUjY} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{DaH:n} appears to be "array", and {chuy:v:nolink} may be related to the verb "to sneeze".</column>
       <column name="components">{vIj:n:inhps}</column>
       <column name="examples"></column>
@@ -7670,6 +8462,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7677,6 +8470,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7690,6 +8484,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="definition_ru">Быть новым</column>
       <column name="definition_zh_HK">新</column>
       <column name="definition_pt">seja novo</column>
+      <column name="definition_fi">olla uusi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngo':v}</column>
       <column name="see_also">{bogh:v}, {Qup:v}</column>
@@ -7700,6 +8495,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{He chu' ghoS, DIvI' neHmaH.:sen}</column>
@@ -7709,6 +8505,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7716,6 +8513,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7729,6 +8527,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="definition_ru">включать, активировать(устройство)</column>
       <column name="definition_zh_HK">參與、激活（設備） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ligar, ativar (um dispositivo)</column>
+      <column name="definition_fi">käynnistää, aktivoida (laite)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chu'Ha':v}</column>
       <column name="see_also">{chu':v:3}</column>
@@ -7739,6 +8538,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7755,6 +8555,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7762,6 +8563,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7775,6 +8577,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="definition_ru">играть на (музыкальном инструменте) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">演奏一種樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tocar (um instrumento musical)</column>
+      <column name="definition_fi">soittaa (soitinta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chu':v:2}, {qeb:v}, {Heng:v}, {rIl:v:2}, {SuS:v}, {weq:v}, {tlhaw':v}, {moq:v}</column>
@@ -7785,6 +8588,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7794,6 +8598,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7801,6 +8606,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7814,6 +8620,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="definition_ru">выключить, отключить, деактивировать(устройство)</column>
       <column name="definition_zh_HK">脫離、停用（設備） [AUTOTRANSLATED]</column>
       <column name="definition_pt">desligar, desativar (um dispositivo)</column>
+      <column name="definition_fi">sammuttaa, deaktivoida (laite)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chu':v:2}</column>
       <column name="see_also"></column>
@@ -7824,6 +8631,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is not defined as such in canon, but appears in the bodies of {TKD:src} and {KGT:src}[1; 2]. This entry is here for ease of reference only.</column>
       <column name="components">{chu':v:2}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -7833,6 +8641,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7840,6 +8649,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.48:src}, [2] {KGT p.54:src}</column>
     </table>
     <table name="mem">
@@ -7853,6 +8663,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="definition_ru">Спусковой крючок, курок, гашетка</column>
       <column name="definition_zh_HK">觸發 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desencadear, ativar</column>
+      <column name="definition_fi">liipaisin, laukaisin, käynnistäjä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chu'wI':n:2}</column>
@@ -7863,6 +8674,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The glossary to {A Burning House:src} claims that {chu'wI':n:nolink} meaning "trigger" is also slang for "rookie", "beginner", or "newbie". See {chu':v:1}.</column>
       <column name="components">{chu':v:2}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7872,6 +8684,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7879,6 +8692,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7892,6 +8706,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="definition_ru">игрок (инструмента) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">球員（樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tocador (de um instrumento)</column>
+      <column name="definition_fi">(soittimen) soittaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chu'wI':n:1}</column>
@@ -7902,6 +8717,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chu':v:3}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7911,6 +8727,7 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7918,5 +8735,6 @@ Watch Gowron say {chuyDaH yIlaQ!:sen:nolink}: {YouTube video:url:http://youtu.be
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>

--- a/mem-03-D.xml
+++ b/mem-03-D.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {D:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{D:sen:nolink}</column>
       <column name="definition_pt">a consoante {D:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {D:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">вести себя как, действовать в стиле кого-то</column>
       <column name="definition_zh_HK">表現得像、行事一樣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comportar-se como, agir da maneira de</column>
+      <column name="definition_fi">käyttäytyä kuin joku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gheS:v}, {DawI':n}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -79,6 +85,7 @@
    И также следует поступить и тебе"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -86,6 +93,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {paq'batlh p.150-151,186-187:src}</column>
     </table>
     <table name="mem">
@@ -99,6 +107,7 @@
       <column name="definition_ru">ты(действие)-ему/ей/им/этому(вещи), вы(действие)-ему/ей/им/этому(вещи)</column>
       <column name="definition_zh_HK">你：他、它、他們、它們</column>
       <column name="definition_pt">você - ele/ela/eles/elas</column>
+      <column name="definition_fi">sinä-hän/se/he/ne</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Du-:v:pref}, {nI-:v:pref}</column>
       <column name="see_also">{bo-:v:pref}, {bI-:v:pref}, {yI-:v:pref}, {tI-:v:pref}</column>
@@ -113,6 +122,9 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
 Когда используется вместе с {-lu':v}, этот префикс означает, что "кто-то (неопределённый субъект) делает что-то для тебя".</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SoH:n}: {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n} = {Da-:v:pref,nolink}
+
+Kun sitä käytetään {-lu':v}: n kanssa, tämä etuliite tarkoittaa "Joku (määrittelemätön aihe) tekee sinulle jotain". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -122,6 +134,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">you-him, you-her, you-it, you-them</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -129,6 +142,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru">ты-ему, ты-ей, ты-этому, ты-им, вы-ему, вы-ей, вы-этому, вы-им</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -142,6 +156,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">жить в / в, проживать в / в [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">住在</column>
       <column name="definition_pt">residir em, habitar em</column>
+      <column name="definition_fi">asua jossakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngan:n}, {toq:v}, {yIn:v}</column>
@@ -152,6 +167,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">В клингоне, когда человек живет в каком-то месте, его или ее считают занятым или населяющим его. То есть, он или она не делают что-то в каком-то месте, а делают что-то с ним.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在克林崗，當一個人居住在一個地方時，他或她被認為是居住或居住於該地方。也就是說，他或她不被視為在某個位置做某事，而是在對該位置做某事。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em Klingon, quando se vive em um lugar, ele ou ela é considerado como ocupando ou habitando. Ou seja, ele ou ela não é visto como fazendo algo em um local, mas como fazendo algo a ele.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun joku asuu paikassa Klingonissa, hänen ajatellaan asuvan tai asuttavan sitä. Toisin sanoen hänen ei katsota tekevän jotain paikassa, vaan pikemminkin tekevänsä jotain sille.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -162,6 +178,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">live at, live in</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -169,6 +186,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KLI mailing list 1999.07.19:src}</column>
     </table>
     <table name="mem">
@@ -182,6 +200,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">грязь, глина, шпатлевка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">泥、粘土、膩子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lama, argila, massa de vidraceiro</column>
+      <column name="definition_fi">muta, savi, kitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -192,6 +211,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Ichabod Mudd" ({'IqbaD:sen:nolink}) was the name of a character on the Captain Midnight radio serial.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -201,6 +221,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -208,6 +229,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -221,6 +243,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Когда тебе угрожают, дерись.</column>
       <column name="definition_zh_HK">受到威脅時，要打架。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quando ameaçado, lute.</column>
+      <column name="definition_fi">Kun sinua uhataan, taistele.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -231,6 +254,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -240,6 +264,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -247,6 +272,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.7:src}</column>
     </table>
     <table name="mem">
@@ -260,6 +286,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">отсутствовать</column>
       <column name="definition_zh_HK">缺席 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser ausente</column>
+      <column name="definition_fi">olla poissaoleva</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SaH:v:1}</column>
       <column name="see_also">{Dach:v:2}</column>
@@ -270,6 +297,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -279,6 +307,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">missing</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -286,6 +315,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -299,6 +329,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">быть невнимательным, быть отвлеченным, не уделять должного внимания</column>
       <column name="definition_zh_HK">不注意、分心、缺乏專注 [AUTOTRANSLATED]</column>
       <column name="definition_pt">não ser atento, distraído, falta de foco</column>
+      <column name="definition_fi">olla huolimaton, olla hajamielinen, olla keskittymätön</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jeH:v}, {SaH:v:2}, {Dach:v:1}</column>
@@ -309,6 +340,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это применяют к человеку, кто не сфокусирован на задании.[1, стр.149]</column>
       <column name="notes_zh_HK">這適用於不專注於手頭任務的人。[1, p.149] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se aplica a uma pessoa que não está focada na tarefa em questão.[1, p.149] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä koskee henkilöä, joka ei ole keskittynyt käsillä olevaan tehtävään[1, p.149] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -318,6 +350,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -325,6 +358,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -338,6 +372,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Дом ДэГора</column>
       <column name="definition_zh_HK">D'Ghor之家 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Casa de D'Ghor</column>
+      <column name="definition_fi">D'Ghorin huone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuq:n}</column>
@@ -348,6 +383,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это Дом {DennaS:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{DennaS:n:name}的房子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a casa do {DennaS:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {DennaS:n:name}-talo. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -357,6 +393,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -364,6 +401,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Battle at the Binary Stars:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -377,6 +415,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">смесь частей животных [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物部分的混合物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mistura de partes de animais</column>
+      <column name="definition_fi">sekoitus eläinten osia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -387,6 +426,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Since {tuj:v} means "hot", this is a "hotdog".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -396,6 +436,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hotdog, hot dog</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -403,6 +444,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -416,6 +458,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">сейчас</column>
       <column name="definition_zh_HK">現在</column>
       <column name="definition_pt">agora</column>
+      <column name="definition_fi">nyt</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SIbI'Ha':adv}</column>
       <column name="see_also">{SIbI':adv}, {pay':adv}</column>
@@ -426,6 +469,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Смотрите, как Гаурон говорит это: {YouTube video:url:http://youtu.be/eM5zeoAf2Ek}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/eM5zeoAf2Ek} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/eM5zeoAf2Ek} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/eM5zeoAf2Ek} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -435,6 +479,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -442,6 +487,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -455,6 +501,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">массив, батарея (военный термин)</column>
       <column name="definition_zh_HK">系列、序列</column>
       <column name="definition_pt">matriz, banco</column>
+      <column name="definition_fi">patteri, sarja (aseita)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{may'morgh:n}</column>
@@ -465,6 +512,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -476,6 +524,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">battery</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -483,6 +532,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -496,6 +546,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Я должен вымыть свои волосы сейчас. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我現在必須洗頭髮。</column>
       <column name="definition_pt">Eu devo lavar meu cabelo agora.</column>
+      <column name="definition_fi">Minun pitää mennä nyt pesemään hiukseni.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -506,6 +557,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это то, что вы можете сказать, чтобы отказаться от чьих-то романтических инициатив. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">您可能會說這是拒絕某人浪漫情調的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é algo que você pode dizer para recusar as aberturas românticas de alguém. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän voit sanoa hylkäämään jonkun romanttiset alkusoittot. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DaH:adv}, {jIb:n}, {-wIj:n}, {vI-:v}, {Say':v}, {-nIS:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -515,6 +567,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -522,6 +575,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -535,6 +589,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Плати сейчас же!</column>
       <column name="definition_zh_HK">即刻畀錢！</column>
       <column name="definition_pt">Pague agora!</column>
+      <column name="definition_fi">Maksa nyt!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -546,6 +601,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DaH:adv}, {yI-:v}, {DIl:v}</column>
       <column name="examples"></column>
@@ -555,6 +611,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -562,6 +619,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -575,6 +633,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Сегодня</column>
       <column name="definition_zh_HK">今日、今天</column>
       <column name="definition_pt">hoje</column>
+      <column name="definition_fi">tänään</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jaj:n}</column>
@@ -645,6 +704,17 @@ Como sujeito de uma frase, {jajvam:n:nolink} é mais comumente encontrado, embor
 {DaHjaj:n:nolink} também é usado com palavras que indicam uma hora do dia para se referir a essa parte do dia atual. Por exemplo, {DaHjaj ram:n}, literalmente "noite de hoje", significa "hoje à noite" .[2]
 
 Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikka sekä {DaHjaj:n:nolink} että {jajvam:n} tarkoittavat "tänään", ne eivät ole aivan keskenään vaihdettavissa. {DaHjaj:n:nolink}: ta (mutta ei {jajvam:n:nolink}) käytetään lauseen aikaelementtinä: {DaHjaj romuluSngan vIHoHpu':sen:nolink} "tänään tapoin romulanin".
+
+Lauseen aiheena {jajvam:n:nolink} löytyy tyypillisemmin, vaikka {DaHjaj:n:nolink} ei ole mahdotonta. Vertailla:
+▶ {nI' jajvam:sen:nolink} "tämä päivä on pitkä"
+▶ {nI' DaHjaj:sen:nolink} "tänään on pitkä" [2]
+
+{DaHjaj:n:nolink} käyttäytyy myös substantiivina sellaisissa substantiivirakenteissa kuin {DaHjaj gheD:n} "tämän päivän saalis", termi, jota usein kuulla Klingonin ravintoloissa ja jonka merkitys on verrattavissa "päivän saaliin".
+
+{DaHjaj:n:nolink}-sanaa käytetään myös sanoilla, jotka osoittavat kellonajan viittaamaan kuluvan päivän kyseiseen osaan. Esimerkiksi {DaHjaj ram:n}, kirjaimellisesti "tämän päivän yö", tarkoittaa "tänä iltana".
+
+Aikaelementtinä {DaHjaj:n} edeltää kaikkia adverbaaleja.[2][2][2][1, sec. 6.7] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DaH:adv}, {jaj:n}</column>
       <column name="examples"></column>
@@ -654,6 +724,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -661,6 +732,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {msn 1997.06.29:src}</column>
     </table>
     <table name="mem">
@@ -674,6 +746,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">Сегодня я воин.</column>
       <column name="definition_zh_HK">我今天成為戰士。</column>
       <column name="definition_pt">Hoje eu sou um guerreiro.</column>
+      <column name="definition_fi">Tänään olen soturi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaHjaj SuvwI' SoH.:sen}</column>
@@ -684,6 +757,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DaHjaj:n}, {SuvwI':n}, {-'e':n}, {jIH:n:1}</column>
       <column name="examples"></column>
@@ -693,6 +767,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -700,6 +775,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.203:src}</column>
     </table>
     <table name="mem">
@@ -713,6 +789,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">Сегодня ты воин.</column>
       <column name="definition_zh_HK">你今天成為戰士。</column>
       <column name="definition_pt">Hoje você é um guerreiro.</column>
+      <column name="definition_fi">Tänään sinä olet soturi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaHjaj SuvwI''e' jIH.:sen}</column>
@@ -723,6 +800,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DaHjaj:n}, {SuvwI':n}, {SoH:n}</column>
       <column name="examples"></column>
@@ -732,6 +810,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -739,6 +818,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -752,6 +832,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">блюдо в ресторане, "блюдо дня"</column>
       <column name="definition_zh_HK">在一家餐館的菜、“當天的捕獲” [AUTOTRANSLATED]</column>
       <column name="definition_pt">prato em um restaurante, "captura do dia"</column>
+      <column name="definition_fi">"päivän saalis" ravintolassa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qe':n}</column>
@@ -762,6 +843,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DaHjaj:n}, {gheD:n}</column>
       <column name="examples"></column>
@@ -771,6 +853,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -778,6 +861,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -791,6 +875,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">Быть интересным</column>
       <column name="definition_zh_HK">很有趣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser interessante</column>
+      <column name="definition_fi">olla kiinnostava</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Dal:v}, {qetlh:v}</column>
       <column name="see_also">{le':v}, {vuQ:v}, {Daj:v:2}</column>
@@ -801,6 +886,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -810,6 +896,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -817,6 +904,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -830,6 +918,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">тестировать безрезультатно</column>
       <column name="definition_zh_HK">測試結果不確定 [AUTOTRANSLATED]</column>
       <column name="definition_pt">testar inconclusivamente</column>
+      <column name="definition_fi">todistaa, testata (tuloksettomasti)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tob:v}</column>
       <column name="see_also">{'ol:v}, {waH:v:1}, {nuD:v}, {poj:v}, {Daj:v:1}</column>
@@ -840,6 +929,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -850,6 +940,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -857,6 +948,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -870,6 +962,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">Желаю тебе умереть до того, как тебя схватят.</column>
       <column name="definition_zh_HK">願你在被俘之前先死。</column>
       <column name="definition_pt">Que você morra antes de ser capturado.</column>
+      <column name="definition_fi">Toivon, että kuolet ennen kuin sinut napataan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -880,6 +973,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -889,6 +983,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -896,6 +991,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.93:src}</column>
     </table>
     <table name="mem">
@@ -909,6 +1005,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">быть скучным</column>
       <column name="definition_zh_HK">無聊、沒勁</column>
       <column name="definition_pt">ser entediante</column>
+      <column name="definition_fi">olla tylsä</column>
       <column name="synonyms">{qetlh:v}</column>
       <column name="antonyms">{Daj:v:1,is}</column>
       <column name="see_also"></column>
@@ -919,6 +1016,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is "dull".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -928,6 +1026,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -935,6 +1034,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -948,6 +1048,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">Никаких врагов - это скучно.</column>
       <column name="definition_zh_HK">沒有敵人是無聊的。</column>
       <column name="definition_pt">Nenhum inimigo é entediante.</column>
+      <column name="definition_fi">Yksikään vihollinen ei ole tylsä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -958,6 +1059,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Dal:v}, {pagh:n:1h}, {jagh:n}</column>
       <column name="examples"></column>
@@ -967,6 +1069,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -974,6 +1077,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.201:src}</column>
     </table>
     <table name="mem">
@@ -987,6 +1091,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">рассматривать как, рассматривать как, рассматривать (относиться к кому-то, как) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">視為，視為，考慮（對待某人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">considerar como, ver como (tratar isso. como ...)</column>
+      <column name="definition_fi">pitää jonakin, kohdella (jotakuta) kuin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -997,6 +1102,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">To "damn" someone as something.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1008,6 +1114,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">treat somebody like</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1015,6 +1122,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1028,6 +1136,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">складка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">皺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dobra (em papel)</column>
+      <column name="definition_fi">kurttu, taitos (paperissa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wer:v}, {wol:v}</column>
@@ -1038,6 +1147,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1047,6 +1157,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fold</column>
       <column name="search_tags_de">Knick</column>
       <column name="search_tags_fa"></column>
@@ -1054,6 +1165,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1067,6 +1179,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">оккупировать(военный термин)</column>
       <column name="definition_zh_HK">佔據（軍事術語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ocupar (termo militar)</column>
+      <column name="definition_fi">miehittää (aluetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DoQ:v}, {Daw':v}</column>
@@ -1077,6 +1190,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1086,6 +1200,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1093,6 +1208,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1106,6 +1222,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">наушники [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頭戴式耳機</column>
       <column name="definition_pt">fones de ouvido</column>
+      <column name="definition_fi">kuulokkeet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rI'wI':n}</column>
@@ -1116,6 +1233,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru">Это относится к устройству, надетому на уши, с обоими ушами, с полосой на голове, так что только пользователь может что-то слушать. Устройство, которое носит Ухура, является {teS HablI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指戴在耳朵上且雙耳被覆蓋且頭上有一條綁帶的設備，因此只有用戶才能聽見。 Uhura佩戴的設備是{teS HablI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um dispositivo usado sobre os ouvidos com os dois ouvidos cobertos, com uma faixa na cabeça, para que apenas o usuário possa ouvir alguma coisa. O dispositivo que Uhura usa é um {teS HablI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa laitteeseen, jota käytetään korvien yli, molemmat korvat peitettynä, nauhalla pään yli, jotta vain käyttäjä voi kuunnella jotain. Uhuran käyttämä laite on {teS HablI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It was clarified during the Q &amp; A session that this word does not apply to earbuds.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1125,6 +1243,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1132,6 +1251,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1145,6 +1265,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">бессмыслица</column>
       <column name="definition_zh_HK">胡說、廢話</column>
       <column name="definition_pt">absurdo, bobagem</column>
+      <column name="definition_fi">hölynpöly</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chatlh:n:2,slang}, {jat Hol:n}, {laq:v:2}, {laqlaq:n}</column>
@@ -1155,6 +1276,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1164,6 +1286,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1171,6 +1294,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1184,6 +1308,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">глупая песня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">無意義的歌</column>
       <column name="definition_pt">música sem sentido</column>
+      <column name="definition_fi">siansaksalaulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}</column>
@@ -1194,6 +1319,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Dap:n}, {bom:n}</column>
       <column name="examples"></column>
@@ -1203,6 +1329,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1210,6 +1337,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1223,6 +1351,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">подслушивать</column>
       <column name="definition_zh_HK">竊聽、偷聽</column>
       <column name="definition_pt">bisbilhotar</column>
+      <column name="definition_fi">salakuunnella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1233,6 +1362,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1244,6 +1374,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">intercept</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1251,6 +1382,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru">перехват, перехватывать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1264,6 +1396,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">объект, местонахождение, локация</column>
       <column name="definition_zh_HK">地點、地方</column>
       <column name="definition_pt">localização, local, área</column>
+      <column name="definition_fi">paikka, sijainti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-Daq:n}</column>
@@ -1274,6 +1407,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1287,6 +1421,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
 ▶ {wej Daqmey yIHeD.:sen:nolink} "Возвращайся на 3 места назад."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1294,6 +1429,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1308,6 +1444,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">юрисдикция, территория</column>
       <column name="definition_zh_HK">轄區、領土</column>
       <column name="definition_pt">jurisdição, território</column>
+      <column name="definition_fi">hallinnollinen alue, tuomiopiiri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{teblaw':n}, {yer:n}</column>
@@ -1318,6 +1455,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru">Это слово появилось только в удалённой сцене фильма {Star Trek:src} 2009.</column>
       <column name="notes_zh_HK">這個詞僅出現在2009年{Star Trek:src}電影的刪除場景中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra apareceu apenas em uma cena excluída do filme {Star Trek:src} de 2009. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on esiintynyt vain poistetussa kohtauksessa vuoden 2009 {Star Trek:src}-elokuvasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Daq:n}, {-'a':n}</column>
       <column name="examples">
@@ -1328,6 +1466,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1335,6 +1474,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek 2009 deleted scene:src}</column>
     </table>
     <table name="mem">
@@ -1348,6 +1488,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">ориентир (не здание) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地標（非建築物）</column>
       <column name="definition_pt">ponto de referência (não um edifício)</column>
+      <column name="definition_fi">nähtävyys (ei rakennus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qach noy:n}</column>
@@ -1358,6 +1499,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Daq:n}, {noy:v}</column>
       <column name="examples"></column>
@@ -1367,6 +1509,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1374,6 +1517,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1387,6 +1531,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">Я заблудился.</column>
       <column name="definition_zh_HK">我迷路了。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Estou perdido.</column>
+      <column name="definition_fi">Olen eksynyt.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1397,6 +1542,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">On {TKD p.172:src}, "I'm lost" is given as {jIHtaHbogh naDev vISovbe'.:sen:nolink} On {PK:src}, "I'm lost" is given in both regular and clipped Klingon versions, the latter of which is {DaqwIj Sovbe'.:sen:nolink}</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1406,6 +1552,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1413,6 +1560,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -1426,6 +1574,7 @@ Como um elemento de tempo, {DaHjaj:n} precede qualquer adverbial. [1, sec. 6.7] 
       <column name="definition_ru">Где ты живешь?</column>
       <column name="definition_zh_HK">你住在哪裡？</column>
       <column name="definition_pt">Onde você mora?</column>
+      <column name="definition_fi">Missä asut?</column>
       <column name="synonyms">
 ▶ {nuqDaq 'oH juHlIj'e'?:sen}</column>
       <column name="antonyms"></column>
@@ -1449,6 +1598,9 @@ Ett godtagbart sätt att uttrycka denna efterfrågan som en fråga är {nuq DaDa
       <column name="notes_pt">Em Klingon, isso é mais uma ordem do que uma pergunta. Literalmente significa: "Identifique o lugar onde você mora!"[1]
 
 Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab?:sen:nolink} [1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonissa tämä on pikemminkin komento kuin kysymys. Se tarkoittaa kirjaimellisesti: "Tunnista asuinpaikkasi!" [1]
+
+Hyväksyttävä tapa muotoilla tämä vaatimus kysymykseksi on {nuq DaDab?: Sen: nolink} [1]{nuq DaDab?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1458,6 +1610,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">address</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1465,6 +1618,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru">адрес</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 1999.07.19:src}</column>
     </table>
     <table name="mem">
@@ -1478,6 +1632,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">залив, залив, бухта [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">海灣、澳</column>
       <column name="definition_pt">baía, entrada, enseada</column>
+      <column name="definition_fi">lahti, poukama</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngeng:n}</column>
@@ -1488,6 +1643,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1497,6 +1653,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1504,6 +1661,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1517,6 +1675,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">хорошо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">井</column>
       <column name="definition_pt">poço (Poços de água subterrânea)</column>
+      <column name="definition_fi">kaivo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIQ:n}, {tlhegh jIrmoHwI':n}</column>
@@ -1527,6 +1686,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru">Обычно это относится к колодцу с водой, но может быть и для других веществ. Это относится к скважине, которая построена (или вырыта), а не естественным путем. Если нужна ясность, можно сказать {bIQ Daqrab:n@@bIQ:n, Daqrab:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常是指水井，但也可能是其他物質。它是指構造（或挖掘）而不是自然發生的井。如果需要澄清，您可以說{bIQ Daqrab:n@@bIQ:n, Daqrab:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso normalmente se refere a um poço de água, mas pode ser para outras substâncias. Refere-se a um poço que é construído (ou escavado), em vez de ocorrer naturalmente. Se for necessária clareza, pode-se dizer {bIQ Daqrab:n@@bIQ:n, Daqrab:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa normaalisti vesikaivoon, mutta voi koskea muita aineita. Se viittaa kaivoon, joka on rakennettu (tai kaivettu) pikemminkin kuin luonnossa esiintyvä. Jos tarvitaan selkeyttä, voidaan sanoa {bIQ Daqrab:n@@bIQ:n, Daqrab:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1536,6 +1696,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1543,6 +1704,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -1556,6 +1718,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">Воинский нож, Дактаг(или Дактар)</column>
       <column name="definition_zh_HK">《d'k tahg》（戰士的刀）</column>
       <column name="definition_pt">faca de guerreiro, d'k tahg</column>
+      <column name="definition_fi">eräs veitsi, soturin veitsi, d'k tahg</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tajHom:n}, {ret'aq:n}, {moQ:n}, {DuQwI'Hom:n}, {taj:n}</column>
@@ -1566,6 +1729,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru">Существует идиома {jej; Daqtagh rur}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{jej; Daqtagh rur}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {jej; Daqtagh rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {jej; Daqtagh rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1575,6 +1739,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1582,6 +1747,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1595,6 +1761,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">Д'актурак (ледяной человек)</column>
       <column name="definition_zh_HK">d'akturak，“冰人” [AUTOTRANSLATED]</column>
       <column name="definition_pt">D'akturak, "homem de gelo" (ice man)</column>
+      <column name="definition_fi">d'akturak, "jäämies"</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qajunpaQ:n}</column>
@@ -1605,6 +1772,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru">Это относится к людям с «ледяной» манерой поведения, особенно к жестким переговорщикам. Неясно, является ли это местным клингонским словом или заимствованным трилловским или криозианским словом или фразой, означающей «ледяной человек», но, в любом случае, это клингонское произношение.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是一個舉止“冰冷”的人，尤其是一個強硬的談判者。目前尚不清楚這是本地克林崗語單詞還是藉來的Trill或Kriosian單詞或短語，意思是“冰人”，但是無論如何，這就是克林貢語發音。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a uma pessoa com uma atitude "fria", especialmente um negociador duro. Não está claro se esta é uma palavra Klingon nativa ou uma palavra ou frase emprestada de Trill ou Kriosian que significa "homem de gelo", mas, em qualquer caso, esta é a pronúncia Klingon.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, jolla on "jäinen" käytös, erityisesti kovaan neuvottelijaan. Ei ole selvää, onko tämä syntyperäinen klingonilainen sana vai lainattu Trill- tai Kriosian-sana tai lause, joka tarkoittaa "jäämies", mutta joka tapauksessa tämä on klingonin ääntäminen.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The requested word was "d'akturak", which is how the definition appears in the new words list. The "ice man" part was added for clarification.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1614,6 +1782,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">iceman, ice man</column>
       <column name="search_tags_de">Eismann</column>
       <column name="search_tags_fa"></column>
@@ -1621,6 +1790,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru">ледяной человек</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt">homem de gelo</column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}, [2] {DS9 - Blood Oath:src}</column>
     </table>
     <table name="mem">
@@ -1634,6 +1804,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">конский хвост(женская прическа)</column>
       <column name="definition_zh_HK">馬尾辮</column>
       <column name="definition_pt">rabo de cavalo</column>
+      <column name="definition_fi">poninhäntä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIb:n}, {choljaH:n}, {naQ:n:2}, {Qeb:n:2}</column>
@@ -1644,6 +1815,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1653,6 +1825,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1660,6 +1833,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1673,6 +1847,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">чай</column>
       <column name="definition_zh_HK">茶</column>
       <column name="definition_pt">chá</column>
+      <column name="definition_fi">tee</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qenvob:n}, {bIQ na':n}, {runpI':n}, {Dargh wIb:n}</column>
@@ -1683,6 +1858,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru">Упоминается только как напиток. Для высушенной смеси, использованной, чтобы заваривать чай, смотрите {Qenvob:n}.</column>
       <column name="notes_zh_HK">這僅指飲料。有關用於沖泡茶的干燥混合物，請參見{Qenvob:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se apenas à bebida. Para a mistura seca usada para fazer chá, consulte {Qenvob:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa vain juomaan. Katso teetä keittämiseen käytetty kuivunut seos kohdasta {Qenvob:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Dark". Also, Darjeeling is a type of tea.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1694,6 +1870,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
 ▶ {Hoch vor Dargh wIb.:sen:nolink} "Кислый чай лечит всё."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1701,6 +1878,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -1714,6 +1892,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">кислый чай [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">酸茶</column>
       <column name="definition_pt">chá azedo</column>
+      <column name="definition_fi">hapan tee</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1724,6 +1903,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Dargh:n}, {wIb:v}</column>
       <column name="examples">
@@ -1734,6 +1914,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1741,6 +1922,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -1754,6 +1936,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">чайная чашка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">茶杯</column>
       <column name="definition_pt">xícara de chá</column>
+      <column name="definition_fi">teekuppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tu'lum:n}</column>
@@ -1764,6 +1947,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru">В {TNK:src} «чашка и блюдце» переводится как {Dargh HIvje' jengva' je:n@@Dargh HIvje':n, jengva':n, je:conj}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{TNK:src}中，“杯子和碟子”被翻譯為{Dargh HIvje' jengva' je:n@@Dargh HIvje':n, jengva':n, je:conj}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No {TNK:src}, "xícara e pires" é traduzido como {Dargh HIvje' jengva' je:n@@Dargh HIvje':n, jengva':n, je:conj}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohdassa {TNK:src} "kuppi ja asetti" käännetään nimellä {Dargh HIvje' jengva' je:n@@Dargh HIvje':n, jengva':n, je:conj}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Dargh:n}, {HIvje':n}</column>
       <column name="examples"></column>
@@ -1773,6 +1957,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1780,6 +1965,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1793,6 +1979,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">дарсек, единица валюты [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">darsek、貨幣單位 [AUTOTRANSLATED]</column>
       <column name="definition_pt">darsek, unidade monetária</column>
+      <column name="definition_fi">eräs valuutta, darsek</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DeQ:n}, {Huch:n}</column>
@@ -1803,6 +1990,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Someone on the show didn't like the sound of {DeQ:n} and added something to the middle to make a new word.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1812,6 +2000,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1819,6 +2008,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1832,6 +2022,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">Ботинок</column>
       <column name="definition_zh_HK">靴</column>
       <column name="definition_pt">bota</column>
+      <column name="definition_fi">saapas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{waq:n}, {mIv je DaS:n}</column>
@@ -1842,6 +2033,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The movie "Das Boot" is a submarine thriller which inspired some of the cloaked ship battle sequences in Star Trek.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1851,6 +2043,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1858,6 +2051,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1871,6 +2065,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">зажимать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">捏 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer movimento de pinça com os dedos</column>
+      <column name="definition_fi">nipistää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1881,6 +2076,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{cha''etlh DaSwI':n}</column>
@@ -1890,6 +2086,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1897,6 +2094,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1910,6 +2108,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">Понедельник</column>
       <column name="definition_zh_HK">星期一</column>
       <column name="definition_pt">Segunda-feira</column>
+      <column name="definition_fi">maanantai</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hogh:n}</column>
@@ -1920,6 +2119,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This refers to a line in "Lady Madonna" by The Beatles: "Monday's child has learned to tie his bootlace."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1929,6 +2129,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1936,6 +2137,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -1949,6 +2151,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">Ботиночный шип</column>
       <column name="definition_zh_HK">靴釘</column>
       <column name="definition_pt">espinho da bota</column>
+      <column name="definition_fi">saapasnaula?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pu':n:2}</column>
@@ -1959,6 +2162,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DaS:n}, {pu':n:2}</column>
       <column name="examples"></column>
@@ -1968,6 +2172,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1975,6 +2180,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1988,6 +2194,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">повсюду, везде</column>
       <column name="definition_zh_HK">到處、周圍</column>
       <column name="definition_pt">em toda parte</column>
+      <column name="definition_fi">kaikkialla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naDev:n}, {pa':n:2}, {vogh:n}, {tIngvo' 'evDaq chanDaq:sen:idiom}</column>
@@ -1998,6 +2205,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="notes_ru">Это слово никогда не следовало за суффиксом, определяющим местонахождение {-Daq:n:suff}. ({TKD 3.3.5:src})</column>
       <column name="notes_zh_HK">該詞後不帶位置後綴{-Daq:n:suff}。 （{TKD 3.3.5:src}） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra nunca é seguida pelo sufixo locativo {-Daq:n:suff}. ({TKD 3.3.5:src}) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa ei koskaan seuraa paikallinen loppuliite {-Daq:n:suff}. ({TKD 3.3.5:src}) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2009,6 +2217,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
 ▶ {qatlh Dat DI tu'lu', tlhIngan?:sen:nolink} "Почему тут повсюду обломки, Клингон?"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">anywhere, nowhere</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2016,6 +2225,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -2029,6 +2239,7 @@ Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab
       <column name="definition_ru">обходить стороной [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">避開，搖擺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desviar, balançar</column>
+      <column name="definition_fi">astua syrjään, horjua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2067,6 +2278,11 @@ Detta verb kan tillämpas på flygplan, för vilka se {Dav:v:2}. [1] [AUTOTRANSL
 Não é usado se os pés de uma pessoa ficarem parados, mas o corpo se inclinar para a esquerda ou para a direita, para ver {ler:v}.
 
 Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä koskee koko kehon tai asian liikkumista vasemmalle tai oikealle.
+
+Sitä ei käytetä, jos henkilön jalat pysyvät paikallaan, mutta keho nojaa vasemmalle tai oikealle, katso {ler:v}.
+
+Tätä verbiä voidaan soveltaa lentokoneisiin, joista ks. {Dav:v:2}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2076,6 +2292,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2083,6 +2300,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -2096,6 +2314,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">качаться (самолет движется в сторону без рыскания) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">搖擺（飛機在沒有偏航的情況下向側面移動） [AUTOTRANSLATED]</column>
       <column name="definition_pt">oscilação (a aeronave se move para o lado sem guinar)</column>
+      <column name="definition_fi">huojua (lentokone kallistuu oikealle tai vasemmalle kääntymättä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Der:v:2}, {jer:v}, {jIm:v:2}, {lol:v:2}, {ron:v:2}, {tor:v:2}, {'or:v}, {nech:v}</column>
@@ -2106,6 +2325,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это просто глагол {Dav:v:1}, применяемый к самолету. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是應用於飛機的動詞{Dav:v:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é apenas o verbo {Dav:v:1} aplicado à aeronave. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain verbi {Dav:v:1}, jota sovelletaan lentokoneisiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2115,6 +2335,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2122,6 +2343,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -2135,6 +2357,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">ложная честь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">虛假的榮譽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falsa honra</column>
+      <column name="definition_fi">väärä kunnia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{batlh:n}, {batlh:adv}, {quv:n}, {quv:v}, {chIvo':n}</column>
@@ -2145,6 +2368,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это слово охватывает то же семантическое основание, что и глаголы {HoQ:v} и {Qaq:v} (но не совсем {mIl:v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞與動詞{HoQ:v}和{Qaq:v}（但實際上不是{mIl:v}）具有相同的語義基礎。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra cobre o mesmo terreno semântico que os verbos {HoQ:v} e {Qaq:v} (mas não realmente {mIl:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana kattaa saman semanttisen kentän kuin verbit {HoQ:v} ja {Qaq:v} (mutta eivät oikeastaan ​​{mIl:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is {maHvaD@@maH:n:1h, -vaD:n} spelled backwards.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2154,6 +2378,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">false honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2161,6 +2386,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, Sept. 2003:src}</column>
     </table>
     <table name="mem">
@@ -2175,6 +2401,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">актер актриса [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">演員、女演員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ator, atriz</column>
+      <column name="definition_fi">näyttelijä</column>
       <column name="synonyms">{ghetwI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{much:n}, {much:v:2}, {muchpa':n}, {much yaH:n}</column>
@@ -2185,6 +2412,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Посмотрите трейлер "Рождественская песнь Klingon", где он используется: {YouTube video:url:http://youtu.be/5Nc5t9AZYsM} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看使用“ A克林崗聖誕節頌歌”預告片的地方：{YouTube video:url:http://youtu.be/5Nc5t9AZYsM} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista ao trailer "A Klingon Christmas Carol", onde é usado: {YouTube video:url:http://youtu.be/5Nc5t9AZYsM} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso "A Klingon Christmas Carol" -traileri, jossa sitä käytetään: {YouTube video:url:http://youtu.be/5Nc5t9AZYsM} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The term {DawI' yaH:n:nolink} was used for "stage" in Hamlet. This was long before {much yaH:n:nolink} was revealed.</column>
       <column name="components">{Da:v}, {-wI':v}</column>
       <column name="examples">
@@ -2195,6 +2423,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2202,6 +2431,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {"A Klingon Christmas Carol" trailer:src}</column>
     </table>
     <table name="mem">
@@ -2215,6 +2445,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">восстание, мятеж</column>
       <column name="definition_zh_HK">反叛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">revoltar</column>
+      <column name="definition_fi">kapinoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daw':n}, {lotlh:v}, {qIQ:v}, {QuS:v}, {Dan:v}</column>
@@ -2225,6 +2456,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2234,6 +2466,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2241,6 +2474,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2254,6 +2488,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">восстание, мятеж, революция</column>
       <column name="definition_zh_HK">反抗、革命 [AUTOTRANSLATED]</column>
       <column name="definition_pt">revolta, revolução</column>
+      <column name="definition_fi">kapina, vallankumous</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daw':v}, {QuD:n}, {QuS:n}, {'urmang:n}</column>
@@ -2264,6 +2499,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2273,6 +2509,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2280,6 +2517,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2293,6 +2531,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">яичко [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">睾丸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">testículo</column>
+      <column name="definition_fi">kives</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'InSep:n}</column>
@@ -2303,6 +2542,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Related to "testify" ({nguH:v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2312,6 +2552,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2319,6 +2560,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -2332,6 +2574,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">тип растения, дикус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">植物類型、dikus植物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de planta, planta dikus</column>
+      <column name="definition_fi">eräs kasvi, dikus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tI:n}</column>
@@ -2342,6 +2585,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2351,6 +2595,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2358,6 +2603,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2371,6 +2617,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">Капрал (ранг)</column>
       <column name="definition_zh_HK">下士（等級） [AUTOTRANSLATED]</column>
       <column name="definition_pt">corporal (classificação)</column>
+      <column name="definition_fi">korpraali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2381,6 +2628,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это второй высший ранг в {QaS:n:1h}.</column>
       <column name="notes_zh_HK">這是{QaS:n:1h}的第二高等級。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o segundo posto mais alto de {QaS:n:1h}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {QaS:n:1h}: n toiseksi korkein sijoitus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2390,6 +2638,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2397,6 +2646,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2410,6 +2660,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">Мастер Дахара</column>
       <column name="definition_zh_HK">達哈爾大師 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mestre Dahar</column>
+      <column name="definition_fi">Dahar-mestari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qor:n:name}</column>
@@ -2420,6 +2671,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это титул для воина, кто достиг статуса ленегды при жизни</column>
       <column name="notes_zh_HK">這是在人生中享有傳奇地位的戰士的頭銜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um título para um guerreiro que alcançou status lendário na vida. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on otsikko soturille, joka on saavuttanut legendaarisen aseman elämässä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2429,6 +2681,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2436,6 +2689,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DS9 - Blood Oath:src}, [2] {A Good Day to Die:src}, [3] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2449,6 +2703,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">птица характеризуется непредсказуемым, непредсказуемым поведением [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種以不穩定、不可預測的行為為特徵的鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro caracterizado por comportamento imprevisível e imprevisível</column>
+      <column name="definition_fi">eräs arvaamattomuudestaan tunnettu lintulaji (jonka käytöstä on vaikea ennakoida)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -2459,6 +2714,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Эта птица похожа на {Da'vI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這隻鳥類似於{Da'vI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este pássaro é semelhante a um {Da'vI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lintu on samanlainen kuin {Da'vI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Donald Duck.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2468,6 +2724,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">duck</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2475,6 +2732,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2488,6 +2746,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">птица характеризуется непредсказуемым, непредсказуемым поведением [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種以不穩定、不可預測的行為為特徵的鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro caracterizado por comportamento imprevisível e imprevisível</column>
+      <column name="definition_fi">eräs arvaamattomuudestaan tunnettu lintulaji (jonka käytöstä on vaikea ennakoida)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -2498,6 +2757,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это похоже на {Da'nal:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這類似於{Da'nal:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é semelhante a um {Da'nal:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on samanlainen kuin {Da'nal:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Daffy Duck.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2507,6 +2767,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">duck</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2514,6 +2775,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2527,6 +2789,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">пустыня</column>
       <column name="definition_zh_HK">沙漠</column>
       <column name="definition_pt">deserto</column>
+      <column name="definition_fi">aavikko, autiomaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SaHa'ra':n}</column>
@@ -2537,6 +2800,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Little Debbie" is a brand of dessert snacks.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2546,6 +2810,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2553,6 +2818,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2566,6 +2832,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">окружать</column>
       <column name="definition_zh_HK">環繞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cercar</column>
+      <column name="definition_fi">ympäröidä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaS:v}, {Sev:v}, {luS:v}</column>
@@ -2576,6 +2843,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Объектом является вещь, которую окружают. Суффикс {-Daq:n:suff} необязателен.[2]</column>
       <column name="notes_zh_HK">對像是被包圍的東西。 {-Daq:n:suff}是不必要的。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é a coisa que está sendo cercada. {-Daq:n:suff} é desnecessário.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on ympäröivä asia. {-Daq:n:suff} on tarpeeton.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2585,6 +2853,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2592,6 +2861,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -2605,6 +2875,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">медаль, эмблема, символ, знаки отличия</column>
       <column name="definition_zh_HK">獎牌、會徽、符號、徽章 [AUTOTRANSLATED]</column>
       <column name="definition_pt">medalha, emblema, símbolo, insígnia</column>
+      <column name="definition_fi">mitali, tunnus, symboli, merkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuq Degh:n}, {ngutlh:n}, {pIqaD:n}, {joqwI':n}, {'oS:v}, {maQ:n}, {tIq'ghob:n:archaic,hyp}, {Degh:n:2}</column>
@@ -2615,6 +2886,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это также может относится к "рубашкам" в колоде игральных карт, для которых смотрите {meyrI':n}, {por:n}, {Sor:n}, и {'eSpeD:n}.</column>
       <column name="notes_zh_HK">這也可以指一副撲克牌中的西服，請參見{meyrI':n}，{por:n}，{Sor:n}和{'eSpeD:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode se referir aos naipes em um baralho de cartas, para os quais consulte {meyrI':n}, {por:n}, {Sor:n} e {'eSpeD:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata myös pelikorttipakan pukuihin, joista katso {meyrI':n}, {por:n}, {Sor:n} ja {'eSpeD:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2633,6 +2905,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       </column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">suit</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2640,6 +2913,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {SkyBox 1:src} (reprinted in {HQ 4.1, p.7:src})</column>
     </table>
     <table name="mem">
@@ -2653,6 +2927,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">руль</column>
       <column name="definition_zh_HK">舵</column>
       <column name="definition_pt">leme</column>
+      <column name="definition_fi">ruori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'orwI':n}, {Degh:n:1}</column>
@@ -2663,6 +2938,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это относится к месту службы на корабле, а не к тому, что надето на голову (что будет {mIv:n:1}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指船上的工作地點，而不是頭上戴的東西（可能是{mIv:n:1}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um posto de serviço em um navio, não a algo usado na cabeça (que seria {mIv:n:1}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa aluksen päivystykseen, ei päähän kuluneeseen esineeseen (mikä olisi {mIv:n:1}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2672,6 +2948,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2679,6 +2956,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2692,6 +2970,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">действовать без плана, импровизировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沒有計劃、即興發揮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agir sem plano, improvisar</column>
+      <column name="definition_fi">toimia ilman sovittua suunnitelmaa, improvisoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Degh:n:2}, {nab:v}</column>
@@ -2702,6 +2981,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это выражение может быть основано на {DeghwI':n}. В не сленговом словаре эта идея может быть выражена с использованием такой фразы, как {nab Hutlh 'ach vang:sen@@nab:n, Hutlh:v, 'ach:conj, vang:v}.[1, p.149] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此表達式可能基於{DeghwI':n}。在非s語詞彙中，可以使用諸如{nab Hutlh 'ach vang:sen@@nab:n, Hutlh:v, 'ach:conj, vang:v}.[1, p.149]之類的短語來表達此想法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão pode ser baseada em {DeghwI':n}. No vocabulário que não seja uma gíria, essa ideia pode ser expressa usando uma frase como {nab Hutlh 'ach vang:sen@@nab:n, Hutlh:v, 'ach:conj, vang:v}.[1, p.149] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lauseke voi perustua kohtaan {DeghwI':n}. Ei-slangisanastossa tämä ajatus voidaan ilmaista käyttämällä ilmausta kuten {nab Hutlh 'ach vang:sen@@nab:n, Hutlh:v, 'ach:conj, vang:v}.[1, p.149] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined as "act without a plan, improvise" in the word lists in the back of {KGT:src}, but as "take action without a plan, improvise" on {KGT p.149:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2711,6 +2991,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2718,6 +2999,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2732,6 +3014,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">Рулевой</column>
       <column name="definition_zh_HK">舵手</column>
       <column name="definition_pt">timoneiro</column>
+      <column name="definition_fi">ruorimies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Degh:n:2}, {Degh:v:slang}</column>
@@ -2742,6 +3025,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Кажется, когда-то существовал глагол {Degh:v:hyp,nolink} со значением «steer», который вышел из употребления.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">似乎曾經有一個動詞{Degh:v:hyp,nolink}，其含義為“轉向”，但已不再使用。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Parece ter havido um verbo {Degh:v:hyp,nolink} ao mesmo tempo com o significado de "direção" que ficou fora de uso.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikuttaa siltä, ​​että kerralla on ollut verbi {Degh:v:hyp,nolink}, jonka merkitys on "ohjata" ja joka on pudonnut käytöstä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Degh:v:hyp,nolink}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2751,6 +3035,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2758,6 +3043,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.149:src}</column>
     </table>
     <table name="mem">
@@ -2771,6 +3057,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">быть созревшим, быть перезревшим(фрукт, овощ)</column>
       <column name="definition_zh_HK">成熟、過熟（水果、蔬菜） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser maduro, ser muito maduro (frutas, vegetais)</column>
+      <column name="definition_fi">olla kypsä, olla ylikypsä (hedelmä, vihannes)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{baQ:v:2}</column>
       <column name="see_also">{naH:n}, {Du' naH:n}, {non:v}, {QaD:v:1}</column>
@@ -2781,6 +3068,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Для клингонов это предпочтительнее {baQ:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於克林崗人而言，這比{baQ:v:2}更可取。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para os klingons, isso é preferível ao {baQ:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonsille tämä on edullisempaa kuin {baQ:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2790,6 +3078,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2797,6 +3086,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2810,6 +3100,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">сплющиваться, сжиматься, разрушаться</column>
       <column name="definition_zh_HK">坍方 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colapso</column>
+      <column name="definition_fi">romahtaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Sach:v:1}</column>
       <column name="see_also">{Qutlh:v}, {jor:v}</column>
@@ -2820,6 +3111,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2830,6 +3122,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2837,6 +3130,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2850,6 +3144,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">Ваше лицо выглядит как свернутая звезда! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你的臉看起來像一個倒塌的明星！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Seu rosto parece uma estrela em colapso!</column>
+      <column name="definition_fi">Kasvosi näyttää romahtaneelta tähdeltä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{luSpet:n}</column>
@@ -2860,6 +3155,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2869,6 +3165,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mu'qaD veS, curse warfare</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2876,6 +3173,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2889,6 +3187,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">описывать</column>
       <column name="definition_zh_HK">描述 [AUTOTRANSLATED]</column>
       <column name="definition_pt">descrever</column>
+      <column name="definition_fi">kuvailla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIj:v}</column>
@@ -2899,6 +3198,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2908,6 +3208,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2915,6 +3216,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2928,6 +3230,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">"Возьми свои станции" [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">“帶上你的車站” [AUTOTRANSLATED]</column>
       <column name="definition_pt">"pegue suas estações" (assumir todos os postos)</column>
+      <column name="definition_fi">Asemiin!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghopDu'wIjDaq yInmeyraj vIlaj.:sen}, {Do':n:hyp}</column>
@@ -2938,6 +3241,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru">Это выражение {no' Hol:n}, используемое капитаном при принятии командования кораблем. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是船長在接管船隻時使用的{no' Hol:n}表達式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma expressão {no' Hol:n} usada por um capitão ao assumir o comando de um navio. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {no' Hol:n}-lauseke, jota kapteeni käyttää alusta johtaessaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2947,6 +3251,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">take your stations</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2954,6 +3259,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.184:src}</column>
     </table>
     <table name="mem">
@@ -2967,6 +3273,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="definition_ru">быть ясным, прозрачным, бесцветным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">清澈透明無色 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser claro, transparente, incolor</column>
+      <column name="definition_fi">olla selkeä, läpinäkyvä, väritön</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chum:v}</column>
       <column name="see_also"></column>
@@ -2977,6 +3284,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Dav:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word was awarded to {Qov:n:name} as a Friend of Maltz, hence the Canadian spelling in the definition.
 
 In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour was described as {Dem:v:nolink}.</column>
@@ -2988,6 +3296,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">colorless</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2995,6 +3304,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -3008,6 +3318,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="definition_ru">Денеб</column>
       <column name="definition_zh_HK">天津四星</column>
       <column name="definition_pt">Deneb</column>
+      <column name="definition_fi">Deneb</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DenIbngan:n}</column>
@@ -3018,6 +3329,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="notes_ru">Это также называется {DenIbya':n:nolink}, как правило, старшими ораторами.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">也稱為{DenIbya':n:nolink}，通常由年長的揚聲器使用。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é chamado {DenIbya':n:nolink}, geralmente por falantes mais antigos.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä kutsutaan tyypillisesti vanhemmiksi puhujiksi {DenIbya':n:nolink}[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "Denebia" in {TKD:src}, but it was later clarified that this was an error and the English name of this planet is actually "Deneb".[3]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3027,6 +3339,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Denebia</column>
       <column name="search_tags_de">Denebia</column>
       <column name="search_tags_fa"></column>
@@ -3034,6 +3347,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="search_tags_ru">Денебия</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.141-142:src}, [3] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -3047,6 +3361,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="definition_ru">{DenIb:n}</column>
       <column name="definition_zh_HK">{DenIb:n}</column>
       <column name="definition_pt">{DenIb:n}</column>
+      <column name="definition_fi">{DenIb:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3057,6 +3372,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3066,6 +3382,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3073,6 +3390,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3086,6 +3404,7 @@ In {DSC - The Vulcan Hello:src}, the albino Voq's (see {voq:n:name}) skin colour
       <column name="definition_ru">Денебианский слизняковый дьявол</column>
       <column name="definition_zh_HK">天津四星礦泥獸</column>
       <column name="definition_pt">Diabo de lama denebiano</column>
+      <column name="definition_fi">Denebialainen limapaholainen?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3110,6 +3429,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [AUTOTRAN
       <column name="notes_pt">Esta criatura também é chamada de {DenIbya' Qatlh:n:nolink}.
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä olentoa kutsutaan myös nimellä {DenIbya' Qatlh:n:nolink}.
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3119,6 +3441,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3126,6 +3449,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3139,6 +3463,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="definition_ru">{DenIb Qatlh:n}</column>
       <column name="definition_zh_HK">{DenIb Qatlh:n}</column>
       <column name="definition_pt">{DenIb Qatlh:n}</column>
+      <column name="definition_fi">{DenIb Qatlh:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3149,6 +3474,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3158,6 +3484,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3165,6 +3492,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3178,6 +3506,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="definition_ru">Денебиан [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">天津四人</column>
       <column name="definition_pt">Denebian</column>
+      <column name="definition_fi">denebialainen?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DenIb:n}</column>
@@ -3188,6 +3517,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="notes_ru">Денебианец также называется {DenIbya'ngan:n:nolink}</column>
       <column name="notes_zh_HK">Denebian也被稱為{DenIbya'ngan:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um denebiano também é chamado de {DenIbya'ngan:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Denebialaista kutsutaan myös {DenIbya'ngan:n:nolink}: ksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DenIb:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -3197,6 +3527,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3204,6 +3535,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3217,6 +3549,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="definition_ru">{DenIbngan:n}</column>
       <column name="definition_zh_HK">{DenIbngan:n}</column>
       <column name="definition_pt">{DenIbngan:n}</column>
+      <column name="definition_fi">{DenIbngan:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3227,6 +3560,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DenIbya':n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -3236,6 +3570,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3243,6 +3578,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3256,6 +3592,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="definition_ru">Деннас</column>
       <column name="definition_zh_HK">Dennas [AUTOTRANSLATED]</column>
       <column name="definition_pt">Dennas</column>
+      <column name="definition_fi">Dennas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3266,6 +3603,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="notes_ru">Она член дома ДэГора ({Daghor tuq:n:name}).</column>
       <column name="notes_zh_HK">她是D'Ghor之家（{Daghor tuq:n:name}）的成員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ela é membro da Casa de D'Ghor ({Daghor tuq:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on D'Ghorin talon ({Daghor tuq:n:name}) jäsen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3275,6 +3613,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3282,6 +3621,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Battle at the Binary Stars:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -3297,6 +3637,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="definition_ru">существо (негуманойд)</column>
       <column name="definition_zh_HK">是（非人形） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser (não humanoide)</column>
+      <column name="definition_fi">olento (ei-humanoidi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yagh:n}, {ghot:n}, {nuv:n}, {yoq:n}, {bIQDep:n}</column>
@@ -3307,6 +3648,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="notes_ru">Суффикс для множественного числа этого слова зависит от того, где это слово используется, чтобы сослаться на возможность использования в (языке {-pu':n:suff}) или невозможность использования в языке (see {-mey:n:suff}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個單詞的複數形式的後綴取決於它是用來表示能夠使用語言的人（請參閱{-pu':n:suff}）還是不能使用語言的人（請參見{-mey:n:suff}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O sufixo para o plural desta palavra depende se é usado para se referir a seres capazes de usar a linguagem (consulte {-pu':n:suff}) ou a seres incapazes de usar a linguagem (consulte {-mey:n:suff}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan monikon loppuliite riippuu siitä, käytetäänkö sitä viittaamaan olentoja, jotka pystyvät käyttämään kieltä (katso {-pu':n:suff}) vai olentoja, jotka eivät kykene käyttämään kieltä (katso {-mey:n:suff}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3316,6 +3658,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">creature, lifeform</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3323,6 +3666,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="search_tags_ru">создание, форма жизни</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3336,6 +3680,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="definition_ru">(быть) бывший, бывший, бывший [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">（以前）、前者、先前、前 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ex, anterior, ex-</column>
+      <column name="definition_fi">olla entinen, edellinen, aikaisempi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'utlh:n}, {mIl:v}, {nung:v}, {veb:v}, {'en:v}</column>
@@ -3346,6 +3691,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="notes_ru">Этот глагол также используется идиоматически, так что, например, {Deq SuvwI'@@Deq:v, SuvwI':n} похож на английское выражение «Этот воин - история». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞也被慣用，因此例如{Deq SuvwI'@@Deq:v, SuvwI':n}與英語表達“ That warrior is history”類似。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado idiomaticamente, de modo que, por exemplo, {Deq SuvwI'@@Deq:v, SuvwI':n} é semelhante à expressão em inglês "That warrior is history". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös idiomaattisesti, joten esimerkiksi {Deq SuvwI'@@Deq:v, SuvwI':n} on samanlainen kuin englanninkielinen ilmaisu "That Warrior is History". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3355,6 +3701,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3362,6 +3709,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -3375,6 +3723,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="definition_ru">кредит (денежный термин)</column>
       <column name="definition_zh_HK">信貸（貨幣單位） [AUTOTRANSLATED]</column>
       <column name="definition_pt">crédito (unidade monetária)</column>
+      <column name="definition_fi">krediitti (valuutta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DarSeq:n}, {Huch:n}, {'ewro:n}</column>
@@ -3385,6 +3734,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Rearrange letters to get "cred"it.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3394,6 +3744,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3401,6 +3752,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3414,6 +3766,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7qXuTn9HpP4} [A
       <column name="definition_ru">поворот (влево или вправо во время путешествия или перемещения) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">轉向（行駛或移動時向左或向右） [AUTOTRANSLATED]</column>
       <column name="definition_pt">virar (para a esquerda ou direita enquanto viaja ou se move)</column>
+      <column name="definition_fi">kääntyä, kaartaa (vasemmalle tai oikealle matkustaessa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3438,6 +3791,9 @@ Detta verb kan tillämpas på flygplan, för vilka se {Der:v:2}.[1] [AUTOTRANSLA
       <column name="notes_pt">Isso significa mudar de direção para a esquerda ou direita enquanto viaja ou se move.
 
 Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa suunnan vaihtamista vasemmalle tai oikealle ajon tai liikkumisen aikana.
+
+Tätä verbiä voidaan soveltaa lentokoneisiin, joista ks. {Der:v:2}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3447,6 +3803,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3454,6 +3811,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -3467,6 +3825,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">рыскание (нос самолета указывает влево или вправо) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">平擺</column>
       <column name="definition_pt">guinada (nariz da aeronave aponta para a esquerda ou direita)</column>
+      <column name="definition_fi">kääntyä (lentokoneen kääntyminen pystyakselin suhteen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dav:v:2}, {jer:v}, {jIm:v:2}, {lol:v:2}, {ron:v:2}, {tor:v:2}, {'or:v}</column>
@@ -3477,6 +3836,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru">Это просто глагол {Der:v:1}, применяемый к самолету. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是應用於飛機的動詞{Der:v:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é apenas o verbo {Der:v:1} aplicado à aeronave. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain verbi {Der:v:1}, jota sovelletaan lentokoneisiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The rud"der" controls the yaw on an airplane.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3486,6 +3846,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3493,6 +3854,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -3506,6 +3868,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">сундук, сундук, ящик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">箱</column>
       <column name="definition_pt">tronco, peito, caixa</column>
+      <column name="definition_fi">arkku, kirstu, laatikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaSwI':n}, {qengHoD:n}</column>
@@ -3516,6 +3879,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Dead Man's Chest", also known as "Derelict", is a fictional song from the novel Treasure Island.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3525,6 +3889,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3532,6 +3897,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -3545,6 +3911,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">рука(от кисти до плеча)</column>
       <column name="definition_zh_HK">手臂</column>
       <column name="definition_pt">braço (parte do corpo)</column>
+      <column name="definition_fi">käsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghop:n}, {ghIv:n}, {volchaH:n}, {DeSqIv:n}, {to'waQ:n}, {yeb:n:1}, {ghIt:n:1}, {DeS:n:2}</column>
@@ -3555,6 +3922,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A writer's arm rests on his or her desk when writing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3564,6 +3932,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3571,6 +3940,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3584,6 +3954,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">ручка топора [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斧頭柄</column>
       <column name="definition_pt">maçaneta</column>
+      <column name="definition_fi">kirveen kahva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'obmaQ:n}, {ghIt:n:2}, {DeS:n:1}</column>
@@ -3594,6 +3965,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3603,6 +3975,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">axe handle</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3610,6 +3983,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
         <table name="mem">
@@ -3623,6 +3997,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">локоть</column>
           <column name="definition_zh_HK">手肘</column>
           <column name="definition_pt">cotovelo</column>
+      <column name="definition_fi">kyynärpää</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{DeS:n:1}, {wIlle':n}, {cha'neH:n}, {nev'ob:n}, {reStav:n}</column>
@@ -3633,6 +4008,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru">Это слово используется как для части тела, так и для ручки {nevDagh:n}. Обратите внимание, что суффикс {-Du':n} используется даже с последним значением. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">該詞用於{nevDagh:n}的身體部位和把手。請注意，即使使用後綴{-Du':n}，也具有後者的含義。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Essa palavra é usada para a parte do corpo e a alça de um {nevDagh:n}. Observe que o sufixo {-Du':n} é usado mesmo com o último significado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään sekä {nevDagh:n}-kehon osaan että kahvaan. Huomaa, että jälkiliitettä {-Du':n} käytetään myös jälkimmäisellä merkityksellä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{DeS:n:1}, {qIv:n}</column>
           <column name="examples"></column>
@@ -3642,6 +4018,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3649,6 +4026,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
     <table name="mem">
@@ -3662,6 +4040,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">шкаф, шкаф, шкаф, стационарное устройство хранения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">壁櫥、櫥櫃、櫃子、固定存儲設備 [AUTOTRANSLATED]</column>
       <column name="definition_pt">armário, cômoda, dispositivo de armazenamento fixo</column>
+      <column name="definition_fi">kaappi, komero, kaapisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'voD:n}, {'ut'at:n}, {yorgh:n}</column>
@@ -3672,6 +4051,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru">Это не обязательно должно быть исправлено на месте. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不一定必須固定在適當的位置。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não precisa necessariamente ser corrigido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän ei tarvitse välttämättä olla paikallaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Arm"oire.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3681,6 +4061,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3688,6 +4069,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
         <table name="mem">
@@ -3701,6 +4083,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">холодильник [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">冰箱 [AUTOTRANSLATED]</column>
           <column name="definition_pt">geladeira</column>
+      <column name="definition_fi">jääkaappi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -3711,6 +4094,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru">Это не клингонское устройство, так как клингоны предпочитают живую еду, но относится к чему-то, что можно найти во многих домах терранов. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這不是Klingon的設備，因為Klingons偏愛活食，而是指許多人族房屋中發現的東西。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este não é um dispositivo Klingon, já que os Klingons preferem comida viva, mas se refere a algo encontrado em muitos lares terráqueos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei ole klingonilaite, koska klingonit suosivat elävää ruokaa, mutta viittaavat johonkin, joka löytyy monista Terran-kodeista. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -3720,6 +4104,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">fridge, cooler</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3727,6 +4112,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
         </table>
     <table name="mem">
@@ -3740,6 +4126,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">вести, руководить</column>
       <column name="definition_zh_HK">領導、指導</column>
       <column name="definition_pt">guiar, conduzir</column>
+      <column name="definition_fi">johtaa, opastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{che':v}, {DevwI':n}</column>
@@ -3750,6 +4137,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3760,6 +4148,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3767,6 +4156,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3780,6 +4170,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">руководство(книга)</column>
       <column name="definition_zh_HK">指導書</column>
       <column name="definition_pt">livro guia</column>
+      <column name="definition_fi">opaskirja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3790,6 +4181,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is not defined in canon, but its meaning is inferred from its translation and components.</column>
       <column name="components">{Dev:v}, {-meH:v}, {paq:n:1h}</column>
       <column name="examples">
@@ -3800,6 +4192,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3807,6 +4200,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -3820,6 +4214,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">лидер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">領袖</column>
       <column name="definition_pt">líder</column>
+      <column name="definition_fi">johtaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3830,6 +4225,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Dev:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3839,6 +4235,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3846,6 +4243,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3859,6 +4257,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">данные, информация</column>
       <column name="definition_zh_HK">數據、信息 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dados, informação</column>
+      <column name="definition_fi">tieto, data, informaatio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qawHaq:n}, {mem:n}, {ngoD:n}, {potlh:n}, {Sov:n}, {ta:n}, {De'wI':n}</column>
@@ -3869,6 +4268,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">If you're looking for someone named "Data", see {qoqyoq:n:hyp}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3879,6 +4279,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3886,6 +4287,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -3899,6 +4301,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">обновление, новости</column>
           <column name="definition_zh_HK">新消息、新聞</column>
           <column name="definition_pt">notícia, novidade</column>
+      <column name="definition_fi">uutinen, päivitys</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{De' chu' ghItlh:n}</column>
@@ -3909,6 +4312,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{De':n}, {chu':v:1}</column>
           <column name="examples">
@@ -3920,6 +4324,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
 ▶ {Hov leng De' chu':sen:nolink} "Звёздный путь обновление"</column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3927,6 +4332,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {STC 104:src}</column>
         </table>
         <table name="mem">
@@ -3940,6 +4346,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">газета</column>
           <column name="definition_zh_HK">報紙</column>
           <column name="definition_pt">jornal</column>
+      <column name="definition_fi">sanomalehti</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -3950,6 +4357,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{De' chu':n}, {ghItlh:n}</column>
           <column name="examples"></column>
@@ -3959,6 +4367,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3966,6 +4375,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -3980,6 +4390,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">компакт-диск, диск с данными</column>
           <column name="definition_zh_HK">CD、數據光盤 [AUTOTRANSLATED]</column>
           <column name="definition_pt">CD, disco de dados</column>
+      <column name="definition_fi">CD, tietolevy</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{De':n}, {jengva':n}</column>
@@ -3990,6 +4401,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{De' ngop:n:inhpl}</column>
           <column name="examples"></column>
@@ -3999,6 +4411,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">DVD, data disk</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4006,6 +4419,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -4019,6 +4433,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">Знание полезной информации может быть неудачным. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">對有用信息的了解可能是不幸的。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">O conhecimento de informações úteis pode ser lamentável.</column>
+      <column name="definition_fi">Hyödylliset tiedot voivat tuoda epäonnea.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4029,6 +4444,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -4038,6 +4454,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">secrecy proverb</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4045,6 +4462,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {PK:src}</column>
         </table>
         <table name="mem">
@@ -4058,6 +4476,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">доступ к данным [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">數據訪問 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Acesso de dados</column>
+      <column name="definition_fi">pääsy tietoihin, pääte?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4068,6 +4487,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{De':n}, {naw':v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -4077,6 +4497,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4084,6 +4505,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {STC 104:src}</column>
         </table>
         <table name="mem">
@@ -4098,6 +4520,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">Компакт-диски, диски с данными [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">CD、數據光盤 [AUTOTRANSLATED]</column>
           <column name="definition_pt">CDs, discos de dados</column>
+      <column name="definition_fi">CD-levyt, tietolevyt</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{De':n}, {ngop:n}</column>
@@ -4108,6 +4531,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{De' jengva':n:inhps}</column>
           <column name="examples"></column>
@@ -4117,6 +4541,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">DVDs, data disks</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4124,6 +4549,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2011:src}</column>
         </table>
         <table name="mem">
@@ -4137,6 +4563,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="definition_ru">библиотекарь [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">圖書管理員</column>
           <column name="definition_pt">bibliotecário</column>
+      <column name="definition_fi">kirjastonhoitaja</column>
           <column name="synonyms">{paq nojwI':n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4147,6 +4574,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{De':n}, {Qul:v}, {-wI':n}</column>
           <column name="examples"></column>
@@ -4156,6 +4584,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4163,6 +4592,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
     <table name="mem">
@@ -4176,6 +4606,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">кстати, в скобках [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">順便說一句 [AUTOTRANSLATED]</column>
       <column name="definition_pt">a propósito, entre parênteses</column>
+      <column name="definition_fi">muuten, asiasta puheen ollen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4186,6 +4617,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru">Это сокращенная форма {'ej De' vIchel:adv}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{'ej De' vIchel:adv}的簡化形式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma forma abreviada de {'ej De' vIchel:adv}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhennetty {'ej De' vIchel:adv}-muoto. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4195,6 +4627,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4202,6 +4635,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4215,6 +4649,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">капельный камень (геология), сталактит, сталагмит [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滴水石（地質），鐘乳石，石筍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gotejamento (geologia), estalactite, estalagmite</column>
+      <column name="definition_fi">tippukivi, stalaktiitti, stalagmiitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIS:n:1}, {'onroS:n}, {nagh:n}</column>
@@ -4225,6 +4660,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru">Существует одно слово для сталактита и сталагмита. Если требуется различие, говорят «{pa' beb De'lor:n@@pa' beb:n, De'lor:n}» и «{rav De'lor:n@@rav:n:1, De'lor:n}». Никто не говорит {rav'eq De'lor:n@@rav'eq:n, De'lor:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">鐘乳石和石筍都有一個詞。如果需要區分，則說{pa' beb De'lor:n@@pa' beb:n, De'lor:n}和{rav De'lor:n@@rav:n:1, De'lor:n}。從來沒有說過{rav'eq De'lor:n@@rav'eq:n, De'lor:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe uma única palavra para estalactite e estalagmite. Se for necessária uma distinção, diz-se {pa' beb De'lor:n@@pa' beb:n, De'lor:n} e {rav De'lor:n@@rav:n:1, De'lor:n}. Nunca se diz {rav'eq De'lor:n@@rav'eq:n, De'lor:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sekä stalaktiitille että stalagmiitille on yksi sana. Jos tarvitaan eroa, sanotaan {pa' beb De'lor:n@@pa' beb:n, De'lor:n} ja {rav De'lor:n@@rav:n:1, De'lor:n}. Kukaan ei koskaan sano {rav'eq De'lor:n@@rav'eq:n, De'lor:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Data ({De':n}) and Lore are alike, and yet opposite.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4234,6 +4670,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4241,6 +4678,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -4255,6 +4693,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">Компьютер</column>
       <column name="definition_zh_HK">電腦</column>
       <column name="definition_pt">computador</column>
+      <column name="definition_fi">tietokone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghun:v:1}, {qawHaq:n}, {De':n}</column>
@@ -4265,6 +4704,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{De':v:hyp,nolink}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4274,6 +4714,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4281,6 +4722,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4294,6 +4736,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">{loHjan:n}</column>
       <column name="definition_zh_HK">{loHjan:n}</column>
       <column name="definition_pt">{loHjan:n}</column>
+      <column name="definition_fi">{loHjan:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4304,6 +4747,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4313,6 +4757,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4320,6 +4765,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4333,6 +4779,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">{nItlh 'echlet:n}</column>
       <column name="definition_zh_HK">{nItlh 'echlet:n}</column>
       <column name="definition_pt">{nItlh 'echlet:n}</column>
+      <column name="definition_fi">{nItlh 'echlet:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4343,6 +4790,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4352,6 +4800,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4359,6 +4808,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4372,6 +4822,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">компьютерная система [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">電腦系統</column>
       <column name="definition_pt">sistema de computador</column>
+      <column name="definition_fi">tietokonejärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4382,6 +4833,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{De'wI':n}, {pat:n}</column>
       <column name="examples"></column>
@@ -4391,6 +4843,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4398,6 +4851,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -4411,6 +4865,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">лаборатория компьютерных исследований [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">電腦研究室</column>
       <column name="definition_pt">laboratório de pesquisa em computação</column>
+      <column name="definition_fi">atk-tutkimuslaboratorio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4421,6 +4876,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{De'wI':n}, {Qulpa':n}</column>
       <column name="examples"></column>
@@ -4430,6 +4886,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">computer research laboratory</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4437,6 +4894,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -4450,6 +4908,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">главное ядро компьютера</column>
       <column name="definition_zh_HK">主要計算機核心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">núcleo do computador principal</column>
+      <column name="definition_fi">päätietokoneydin?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loHjan:n}</column>
@@ -4460,6 +4919,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru">Этот термин обычно используется только для довольно больших (или мощных) компьютеров.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該術語通常僅用於相當大（或功能強大）的計算機。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo é normalmente usado apenas para computadores razoavelmente grandes (ou poderosos).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä termiä käytetään normaalisti vain melko isoissa (tai tehokkaissa) tietokoneissa[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{De'wI':n}, {SoSbor'a':n}</column>
       <column name="examples"></column>
@@ -4469,6 +4929,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4476,6 +4937,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4489,6 +4951,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">{De'wI'Hom:n}</column>
       <column name="definition_zh_HK">{De'wI'Hom:n}</column>
       <column name="definition_pt">{De'wI'Hom:n}</column>
+      <column name="definition_fi">{De'wI'Hom:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4499,6 +4962,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4508,6 +4972,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4515,6 +4980,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4528,6 +4994,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">Компьютерный сервер</column>
       <column name="definition_zh_HK">電腦伺服器</column>
       <column name="definition_pt">servidor de computador</column>
+      <column name="definition_fi">palvelin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4538,6 +5005,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{De'wI':n}, {turwI':n}</column>
       <column name="examples"></column>
@@ -4547,6 +5015,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4554,6 +5023,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4567,6 +5037,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">{'echlet Hab:n}</column>
       <column name="definition_zh_HK">{'echlet Hab:n}</column>
       <column name="definition_pt">{'echlet Hab:n}</column>
+      <column name="definition_fi">{'echlet Hab:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4577,6 +5048,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4586,6 +5058,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4593,6 +5066,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4606,6 +5080,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">ноутбук [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">膝上型電腦、筆記本電腦</column>
       <column name="definition_pt">notebook</column>
+      <column name="definition_fi">kannettava tietokone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{raS De'wI':n}</column>
@@ -4616,6 +5091,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{De'wI':n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -4625,6 +5101,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4632,6 +5109,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4645,6 +5123,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">мусор, обломки, осколки</column>
       <column name="definition_zh_HK">垃圾、碎石、碎片 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lixo, entulho, detritos</column>
+      <column name="definition_fi">roska, jäte, romu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{veQ:n}</column>
@@ -4655,6 +5134,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4666,6 +5146,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
 ▶ {qatlh Dat DI tu'lu', tlhIngan?:sen:nolink} "Почему здесь повсюду мусор, Клингон?"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4673,6 +5154,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -4686,6 +5168,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">мы(действие)-им</column>
       <column name="definition_zh_HK">我們：他們、它們</column>
       <column name="definition_pt">nós-eles</column>
+      <column name="definition_fi">me-heitä/niitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nu-:v:pref}</column>
       <column name="see_also">{vI-:v:pref}, {wI-:v:pref}</column>
@@ -4696,6 +5179,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{maH:n:1h}: {chaH:n} / {bIH:n} = {DI-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4705,6 +5189,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4712,6 +5197,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4725,6 +5211,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">Право, привилегия</column>
       <column name="definition_zh_HK">對、特權 [AUTOTRANSLATED]</column>
       <column name="definition_pt">direito, privilégio</column>
+      <column name="definition_fi">oikeus, etuoikeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qotlh:v:2}</column>
@@ -4735,6 +5222,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In slang, "(first) dibs" means the right to something.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4745,6 +5233,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4752,6 +5241,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4765,6 +5255,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">Определенность</column>
       <column name="definition_zh_HK">肯定 [AUTOTRANSLATED]</column>
       <column name="definition_pt">certeza</column>
+      <column name="definition_fi">varmuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-bej:v}, {bej:v:2}, {na':v:2}, {Hon:v}</column>
@@ -4775,6 +5266,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4784,6 +5276,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4791,6 +5284,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4804,6 +5298,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">порядковый номер (суффикс)</column>
       <column name="definition_zh_HK">序數（後綴）</column>
       <column name="definition_pt">número ordinal (sufixo)</column>
+      <column name="definition_fi">(merkitsee järjestyslukua)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-logh:n:num,suff}</column>
@@ -4814,6 +5309,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru">Этот суффикс превращает количественное числительное в порядковый номер. Например, {wa'DIch:n:num} "первый" из {wa':n:num} "один", {cha'DIch:n:1,num} "второй" из {cha':n:num} "два", и так далее. Порядковые номера следуют за именем существительным, к которым они применяются.</column>
       <column name="notes_zh_HK">此後綴將基數轉換為序數。例如，來自{wa':n:num}“一個”的{wa'DIch:n:num}“第一”，來自{cha':n:num}“兩個”的{cha'DIch:n:1,num}“第二”，依此類推。序數跟隨它們所應用的名詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo transforma um número cardinal em um número ordinal. Por exemplo, {wa'DIch:n:num} "primeiro" de {wa':n:num} "um", {cha'DIch:n:1,num} "segundo" de {cha':n:num} "dois" e assim por diante. Os números ordinais seguem o substantivo ao qual eles se aplicam. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä pääte muuttaa kardinaalinumeron järjestysluvuksi. Esimerkiksi {wa'DIch:n:num} "ensimmäinen" {wa':n:num}: sta "yksi", {cha'DIch:n:1,num} "toinen" julkaisusta {cha':n:num} "kaksi" ja niin edelleen. Järjestysnumerot seuraavat substantiivia, johon niitä sovelletaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4825,6 +5321,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">suffix</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4832,6 +5329,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4845,6 +5343,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">предпринимать, вести с кем-то дела</column>
       <column name="definition_zh_HK">承擔、處理 [AUTOTRANSLATED]</column>
       <column name="definition_pt">empreender, lidar com</column>
+      <column name="definition_fi">ryhtyä, ruveta, tehdä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ta':v}, {chav:v}</column>
@@ -4855,6 +5354,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">An undertaker is someone who "dig"s. The slang phrase "infra dig" (from Latin "infra dignitatem") means "beneath one's dignity".</column>
       <column name="components"></column>
       <column name="examples">
@@ -4865,6 +5365,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4872,6 +5373,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4885,6 +5387,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">Тип растения, Дигна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">植物類型、digna [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de planta, digna</column>
+      <column name="definition_fi">eräs kasvilaji, digna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tI:n}</column>
@@ -4895,6 +5398,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru">Его лист ({DIghna' por:n:nolink}) поджарен (см. {mIQ:v}) опытными поварами.[1, p.94] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它的葉子（{DIghna' por:n:nolink}）由經驗豐富的廚師烹製（請參閱{mIQ:v}）。[1, p.94] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Sua folha ({DIghna' por:n:nolink}) é frita (consulte {mIQ:v}) por cozinheiros experientes.[1, p.94] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen kokki kokit paistavat sen lehtiä ({DIghna' por:n:nolink}) (katso {mIQ:v}).[1, p.94] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4904,6 +5408,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4911,6 +5416,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4924,6 +5430,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">лист Дигна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">digna葉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">folha de digna</column>
+      <column name="definition_fi">dignan lehti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4934,6 +5441,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru">Это во фритюре (см. {mIQ:v}) и съел.[1, p.94] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是油炸的（請參閱{mIQ:v}）並已吃掉。[1, p.94] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é frito (consulte {mIQ:v}) e comido.[1, p.94] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on paistettua (katso {mIQ:v}) ja syödään.[1, p.94] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DIghna':n}, {por:n}</column>
       <column name="examples"></column>
@@ -4943,6 +5451,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4950,6 +5459,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4963,6 +5473,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">скользить лезвием меча по лезвию противника [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沿著對手的刀刃滑動劍刃 [AUTOTRANSLATED]</column>
       <column name="definition_pt">deslize a lâmina da espada ao longo da lâmina do oponente</column>
+      <column name="definition_fi">liu'uttaa miekan terää vastustajan terää pitkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yan:n}, {jop:v:1}, {way':v}, {chaQ:v}, {ngol:v}, {lev:v}, {jIrmoH:v:1}, {baQ:v:1}, {DIj:v:2}</column>
@@ -4973,6 +5484,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4982,6 +5494,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4989,6 +5502,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5002,6 +5516,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {Der:v:2}. [1] 
       <column name="definition_ru">используйте пигментную палочку, рисуйте пигментной палочкой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">使用顏料棒、塗上顏料棒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">use um bastão de pigmento, pinte com um bastão de pigmento</column>
+      <column name="definition_fi">käyttää maalitikkua?, maalata maalitikulla?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wev:v}, {rItlh:n}, {DIjwI':n}, {ngoH:v:2}, {vol:n}, {DIj:v:1}</column>
@@ -5028,6 +5543,11 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän verbin kohde on asia, jota koskettaa {rItlh naQ:n}, esimerkiksi {nagh beQ:n}. Koska {DIj:v:2,nolink} on jo liitetty {nagh beQ:n:nolink}: ään, se voidaan jättää pois. Jos kuitenkin maalataan tai piirretään jollekin muulle kuin {nagh beQ:n:nolink}: lle, se on määriteltävä.
+
+Piirrettävän asian määrittämiseksi voidaan käyttää verbejä {cha':v} tai {nargh:v:0}. Jälkimmäinen tarkoittaa sekä "esiintymistä" että "paeta", ja samanlainen kuin {qon:v}: n käyttö musiikin säveltämisessä tai kirjoitusten kirjoittamisessa, sen käyttö viittaa siihen, että kuva on jo olemassa ja {DIjwI':n} jotenkin mahdollistaa sen paeta ja ilmestyä. Yleensä {nargh:v:0,nolink}: tä käytetään liitetiedoston {-moH:v} kanssa, mutta sitä on myös mahdollista käyttää ilman, vaikka tätä rakennetta kuullaan harvemmin. {cha':v:nolink}-versio on yleisempi epävirallisissa asetuksissa ja {nargh:v:nolink} (yleensä {narghmoH:v:nolink}) -versio on yleisempi kirjallisuudessa tai taiteesta käytävissä keskusteluissa.
+
+Tätä verbiä voidaan käyttää visuaalisen kuvan tuottamiseen, vaikka siinä ei olisikaan maalia tai pigmenttitikkua, esimerkiksi lyijykynällä tai laitteella tai tietokoneohjelmalla.[2][2][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5043,6 +5563,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">draw, paint</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5050,6 +5571,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KLI mailing list 2018.09.03:src}</column>
     </table>
     <table name="mem">
@@ -5063,6 +5585,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="definition_ru">художник, художник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">藝術家、畫家</column>
       <column name="definition_pt">artista, pintor</column>
+      <column name="definition_fi">taidemaalari, maalaaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5073,6 +5596,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DIj:v:2}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5082,6 +5606,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5089,6 +5614,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.09.03:src}</column>
     </table>
     <table name="mem">
@@ -5102,6 +5628,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="definition_ru">платить за что-то</column>
       <column name="definition_zh_HK">畀錢</column>
       <column name="definition_pt">pagar por</column>
+      <column name="definition_fi">maksaa jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{je':v:1}, {ghaq:v}, {nob:v}, {rup:v}, {qav'ap:n}</column>
@@ -5112,6 +5639,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sounds like "deal".</column>
       <column name="components"></column>
       <column name="examples">
@@ -5125,6 +5653,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5132,6 +5661,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -5145,6 +5675,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="definition_ru">цена</column>
       <column name="definition_zh_HK">價錢</column>
       <column name="definition_pt">preço</column>
+      <column name="definition_fi">hinta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5155,6 +5686,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is not defined as such in canon, but appears in the example from {TKD p.171:src}. This entry is here for ease of reference only.</column>
       <column name="components">{DIl:v}, {-meH:v}, {Huch:n}</column>
       <column name="examples">
@@ -5165,6 +5697,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5172,6 +5705,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -5185,6 +5719,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="definition_ru">селитра [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">硝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">salitre</column>
+      <column name="definition_fi">salpietari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5195,6 +5730,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="notes_ru">Это один из трех ключевых ингредиентов, необходимых для приготовления {ngat:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是製作{ngat:n:1}的三個關鍵成分之一。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um dos três principais ingredientes necessários para fazer {ngat:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksi kolmesta avainkomponentista, joita tarvitaan DONUT TRANSLATE1: n valmistamiseen.{ngat:n:1} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In "Travels Through Spain" by Sir John Talbot Dillon, he describes various methods of making saltpeter.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5204,6 +5740,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5211,6 +5748,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5224,6 +5762,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="definition_ru">Триллий</column>
       <column name="definition_zh_HK">延齡草（貿易商品） [AUTOTRANSLATED]</column>
       <column name="definition_pt">trillium (uma mercadoria comercializada)</column>
+      <column name="definition_fi">trillium</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5234,6 +5773,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="notes_ru">Это товар, которым можно торговать, подобно {qevaS:n}.</column>
       <column name="notes_zh_HK">這是一種交易商品，例如{qevaS:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma mercadoria comercializada, como {qevaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kauppatavara, kuten {qevaS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">There is a genus of Terran flowering plants called the trillium. However, it seems that this word may actually refer to a mineral or perhaps a type of gemstone, although this is unclear.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5243,6 +5783,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5250,6 +5791,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5263,6 +5805,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="definition_ru">открытый проход (в коридор, тунель, трубопровод, Трубу Джеффри, ветвь коллектора)</column>
       <column name="definition_zh_HK">開放式入口通道（走廊、隧道、管道、杰弗里斯管、下水道分支） [AUTOTRANSLATED]</column>
       <column name="definition_pt">entrada aberta (para corredor, túnel, conduto, tubo Jeffries, filial do esgoto)</column>
+      <column name="definition_fi">oveton sisäänkäynti, aukko (tunneliin, putkeen, viemäriin tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chob:n}, {lojmIt:n}, {'och:n}, {megh'an:n}, {'er'In:n}, {'ImSIng:n}</column>
@@ -5273,6 +5816,7 @@ Detta verb kan användas för att producera en visuell bild även om ingen färg
       <column name="notes_ru">Это относится к открытому входу, ведущему в длинное замкнутое пространство, или, другими словами, к {qa'rI':n}, в котором можно войти или выйти. Если там есть дверь, дверь называется обычным словом {lojmIt:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指通向一個較長的封閉空間的開放式入口通道，換句話說就是一個{qa'rI':n}，從該入口處可以進入或退出。如果那裡有一扇門，則用通常的單詞{lojmIt:n}來指代該門。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à entrada aberta que leva a um espaço fechado longo ou, em outras palavras, um {qa'rI':n} no qual é possível entrar ou sair. Se houver uma porta lá, a porta é referida pela palavra usual {lojmIt:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa avointa sisäänkäyntiä, joka johtaa pitkään suljettuun tilaan, tai toisin sanoen {qa'rI':n}, josta voi tulla tai josta voi poistua. Jos siellä on ovi, oveen viitataan tavallisella sanalla {lojmIt:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a private joke referring to a specific person.
 
 The description originally given in the {KLI:src} New Klingon Words list says that if there is "a door that closes", then the entryway is "not a {DIn:n:nolink}" but "merely a {lojmIt:n:nolink}". However, this is an incorrect interpretation of the definition, as clarified subsequently.[2; 3]</column>
@@ -5284,6 +5828,7 @@ The description originally given in the {KLI:src} New Klingon Words list says th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5291,6 +5836,7 @@ The description originally given in the {KLI:src} New Klingon Words list says th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}, [2] {KLI mailing list 2019.04.11:src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -5304,6 +5850,7 @@ The description originally given in the {KLI:src} New Klingon Words list says th
       <column name="definition_ru">вращаться, крутиться</column>
       <column name="definition_zh_HK">紡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">girar</column>
+      <column name="definition_fi">pyöriä</column>
       <column name="synonyms">{jIr:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{jIrmoH:v:1}</column>
@@ -5314,6 +5861,7 @@ The description originally given in the {KLI:src} New Klingon Words list says th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">MO implied at {Saarbrücken qepHom'a' 2011:src} that {DIng:v:nolink} is intransitive by saying that it works in the same way as {jIr:v:nolink}, but did not elaborate on the exact difference between the two verbs.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5323,6 +5871,7 @@ The description originally given in the {KLI:src} New Klingon Words list says th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5330,6 +5879,7 @@ The description originally given in the {KLI:src} New Klingon Words list says th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5343,6 +5893,7 @@ The description originally given in the {KLI:src} New Klingon Words list says th
       <column name="definition_ru">имя существительное</column>
       <column name="definition_zh_HK">名詞</column>
       <column name="definition_pt">substantivo</column>
+      <column name="definition_fi">substantiivi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wot:n}</column>
@@ -5417,6 +5968,39 @@ Noun Type 5: Syntactic markers
 ▶ {-'e':n:suff}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin kielessä on viisi erilaista substantiiviliitetyyppiä.
+
+Liitetyyppi 1: augmentatiivi/diminutiivi
+▶ {-'a':n:suff}
+▶ {-Hom:n:suff}
+▶ {-oy:n:suff}
+
+Liitetyyppi 2: luku
+▶ {-pu':n:suff}
+▶ {-Du':n:suff}
+▶ {-mey:n:suff}
+
+Liitetyyppi 3: täsmennys
+▶ {-qoq:n:suff}
+▶ {-Hey:n:suff}
+▶ {-na':n:suff}
+
+Liitetyyppi 4: omistus-, demonstratiiviliitteet
+▶ {-wIj:n:suff} / {-wI':n:suff}
+▶ {-lIj:n:suff} / {-lI':n:suff}
+▶ {-Daj:n:suff}
+▶ {-maj:n:suff} / {-ma':n:suff}
+▶ {-raj:n:suff} / {-ra':n:suff}
+▶ {-chaj:n:suff}
+▶ {-vam:n:suff}
+▶ {-vetlh:n:suff}
+
+Liitetyyppi 5: sijamuodot
+▶ {-Daq:n:suff}
+▶ {-vo':n:suff}
+▶ {-mo':n:suff}
+▶ {-vaD:n:suff}
+▶ {-'e':n:suff}</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5427,6 +6011,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5434,6 +6019,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5447,6 +6033,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">кожа</column>
       <column name="definition_zh_HK">皮膚 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pele</column>
+      <column name="definition_fi">iho</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{veD:n}, {ghISDen:n}, {quHvaj:n}, {veDDIr:n}, {Surgh:v}</column>
@@ -5457,6 +6044,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru">Это слово принимает суффикс {-Du':n:suff} когда оно относится к коже, что все еще на теле, и {-mey:n:suff} в остальных случаях.[2]</column>
       <column name="notes_zh_HK">當這個詞表示皮膚仍然在身體上時，它的後綴為{-Du':n:suff}，否則為{-mey:n:suff}。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra usa o sufixo {-Du':n:suff} quando se refere à pele ainda no corpo e {-mey:n:suff} em caso contrário.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana vie loppuliitteen {-Du':n:suff}, kun se viittaa vielä kehossa olevaan ihoon, ja {-mey:n:suff} muuten.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Deer" skin.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5473,6 +6061,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5480,6 +6069,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1998.03.23:src}</column>
     </table>
     <table name="mem">
@@ -5493,6 +6083,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">{DIr paH bID:n}</column>
       <column name="definition_zh_HK">{DIr paH bID:n}</column>
       <column name="definition_pt">{DIr paH bID:n}</column>
+      <column name="definition_fi">{DIr paH bID:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5503,6 +6094,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5512,6 +6104,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5519,6 +6112,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5532,6 +6126,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">килтоподобная одежда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">短裙式服裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">roupa tipo kilt</column>
+      <column name="definition_fi">kilttimäinen vaate</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paH bID:n}</column>
@@ -5542,6 +6137,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru">Когда контекст понятен, это иногда сокращается до {DIr bID:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">當上下文清楚時，有時會縮短為{DIr bID:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando o contexto é claro, isso às vezes é reduzido para {DIr bID:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun asiayhteys on selvä, tämä joskus lyhennetään muotoon {DIr bID:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DIr:n}, {paH bID:n}</column>
       <column name="examples"></column>
@@ -5551,6 +6147,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5558,6 +6155,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5571,6 +6169,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">лосьон для загара</column>
       <column name="definition_zh_HK">防曬霜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">protetor solar</column>
+      <column name="definition_fi">aurinkovoide</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5581,6 +6180,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DIr:n}, {Qan:v}, {-wI':v}, {taS:n}</column>
       <column name="examples"></column>
@@ -5590,6 +6190,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5597,6 +6198,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5610,6 +6212,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">тип кожного заболевания</column>
       <column name="definition_zh_HK">一種皮膚病 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um tipo de doença de pele</column>
+      <column name="definition_fi">eräs ihosairaus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5620,6 +6223,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru">Это название специфичного кожного заболевания со времен Кейлеса</column>
       <column name="notes_zh_HK">從Kahless時代起，這就是特定皮膚病的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma doença de pele específica da época de Kahless. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on nimenomainen kahvitauti Kahlessin ajalta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DIr:n}, {rop:n}</column>
       <column name="examples"></column>
@@ -5629,6 +6233,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5636,6 +6241,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {The Klingon Art of War:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -5650,6 +6256,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">тату [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">黥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tatuagem</column>
+      <column name="definition_fi">tatuointi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tutlh:v:1}</column>
@@ -5660,6 +6267,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru">Это может относиться к одному шаблону / дизайну или ко многим из них, взятым вместе. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以指的是一種模式/設計，也可以指一整套的模式/設計。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode se referir a um padrão / design, ou a muitos deles juntos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata yhteen malliin / kuvioon tai useisiin niistä yhdessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DIr:n}, {tutlh:v:1}</column>
       <column name="examples"></column>
@@ -5669,6 +6277,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5676,6 +6285,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Facebook "Learn Klingon" group 2017.10.07:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -5690,6 +6300,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">кожный барабан [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">皮鼓</column>
       <column name="definition_pt">tambor de pele, instrumento de percussão</column>
+      <column name="definition_fi">eläimennahasta valmistettu rumpu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'In:n}</column>
@@ -5700,6 +6311,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru">Это барабан, сделанный из кожи животного, натянутой на цилиндр, обычно только на один конец. Если кожа растянута по обоим концам барабана, это {'o'lav:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種用動物皮製成的鼓，其鼓膜通常延伸到圓柱體的一端。如果皮膚在鼓的兩端伸展，則為{'o'lav:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tambor feito com pele de animal esticada sobre um cilindro, geralmente em apenas uma extremidade. Se a pele estiver esticada sobre as duas extremidades de um tambor, será um {'o'lav:n}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on rumpu, jonka eläinnahka on venytetty sylinterin yli, yleensä vain yhden pään yli. Jos iho on venytetty rummun molempien päiden yli, se on {'o'lav:n}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DIr:n}, {'In:n}</column>
       <column name="examples"></column>
@@ -5709,6 +6321,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5716,6 +6329,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.75:src}</column>
     </table>
     <table name="mem">
@@ -5729,6 +6343,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">волынка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">風笛</column>
       <column name="definition_pt">gaita de fole</column>
+      <column name="definition_fi">säkkipilli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Heng:v}, {qeb:v}</column>
@@ -5739,6 +6354,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru">Это тип {SuSDeq:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種{SuSDeq:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de {SuSDeq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen {SuSDeq:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Drone".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5748,6 +6364,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5755,6 +6372,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5768,6 +6386,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">пещера</column>
       <column name="definition_zh_HK">洞穴</column>
       <column name="definition_pt">caverna</column>
+      <column name="definition_fi">luola</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{De'lor:n}</column>
@@ -5778,6 +6397,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5787,6 +6407,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5794,6 +6415,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5807,6 +6429,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">Год (клингонский)</column>
       <column name="definition_zh_HK">年（克林崗日曆）</column>
       <column name="definition_pt">ano (klingon)</column>
+      <column name="definition_fi">(klingonien) vuosi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jar:n}, {Hogh:n}, {jaj:n}, {'ISjaH:n}, {tera' poH:n}</column>
@@ -5817,6 +6440,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru">Для "X лет назаж" и "Х лет от текущего момента", см {ben:n:1} и {nem:n}, соответственно.</column>
       <column name="notes_zh_HK">對於“年前”和“從現在開始”，請分別參見{ben:n:1}和{nem:n}。有關“歲數”，請參閱{ben:n:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para "anos atrás" e "anos a partir de agora", consulte {ben:n:1} e {nem:n}, respectivamente. Para "anos", consulte {ben:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso "vuotta sitten" ja "vuotta sitten" vastaavasti kohdat {ben:n:1} ja {nem:n}. Katso "vuotta vanha" kohdasta {ben:n:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5827,6 +6451,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5834,6 +6459,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek The Exhibition:src} invitation</column>
     </table>
     <table name="mem">
@@ -5847,6 +6473,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">признаваться</column>
       <column name="definition_zh_HK">承認 [AUTOTRANSLATED]</column>
       <column name="definition_pt">confessar</column>
+      <column name="definition_fi">tunnustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIv:v}, {luH:v:2}, {HeS:v}</column>
@@ -5857,6 +6484,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">To "cave" (see {DIS:n:1}) is to give in to something under pressure. To "dish (out)" is slang for giving away information.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5866,6 +6494,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5873,6 +6502,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5886,6 +6516,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">Новый год</column>
       <column name="definition_zh_HK">新年</column>
       <column name="definition_pt">Ano Novo</column>
+      <column name="definition_fi">uusi vuosi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QISmaS:n}</column>
@@ -5896,6 +6527,7 @@ Noun Type 5: Syntactic markers
       <column name="notes_ru">Не существует традиционного клингонского способа сказать "Счастливого нового года", хотя Клингон может понимать следующие выражения- {DIS chu' yItIv@@DIS:n:2, chu':v:1, yI-:v, tIv:v} или {DIS chu' DatIvjaj@@DIS:n:2, chu':v:1, Da-:v, tIv:v, -jaj:v} или {DIS chu' botIvjaj@@DIS:n:2, chu':v:1, bo-:v, tIv:v, -jaj:v}.[1]</column>
       <column name="notes_zh_HK">儘管克林崗語可能會理解{DIS chu' yItIv@@DIS:n:2, chu':v:1, yI-:v, tIv:v}或{DIS chu' DatIvjaj@@DIS:n:2, chu':v:1, Da-:v, tIv:v, -jaj:v}或{DIS chu' botIvjaj@@DIS:n:2, chu':v:1, bo-:v, tIv:v, -jaj:v}.[1]，但傳統的克林貢語沒有“新年快樂”的說法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não existe uma maneira tradicional de Klingon dizer "Feliz Ano Novo", embora um Klingon possa entender {DIS chu' yItIv@@DIS:n:2, chu':v:1, yI-:v, tIv:v} ou {DIS chu' DatIvjaj@@DIS:n:2, chu':v:1, Da-:v, tIv:v, -jaj:v} ou {DIS chu' botIvjaj@@DIS:n:2, chu':v:1, bo-:v, tIv:v, -jaj:v}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei ole perinteistä klingonilaista tapaa sanoa "Hyvää uutta vuotta", vaikka klingonilainen voi ymmärtää {DIS chu' yItIv@@DIS:n:2, chu':v:1, yI-:v, tIv:v}-, {DIS chu' DatIvjaj@@DIS:n:2, chu':v:1, Da-:v, tIv:v, -jaj:v}- tai {DIS chu' botIvjaj@@DIS:n:2, chu':v:1, bo-:v, tIv:v, -jaj:v}.[1]-sanat [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Maltz thought "Merry Christmas" and "Happy New Year" were silly things to say.[1]</column>
       <column name="components">{DIS:n:2}, {chu':v:1}</column>
       <column name="examples"></column>
@@ -5905,6 +6537,7 @@ Noun Type 5: Syntactic markers
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5912,6 +6545,7 @@ Noun Type 5: Syntactic markers
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2013.12.13:src}</column>
     </table>
     <table name="mem">
@@ -5925,6 +6559,7 @@ Noun Type 5: Syntactic markers
       <column name="definition_ru">Годовщина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">週年（每年紀念日）</column>
       <column name="definition_pt">aniversário</column>
+      <column name="definition_fi">vuosipäivä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qoS:n}</column>
@@ -5963,6 +6598,11 @@ Både kardinalnummer ({DISjaj wa':n@@DISjaj:n, wa':n:num}) och ordinalnummer ({D
 Também é possível usar outras unidades de tempo, como {tupjaj:n@@tup:n, jaj:n}, como uma forma de jogo de palavras.
 
 Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ordinais ({DISjaj wa'DIch:n@@DISjaj:n, wa'DIch:n}) são aceitáveis ​​para se referir a aniversários. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on päivä, jolloin tunnistetaan tai muistetaan tapahtuma, joka tapahtui useita vuosia sitten. Muut aikayksiköt ovat mahdollisia, kuten {jarjaj:n} ja {Hoghjaj:n}.
+
+On myös mahdollista käyttää muita aikayksikköjä, kuten {tupjaj:n@@tup:n, jaj:n} sanamuotona.
+
+Sekä kardinaalinumerot ({DISjaj wa':n@@DISjaj:n, wa':n:num}) että järjestysnumerot ({DISjaj wa'DIch:n@@DISjaj:n, wa'DIch:n}) ovat hyväksyttäviä viitattaessa vuosipäiviin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DIS:n:2}, {jaj:n}</column>
       <column name="examples"></column>
@@ -5972,6 +6612,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5979,6 +6620,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -5992,6 +6634,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="definition_ru">Дискавери</column>
       <column name="definition_zh_HK">發現號（星艦）</column>
       <column name="definition_pt">Descoberta</column>
+      <column name="definition_fi">löytö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Senjo':n:name}, {Hov leng:n}</column>
@@ -6002,6 +6645,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="notes_ru">Это название корабля Федерации.</column>
       <column name="notes_zh_HK">這是聯邦星艦的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma nave estelar da Federação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on federaation tähtialuksen nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6011,6 +6655,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6018,6 +6663,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC:src}, [2] {Kauderwelsch Klingonisch:src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6031,6 +6677,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="definition_ru">Рубин [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">紅寶石 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rubi</column>
+      <column name="definition_fi">rubiini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naghboch:n}, {patmor:n}</column>
@@ -6041,6 +6688,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {Star Trek First Contact:src}, Ruby was the name of a character in a Dixon Hill holonovel.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6050,6 +6698,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6057,6 +6706,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -6070,6 +6720,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="definition_ru">быть виновным</column>
       <column name="definition_zh_HK">有罪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser culpado</column>
+      <column name="definition_fi">olla syyllinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chun:v}</column>
       <column name="see_also">{DIS:v}</column>
@@ -6080,6 +6731,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6089,6 +6741,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6096,6 +6749,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6109,6 +6763,7 @@ Ambos os números cardinais ({DISjaj wa':n@@DISjaj:n, wa':n:num}) e números ord
       <column name="definition_ru">федерация, организация, ассоциация, лига, союз</column>
       <column name="definition_zh_HK">聯邦、聯合會、聯盟</column>
       <column name="definition_pt">federação, organização, associação, liga, união</column>
+      <column name="definition_fi">järjestö, yhdistys, liitto, federaatio, unioni</column>
       <column name="synonyms">{Qa':n:2,hyp}</column>
       <column name="antonyms"></column>
       <column name="see_also">{yuQjIjDIvI':n}, {boq:n:1}, {ghom:n}, {qev:n}, {tlhach:n}</column>
@@ -6133,6 +6788,9 @@ Sammanfattningsvis eller inte låter detta ord liknar {DI vI':n:nolink} "det ack
       <column name="notes_pt">Esta palavra é usada para se referir a "Federação", uma forma abreviada de "Federação Unida dos Planetas" ({yuQjIjDIvI':n}).
 
 Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele acumula detritos". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään viittaamaan "liittoon", lyhennettyyn muotoon "Yhdistyneiden planeettojen federaatio" ({yuQjIjDIvI':n}).
+
+Sattumalta tai ei, nämä sanat kuulostavat samanlaisilta kuin {DI vI':n:nolink} "se kerää roskia". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The real reason {DIvI':n:nolink} and {DI vI':n:nolink} sound alike is because of the backfitting of {vaj toDuj Daj ngeHbej DI vI'.:sen}</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6142,6 +6800,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">organisation</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6149,6 +6808,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="search_tags_ru">организация</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 4.4, Dec. 1995:src}</column>
     </table>
     <table name="mem">
@@ -6162,6 +6822,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="definition_ru">Стандарт Федерации(языковой), Английский язык</column>
       <column name="definition_zh_HK">英文、英語</column>
       <column name="definition_pt">Padrão da Federação, Inglês (idioma)</column>
+      <column name="definition_fi">Federation Standard, englannin kieli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIvI':n}, {Hol:n}</column>
@@ -6172,6 +6833,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DIvI':n}, {Hol:n}</column>
       <column name="examples"></column>
@@ -6181,6 +6843,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6188,6 +6851,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -6201,6 +6865,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="definition_ru">Ты говоришь по английски? Ты говоришь на языке Федерации?</column>
       <column name="definition_zh_HK">你說聯邦標準語（英語）嗎？</column>
       <column name="definition_pt">Você fala Padrão da Federação?</column>
+      <column name="definition_fi">Puhutko Federation Standardia?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6211,6 +6876,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DIvI' Hol:n}, {Da-:v}, {jatlh:v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -6220,6 +6886,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Do you speak English?</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6227,6 +6894,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="search_tags_ru">Ты говоришь по английски?</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -6240,6 +6908,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="definition_ru">Боевой крейсер Федерации</column>
       <column name="definition_zh_HK">聯邦戰艦</column>
       <column name="definition_pt">Cruzador de batalha da Federação</column>
+      <column name="definition_fi">Liiton taisteluristeilijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6250,6 +6919,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DIvI':n}, {may'Duj:n}</column>
       <column name="examples"></column>
@@ -6259,6 +6929,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6266,6 +6937,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6279,6 +6951,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="definition_ru">застрять (физически не сдвинется с места) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陷入困境（實際上不會讓步） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficar preso (fisicamente não se mexe)</column>
+      <column name="definition_fi">olla jumissa (fyysisesti kykenemätön liikkumaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngItlh:v}</column>
@@ -6289,6 +6962,7 @@ Coincidentemente ou não, esta palavra soa semelhante a {DI vI':n:nolink} "ele a
       <column name="notes_ru">Это означает, что что-то застревает, когда вы не можете открыть дверь или окно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著有些東西卡住了，例如無法打開門或窗戶。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa que algo está preso como quando você não pode abrir uma porta ou janela. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa jotain juuttunutta kuin silloin, kun et saa ovea tai ikkunaa auki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Do It Yourself" is a term used to describe home improvement without the assistance of professionals.
 
 This was defined as "be stuck" with an explanation, along with a bunch of other words which can be translated into various senses of "be stuck" in English.</column>
@@ -6300,6 +6974,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6307,6 +6982,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -6320,6 +6996,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">характеристика, черта [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">特徵</column>
       <column name="definition_pt">característica, traço</column>
+      <column name="definition_fi">ominaisuus, piirre</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6330,6 +7007,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это может использоваться для «личности» в смысле качества или черты, которая формирует характер человека.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在形成一個人性格的品質或特質的意義上，這可以用於“個性”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para "personalidade" no sentido de uma qualidade ou característica que forma o caráter de uma pessoa.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää "persoonallisuuteen" sen ominaisuuden tai piirteen merkityksessä, joka muodostaa henkilön luonteen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6340,6 +7018,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">personality, feature</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6347,6 +7026,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}, [2] {Saarbrücken qepHom'a' 2017:src}, [3] {KLI mailing list 2017.10.22:src}</column>
     </table>
     <table name="mem">
@@ -6360,6 +7040,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">овец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">羊</column>
       <column name="definition_pt">ovelha</column>
+      <column name="definition_fi">lammas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gha'cher:n}, {bolmaq:n:extcan}</column>
@@ -6370,6 +7051,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это пушистое, пушистое, мохнатое клингонское животное. Баран будет {DI'raq loD:n@@DI'raq:n, loD:n}, а овца будет {DI'raq be':n@@DI'raq:n, be':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種蓬鬆的，毛茸茸的克林崗動物。公羊是{DI'raq loD:n@@DI'raq:n, loD:n}，母羊是{DI'raq be':n@@DI'raq:n, be':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um animal Klingon fofo, felpudo e felpudo. Um carneiro seria um {DI'raq loD:n@@DI'raq:n, loD:n} e uma ovelha seria um {DI'raq be':n@@DI'raq:n, be':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on pörröinen, villavainen, pörröinen klingonilainen eläin. Jäärä olisi {DI'raq loD:n@@DI'raq:n, loD:n} ja uuhi olisi {DI'raq be':n@@DI'raq:n, be':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Dirac equation failed to predict the Lamb shift.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6379,6 +7061,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ram, ewe</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6386,6 +7069,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -6399,6 +7083,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">реальность [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">現實 [AUTOTRANSLATED]</column>
       <column name="definition_pt">realidade</column>
+      <column name="definition_fi">todellisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6409,6 +7094,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6418,6 +7104,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6425,6 +7112,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
       <table name="mem">
@@ -6438,6 +7126,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
         <column name="definition_ru">метафизика [AUTOTRANSLATED]</column>
         <column name="definition_zh_HK">形而上學 [AUTOTRANSLATED]</column>
         <column name="definition_pt">metafísica</column>
+      <column name="definition_fi">metafysiikka</column>
         <column name="synonyms"></column>
         <column name="antonyms"></column>
         <column name="see_also">{HapQeD:n}</column>
@@ -6448,6 +7137,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
         <column name="notes_ru">В отличие от общего паттерна с {QeD:n}, это записано в виде двух слов. Человек, который делает это {DI'ruj tej:n@@DI'ruj:n, tej:n}.[2] [AUTOTRANSLATED]</column>
         <column name="notes_zh_HK">與{QeD:n}的一般模式相反，這是兩個單詞。這樣做的人是{DI'ruj tej:n@@DI'ruj:n, tej:n}.[2] [AUTOTRANSLATED]</column>
         <column name="notes_pt">Ao contrário do padrão geral com {QeD:n}, isso é escrito como duas palavras. Uma pessoa que faz isso é um {DI'ruj tej:n@@DI'ruj:n, tej:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Päinvastoin kuin {QeD:n}-mallissa, tämä kirjoitetaan kahtena sanana. Tämän tekevä henkilö on {DI'ruj tej:n@@DI'ruj:n, tej:n}.[2] [AUTOTRANSLATED]</column>
         <column name="hidden_notes"></column>
         <column name="components">{DI'ruj:n}, {QeD:n}</column>
         <column name="examples"></column>
@@ -6457,6 +7147,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
         <column name="examples_ru"></column>
         <column name="examples_zh_HK"></column>
         <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
         <column name="search_tags"></column>
         <column name="search_tags_de"></column>
         <column name="search_tags_fa"></column>
@@ -6464,6 +7155,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
         <column name="search_tags_ru"></column>
         <column name="search_tags_zh_HK"></column>
         <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
         <column name="source">[1] {qep'a' 26 (2019):src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
       </table>
     <table name="mem">
@@ -6477,6 +7169,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">виртуальная реальность [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">虛擬現實 [AUTOTRANSLATED]</column>
       <column name="definition_pt">realidade virtual</column>
+      <column name="definition_fi">virtuaalitodellisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tojbogh pa':n}</column>
@@ -6487,6 +7180,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DI'ruj:n}, {velqa':n}</column>
       <column name="examples">
@@ -6497,6 +7191,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6504,6 +7199,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -6517,6 +7213,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">скорость</column>
       <column name="definition_zh_HK">速度</column>
       <column name="definition_pt">velocidade</column>
+      <column name="definition_fi">nopeus, vauhti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chung:v}</column>
@@ -6527,6 +7224,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6536,6 +7234,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">speed</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6543,6 +7242,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru">скорость</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6556,6 +7256,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Ресторан быстрого питания [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">快餐店</column>
       <column name="definition_pt">restaurante fast food</column>
+      <column name="definition_fi">pikaruokaravintola</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tebwI':n}, {moD:v}, {Soj:n:1}</column>
@@ -6566,6 +7267,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это {Qe':n} со знаком «{moD Soj:sen:nolink}.[1, p.102]» [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este é um {Qe':n} com uma placa que diz {moD Soj:sen:nolink}.[1, p.102] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {Qe':n}, jossa on merkki {moD Soj:sen:nolink}.[1, p.102] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Do:n}, {Qe':n}</column>
       <column name="examples"></column>
@@ -6575,6 +7277,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6582,6 +7285,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6595,6 +7299,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">гонка (соревнование скорости) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">比賽（速度比賽）</column>
       <column name="definition_pt">corrida (competição de velocidade)</column>
+      <column name="definition_fi">nopeuskilpailu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ov:v}</column>
@@ -6605,6 +7310,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Do:n}, {qaD:n}</column>
       <column name="examples"></column>
@@ -6614,6 +7320,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6621,6 +7328,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -6634,6 +7342,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть грубым</column>
       <column name="definition_zh_HK">粗魯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser rude</column>
+      <column name="definition_fi">olla töykeä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{DochHa':v}</column>
       <column name="see_also">{ngIj:v}, {qej:v}, {Qut:v}</column>
@@ -6644,6 +7353,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6653,6 +7363,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6660,6 +7371,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6673,6 +7385,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть вежливым, быть воспитанным, быть учтивым</column>
       <column name="definition_zh_HK">禮貌、文明、有禮貌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser educado, civilizado, cortês</column>
+      <column name="definition_fi">olla kohtelias</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Doch:v}</column>
       <column name="see_also"></column>
@@ -6683,6 +7396,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это описывает скорее неКлингонский способ поведения</column>
       <column name="notes_zh_HK">這描述了一種不太克林崗的行為方式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso descreve uma maneira bastante não-klingon de se comportar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kuvaa melko epäklingonilaista tapaa käyttäytyä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Doch:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -6692,6 +7406,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6699,6 +7414,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.01:src}</column>
     </table>
     <table name="mem">
@@ -6712,6 +7428,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">вещь</column>
       <column name="definition_zh_HK">事物、東西</column>
       <column name="definition_pt">coisa</column>
+      <column name="definition_fi">asia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vay':n}</column>
@@ -6722,6 +7439,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6731,6 +7449,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6738,6 +7457,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6751,6 +7471,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Что это такое?</column>
       <column name="definition_zh_HK">這是什麼？</column>
       <column name="definition_pt">O que é isso?</column>
+      <column name="definition_fi">Mikä tämä on?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{... 'oH Dochvam'e'.:sen}</column>
@@ -6761,6 +7482,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Doch:n}, {-vam:n}, {nuq:ques}</column>
       <column name="examples"></column>
@@ -6770,6 +7492,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6777,6 +7500,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -6790,6 +7514,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Сколько ты хочешь за это?</column>
       <column name="definition_zh_HK">你想要多少錢？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quanto você quer por isso?</column>
+      <column name="definition_fi">Kuinka paljon haluat siitä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIlmeH Huch:n}</column>
@@ -6800,6 +7525,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Doch:n}, {-vetlh:n}, {DIlmeH Huch:n}, {'ar:ques}, {Da-:v}, {neH:v}</column>
       <column name="examples"></column>
@@ -6809,6 +7535,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6816,6 +7543,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -6829,6 +7557,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Я не могу это есть.</column>
       <column name="definition_zh_HK">我不能吃那個。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu não posso comer isso.</column>
+      <column name="definition_fi">En voi syödä sitä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6839,6 +7568,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6848,6 +7578,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6855,6 +7586,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -6868,6 +7600,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Я не могу это пить.</column>
       <column name="definition_zh_HK">我不能喝那個。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu não posso beber isso.</column>
+      <column name="definition_fi">En voi juoda sitä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6878,6 +7611,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6887,6 +7621,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6894,6 +7629,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -6907,6 +7643,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">отметка (координаты)</column>
       <column name="definition_zh_HK">標記（坐標）</column>
       <column name="definition_pt">marca, ponto (em coordenadas)</column>
+      <column name="definition_fi">erotin (koordinaateissa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quv:n}, {vI':n:2}</column>
@@ -6917,6 +7654,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это относится к разделителю, используемому, чтобы определить набор координат, а не определенную координатную точку или локацию (для которой смотрите {Quv:n}).</column>
       <column name="notes_zh_HK">這是指用於指定一組坐標的分隔符，而不是特定的坐標點或位置（有關此信息，請參見{Quv:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao separador usado na especificação de um conjunto de coordenadas, e não a um ponto ou local de coordenadas específico (para o qual consulte {Quv:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa erottimeen, jota käytetään määrittelemään joukko koordinaatteja, eikä tiettyyn koordinaattipisteeseen tai sijaintiin (josta katso {Quv:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6931,6 +7669,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       </column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6938,6 +7677,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {s.k 1999.11.21:src} (reprinted in {HQ 8.4, p.8, Dec. 1999:src}), [3] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -6951,6 +7691,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть глупым</column>
       <column name="definition_zh_HK">愚蠢</column>
       <column name="definition_pt">ser tolo, bobo</column>
+      <column name="definition_fi">olla typerä, olla naurettava</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chul:v}</column>
       <column name="see_also">{qoH:n}, {tIghla':n}, {Dap:n}, {QIp:v}, {chatlh!:excl}</column>
@@ -6961,6 +7702,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Existe um idioma {Dogh; tIghla' rur:sen@@Dogh:v, tIghla':n, rur:v}.[2, p.127] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {Dogh; tIghla' rur:sen@@Dogh:v, tIghla':n, rur:v}.[2, p.127] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"D'oh!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6970,6 +7712,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6977,6 +7720,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6990,6 +7734,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">безоговорочная сдача</column>
       <column name="definition_zh_HK">無條件投降</column>
       <column name="definition_pt">rendição incondicional</column>
+      <column name="definition_fi">ehdoton antautuminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dogh:v}, {jey:v}</column>
@@ -7000,6 +7745,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This consists of the words for "silly" and "defeat".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7009,6 +7755,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7016,6 +7763,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7029,6 +7777,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">отходить, отступать, уйти от</column>
       <column name="definition_zh_HK">遠離、退縮、遠離 [AUTOTRANSLATED]</column>
       <column name="definition_pt">afastar-se de algo, voltar atrás, ir embora</column>
+      <column name="definition_fi">perääntyä jostakin, etääntyä jostakin, mennä pois jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chol:v}</column>
       <column name="see_also">{HeD:v}, {ghoS:v:1}</column>
@@ -7039,6 +7788,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7049,6 +7799,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7056,6 +7807,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW p.211:src}</column>
     </table>
     <table name="mem">
@@ -7069,6 +7821,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">ехать обратно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">開車回來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dirija de volta</column>
+      <column name="definition_fi">ajaa pois</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7079,6 +7832,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Основываясь на примере {qawmoH:v}, субъект {DoHmoH:v:nolink} выполняет движение назад, {-vaD:n} помечает то, что движется назад, а объект - это вещь или место, из которого он движется назад. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據{qawmoH:v}的示例，{DoHmoH:v:nolink}的主題執行回退操作，{-vaD:n}標記被回退的對象，並且對像是從其回退的物體或位置。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Com base no exemplo de {qawmoH:v}, o assunto {DoHmoH:v:nolink} faz o retorno, {-vaD:n} marca o que é retrocedido e o objeto é a coisa ou o local de onde ele é retrocedido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{qawmoH:v}-esimerkin perusteella {DoHmoH:v:nolink}-aihe tekee ajon taaksepäin, {-vaD:n} merkitsee sen, mikä ajetaan takaisin, ja esine on asia tai paikka, josta se ajaa takaisin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
       <column name="components">{DoH:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -7088,6 +7842,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">repel</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7095,6 +7850,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7108,6 +7864,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">партия, куча, куча, накопление [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">批量、堆、堆、積累 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lote, pilha, acúmulo</column>
+      <column name="definition_fi">kasa, keko, pino, erä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7118,6 +7875,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это слово может относиться к людям или иным образом. Даже если речь идет только о существах, способных использовать язык, обычно говорят {Dojmey:n}, а не {Dojpu':n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞可以指人或其他。即使僅指具有語言能力的人，通常也會說{Dojmey:n}而不是{Dojpu':n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra pode se referir a pessoas ou não. Mesmo se referindo apenas a seres capazes de usar a linguagem, normalmente se diria {Dojmey:n} em vez de {Dojpu':n:nolink}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi viitata ihmisiin tai muuten. Vaikka viitattaisiin vain olentoihin, jotka kykenevät käyttämään kieltä, sanotaan yleensä {Dojmey:n} eikä {Dojpu':n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7127,6 +7885,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7134,6 +7893,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -7147,6 +7907,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">масса, массы, множество, очень большая, но неопределенная группа чего-то [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">群眾、群眾、群眾、一個非常大但不確定的群體 [AUTOTRANSLATED]</column>
       <column name="definition_pt">massa, massas, multidão, um grupo muito grande mas indeterminado de algo</column>
+      <column name="definition_fi">massa (suuri mutta tuntematon määrä esineitä tai ihmisiä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghom'a':n}, {qev:n}, {qabDu' law':n}</column>
@@ -7157,6 +7918,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это слово может относиться к людям или иным образом. Даже если речь идет только о существах, способных использовать язык, обычно говорят {Dojmey:n:nolink}, а не {Dojpu':n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞可以指人或其他。即使僅指具有語言能力的人，通常也會說{Dojmey:n:nolink}而不是{Dojpu':n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra pode se referir a pessoas ou não. Mesmo se referindo apenas a seres capazes de usar a linguagem, normalmente se diria {Dojmey:n:nolink} em vez de {Dojpu':n:nolink}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi viitata ihmisiin tai muuten. Vaikka viitattaisiin vain olentoihin, jotka kykenevät käyttämään kieltä, sanotaan yleensä {Dojmey:n:nolink} eikä {Dojpu':n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example sentence is a lip-match for {'ej DochmeywIj vItlhapqa'meH}.</column>
       <column name="components">{Doj:n}, {-mey:n}</column>
       <column name="examples">
@@ -7168,6 +7930,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7175,6 +7938,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -7188,6 +7952,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть впечатляющим</column>
       <column name="definition_zh_HK">令人印象深刻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser impressionante</column>
+      <column name="definition_fi">olla vaikuttava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pov:v}, {po':v}</column>
@@ -7198,6 +7963,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7207,6 +7973,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7214,6 +7981,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7228,6 +7996,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">сущность, целый(как определение размера)</column>
       <column name="definition_zh_HK">實體、整體 [AUTOTRANSLATED]</column>
       <column name="definition_pt">unidade, todo</column>
+      <column name="definition_fi">kokonaisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQ:v}, {bID:n}</column>
@@ -7238,6 +8007,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined as "entity" in {TKD:src} and as "whole" in {TKW:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7249,6 +8019,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">entirety</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7256,6 +8027,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru">целиком</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}, [3] {paq'batlh p.102-103:src}</column>
     </table>
     <table name="mem">
@@ -7269,6 +8041,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Радан(сырой дилитиевый кристалл)</column>
       <column name="definition_zh_HK">radan（粗二鋰晶體） [AUTOTRANSLATED]</column>
       <column name="definition_pt">radan (cristal bruto de dilítio)</column>
+      <column name="definition_fi">radaani (raaka dilitiumkide)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'puj:n}</column>
@@ -7279,6 +8052,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7288,6 +8062,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7295,6 +8070,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7308,6 +8084,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть параллельным, идти параллельно чему-то, идти параллельно кому-то</column>
       <column name="definition_zh_HK">並行、平行</column>
       <column name="definition_pt">ser paralelo, ir paralelo a</column>
+      <column name="definition_fi">olla yhdensuuntainen jonkin kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{leD:v}, {DonHa':v}</column>
       <column name="see_also">{HeDon:n}, {Dop:v:1}, {neq:v}</column>
@@ -7318,6 +8095,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Чтобы сказать, что две или более вещи являются параллельными, глагол используется с подлежащим во множественном числе.[2]</column>
       <column name="notes_zh_HK">要說兩個或多個事物是平行的，則該動詞用於復數主語。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para dizer que duas ou mais coisas são paralelas, esse verbo é usado com um assunto plural.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä sanotaan, että kaksi tai useampia asioita on rinnakkain monikkomuodon kanssa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The "go parallel to" definition suggests that this verb can be used transitively. However, the noun {HeDon} also suggests that {Don} acts like a verb of quality.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7327,6 +8105,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7334,6 +8113,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -7348,6 +8128,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть смещенным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不對齊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desalinhado</column>
+      <column name="definition_fi">olla vinossa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Don:v}</column>
       <column name="see_also">{leD:v}</column>
@@ -7358,6 +8139,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Don:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -7367,6 +8149,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7374,6 +8157,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -7388,6 +8172,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Сторона</column>
       <column name="definition_zh_HK">邊、面、側</column>
       <column name="definition_pt">lado</column>
+      <column name="definition_fi">sivu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurgh:n}, {reD:n:2}</column>
@@ -7398,6 +8183,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">В {Klingon Monopoly:src} {Dop:n:nolink} используется для обозначения одного лица игральной карты. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{Klingon Monopoly:src}中，{Dop:n:nolink}用於指示紙牌的一個面。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em {Klingon Monopoly:src}, {Dop:n:nolink} é usado para indicar uma face de um baralho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohdassa {Klingon Monopoly:src} {Dop:n:nolink} käytetään osoittamaan pelikortin yhtä kasvoa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7411,6 +8197,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
 ▶ {'echletHom Dopvam yIcha':sen:nolink} "карта должна быть развернута этой стороной наверх"[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">direction, face</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7418,6 +8205,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {PK:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -7431,6 +8219,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть противоположным, противоположным, противоречивым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">相反、對立、矛盾</column>
       <column name="definition_pt">ser oposto, antitético, contraditório</column>
+      <column name="definition_fi">olla päinvastainen, vastakkainen, ristiriitainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Don:v}, {leD:v}</column>
@@ -7441,6 +8230,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Конструкция {DopmoH:v} используется для изменения списка. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{DopmoH:v}的結構用於反轉列表。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A construção {DopmoH:v} é usada para reverter uma lista. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Rakennetta {DopmoH:v} käytetään luettelon kääntämiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Doppelgänger."</column>
       <column name="components"></column>
       <column name="examples">
@@ -7451,6 +8241,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7458,6 +8249,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.08:src}</column>
     </table>
     <table name="mem">
@@ -7471,6 +8263,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть отрицательным (используется в математике) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">為負（用於數學） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser negativo (usado em matemática)</column>
+      <column name="definition_fi">olla negatiivinen (matematiikka)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taH:v:2}, {boqHa':v}</column>
@@ -7481,6 +8274,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это просто глагол {Dop:v:1}, применяемый к числам в математике. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是動詞{Dop:v:1}應用於數學中的數字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é apenas o verbo {Dop:v:1} aplicado aos números em matemática. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain verbi {Dop:v:1}, jota sovelletaan matematiikan numeroihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7491,6 +8285,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7498,6 +8293,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7511,6 +8307,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">обратный (например, список) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">反向（例如列表） [AUTOTRANSLATED]</column>
       <column name="definition_pt">reverso (por exemplo, uma lista)</column>
+      <column name="definition_fi">kääntää (listan järjestys) päinvastaiseksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{patlhmoH:v}, {yoymoH:v}</column>
@@ -7521,6 +8318,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Dop:v:1}, {-moH:v}</column>
       <column name="examples"></column>
@@ -7530,6 +8328,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7537,6 +8336,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.10:src}</column>
     </table>
     <table name="mem">
@@ -7550,6 +8350,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Поджечь сбоку, когда есть опасность. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有危險時，側面放火。</column>
       <column name="definition_pt">Atear fogo ao lado quando houver perigo.</column>
+      <column name="definition_fi">Kun tilanne on vaarallinen, sytytä sivulle tuli.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yut:v}</column>
@@ -7560,6 +8361,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Dop:n}, {-Daq:n}, {qul:n}, {yI-:v}, {chenmoH:v}, {Qob:v}, {-DI':v}, {ghu':n}</column>
       <column name="examples"></column>
@@ -7569,6 +8371,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">replacement proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7576,6 +8379,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -7589,6 +8393,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть оранжевым, быть красным</column>
       <column name="definition_zh_HK">橙色、紅色</column>
       <column name="definition_pt">ser laranja, ser vermelho</column>
+      <column name="definition_fi">olla oranssi, punainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuD:v:1}, {nguv:v}</column>
@@ -7599,6 +8404,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Этот глагол также покрывает цвета, которые называются "корчиневый" (и его оттенками). Чтобы обозначить различие коричневого объекта, от другого объекта, который также может быть описан, используя {Doq:v:nolink}, используется фраза, такая как {Doq 'ej wovbe':sen@@Doq:v, 'ej:conj, wov:v, -be':v}.[2] Слово {Doqqu':v@@Doq:v, -qu':v} относится к цвету, более красному, чем оранжевый.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este verbo também cobre cores que seriam chamadas de "marrom". Para diferenciar um objeto marrom de outro objeto que também pode ser descrito usando {Doq:v:nolink}, é usada uma frase como {Doq 'ej wovbe':sen@@Doq:v, 'ej:conj, wov:v, -be':v}.[2] A palavra {Doqqu':v@@Doq:v, -qu':v} refere-se a uma cor mais vermelha que laranja.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi kattaa myös värit, joita kutsutaan "ruskeiksi". Ruskean objektin erottamiseksi toisesta objektista, joka voidaan kuvata myös {Doq:v:nolink}: llä, käytetään ilmausta kuten {Doq 'ej wovbe':sen@@Doq:v, 'ej:conj, wov:v, -be':v}. [2] Sana {Doqqu':v@@Doq:v, -qu':v} viittaa väreihin, jotka ovat enemmän punaisia ​​kuin oransseja.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">All natural languages found on Earth divide colours into "warm" and "cool" in the same way. Klingon distinguishes between {Doq:v:nolink} and {SuD:v:1}, but it groups "yellow" with the "cool" colours rather than with the "warm" colours.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7612,6 +8418,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">brown, pink</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7619,6 +8426,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1998.02.21:src} (reprinted in {HQ 8.1, p.7, Mar. 1999:src}), [3] {KGT p.82:src}, [4] {TNK:src}</column>
     </table>
         <table name="mem">
@@ -7632,6 +8440,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="definition_ru">случилось что-то важное</column>
           <column name="definition_zh_HK">發生了重大事件</column>
           <column name="definition_pt">algo importante aconteceu</column>
+      <column name="definition_fi">jotain merkittävää on tapahtunut</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{'ej HumtaH 'ej DechtaH 'Iw:sen}</column>
@@ -7642,6 +8451,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="notes_ru">Выражения {Doq bIQtIq:sen:nolink} ("река красная") и {Doq bIQtIq bIQ:sen:nolink} ("вода реки красная") могут быть прослежены от старой застольной песни, напоминающей, как {qeylIS'e' lIjlaHbe'bogh vay':n:name} убил {molor:n:name}.</column>
           <column name="notes_zh_HK">{Doq bIQtIq:sen:nolink}（“河是紅色的”）和{Doq bIQtIq bIQ:sen:nolink}（“河水是紅色的”）的表達可以追溯到一首古老的飲酒歌，以紀念{qeylIS'e' lIjlaHbe'bogh vay':n:name}殺死{molor:n:name}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">As expressões {Doq bIQtIq:sen:nolink} ("o rio é vermelho") e {Doq bIQtIq bIQ:sen:nolink} ("a água do rio é vermelha") podem ser rastreadas até uma música antiga para comemorar o assassinato de {molor:n:name} por {qeylIS'e' lIjlaHbe'bogh vay':n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Lausekkeet {Doq bIQtIq:sen:nolink} ("joki on punainen") ja {Doq bIQtIq bIQ:sen:nolink} ("jokivesi on punainen") voidaan jäljittää vanhaan juomalauluun, joka muistuttaa {molor:n:name}: n tappamista {qeylIS'e' lIjlaHbe'bogh vay':n:name}: n toimesta. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -7651,6 +8461,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7658,6 +8469,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.123:src}</column>
         </table>
         <table name="mem">
@@ -7671,6 +8483,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="definition_ru">быть определенного оттенка коричневого [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">一種特殊的啡色</column>
           <column name="definition_pt">ser um tom particular de marrom</column>
+      <column name="definition_fi">olla erästä ruskean sävyä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7681,6 +8494,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="notes_ru">У краджа коричневые губы. Это выражение используется для описания объекта, который имеет определенный оттенок коричневого (см. {Doq 'ej wovbe':sen}). [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">邊緣有棕色的嘴唇。此表達式用於描述特定的棕色陰影對象（請參閱{Doq 'ej wovbe':sen}）。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Um kradge tem lábios castanhos. Essa expressão é usada para descrever um objeto que é um tom de marrom específico (consulte {Doq 'ej wovbe':sen}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kradge on ruskeat huulet. Tätä lauseketta käytetään kuvaamaan kohdetta, joka on tietty ruskea sävy (katso {Doq 'ej wovbe':sen}). [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -7690,6 +8504,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">brown, brown-colour</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7697,6 +8512,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {s.k 1998.02.21:src} (reprinted in {HQ 8.1, p.7, Mar. 1999:src})</column>
         </table>
         <table name="mem">
@@ -7710,6 +8526,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="definition_ru">быть коричневым [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">啡色</column>
           <column name="definition_pt">ser marrom</column>
+      <column name="definition_fi">olla ruskea</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Qaj:n}</column>
@@ -7720,6 +8537,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="notes_ru">Чтобы быть более точным в отношении оттенка коричневого, используется сравнение. Например, можно сказать {Doq 'ej Qaj wuS rur:sen} (губы крагеда имеют определенный оттенок коричневого) .[1] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">為了更具體地描述棕色的陰影，使用了比較。例如，可能會說{Doq 'ej Qaj wuS rur:sen}（邊緣邊緣是一種特殊的棕色陰影）。[1] [AUTOTRANSLATED]</column>
           <column name="notes_pt">Para ser mais específico sobre o tom de marrom, é usada uma comparação. Por exemplo, pode-se dizer {Doq 'ej Qaj wuS rur:sen} (os lábios do kradge são um tom de marrom específico).[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ruskean sävyn tarkentamiseksi käytetään vertailua. Esimerkiksi voidaan sanoa {Doq 'ej Qaj wuS rur:sen} (kradge-huulet ovat tietty ruskea sävy).[1] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -7729,6 +8547,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7736,6 +8555,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {s.k 1998.02.21:src} (reprinted in {HQ 8.1, p.7, Mar. 1999:src})</column>
         </table>
     <table name="mem">
@@ -7749,6 +8569,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">претендовать (территория)</column>
       <column name="definition_zh_HK">索賠（領土） [AUTOTRANSLATED]</column>
       <column name="definition_pt">reivindicação (território)</column>
+      <column name="definition_fi">tehdä aluevaatimus, vaatia (aluetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dan:v}, {yer:n}, {ghajwI':n}</column>
@@ -7759,6 +8580,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Объектом этого глагола могут быть физические вещи, такие как территория или меч, или более абстрактные понятия, такие как власть. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞的賓語可以是諸如領土或劍之類的物理事物，也可以是諸如權威之類的更抽象的概念。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto desse verbo pode ser coisas físicas, como território ou espada, ou conceitos mais abstratos, como autoridade. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde voi olla fyysisiä asioita, kuten alue tai miekka, tai abstraktimpia käsitteitä, kuten auktoriteetti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Even though the definition says "territory", the canon usages show that this is just an example, and {DoQ:v:nolink} can be used to claim other things.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7788,6 +8610,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
    Demanding to get in."[2, p.130-131]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7795,6 +8618,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -7808,6 +8632,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">раковина для мытья рук, лица, еды и т. д. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用於清潔手、臉、食物等的水槽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pia para limpeza de mãos, rosto, comida, etc.</column>
+      <column name="definition_fi">lavuaari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puchpa':n}, {HaySIn:n}</column>
@@ -7818,6 +8643,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Ванна или бассейн будут {DoQmIv'a':n}. {DoQmIvHom:n@@DoQmIv:n, -Hom:n} будет ведром или чем-то подобным. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Uma banheira ou piscina seria um {DoQmIv'a':n}. Um {DoQmIvHom:n@@DoQmIv:n, -Hom:n} seria um balde ou qualquer coisa semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kylpyamme tai uima-allas olisi {DoQmIv'a':n}. {DoQmIvHom:n@@DoQmIv:n, -Hom:n} olisi ämpäri tai mikä tahansa vastaava. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7827,6 +8653,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bucket, pail</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7834,6 +8661,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7847,6 +8675,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">ванна, бассейн [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沖涼缸、游泳池</column>
       <column name="definition_pt">banheira, piscina</column>
+      <column name="definition_fi">kylpyamme, uima-allas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7857,6 +8686,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">При необходимости, «ванна» и «бассейн» можно различить с помощью классификаторов: {Say'moHmeH DoQmIv'a':n}, {QalmeH DoQmIv'a':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如有必要，可以使用限定符區分“浴缸”和“游泳池”：{Say'moHmeH DoQmIv'a':n}、{QalmeH DoQmIv'a':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se necessário, "banheira" e "piscina" podem ser distinguidas usando qualificadores: {Say'moHmeH DoQmIv'a':n}, {QalmeH DoQmIv'a':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tarvittaessa "kylpyamme" ja "uima-allas" voidaan erottaa toisistaan ​​karsinnoilla: {Say'moHmeH DoQmIv'a':n}, {QalmeH DoQmIv'a':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DoQmIv:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -7866,6 +8696,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7873,6 +8704,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7886,6 +8718,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">сопровождать, эскортировать</column>
       <column name="definition_zh_HK">護送</column>
       <column name="definition_pt">escoltar</column>
+      <column name="definition_fi">saattaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhej:v}</column>
@@ -7896,6 +8729,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Escort (someone) to the door."</column>
       <column name="components"></column>
       <column name="examples">
@@ -7906,6 +8740,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7913,6 +8748,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7926,6 +8762,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">конец (периода времени) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結束（一段時間） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fim (de um período de tempo)</column>
+      <column name="definition_fi">loppua (ajanjaksosta, resurssista tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIn:v}</column>
@@ -7936,6 +8773,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Предметом этого глагола является период или единица времени, например, месяц. Это не должно быть событие, окончание которого контролируется (см. {van:v:2}, {ghang:v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞的主題是一個時期或時間單位，例如一個月。這不應是事件的結束可以控制的事件（有關此事件，請參閱{van:v:2}，{ghang:v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O assunto desse verbo é um período ou unidade de tempo, como um mês. Não deve ser um evento cujo final tenha algum controle (para o qual consulte {van:v:2}, {ghang:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin aihe on jakso tai aikayksikkö, kuten kuukausi. Sen ei pitäisi olla tapahtuma, jonka loppua hallitaan jonkin verran (katso {van:v:2}, {ghang:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7946,6 +8784,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7953,6 +8792,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}, [2] {KLI mailing list 2012.03.30:src}</column>
     </table>
     <table name="mem">
@@ -7967,6 +8807,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">цель</column>
       <column name="definition_zh_HK">目標（單數）</column>
       <column name="definition_pt">alvo</column>
+      <column name="definition_fi">kohde</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uch:v:2}, {chIl:v}, {buS:v}, {ghoch:v}</column>
@@ -7977,6 +8818,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ray':n:inhpl}</column>
       <column name="examples">
@@ -7991,6 +8833,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7998,6 +8841,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8011,6 +8855,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">отвлекаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">離題 [AUTOTRANSLATED]</column>
       <column name="definition_pt">discordar</column>
+      <column name="definition_fi">poiketa (aiheesta?)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8021,6 +8866,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это идиоматическое выражение, которое буквально означает «потерять или потерять цель», означает «отступить». {DoS vIchIl:sen:nolink} означает «я отвлекся» и так далее. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是失去或放錯目標，意思是“離題”。 {DoS vIchIl:sen:nolink}的意思是“我離題”，依此類推。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática, que literalmente significa perder ou deslocar um alvo, significa "discordar". {DoS vIchIl:sen:nolink} significa "discordo", e assim por diante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu, joka kirjaimellisesti tarkoittaa kohteen menettämistä tai väärin sijoittamista, tarkoittaa "poikkeamista". {DoS vIchIl:sen:nolink} tarkoittaa "poikkeamaan" ja niin edelleen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DoS:n}, {chIl:v}</column>
       <column name="examples"></column>
@@ -8030,6 +8876,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8037,6 +8884,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 15 (2008):src}</column>
     </table>
     <table name="mem">
@@ -8050,6 +8898,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">{cha' DoSmey DIqIp.:sen}</column>
       <column name="definition_zh_HK">{cha' DoSmey DIqIp.:sen}</column>
       <column name="definition_pt">{cha' DoSmey DIqIp.:sen}</column>
+      <column name="definition_fi">{cha' DoSmey DIqIp.:sen}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8060,6 +8909,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8069,6 +8919,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8076,6 +8927,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.106:src}</column>
     </table>
     <table name="mem">
@@ -8089,6 +8941,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">{wa' DoS wIqIp.:sen}</column>
       <column name="definition_zh_HK">{wa' DoS wIqIp.:sen}</column>
       <column name="definition_pt">{wa' DoS wIqIp.:sen}</column>
+      <column name="definition_fi">{wa' DoS wIqIp.:sen}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8099,6 +8952,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8108,6 +8962,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8115,6 +8970,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.106:src}</column>
     </table>
     <table name="mem">
@@ -8128,6 +8984,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">созвездие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星座 [AUTOTRANSLATED]</column>
       <column name="definition_pt">constelação</column>
+      <column name="definition_fi">tähdistö, tähtikuvio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hov:n}, {Hovtay':n}, {ghochwI':n}</column>
@@ -8138,6 +8995,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Connect ({rar:v}) the dots.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8147,6 +9005,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8154,6 +9013,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8167,6 +9027,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Статус</column>
       <column name="definition_zh_HK">狀態</column>
       <column name="definition_pt">status</column>
+      <column name="definition_fi">tila, tilanne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8177,6 +9038,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{muD Dotlh:n}</column>
@@ -8186,6 +9048,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">condition</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8193,6 +9056,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8206,6 +9070,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">флейта, дудка</column>
       <column name="definition_zh_HK">長笛、橫笛</column>
       <column name="definition_pt">flauta, pífano</column>
+      <column name="definition_fi">huilu, pilli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qung:n}, {Heng:v}, {gheb:n}</column>
@@ -8216,6 +9081,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это вообще сделано из кости. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常是由骨頭製成的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso geralmente é criado a partir de ossos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleensä valmistettu luusta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8225,6 +9091,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">whistle, pipe</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8232,6 +9099,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru">труба</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8245,6 +9113,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">тележка (транспортное средство на колесах, потянув или толкнул) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">推車（輪式車輛，拉動或推入） [AUTOTRANSLATED]</column>
       <column name="definition_pt">carrinho (veículo com rodas, puxado ou empurrado)</column>
+      <column name="definition_fi">kärry (vedetty tai työnnetty pyörillä kulkeva ajoneuvo)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}</column>
@@ -8255,6 +9124,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это может иметь любое количество колес (как правило, два). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它可以具有任意數量的輪子（通常為兩個）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ter qualquer número de rodas (normalmente duas). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tässä voi olla mikä tahansa määrä pyöriä (tyypillisesti kaksi). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the D'Oyly Carte Opera Company.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8264,6 +9134,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8271,6 +9142,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -8284,6 +9156,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть уставшим</column>
       <column name="definition_zh_HK">癐、累</column>
       <column name="definition_pt">estar cansado</column>
+      <column name="definition_fi">olla väsynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hob:v}, {Qong:v}</column>
@@ -8294,6 +9167,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It is unclear if {tlhuch:v} "exhaust" means to "tire someone out".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8303,6 +9177,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8310,6 +9185,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8323,6 +9199,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Троя</column>
       <column name="definition_zh_HK">Troyius [AUTOTRANSLATED]</column>
       <column name="definition_pt">Troyius</column>
+      <column name="definition_fi">Troyius</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'elaS:n}, {telun Hovtay':n}</column>
@@ -8333,6 +9210,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8342,6 +9220,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8349,6 +9228,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8362,6 +9242,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">быть благоприятным, быть счастливым, быть удачливым</column>
       <column name="definition_zh_HK">幸運</column>
       <column name="definition_pt">ter sorte</column>
+      <column name="definition_fi">olla onnekas</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Do'Ha':v}</column>
       <column name="see_also"></column>
@@ -8372,6 +9253,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8382,6 +9264,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8389,6 +9272,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8402,6 +9286,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">к счастью, если повезет</column>
       <column name="definition_zh_HK">好彩、幸運地</column>
       <column name="definition_pt">felizmente, com sorte</column>
+      <column name="definition_fi">onneksi, onnekkaasti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Do'Ha':adv}</column>
       <column name="see_also"></column>
@@ -8412,6 +9297,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8421,6 +9307,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fortunately</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8428,6 +9315,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -8441,6 +9329,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="definition_ru">к несчастью</column>
           <column name="definition_zh_HK">不幸、可惜</column>
           <column name="definition_pt">infelizmente</column>
+      <column name="definition_fi">epäonnekkaasti, valitettavasti</column>
           <column name="synonyms"></column>
           <column name="antonyms">{Do':adv}</column>
           <column name="see_also">{-Ha':v:suff}</column>
@@ -8451,6 +9340,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -8460,6 +9350,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">unluckily</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8467,6 +9358,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}, [2] {HQ 4.4, p.11:src}</column>
         </table>
         <table name="mem">
@@ -8480,6 +9372,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="definition_ru">быть неблагоприятным, быть несчастливым</column>
           <column name="definition_zh_HK">不幸、觸霉頭</column>
           <column name="definition_pt">ser infeliz</column>
+      <column name="definition_fi">olla epäonnekas, olla valitettava?</column>
           <column name="synonyms"></column>
           <column name="antonyms">{Do':v}</column>
           <column name="see_also">{SaS:v:2}</column>
@@ -8490,6 +9383,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Do':v}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -8499,6 +9393,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">unlucky</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8506,6 +9401,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="search_tags_ru">несчастливый</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -8519,6 +9415,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="definition_ru">Это к несчастью.</column>
           <column name="definition_zh_HK">太不幸了。</column>
           <column name="definition_pt">Isso é uma pena.</column>
+      <column name="definition_fi">Onpas harmillista.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{SaS:v:2}</column>
@@ -8529,6 +9426,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="notes_ru">По сути, это глагол {Do'Ha':v} как отдельное предложение. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">本質上，動詞{Do'Ha':v}是一個獨立的句子。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este é essencialmente o verbo {Do'Ha':v} como uma frase autônoma. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lähinnä verbi {Do'Ha':v} erillisenä lauseena. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -8538,6 +9436,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8545,6 +9444,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD p.1:src}</column>
         </table>
     <table name="mem">
@@ -8558,6 +9458,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Телец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小牛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bezerro</column>
+      <column name="definition_fi">pohje</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'neH:n}, {reStav:n}</column>
@@ -8568,6 +9469,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это означает заднюю часть голени. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著小腿的背部。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa a parte de trás da perna. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa säären takaosaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Dogie" is a regional US word used to refer to a calf (bovine animal) separated from its mother.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8577,6 +9479,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8584,6 +9487,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -8597,6 +9501,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Донату 5</column>
       <column name="definition_zh_HK">多納圖五星球</column>
       <column name="definition_pt">Donatu V</column>
+      <column name="definition_fi">Donatu V</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8607,6 +9512,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru">Это название планеты, что является предметом спора между Объединенной Федерацией Планет ({yuQjIjDIvI':n}) и Клингонской Империей ({tlhIngan wo':n}).</column>
       <column name="notes_zh_HK">這是行星聯合會（{yuQjIjDIvI':n}）和克林崗帝國（{tlhIngan wo':n}）之間有爭議的行星的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um planeta que foi disputado entre a Federação Unida de Planetas ({yuQjIjDIvI':n}) e o Império Klingon ({tlhIngan wo':n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on planeetan nimi, josta riitautettiin Yhdistyneiden planeettojen federaatio ({yuQjIjDIvI':n}) ja Klingon Empire ({tlhIngan wo':n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8616,6 +9522,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8623,6 +9530,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -8636,6 +9544,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">Песок</column>
       <column name="definition_zh_HK">沙</column>
       <column name="definition_pt">areia</column>
+      <column name="definition_fi">hiekka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Do'ol raS'IS:n}, {Do'ol HuD:n}, {Say'qIS:n}, {Santlhar:n}</column>
@@ -8646,6 +9555,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to the soap opera "Days Of Our Lives". The opening voiceover begins, "Like sands through the hourglass...".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8655,6 +9565,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8662,6 +9573,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8675,6 +9587,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">дюна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沙丘</column>
       <column name="definition_pt">duna</column>
+      <column name="definition_fi">dyyni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8685,6 +9598,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Do'ol:n}, {HuD:n:1}</column>
       <column name="examples"></column>
@@ -8694,6 +9608,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8701,6 +9616,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8714,6 +9630,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">песчинка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沙粒</column>
       <column name="definition_pt">grão de areia</column>
+      <column name="definition_fi">hiekanjyvä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8724,6 +9641,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Do'ol:n}, {raS'IS:n}</column>
       <column name="examples"></column>
@@ -8733,6 +9651,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8740,6 +9659,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8753,6 +9673,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">он/она/это(действие)-тебе, он/она/это(действие)-вам(единственное число)</column>
       <column name="definition_zh_HK">他、它：你</column>
       <column name="definition_pt">ele/ela-você</column>
+      <column name="definition_fi">hän/se-sinua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Da-:v:pref}</column>
       <column name="see_also">{nI-:v:pref}, {lI-:v:pref}</column>
@@ -8763,6 +9684,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{ghaH:n} / {'oH:n}: {SoH:n} = {Du-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8772,6 +9694,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">he-you, she-you, it-you</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8779,6 +9702,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru">он(действие)-тебе, она(действие)-тебе, это(действие)-тебе</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8792,6 +9716,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">спина</column>
       <column name="definition_zh_HK">背脊</column>
       <column name="definition_pt">costas (do corpo)</column>
+      <column name="definition_fi">selkä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ro:n}, {porgh:n}</column>
@@ -8802,6 +9727,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8811,6 +9737,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8818,6 +9745,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8831,6 +9759,7 @@ This was defined as "be stuck" with an explanation, along with a bunch of other 
       <column name="definition_ru">улучшать</column>
       <column name="definition_zh_HK">改進</column>
       <column name="definition_pt">melhorar</column>
+      <column name="definition_fi">parantaa (ei haavoja tms.), parannella</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Sab:v}, {'argh:v}</column>
       <column name="see_also">{tI':v}</column>
@@ -8853,6 +9782,9 @@ Detta verb används för att förbättra mer abstrakt karaktär, till exempel i 
       <column name="notes_pt">O objeto é aquilo que é melhorado.
 
 Este verbo é usado para melhoria de natureza mais abstrata, como em status, habilidade, compreensão, etc. Para melhoria em um sentido mais concreto, consulte {rach:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on asia, jota parannetaan.
+
+Tätä verbiä käytetään parantamaan abstraktimpaa luonnetta, kuten tila, taito, ymmärrys jne. Parannusta konkreettisemmassa mielessä, katso {rach:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8862,6 +9794,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8869,6 +9802,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1998.10.20:src}</column>
     </table>
     <table name="mem">
@@ -8882,6 +9816,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">Если он на твоем пути, сбей его.</column>
       <column name="definition_zh_HK">如果它阻擋了你，擊倒它。</column>
       <column name="definition_pt">Se estiver no seu caminho, derrube-o.</column>
+      <column name="definition_fi">Jos se on tielläsi, kaada se.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8892,6 +9827,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Du-:v}, {bot:v}, {-chugh:v}, {yI-:v}, {pum:v:2}, {-moH:v}</column>
       <column name="examples"></column>
@@ -8901,6 +9837,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8908,6 +9845,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.9:src}</column>
     </table>
     <table name="mem">
@@ -8921,6 +9859,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">мешать(компоненты друг с другом), перемешивать, смешивать</column>
       <column name="definition_zh_HK">混合、攪拌</column>
       <column name="definition_pt">misturar</column>
+      <column name="definition_fi">sekoittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qev:v}, {mIS:v}, {mergh:v}</column>
@@ -8931,6 +9870,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8940,6 +9880,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">scramble</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8947,6 +9888,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8960,6 +9902,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">палка для перемешивания</column>
       <column name="definition_zh_HK">攪拌棒、攪拌器</column>
       <column name="definition_pt">bastão de agitação</column>
+      <column name="definition_fi">sekoitukseen käytettävä keppi/tikku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'un naQ:n}, {ngawDeq:n}</column>
@@ -8970,6 +9913,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DuD:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -8979,6 +9923,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8986,6 +9931,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8999,6 +9945,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">быть бдительным</column>
       <column name="definition_zh_HK">保持警惕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser vigilante</column>
+      <column name="definition_fi">olla valppaana, varuillaan, varovainen, tarkkaavainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{buS:v}</column>
@@ -9009,6 +9956,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">As a joke, this is missing from the E-K side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9018,6 +9966,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9025,6 +9974,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9038,6 +9988,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">череп [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頭骨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">crânio</column>
+      <column name="definition_fi">kallo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hom:n:1}</column>
@@ -9048,6 +9999,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="notes_ru">{nach Hom:n@@nach:n, Hom:n:1} тоже подойдет, но {DughrI':n:nolink} - более технический термин. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{nach Hom:n@@nach:n, Hom:n:1}也可以，但是{DughrI':n:nolink}是一個技術術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">{nach Hom:n@@nach:n, Hom:n:1} também é bom, mas {DughrI':n:nolink} é um termo mais técnico. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{nach Hom:n@@nach:n, Hom:n:1} on myös hieno, mutta {DughrI':n:nolink} on teknisempi termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Skullduggery".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9057,6 +10009,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9064,6 +10017,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -9077,6 +10031,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">Быть возможным</column>
       <column name="definition_zh_HK">有可能</column>
       <column name="definition_pt">ser possível</column>
+      <column name="definition_fi">olla mahdollinen</column>
       <column name="synonyms">{qIt:v}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9087,6 +10042,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9097,6 +10053,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9104,6 +10061,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9117,6 +10075,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">возможность, опция</column>
       <column name="definition_zh_HK">可能性、選擇</column>
       <column name="definition_pt">possibilidade, opção</column>
+      <column name="definition_fi">mahdollisuus, vaihtoehto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuH:n:2}</column>
@@ -9127,6 +10086,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="notes_ru">Это может быть использовано в качестве "настройки" в {SeHlaw:n}.[2]</column>
       <column name="notes_zh_HK">這可以用於{SeHlaw:n}.[2]中的“設置” [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para uma "configuração" em um {SeHlaw:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää {SeHlaw:n}.[2]-asetuksen "asetukseen" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9136,6 +10096,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">setting</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9143,6 +10104,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -9156,6 +10118,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">дворец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">宮殿</column>
       <column name="definition_pt">Palácio</column>
+      <column name="definition_fi">palatsi, linna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9166,6 +10129,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="notes_ru">Это тип {jem'IH:n}. Это слово может быть использовано, если акцент делается на элегантность или величие здания. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種{jem'IH:n}。如果重點是建築物的典雅或宏偉，則可以使用該詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de {jem'IH:n}. Essa palavra pode ser usada se a ênfase estiver na elegância ou grandeza do edifício. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen {jem'IH:n}. Tätä sanaa voidaan käyttää, jos painotetaan rakennuksen tyylikkyyttä tai loistoa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Palatine Hill is one of the hills of Rome ({rom HuD:sen:nolink}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9175,6 +10139,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9182,6 +10147,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.01:src}</column>
     </table>
     <table name="mem">
@@ -9195,6 +10161,7 @@ Este verbo é usado para melhoria de natureza mais abstrata, como em status, hab
       <column name="definition_ru">корабль, судно</column>
       <column name="definition_zh_HK">船輛、車輛、星艦</column>
       <column name="definition_pt">navio, embarcação</column>
+      <column name="definition_fi">alus, laiva, avaruusalus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ejDo':n}, {Som:n}, {HanDogh:n}, {botjan:n}, {chIj:v}, {vergh:v}, {vergh:n}, {DoylI':n}</column>
@@ -9245,6 +10212,13 @@ Alguma terminologia especial é usada para as partes de um {Duj:n:1h,nolink}. A 
 Para verbos relacionados ao movimento do navio, consulte {'or:v}.
 
 As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'nga':n}, {qISa'ruj:n} e {toQDuj:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi viitata mihin tahansa ajoneuvoon, ei vain avaruusaluksiin, määrittelemällä ympäristön, jossa ajoneuvo kulkee. Katso {puH Duj:n}, {muD Duj:n}, {bIQ Duj:n}.
+
+Joitakin erityisiä termejä käytetään {Duj:n:1h,nolink}: n osiin. Kohtaa {tlhop:n:1h} kohti kutsutaan {'et:n:2h}: ksi, kun taas osaa {'em:n} kohti kutsutaan {'o':n}: ksi. Jos haluat viitata aluksen selkä-, vatsa-, satama- ja oikeanpuoleiseen alueeseen, katso {Dung:n}, {bIng:n}, {poS:n} ja {nIH:n}.
+
+Katso aluksen liikkumiseen liittyvät verbit kohdasta {'or:v}.
+
+Klingonin alusten tunnettuja luokkia ovat {neghvar:n}, {vorcha':n}, {qItI'nga':n}, {qISa'ruj:n} ja {toQDuj:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9254,6 +10228,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">vehicle, craft, boat, barge, spaceship</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9261,6 +10236,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9275,6 +10251,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="definition_ru">инстинкт, инстинкты</column>
       <column name="definition_zh_HK">本能</column>
       <column name="definition_pt">instinto, instintos</column>
+      <column name="definition_fi">vaistot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaj Duj:n}</column>
@@ -9285,6 +10262,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="notes_ru">Грамматически корректно рассматривать это слово в единственном числе(набор инстинктов) или во множественном (индивидуальные инстинкты)</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">É gramaticalmente correto tratar essa palavra como singular (um conjunto de instintos) ou plural (instintos individuais).[2, p.27] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kieliopillisesti on oikein käsitellä tätä sanaa yksikkönä (vaistopaketti) tai monikkona (yksittäiset vaistot).[2, p.27] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9297,6 +10275,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9304,6 +10283,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -9317,6 +10297,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="definition_ru">безответственный человек, недисциплинированный человек [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不負責任的人、沒有紀律的人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pessoa irresponsável, pessoa indisciplinada</column>
+      <column name="definition_fi">vastuuton tai kuriton henkilö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9327,6 +10308,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Duj:n:1}, {ngaD:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -9336,6 +10318,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9343,6 +10326,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9356,6 +10340,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="definition_ru">Всегда доверяй своим инстинктам.</column>
       <column name="definition_zh_HK">永遠相信你的直覺。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sempre confie em seus instintos.</column>
+      <column name="definition_fi">Luota aina vaistoihisi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DujlIj yIvoq.:sen}</column>
@@ -9366,6 +10351,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Duj:n:2}, {tI-:v}, {voq:v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -9375,6 +10361,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9382,6 +10369,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -9395,6 +10383,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="definition_ru">Умереть, защищая его корабль, надежда каждого Клингона.</column>
       <column name="definition_zh_HK">為了保衛他的艦而死是每個克林崗人的希望。</column>
       <column name="definition_pt">Morrer defendendo sua embarcação é a esperança de todo klingon.</column>
+      <column name="definition_fi">Jokainen klingoni toivoo kuolevansa puolustaessaan alustaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9405,6 +10394,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Duj:n:1}, {-Daj:n}, {Hub:v}, {-taH:v}, {-vIS:v}, {Hegh:v}, {'e':n}, {tul:v}, {Hoch:n}, {tlhIngan:n}</column>
       <column name="examples"></column>
@@ -9414,6 +10404,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9421,6 +10412,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.74:src}</column>
     </table>
     <table name="mem">
@@ -9434,6 +10426,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="definition_ru">Нет ничего постыдного, чтобы пасть перед превосходящим врагом.</column>
       <column name="definition_zh_HK">在一個優勢敵人面前墜落並沒有什麼可恥的。</column>
       <column name="definition_pt">Não há nada de vergonhoso em cair diante de um inimigo superior.</column>
+      <column name="definition_fi">Ei ole häpeällistä hävitä ylivoimaiselle viholliselle.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9444,6 +10437,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9453,6 +10447,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9460,6 +10455,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.ix,24:src}</column>
     </table>
     <table name="mem">
@@ -9473,6 +10469,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="definition_ru">Доверяй своим инстинктам.</column>
       <column name="definition_zh_HK">相信你的直覺。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Confie nos seus instintos.</column>
+      <column name="definition_fi">Luota vaistoihisi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj tIvoqtaH.:sen}</column>
@@ -9483,6 +10480,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Duj:n:2}, {-lIj:n}, {yI-:v}, {voq:v}</column>
       <column name="examples"></column>
@@ -9492,6 +10490,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9499,6 +10498,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.27:src}</column>
     </table>
     <table name="mem">
@@ -9512,6 +10512,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="definition_ru">управлял многими кораблями</column>
       <column name="definition_zh_HK">已經導航了許多船隻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">navegou em muitos navios</column>
+      <column name="definition_fi">on toiminut navigoijana useilla aluksilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9522,6 +10523,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="notes_ru">Это выражение означает "быть опытным"</column>
       <column name="notes_zh_HK">這個表達的意思是“有經驗”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta expressão significa "ser experimentado". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ilmaisu tarkoittaa "ole kokenut". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Duj:n:1}, {-mey:n}, {law':v}, {chIj:v}, {-pu':v}</column>
       <column name="examples">
@@ -9532,6 +10534,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be experienced</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9539,6 +10542,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="search_tags_ru">быть опытным</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.115:src}</column>
     </table>
     <table name="mem">
@@ -9552,6 +10556,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="definition_ru">Звезда(геометрическая фигура)</column>
       <column name="definition_zh_HK">星形</column>
       <column name="definition_pt">estrela (geometria)</column>
+      <column name="definition_fi">tähti (geometrinen muoto)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mey':n}, {QIn:n:2}, {'ejvoH:n}</column>
@@ -9562,6 +10567,7 @@ As classes conhecidas de navios Klingon incluem {neghvar:n}, {vorcha':n}, {qItI'
       <column name="notes_ru">Это относится к геометрической фигуре, а не к астрономическому телу, для которого смотрите {Hov:n}.</column>
       <column name="notes_zh_HK">這指的是幾何圖形，而不是指天文學的物體，請參見{Hov:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à figura geométrica, e não a um corpo astronômico, para o qual veja {Hov:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa geometriseen kuvioon eikä tähtitieteelliseen kappaleeseen, josta katso {Hov:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This seems to be made up of the words {Duj:n:1} and {tlhuQ:n}.
 
 The logo of Star Alliance, the largest airline alliance on Earth, is often painted on the tailfins of its members' airplanes.</column>
@@ -9573,6 +10579,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9580,6 +10587,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -9593,6 +10601,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">вздремнуть</column>
       <column name="definition_zh_HK">小憩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cochilo</column>
+      <column name="definition_fi">ottaa torkut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leS:v}, {Qong:v}</column>
@@ -9603,6 +10612,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9612,6 +10622,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9619,6 +10630,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9632,6 +10644,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">быть чудесным, быть великим</column>
       <column name="definition_zh_HK">很棒、太棒了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser maravilhoso, ser ótimo</column>
+      <column name="definition_fi">ole ihana, hieno</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9642,6 +10655,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9653,6 +10667,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9660,6 +10675,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9673,6 +10689,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">территория над, территория вверху</column>
       <column name="definition_zh_HK">上面、上方</column>
       <column name="definition_pt">área acima, área em cima</column>
+      <column name="definition_fi">yllä, alue yläpuolella</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bIng:n}</column>
       <column name="see_also">{joj:n}, {retlh:n}, {tlhop:n:1}, {'em:n}</column>
@@ -9683,6 +10700,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru">Смотрите {'aqroS:n:1} и {yor:n} для верхних частей объекта. Смотрите также {lurgh:n} для других слов, имеющих отношение к направлениям в пространстве.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Katso kohteen yläosat kohdista {'aqroS:n:1} ja {yor:n}. Katso myös {lurgh:n} muista paikkatietoihin liittyvistä sanoista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9692,6 +10710,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">top, dorsal</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9699,6 +10718,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9712,6 +10732,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">полдень</column>
       <column name="definition_zh_HK">中午</column>
       <column name="definition_pt">meio dia</column>
+      <column name="definition_fi">keskipäivä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ramjep:n:1}</column>
       <column name="see_also">{megh:n}, {po:n}, {pov:n}, {pemjep:n}</column>
@@ -9722,6 +10743,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9731,6 +10753,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9738,6 +10761,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -9751,6 +10775,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">Стратегия</column>
       <column name="definition_zh_HK">戰略 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estratégia</column>
+      <column name="definition_fi">strategia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{to':n}</column>
@@ -9761,6 +10786,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a way to "dupe" your enemies.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9770,6 +10796,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9777,6 +10804,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9790,6 +10818,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">чаша (маленькая) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">碗（小） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tigela (pequena)</column>
+      <column name="definition_fi">pieni kulho</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chatlh:n:1}, {maHpIn:n}</column>
@@ -9800,6 +10829,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru">Это миска, используемая для поедания {chatlh:n:1}, который посетитель наливает в {Duq:n:nolink} из {maHpIn:n}.[1, p.99] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個用來吃{chatlh:n:1}的碗，將晚餐從{maHpIn:n}倒入{Duq:n:nolink}。[1, p.99] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma tigela usada para comer {chatlh:n:1}, que um comensal derrama na {Duq:n:nolink} de uma {maHpIn:n}.[1, p.99] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kulho, jota käytetään {chatlh:n:1}: n syömiseen, jonka ruokala ruokaa {Duq:n:nolink}: een {maHpIn:n}: sta.[1, p.99] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Norm Duke is the name of a successful American professional bowler. Also, "duckpin bowling" is a variation of "ten-pin bowling" using a smaller ball.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9809,6 +10839,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9816,6 +10847,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9829,6 +10861,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">быть оглушенным, быть остолбеневшим</column>
       <column name="definition_zh_HK">被驚呆了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser chocado, ser espantado</column>
+      <column name="definition_fi">olla hämmästynyt, olla järkyttynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mer:v}, {mot:v}</column>
@@ -9839,6 +10872,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru">Это употребляется в смысле изумленный, ошеломленный, шокированый. Это сильнее, чем {yay':v}</column>
       <column name="notes_zh_HK">這意味著驚訝，震驚，傻眼，震驚。它比{yay':v}強 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa, no sentido de atônito, atônito, aturdido, chocado. É mais forte que {yay':v} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa hämmästyneenä, hämmästyneenä, tyhmänä, järkyttyneenä. Se on vahvempi kuin {yay':v} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">To be "bowled over" (see {Duq:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9848,6 +10882,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9855,6 +10890,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -9868,6 +10904,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">колоть, наносить удар холодным оружием</column>
       <column name="definition_zh_HK">刺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">punhalada</column>
+      <column name="definition_fi">puukottaa, pistää (terävällä esineellä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'urgh:v}, {pe':v}, {SIj:v:1}, {jeq:v}, {DuQ:v:2}</column>
@@ -9878,6 +10915,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9888,6 +10926,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9895,6 +10934,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9908,6 +10948,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">трогать (эмоционально) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">觸摸（情感上） [AUTOTRANSLATED]</column>
       <column name="definition_pt">toque (emocionalmente)</column>
+      <column name="definition_fi">koskettaa (emotionaalisesti)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DuQ:v:1}, {'ey:v}, {tIv:v}</column>
@@ -9918,6 +10959,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="notes_ru">Это говорит о хорошей музыке или еде. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是好音樂或美食。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é dito sobre boa música ou comida. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sanotaan hyvästä musiikista tai ruoasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9927,6 +10969,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9934,6 +10977,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9947,6 +10991,7 @@ The logo of Star Alliance, the largest airline alliance on Earth, is often paint
       <column name="definition_ru">колос [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">穗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espinho</column>
+      <column name="definition_fi">piikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIghon DuQwI' pogh:n}, {pu':n:2}</column>
@@ -9971,6 +11016,9 @@ För en fristående topp som t.ex. en insats, se {wIl:n}. [AUTOTRANSLATED]</colu
       <column name="notes_pt">Isso é usado para se referir aos picos anexados a {pogh:n}, {ghanjaq:n}, {'alngegh:n} e assim por diante.
 
 Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään viittaamaan piikkeihin, jotka on liitetty {pogh:n}-, {ghanjaq:n}-, {'alngegh:n}- ja niin edelleen.
+
+Katso erillinen piikki, kuten panos, kohdasta {wIl:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DuQ:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -9980,6 +11028,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9987,6 +11036,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10000,6 +11050,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="definition_ru">маленький шип [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小穗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pequeno espinho</column>
+      <column name="definition_fi">pieni piikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10010,6 +11061,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="notes_ru">Это используется для обозначения небольших всплесков, обнаруженных на {Daqtagh:n}.[1, p.61]. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於指代{Daqtagh:n}.[1, p.61]上的小尖峰 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para se referir aos pequenos picos encontrados na {Daqtagh:n}.[1, p.61] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään viittaamaan pieniin piikkeihin, jotka löytyvät sivulta {Daqtagh:n}.[1, p.61] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DuQ:v:1}, {-wI':v}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -10019,6 +11071,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10026,6 +11079,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10039,6 +11093,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="definition_ru">Ящерица Дюрани</column>
       <column name="definition_zh_HK">杜拉尼蜥蜴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Lagarto Durani</column>
+      <column name="definition_fi">eräs lisko, durani</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lung:n}, {Duran lung DIr:n}</column>
@@ -10049,6 +11104,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This term was not defined independently, but is inferred from {Duran lung DIr:n:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10058,6 +11114,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10065,6 +11122,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -10079,6 +11137,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="definition_ru">Шкуры ящериц Дюрани</column>
       <column name="definition_zh_HK">Durani蜥蜴皮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Peles de lagarto Durani</column>
+      <column name="definition_fi">duranin nahat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duran lung:n}, {DIr:n}</column>
@@ -10089,6 +11148,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="notes_ru">Этот предмет употребляется в пищу. Он никогда не используется ни с какими суффиксами множественного числа</column>
       <column name="notes_zh_HK">這是食品。它從不使用任何復數後綴。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um item de comida. Ele nunca usa nenhum sufixo plural. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on elintarvike. Se ei koskaan käytä mitään monikkomuodon loppuliitettä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10098,6 +11158,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10105,6 +11166,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -10118,6 +11180,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="definition_ru">Дюрас</column>
       <column name="definition_zh_HK">杜拉斯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Duras</column>
+      <column name="definition_fi">Duras</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurSa':n:name}, {be'etor:n:name}</column>
@@ -10128,6 +11191,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="notes_ru">Брат Лурсы и БэТор</column>
       <column name="notes_zh_HK">魯薩和貝託的兄弟。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Irmão de Lursa e B'Etor. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Lursan ja B'Etorin veli. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10137,6 +11201,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10144,6 +11209,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.3, Sept. 1996:src}</column>
     </table>
     <table name="mem">
@@ -10157,6 +11223,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="definition_ru">замок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鎖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trava</column>
+      <column name="definition_fi">lukko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaQHa'moHwI':n}, {lojmIt:n}, {chaw' ngoq:n}, {ngaQ:v}, {ngaQmoH:v:1}</column>
@@ -10167,6 +11234,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="notes_ru">Это устройство, для открытия которого требуется другое устройство, например ключ или код. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個需要其他設備（例如鑰匙或密碼）才能打開的設備。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um dispositivo que requer outro dispositivo, como uma chave ou um código para abrir. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on laite, jonka avaamiseen tarvitaan toinen laite, kuten avain tai koodi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In Germany, locked doors found in public often have a sign saying "kein Durchgang" (no passage). Marc Okrand has said that this was not intentional.[1]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10176,6 +11244,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10183,6 +11252,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -10196,6 +11266,7 @@ Para um pico independente, como uma estaca, consulte {wIl:n}. [AUTOTRANSLATED]</
       <column name="definition_ru">Торпедная труба</column>
       <column name="definition_zh_HK">魚雷發射管</column>
       <column name="definition_pt">tubo de torpedo</column>
+      <column name="definition_fi">torpedoputki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chetvI':n:1}</column>
@@ -10221,6 +11292,9 @@ Skillnaden mellan en {DuS:n:nolink} och en {chetvI':n:1} har att göra med hur p
       <column name="notes_pt">Isso é usado para iniciar um {peng:n}.
 
 A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o projétil é carregado.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään {peng:n}: n käynnistämiseen.
+
+{DuS:n:nolink}: n ja {chetvI':n:1}: n välinen ero liittyy ammuksen lataamiseen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10230,6 +11304,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10237,6 +11312,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.57:src}</column>
     </table>
     <table name="mem">
@@ -10250,6 +11326,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">Школа</column>
       <column name="definition_zh_HK">學校</column>
       <column name="definition_pt">escola</column>
+      <column name="definition_fi">koulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoj:v}, {ghojmoH:v}, {paQDI'norgh:n}, {'ampaS:n}, {yejHaD:n}, {yej'an:n}</column>
@@ -10260,6 +11337,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru">Это наиболее общее слово для места обучения.[1]</column>
       <column name="notes_zh_HK">這是學習場所中最通用的詞。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a palavra mais geral para um local de aprendizado.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleisin sana oppimispaikalle.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's probably just a coincidence that this word looks like it's formed from {Du-:v} and {SaQ:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10269,6 +11347,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10276,6 +11355,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 4.4, p.11:src}</column>
     </table>
     <table name="mem">
@@ -10289,6 +11369,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">хлопнуть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">砰地一聲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pressionar para baixo, apertar</column>
+      <column name="definition_fi">painaa (leimasin) alas, lyödä esine voimallisesti alas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10299,6 +11380,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">There is a Seinfeld skit about how one can't slam down a mobile phone, but must swipe or press a button ("doot").</column>
       <column name="components"></column>
       <column name="examples">
@@ -10309,6 +11391,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10316,6 +11399,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -10329,6 +11413,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">подчеркнуть, подчеркнуть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">強調 [AUTOTRANSLATED]</column>
       <column name="definition_pt">enfatizar, estressar</column>
+      <column name="definition_fi">korostaa, painottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10339,6 +11424,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on kirjaimellisesti "slam down" (katso {Dut:v:1}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10348,6 +11434,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">emphasise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10355,6 +11442,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -10368,6 +11456,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">продвигаться, делать успехи</column>
       <column name="definition_zh_HK">前進</column>
       <column name="definition_pt">avançar</column>
+      <column name="definition_fi">edetä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeD:v}, {chol:v}, {ghoS:v:1}</column>
@@ -10378,6 +11467,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10387,6 +11477,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10394,6 +11485,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10407,6 +11499,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">Агент, эмиссар</column>
       <column name="definition_zh_HK">特工、使者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agente, emissário</column>
+      <column name="definition_fi">lähettiläs, edustaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghar:v}, {gharwI':n}, {Duy'a':n}, {'oSwI':n}</column>
@@ -10417,6 +11510,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru">Не путать с {Duy':n}.</column>
       <column name="notes_zh_HK">不要與{Duy':n}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda com {Duy':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita {Duy':n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10426,6 +11520,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10433,6 +11528,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10446,6 +11542,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">быть дефектным</column>
       <column name="definition_zh_HK">有缺陷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser defeituoso</column>
+      <column name="definition_fi">olla viallinen, olla puutteellinen, olla rikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duy':n}</column>
@@ -10456,6 +11553,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10465,6 +11563,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10472,6 +11571,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10485,6 +11585,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">Дефект</column>
       <column name="definition_zh_HK">缺陷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">defeito</column>
+      <column name="definition_fi">vika, toimintahäiriö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duy':v}</column>
@@ -10495,6 +11596,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru">Не путать с {Duy:n}.</column>
       <column name="notes_zh_HK">不要與{Duy:n}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda com {Duy:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita {Duy:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10504,6 +11606,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10511,6 +11614,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10524,6 +11628,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">Посол</column>
       <column name="definition_zh_HK">大使 [AUTOTRANSLATED]</column>
       <column name="definition_pt">embaixador</column>
+      <column name="definition_fi">suurlähettiläs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghar:v}, {gharwI':n}, {jojlu':n}, {'oSwI':n}, {rIvSo':n}</column>
@@ -10534,6 +11639,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Duy:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -10543,6 +11649,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10550,6 +11657,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -10563,6 +11671,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">Ферма</column>
       <column name="definition_zh_HK">農場、田</column>
       <column name="definition_pt">fazenda</column>
+      <column name="definition_fi">maatila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wIj:v}, {yotlh:n}, {Satlh:n}, {poch:v}, {yob:v}, {qInut:n}</column>
@@ -10573,6 +11682,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10582,6 +11692,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10589,6 +11700,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -10602,6 +11714,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="definition_ru">Сад</column>
           <column name="definition_zh_HK">花園</column>
           <column name="definition_pt">jardim</column>
+      <column name="definition_fi">puutarha</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -10612,6 +11725,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Du':n}, {-Hom:n}</column>
           <column name="examples"></column>
@@ -10621,6 +11735,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10628,6 +11743,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -10641,6 +11757,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="definition_ru">случайное число [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">隨機數 [AUTOTRANSLATED]</column>
           <column name="definition_pt">número aleatório</column>
+      <column name="definition_fi">satunnaisluku</column>
           <column name="synonyms">{mI' 'al:n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -10651,6 +11768,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="notes_ru">Это буквально означает «номер сада». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這字面意思是“花園編號”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso significa literalmente "número do jardim". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "puutarhan numeroa". [AUTOTRANSLATED]</column>
           <column name="hidden_notes">The earliest dice were made from bones ({HomDu':n@@Hom:n:1, -Du':n}).</column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -10660,6 +11778,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10667,6 +11786,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 26 (2019):src}</column>
         </table>
         <table name="mem">
@@ -10680,6 +11800,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="definition_ru">производить(сельское хозяйство)</column>
           <column name="definition_zh_HK">農產品</column>
           <column name="definition_pt">produto (produto agrícola)</column>
+      <column name="definition_fi">maataloustuote</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{baQ:v:2}, {DeH:v}, {naH:n}, {naH tlhab:n}, {yob:v}, {wIj:v}, {yotlh:n}</column>
@@ -10690,6 +11811,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="notes_ru">Это относится к фруктам или овощам, что приходят с фермы, как противоположность к {naH tlhab:n}.[1, стр.89]</column>
           <column name="notes_zh_HK">這是指來自農場的水果或蔬菜，而不是{naH tlhab:n}.[1, p.89] [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso se refere a frutas ou vegetais que vêm de uma fazenda, ao contrário de {naH tlhab:n}.[1, p.89] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa hedelmiä tai vihanneksia, jotka tulevat maatilalta, toisin kuin {naH tlhab:n}.[1, p.89] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Du':n}, {naH:n}</column>
           <column name="examples"></column>
@@ -10699,6 +11821,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10706,6 +11829,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
     <table name="mem">
@@ -10719,6 +11843,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">Этот шлем подходит тебе.</column>
       <column name="definition_zh_HK">這款頭盔適合你。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Este capacete combina com você.</column>
+      <column name="definition_fi">Tämä kypärä sopii sinulle.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10729,6 +11854,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">There is a typo in this sentence in {TKD:src}, an extra space right after {mIv:n:1}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10738,6 +11864,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10745,6 +11872,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -10758,6 +11886,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="definition_ru">губной желобок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">人中</column>
       <column name="definition_pt">buço</column>
+      <column name="definition_fi">ylähuulen vako</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wuS:n}, {ghIch:n}</column>
@@ -10768,6 +11897,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="notes_ru">Это отступ чуть выше середины верхней губы. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是上唇中部上方的壓痕。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o recuo logo acima do meio do lábio superior. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sisennys juuri ylähuulen keskiosan yläpuolella. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The cover of the Duran Duran album Rio features an iconic pair of lips.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10777,6 +11907,7 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10784,5 +11915,6 @@ A distinção entre um {DuS:n:nolink} e um {chetvI':n:1} tem a ver com como o pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>

--- a/mem-03-D.xml
+++ b/mem-03-D.xml
@@ -1600,7 +1600,7 @@ Ett godtagbart sätt att uttrycka denna efterfrågan som en fråga är {nuq DaDa
 Uma maneira aceitável de expressar essa demanda como uma pergunta é {nuq DaDab?:sen:nolink} [1] [AUTOTRANSLATED]</column>
       <column name="notes_fi">Klingonissa tämä on pikemminkin komento kuin kysymys. Se tarkoittaa kirjaimellisesti: "Tunnista asuinpaikkasi!" [1]
 
-Hyväksyttävä tapa muotoilla tämä vaatimus kysymykseksi on {nuq DaDab?: Sen: nolink} [1]{nuq DaDab?:sen:nolink} [AUTOTRANSLATED]</column>
+Hyväksyttävä tapa muotoilla tämä vaatimus kysymykseksi on {nuq DaDab?:sen:nolink} [1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>

--- a/mem-04-gh.xml
+++ b/mem-04-gh.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {gh:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{gh:sen:nolink}</column>
       <column name="definition_pt">a consoante {gh:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {gh:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">мясо с туловища животного, животное, животное(лёгкое оскорбление)</column>
       <column name="definition_zh_HK">肉從動物的腹部 [AUTOTRANSLATED]</column>
       <column name="definition_pt">carne da parte do meio dos animais</column>
+      <column name="definition_fi">liha eläimen keskiosasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'DIbaH:n:1}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Данное "мясо" может иметь кости. В некоторых региональных диалектах, слово {ghab:n:nolink} не применяется к мясу, у которого отсутствуют кости. Для этого предпочтительней использовать {ghab tun:n}.[1, p.27]</column>
       <column name="notes_zh_HK">這可能有骨頭。在某些地區性方言中，{ghab:n:nolink}不適用於缺少骨骼的肉類，而是使用{ghab tun:n}。[1, p.27] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ter ossos. Em alguns dialetos regionais, {ghab:n:nolink} não é aplicado a carne sem ossos, mas em vez disso, {ghab tun:n} é usado.[1, p.27] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tässä voi olla luita. Joissakin alueellisissa murteissa {ghab:n:nolink} ei koske lihaa, josta puuttuu luita, vaan pikemminkin {ghab tun:n}: ta.[1, p.27] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A "gob" of meat.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">мясо с животного, без костей [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物中段的肉、沒有骨頭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">carne da parte do meio dos animais, sem ossos</column>
+      <column name="definition_fi">luuton liha eläimen keskiosasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -97,6 +106,7 @@
       <column name="notes_ru">В стандартном диалекте, это может быть выражено, используя фразу {Hom Hutlhbogh ghab@@Hom:n:1, Hutlh:v, -bogh:v, ghab:n}.[1, p.27]</column>
       <column name="notes_zh_HK">在標準方言中，將使用短語{Hom Hutlhbogh ghab@@Hom:n:1, Hutlh:v, -bogh:v, ghab:n}來表達。[1, p.27] [AUTOTRANSLATED]</column>
       <column name="notes_pt">No dialeto padrão, isso seria expresso usando a frase {Hom Hutlhbogh ghab@@Hom:n:1, Hutlh:v, -bogh:v, ghab:n}.[1, p.27] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tavallisessa murteessa tämä ilmaistaan ​​sanalla {Hom Hutlhbogh ghab@@Hom:n:1, Hutlh:v, -bogh:v, ghab:n}.[1, p.27] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghab:n}, {tun:v}</column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fillet</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru">филе</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">убить (когда на охоте) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">殺死（狩獵時） [AUTOTRANSLATED]</column>
       <column name="definition_pt">matar (quando em uma caçada)</column>
+      <column name="definition_fi">tappaa (metsästyksen aikana)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wam:v}</column>
@@ -136,6 +149,7 @@
       <column name="notes_ru">Общее слово для уничтожения - {HoH:v}. {ghab:v:nolink} означает «убить» в результате охоты (таким образом, охота была успешной) или когда убийство является результатом запланированного процесса.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">殺人的通用詞是{HoH:v}。 {ghab:v:nolink}的意思是狩獵導致的“殺戮”（因此狩獵是成功的一次），或者是由於計劃外的謀殺而導致的殺戮。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra geral para matar é {HoH:v}. {ghab:v:nolink} significa "matar" como resultado da caça (portanto, a caça foi bem-sucedida), ou quando a matança é o resultado de um processo planejado.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yleinen sana tappaa on {HoH:v}. {ghab:v:nolink} tarkoittaa "tappamista" metsästyksen seurauksena (siten metsästys onnistui) tai kun tappaminen on suunnitellun prosessin tulos.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In hunting jargon, to "bag" an animal is to successfully hunt it.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -145,6 +159,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -152,6 +167,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -165,6 +181,7 @@
       <column name="definition_ru">прячься, подожди, ложись [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">潛伏、等待、低沉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espreitar, ficar à espreita, ficar abaixado</column>
+      <column name="definition_fi">väijyä, odottaa maaten, piileskellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -175,6 +192,7 @@
       <column name="notes_ru">Это означает, что субъект скрыт, но представляет угрозу, такую ​​как готовность к засаде.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著該對象處於隱藏狀態，但構成威脅，例如準備伏擊。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa que o assunto está oculto, mas representa uma ameaça, como estar pronto para uma emboscada.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa, että kohde on piilotettu, mutta uhkaa, kuten on valmis väijytykseen.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -185,6 +203,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -192,6 +211,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -205,6 +225,7 @@
       <column name="definition_ru">полоскать</column>
       <column name="definition_zh_HK">漱口</column>
       <column name="definition_pt">gargarejo</column>
+      <column name="definition_fi">kurlata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -215,6 +236,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is the sound made when gargling.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -224,6 +246,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -231,6 +254,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -244,6 +268,7 @@
       <column name="definition_ru">он, она, его, её</column>
       <column name="definition_zh_HK">他、她</column>
       <column name="definition_pt">ele, ela</column>
+      <column name="definition_fi">hän</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oH:n:pro}, {-Daj:n}</column>
@@ -287,6 +312,25 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
 Глагольный префикс повелительного наклонения, когда {ghaH:n:nolink} является объектом, {yI-:v:pref}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän pronominin monikko on {chaH:n:pro}.
+
+Verbien etuliitteet, kun aihe {ghaH:n:nolink} on:
+▶ {ghaH:n:nolink}: {pagh:n:1h} = {0:v:pref}
+▶ {ghaH:n:nolink}: {jIH:n:1h} = {mu-:v:pref}
+▶ {ghaH:n:nolink}: {maH:n:1h} = {nu-:v:pref}
+▶ {ghaH:n:nolink}: {SoH:n} = {Du-:v:pref}
+▶ {ghaH:n:nolink}: {tlhIH:n} = {lI-:v:pref}
+▶ {ghaH:n:nolink}: {ghaH:n:nolink} / {'oH:n} / {chaH:n} / {bIH:n} = {0:v:pref}
+
+Verbien etuliitteet, kun {ghaH:n:nolink} on objekti:
+▶ {jIH:n:1h}: {ghaH:n:nolink} = {vI-:v:pref}
+▶ {maH:n:1h}: {ghaH:n:nolink} = {wI-:v:pref}
+▶ {SoH:n}: {ghaH:n:nolink} = {Da-:v:pref}
+▶ {tlhIH:n}: {ghaH:n:nolink} = {bo-:v:pref}
+▶ {ghaH:n:nolink} / {'oH:n}: {ghaH:n:nolink} = {0:v:pref}
+▶ {chaH:n} / {bIH:n}: {ghaH:n:nolink} = {lu-:v:pref}
+
+Pakollinen verbin etuliite, kun kohde on {ghaH:n:nolink}, on {yI-:v:pref}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -296,6 +340,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -303,6 +348,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -316,6 +362,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">быть глупым, быть дураком</column>
       <column name="definition_zh_HK">是愚蠢的、是個傻瓜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser tolo</column>
+      <column name="definition_fi">hän toimii tyhmästi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qoH vuvbe' SuS.:sen}, {chatlh!:excl}</column>
@@ -326,6 +373,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru">Дословно это означает "он/она хочет, чтобы ветер уважал её"</column>
       <column name="notes_zh_HK">這字面意思是“他/她希望風尊重他/她”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "ele / ela quer que o vento o respeite". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "hän haluaa tuulen kunnioittavan häntä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghaH:n}, {vuv:v}, {SuS:n}, {neH:v}</column>
       <column name="examples">
@@ -339,6 +387,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
 ▶ {bImaw''a'? Duvuv SuS DaneH'a'?:sen:nolink} "Что с тобой такое? Ты идиот?"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -346,6 +395,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.122:src}</column>
     </table>
     <table name="mem">
@@ -359,6 +409,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">иметь в собственности, владеть, обладать</column>
       <column name="definition_zh_HK">擁有</column>
       <column name="definition_pt">ter, possuir</column>
+      <column name="definition_fi">olla, omistaa, pitää hallussaan</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hutlh:v}</column>
       <column name="see_also">{ghajwI':n}</column>
@@ -369,6 +420,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru">Это слово может быть использовано как для обозначения владения над объектом (see {yer ghajwI' chaw':n}) как и для владения более абстрактными вещами (see {pIch:n} and {quv:n}).</column>
       <column name="notes_zh_HK">這個詞既可以用來表示對某個對象的所有權（請參閱{yer ghajwI' chaw':n}），也可以用於擁有更抽象的性質（請參閱{pIch:n}和{quv:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra pode ser usada para indicar propriedade sobre um objeto (consulte {yer ghajwI' chaw':n}) e posse de natureza mais abstrata (consulte {pIch:n} e {quv:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää sekä osoittamaan kohteen omistusoikeus (katso {yer ghajwI' chaw':n}) että abstraktimpi hallussapito (katso {pIch:n} ja {quv:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -386,6 +438,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
 ▶ {Duj ghajchugh pagh, beylI'vo' 'oH Daje' net chaw'.:sen:nolink} "Если (корабль) безхозный, вы можете выкупить его у банка."[4]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hold, own</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -393,6 +446,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {PK:src}, [3] {ENT - The Augments:src}, [4] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -406,6 +460,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">владелец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">所有者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">proprietário</column>
+      <column name="definition_fi">omistaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DoQ:v}, {yer ghajwI' chaw':n}</column>
@@ -416,6 +471,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru">Обратите внимание, что клингонские представления о законной собственности могут не совпадать с понятиями Федерации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，法定所有權的克林崗概念可能與聯邦的概念不同。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que as noções klingon de propriedade legal podem não ser as mesmas da Federação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että Klingonin oikeudellisen omistuksen käsitteet eivät välttämättä ole samat kuin federaation. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Throughout {Klingon Monopoly:src}, {ghaj:v} is translated as "own", but this may be because possession is the closest concept in Klingon culture to ownership.</column>
       <column name="components">{ghaj:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -425,6 +481,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -432,6 +489,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -445,6 +503,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">завидовать, завидовать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">妒忌</column>
       <column name="definition_pt">ter ciumento (de), invejar</column>
+      <column name="definition_fi">olla kateellinen jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -455,6 +514,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru">Ревность также выражается идиомой {SuD veqlargh mInDu'.:sen} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">嫉妒也由成語{SuD veqlargh mInDu'.:sen}表達 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O ciúme também é expresso pelo idioma {SuD veqlargh mInDu'.:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kateutta ilmaisee myös idioomi {SuD veqlargh mInDu'.:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The word {ghal:v:nolink} was mistakenly used as a noun meaning "envoy" in the Dramatis Personae on {paq'batlh p.40-41:src} in the first edition.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -464,6 +524,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -471,6 +532,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.4, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -484,6 +546,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">конечность (животного) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肢體（動物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">membro (de um animal)</column>
+      <column name="definition_fi">(eläimen) raaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HajDob:n}, {namwech:n}, {lem:n}</column>
@@ -494,6 +557,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru">Это животная версия {ghIv:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{ghIv:n}的動物版本。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a versão animal do {ghIv:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {ghIv:n}-eläinversio. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">There is a slang word "gam" in English which means "leg".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -503,6 +567,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -510,6 +575,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -523,6 +589,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">быть беспокойным, очень активным, живым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">忙碌、非常活躍、活潑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser agitado, muito ativo, animado</column>
+      <column name="definition_fi">olla kiireinen, aktiivinen, vilkas</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghanHa':v}</column>
       <column name="see_also"></column>
@@ -533,6 +600,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -542,6 +610,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -549,6 +618,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -562,6 +632,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">быть спокойным, спокойным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">和平、平靜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser pacífico, estar relaxado, ser calmo</column>
+      <column name="definition_fi">olla rauhallinen, rento</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghan:v:1}</column>
       <column name="see_also"></column>
@@ -572,6 +643,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghan:v:1}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -581,6 +653,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -588,6 +661,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -601,6 +675,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">взглянуть на, быстро взглянуть на [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">瞥了一眼、快看一下 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dê uma olhada, dê uma olhada rápida em</column>
+      <column name="definition_fi">vilkaista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{legh:v}</column>
@@ -611,6 +686,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">To "take a gander" is to take a quick look at something.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -620,6 +696,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -627,6 +704,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -640,6 +718,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">булава (палка, клуб) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">梅斯（棍棒、俱樂部） [AUTOTRANSLATED]</column>
       <column name="definition_pt">bastão, taco, cajado</column>
+      <column name="definition_fi">nuija, sauva, valtikka?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jeqqIj:n}, {DuQwI':n}</column>
@@ -650,6 +729,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -659,6 +739,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -666,6 +747,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -679,6 +761,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="definition_ru">основа, основа (концептуальная) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">基礎（概念）</column>
       <column name="definition_pt">base, fundação (conceitual)</column>
+      <column name="definition_fi">(käsitteellinen, teoreettinen) perusta, pohja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -689,6 +772,7 @@ The imperative verb prefix when {ghaH:n:nolink} is the object is {yI-:v:pref}.</
       <column name="notes_ru">Это обозначает базовую поддержку идеи, аргумента или процесса, которые в зависимости от контекста могут также быть {meq:n} или {qolqoS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這表示對思想，論點或過程的潛在支持，根據上下文，這些支持也可能是{meq:n}或{qolqoS:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso denota o suporte subjacente para uma ideia, argumento ou processo, que dependendo do contexto também pode ser {meq:n} ou {qolqoS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa idean, argumentin tai prosessin taustalla olevaa tukea, joka voi kontekstista riippuen olla myös {meq:n} tai {qolqoS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "basis/foundation". The word "conceptual" was added to distinguish this from {qappam:n}.
 
 This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
@@ -700,6 +784,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -707,6 +792,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -720,6 +806,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">модель, пример, выкройка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">模型、例子、模式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">modelo, exemplo, padrão</column>
+      <column name="definition_fi">malli, esimerkki, kaava?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chovnatlh:n}</column>
@@ -730,6 +817,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это относится к чему-то, что один копирует или относится к созданию вещей [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是一個人復製或指的是製造事物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a algo que se copia ou se refere ao fazer coisas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa johonkin, johon yksi kopioidaan tai johon asioita tehdään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A "touchstone".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -739,6 +827,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -746,6 +835,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -759,6 +849,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">захват (медицина) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">癲癇發作（藥物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">convulsão (termo médico)</column>
+      <column name="definition_fi">kohtaus (lääketiede)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jergh:v}</column>
@@ -769,6 +860,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -778,6 +870,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -785,6 +878,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -798,6 +892,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">полиция [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">警察隊</column>
       <column name="definition_pt">força policial</column>
+      <column name="definition_fi">poliisivoimat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hung:n}, {qop:v}, {chut:n}, {ghan'Iq yaS:n}</column>
@@ -808,6 +903,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reversed, this is {qI':sen:nolink} (sounds like "key") + {nagh:n} ("stone"), a reference to the Keystone Cops.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -817,6 +913,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cops</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -824,6 +921,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -837,6 +935,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">офицер полиции [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">警察、警官</column>
       <column name="definition_pt">policial</column>
+      <column name="definition_fi">poliisi (henkilö)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hung:n}, {qop:v}, {chut:n}</column>
@@ -847,6 +946,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghan'Iq:n}, {yaS:n}</column>
       <column name="examples"></column>
@@ -856,6 +956,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cop</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -863,6 +964,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -876,6 +978,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">преждевременный конец (событие, путешествие, битва, игра, опера, история, песня и т. д.) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">過早結束（事件，航程、戰鬥、戲劇、歌劇、故事、歌曲等） [AUTOTRANSLATED]</column>
       <column name="definition_pt">terminar prematuramente (um evento, viagem, batalha, peça, ópera, história, música etc.)</column>
+      <column name="definition_fi">loppua ennenaikaisesti (tapahtuma, matka, taistelu, näytelmä, ooppera, laulu, tarina tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bertlham:n}, {Dor:v:2}, {rIn:v}, {van:v:2}, {'o'megh:n}</column>
@@ -886,6 +989,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Субъект этого глагола - лицо, вызывающее преждевременное завершение события. Объект - это законченное событие. Если завершение события не было преждевременным, используйте вместо этого {van:v:2}. Чтобы описать окончание периода времени, используйте вместо этого {Dor:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞的主題是導致事件過早結束的人。對像是結束的事件。如果事件的結束不是不成熟的，請改用{van:v:2}。要描述一段時間的結束，請改用{Dor:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O sujeito deste verbo é a pessoa que causa o término prematuro de um evento. O objeto é o evento que terminou. Se o término do evento não foi prematuro, use {van:v:2}. Para descrever o final de um período de tempo, use {Dor:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin aihe on henkilö, joka aiheuttaa tapahtuman ennenaikaisen päättymisen. Kohde on tapahtuma, joka on päättynyt. Jos tapahtuman loppu ei ollut ennenaikainen, käytä sen sijaan {van:v:2}. Käytä ajanjakson päättymistä kuvaamalla {Dor:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Quite often, the hitting of a "gong" brings an event to a premature end.</column>
       <column name="components"></column>
       <column name="examples">
@@ -896,6 +1000,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">halt, stop</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -903,6 +1008,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -916,6 +1022,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">горизонт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地平線 [AUTOTRANSLATED]</column>
       <column name="definition_pt">horizonte</column>
+      <column name="definition_fi">horisontti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeH:n}, {veH:n}</column>
@@ -926,6 +1033,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghang:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -935,6 +1043,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -942,6 +1051,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -955,6 +1065,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">или, или/или (объединяющие существительные)</column>
       <column name="definition_zh_HK">或者、或者/或（加入名詞） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ou um / ou outro (juntando substantivos)</column>
+      <column name="definition_fi">tai, joko tai (eksklusiivinen tai) (yhdistää lauseita, verbejä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joq:conj}, {pagh:conj}</column>
@@ -965,6 +1076,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это следует за последним существительным.</column>
       <column name="notes_zh_HK">這是最後一個名詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto segue o substantivo final. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä seuraa lopullista substantiivia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -974,6 +1086,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -981,6 +1094,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -994,6 +1108,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">челюсть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">顎 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mandíbula</column>
+      <column name="definition_fi">leuka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuj:n}, {Ho':n:1}</column>
@@ -1004,6 +1119,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это также можно использовать для вещей, которые напоминают челюсти, и в этом случае множественное число остается {ghapqa'Du':n@@ghapqa':n, -Du':n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也可以用於類似下巴的東西，在這種情況下，複數保持為{ghapqa'Du':n@@ghapqa':n, -Du':n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser usado para coisas que se parecem com mandíbulas, caso em que o plural permanece {ghapqa'Du':n@@ghapqa':n, -Du':n}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää myös asioihin, jotka muistuttavat leukoja, jolloin monikko pysyy {ghapqa'Du':n@@ghapqa':n, -Du':n}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Orca ({ghap:conj}, {-qa':v:suff}) was the name of the boat in the movie "Jaws".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1013,6 +1129,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1020,6 +1137,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1033,6 +1151,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">экватор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">赤道 [AUTOTRANSLATED]</column>
       <column name="definition_pt">equador</column>
+      <column name="definition_fi">päiväntasaaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuQ:n}</column>
@@ -1043,6 +1162,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The equator is at "lat"itude zero ({pagh:n:2}). Also, the transit token for the Capital Transit Company has a circular shape with the word "Capital" written across the equator.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1052,6 +1172,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1059,6 +1180,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1072,6 +1194,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">способствовать, делать вклад в какое-то дело</column>
       <column name="definition_zh_HK">捐資、捐款、獻金</column>
       <column name="definition_pt">contribuir</column>
+      <column name="definition_fi">osallistua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nob:v}, {DIl:v}, {rup:v}, {ngaq:n}, {wuv:v}</column>
@@ -1082,6 +1205,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это слово также используется для обозначения денежной поддержки</column>
       <column name="notes_zh_HK">這個詞在金錢上也被用作“支持”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra também é usada para "suporte" no sentido monetário.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään myös "tukeen" rahallisessa mielessä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1094,6 +1218,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       </column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">support</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1101,6 +1226,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2010.07.26:src}, [3] {Pop Culture Hero Coalition announcement:src} ({KLI mailing list 2016.11.30:src})</column>
     </table>
     <table name="mem">
@@ -1114,6 +1240,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">проводить дипломатию</column>
       <column name="definition_zh_HK">進行外交</column>
       <column name="definition_pt">conduzir diplomacia</column>
+      <column name="definition_fi">harjoittaa diplomatiaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghar:n}, {gharwI':n}</column>
@@ -1124,6 +1251,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1133,6 +1261,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1140,6 +1269,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1153,6 +1283,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">дипломатия</column>
       <column name="definition_zh_HK">外交</column>
       <column name="definition_pt">diplomacia</column>
+      <column name="definition_fi">diplomatia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghar:v}, {gharwI':n}</column>
@@ -1163,6 +1294,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1172,6 +1304,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1179,6 +1312,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1192,6 +1326,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">дипломат(профессия)</column>
       <column name="definition_zh_HK">外交官</column>
       <column name="definition_pt">diplomata</column>
+      <column name="definition_fi">diplomaatti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duy:n}, {Duy'a':n}</column>
@@ -1202,6 +1337,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghar:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1211,6 +1347,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1218,6 +1355,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1231,6 +1369,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">змей, червь</column>
       <column name="definition_zh_HK">蛇、蠕蟲</column>
       <column name="definition_pt">serpente, verme</column>
+      <column name="definition_fi">käärme, mato</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qagh:n}, {ghIS:v}, {nogh:v}, {Humlaw':n}</column>
@@ -1241,6 +1380,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1250,6 +1390,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">snake</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1257,6 +1398,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru">змей, змея</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1270,6 +1412,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">чеснок</column>
       <column name="definition_zh_HK">大蒜</column>
       <column name="definition_pt">alho</column>
+      <column name="definition_fi">valkosipuli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oQqar:n}, {'anyan 'oQqar:n}</column>
@@ -1280,6 +1423,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это то, что Клингоны называют земным овощем.</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族蔬菜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que os klingons chamariam de vegetal terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-vihannekseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1289,6 +1433,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1296,6 +1441,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -1309,6 +1455,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">доминировать</column>
       <column name="definition_zh_HK">支配 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dominar</column>
+      <column name="definition_fi">hallita täysin, pitää hallussaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{che':v}</column>
@@ -1319,6 +1466,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1328,6 +1476,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">subjugate, overshadow, domineer, predominate</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1335,6 +1484,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1348,6 +1498,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">углерод [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">碳</column>
       <column name="definition_pt">carbono</column>
+      <column name="definition_fi">hiili</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {namchIl:n}</column>
@@ -1358,6 +1509,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1367,6 +1519,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1374,6 +1527,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -1387,6 +1541,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">стали [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鋼</column>
       <column name="definition_pt">aço</column>
+      <column name="definition_fi">teräs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}, {velSo' 'uSqan:n}</column>
@@ -1397,6 +1552,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghav:n}, {'uSqan:n}</column>
       <column name="examples"></column>
@@ -1406,6 +1562,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1413,6 +1570,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1426,6 +1584,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">раскопки (яма, желоб) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">開挖（一個洞，一個溝槽） [AUTOTRANSLATED]</column>
       <column name="definition_pt">escavar (um buraco, uma vala)</column>
+      <column name="definition_fi">kaivaa (ojaa, vallihautaa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QemjIq:n}, {taSman:n}, {tlhan:v}</column>
@@ -1436,6 +1595,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Объектом этого глагола является отверстие, которое производится (например, траншея или канава). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞的對像是產生的孔（例如溝槽或溝渠）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto desse verbo é o buraco produzido (como uma vala ou uma vala). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde on muodostunut reikä (kuten kaivanto tai oja). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1445,6 +1605,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1452,6 +1613,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1465,6 +1627,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">Гаурон</column>
       <column name="definition_zh_HK">Gowron [AUTOTRANSLATED]</column>
       <column name="definition_pt">Gowron</column>
+      <column name="definition_fi">Gowron</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1475,6 +1638,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Имя Клингонского канцлера. Он сыгран актёром {rabe'rIt 'o'raylIy:n:name}.</column>
       <column name="notes_zh_HK">克林崗校長的名字。他由演員{rabe'rIt 'o'raylIy:n:name}飾演。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O nome de um Chanceler Klingon. Ele é interpretado pelo ator {rabe'rIt 'o'raylIy:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin kanslerin nimi. Näyttelijä {rabe'rIt 'o'raylIy:n:name} kuvaa häntä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1484,6 +1648,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1491,6 +1656,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.3, Sept. 1996:src}</column>
     </table>
     <table name="mem">
@@ -1504,6 +1670,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">Печеночный суп Игва</column>
       <column name="definition_zh_HK">igvah肝湯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sopa de fígado igvah</column>
+      <column name="definition_fi">igvah-maksakeitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IghvaH:n}, {ghaw':n:2}, {'IghvaH chej chatlh:n}</column>
@@ -1514,6 +1681,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это слово избегается в {voSpegh Sep:n}, где вместо него используется {'IghvaH chej chatlh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{voSpegh Sep:n}中避免使用此詞，而在其中使用{'IghvaH chej chatlh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra é evitada em {voSpegh Sep:n}, onde {'IghvaH chej chatlh:n} é usado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa vältetään {voSpegh Sep:n}: ssä, jossa sen sijaan käytetään {'IghvaH chej chatlh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1523,6 +1691,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1530,6 +1699,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1543,6 +1713,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">неуверенный, полный сомнений в себе [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不安全的人、一個充滿自我懷疑的人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pessoa insegura, pessoa cheia de dúvidas</column>
+      <column name="definition_fi">epävarma henkilö jolla ei ole itseluottamusta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghaw':n:1}</column>
@@ -1553,6 +1724,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это диалектическое слово, используемое в {voSpegh Sep:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{voSpegh Sep:n}中使用的辯證詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra dialética usada em {voSpegh Sep:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on dialektinen sana, jota käytetään {voSpegh Sep:n}-sanassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1562,6 +1734,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1569,6 +1742,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1582,6 +1756,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">десна (оральная анатомия) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">牙齦（口腔解剖） [AUTOTRANSLATED]</column>
       <column name="definition_pt">gengiva (anatomia oral)</column>
+      <column name="definition_fi">ien</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1592,6 +1767,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Не сленговый способ сказать это - {repnuj:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">非this語的說法是{repnuj:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A maneira sem gíria de dizer isso é {repnuj:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei-slangi tapa sanoa tämä on {repnuj:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1601,6 +1777,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1608,6 +1785,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1621,6 +1799,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">распылять, разбрызгивать, бомбардировать, закидывать, заливать чем-то</column>
       <column name="definition_zh_HK">噴霧、轟擊、下雨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pulverizar, bombardear, chover</column>
+      <column name="definition_fi">ruiskuttaa, suihkuttaa, sumuttaa, pommittaa, sataa maahan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIt:v}, {SIS:v}</column>
@@ -1631,6 +1810,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это один из возможных глаголов для использования с {watrIn:n}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是與{watrIn:n}.[3]一起使用的可能動詞 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um verbo possível para usar com {watrIn:n}.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksi mahdollinen verbi, jota voidaan käyttää {watrIn:n}.[3]: n kanssa [AUTOTRANSLATED]</column>
       <column name="hidden_notes">An English definition has never been given for this word. Its meaning is inferred from the examples of its usage.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1644,6 +1824,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
 ▶ {jorwI'mey ghaymo' qarDaSnganpu', Hegh SuvwI'pu'lI' law' 'ej rIQ SuvwI'pu'lI' law'.:sen:nolink} "Страдают от крупных потерь после Кардассианской бомбардировки."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1651,6 +1832,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}, [2] {Klingon Monopoly:src}, [3] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -1664,6 +1846,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">вероятно</column>
       <column name="definition_zh_HK">極有可能、大半</column>
       <column name="definition_pt">provável</column>
+      <column name="definition_fi">todennäköisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghaytanHa':adv}</column>
       <column name="see_also">{chaq:adv}</column>
@@ -1674,6 +1857,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1683,6 +1867,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">probable, probably</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1690,6 +1875,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru">возможно, возможный</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1703,6 +1889,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">Ругательство общего характера(Прямого перевода не имеет)</column>
       <column name="definition_zh_HK">不太可能、少機會</column>
       <column name="definition_pt">improvável</column>
+      <column name="definition_fi">epätodennäköinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghaytan:adv}</column>
       <column name="see_also">{chaq:adv}, {-Ha':v:suff}</column>
@@ -1713,6 +1900,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1722,6 +1910,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">improbable, improbably, unprobable, unprobably</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1729,6 +1918,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Radio Times Star Trek 30th Anniversary Special Issue:src}</column>
     </table>
     <table name="mem">
@@ -1742,6 +1932,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">общий оскорбительный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一般粗口</column>
       <column name="definition_pt">invectivo geral</column>
+      <column name="definition_fi">eräs kirosana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuy'cha':excl}</column>
@@ -1752,6 +1943,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This might have been a retrofit for a mispronunciation of {ghuy'cha':excl:nolink} by Patrick Stewart in the episode {TNG - The Mind's Eye:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1761,6 +1953,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1768,6 +1961,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1781,6 +1975,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">козоподобное существо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">山羊般的生物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">criatura parecida com uma cabra</column>
+      <column name="definition_fi">eräs vuohta muistuttava eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DI'raq:n}, {bolmaq:n:extcan}</column>
@@ -1791,6 +1986,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In English, "got your goat" is a slang expression referring to irritating someone.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1800,6 +1996,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1807,6 +2004,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1820,6 +2018,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">Соус грапок</column>
       <column name="definition_zh_HK">grapok醬 [AUTOTRANSLATED]</column>
       <column name="definition_pt">molho grapok</column>
+      <column name="definition_fi">grapok-kastike</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Se'tu':n}</column>
@@ -1830,6 +2029,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru">Это приправа, которая часто используется для усиления вкуса в {qagh:n} или {raHta':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種調味品，通常用於在{qagh:n}或{raHta':n}中帶出風味。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um condimento frequentemente usado para realçar o sabor em {qagh:n} ou {raHta':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä maustetta käytetään usein tuoda esiin maku {qagh:n}- tai {raHta':n} -tuotteissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1839,6 +2039,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1846,6 +2047,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -1859,6 +2061,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="definition_ru">ода уважения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">尊重的頌歌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ode de respeito</column>
+      <column name="definition_fi">kunnioituslaulu?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}, {ghuQ:n}</column>
@@ -1869,6 +2072,7 @@ This is the "cornerstone" ({qor:sen:nolink}-{nagh:n}) of something.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "gothic" poem.
 
 In the list of vocabulary used in {KCD:src} which was given to the KLI in advance (and printed in {HQ 5.1:src}), this was defined as "GaTH'K, Ode of respect", but this transliteration appears nowhere else in Okrand's works.[3] (However, it is used in the novelisation of the game.)</column>
@@ -1880,6 +2084,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">poem, GaTH'K</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1887,6 +2092,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KCD:src}, [3] {HQ 5.1, Mar. 1996 p.20:src}</column>
     </table>
     <table name="mem">
@@ -1900,6 +2106,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="definition_ru">Grafk [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Grafk [AUTOTRANSLATED]</column>
       <column name="definition_pt">Grafk</column>
+      <column name="definition_fi">Grafk</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIr'el:n:name}</column>
@@ -1910,6 +2117,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1919,6 +2127,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1926,6 +2135,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Si Vis Pacem, Para Bellum:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1939,6 +2149,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="definition_ru">рог (музыкальный инструмент) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">喇叭（樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">buzina (instrumento musical)</column>
+      <column name="definition_fi">torvi (soitin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIl:v:2}, {Dov'agh:n}</column>
@@ -1949,6 +2160,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{gheb rIl:sen:nolink} is a reference to the horn of Gabriel.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1959,6 +2171,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1966,6 +2179,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1979,6 +2193,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="definition_ru">добыча [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">獵物</column>
       <column name="definition_pt">presa</column>
+      <column name="definition_fi">saalis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wam:v}, {chon:n}, {DaHjaj gheD:n}</column>
@@ -1989,6 +2204,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1998,6 +2214,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2005,6 +2222,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2018,6 +2236,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="definition_ru">быть грубым, быть жестким</column>
       <column name="definition_zh_HK">粗暴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser áspero, ser grosseiro</column>
+      <column name="definition_fi">olla karkea, olla epätasainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hab:v}</column>
       <column name="see_also">{tlher:v}</column>
@@ -2028,6 +2247,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2037,6 +2257,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2044,6 +2265,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.179:src}</column>
     </table>
     <table name="mem">
@@ -2057,6 +2279,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="definition_ru">иметь температуру [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">溫度為 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter a temperatura de</column>
+      <column name="definition_fi">olla lämpötilaltaan jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SImyon:n}, {Hat:n}, {juv:v}</column>
@@ -2067,6 +2290,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2076,6 +2300,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2083,6 +2308,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -2096,6 +2322,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="definition_ru">Задайте (вопрос) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發問（問題）</column>
       <column name="definition_pt">perguntar (fazer uma pergunta)</column>
+      <column name="definition_fi">kysyä (kysymys)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhob:v}, {yu':v}, {jang:v}</column>
@@ -2106,6 +2333,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="notes_ru">Этот глагол используется, чтобы задать вопрос, тогда как {tlhob:v} используется для выполнения запроса.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞用於提出問題，而{tlhob:v}用於提出請求。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo é usado para fazer uma pergunta, enquanto {tlhob:v} é usado para fazer uma solicitação.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään kysymyksen esittämiseen, kun taas {tlhob:v} käytetään pyynnön tekemiseen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's implied that {ghel:v:nolink} works in a similar manner to {tlhob:v:nolink}, but this isn't explicitly stated.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2115,6 +2343,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2122,6 +2351,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 7.4, p.3-4, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -2135,6 +2365,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="definition_ru">Ночная закуска</column>
       <column name="definition_zh_HK">宵夜</column>
       <column name="definition_pt">lanche da meia-noite</column>
+      <column name="definition_fi">yöpala</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uQ:n}, {ramjep:n:1}</column>
@@ -2145,6 +2376,7 @@ In the list of vocabulary used in {KCD:src} which was given to the KLI in advanc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In the movie "Gremlins", the most important rule is that the creatures must not be fed after midnight.
 
 This is the reverse of {megh:n}.</column>
@@ -2156,6 +2388,7 @@ This is the reverse of {megh:n}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2163,6 +2396,7 @@ This is the reverse of {megh:n}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2176,6 +2410,7 @@ This is the reverse of {megh:n}.</column>
       <column name="definition_ru">оркестр [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">管弦樂隊</column>
       <column name="definition_pt">orquestra</column>
+      <column name="definition_fi">orkesteri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2190,6 +2425,9 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa kohtuullisen suureen ryhmään instrumentalisteja. Orkesterin johtamiseen käytetty verbi on {ra':v:2}.
+
+Yleisempi termi musiikkia soittavalle ryhmälle (kaikenkokoisille) on {QoQ ghom:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Carnegie Hall is a place where many famous orchestras come to play.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2199,6 +2437,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2206,6 +2445,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -2219,6 +2459,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">обнять, обнять [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擁抱，擁抱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">abraçar</column>
+      <column name="definition_fi">halata, syleillä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2229,6 +2470,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Grip".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2238,6 +2480,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2245,6 +2488,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2258,6 +2502,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">сформулировать, собрать, собрать вместе [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">制定、編譯、拉攏 [AUTOTRANSLATED]</column>
       <column name="definition_pt">formular, compilar, reunir</column>
+      <column name="definition_fi">muotoilla, laatia, koota</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tetlh:n}, {mem:n}, {buv:v}</column>
@@ -2268,6 +2513,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Этот глагол выражает идею объединения мыслей в достаточно связную форму, чтобы их можно было передать кому-то другому. Он отличается от {qon:v} тем, что {gher:v:nolink} предполагает, что информация просто передается.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞表達了將思想匯聚成合理連貫的形式以便可以將其表達給其他人的想法。它與{qon:v}的不同之處在於{gher:v:nolink}表示僅在傳遞信息。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo expressa a ideia de reunir pensamentos em uma forma razoavelmente coerente para que possam ser expressos para outra pessoa. É diferente de {qon:v} porque {gher:v:nolink} sugere que as informações estão apenas sendo repassadas.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi ilmaisee ajatuksen ajatusten yhdistämisestä kohtuullisen yhtenäiseen muotoon, jotta ne voidaan ilmaista jollekin muulle. Se eroaa {qon:v}: stä siinä, että {gher:v:nolink} viittaa siihen, että tietoja välitetään vain eteenpäin.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2277,6 +2523,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2284,6 +2531,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.07.09:src} (reprinted in {HQ 8.1, p.8, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -2297,6 +2545,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">Гертруда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">格特魯德 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Gertrude</column>
+      <column name="definition_fi">Gertrude</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -2307,6 +2556,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2316,6 +2566,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2323,6 +2574,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -2336,6 +2588,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">результаты, исход, эффект, последствия, последствия, разветвление [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結果、結果、影響、反響、結果、分枝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">resultados, efeito, repercussões, consequência, ramificação</column>
+      <column name="definition_fi">tulos, vaikutus, seuraus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2360,6 +2613,9 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_pt">As palavras na definição em inglês podem ser interpretadas como singular ou plural, dependendo do contexto. Se for importante indicar pluralidade no Klingon, adicione {-mey:n:suff}. Se for importante indicar a singularidade, use {wa':n:num} com {neH:adv} (ou algo parecido) .[2]
 
 "Resultados" no sentido de "pontuação, contagem" é {mIvwa'mey:n@@mIvwa':n, -mey:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sanat englanninkielisessä määritelmässä voidaan tulkita yksikkö- tai monikkomuodoksi kontekstista riippuen. Jos on tärkeää ilmoittaa moninaisuus Klingonissa, lisää {-mey:n:suff}. Jos on tärkeää ilmoittaa singulariteetti, käytä {wa':n:num} {neH:adv}: n kanssa (tai jotain näiden linjojen kanssa).
+
+"Tulokset" tarkoittaa "pisteet, yhteen" on {mIvwa'mey:n@@mIvwa':n, -mey:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2369,6 +2625,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2376,6 +2633,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}, [2] {KLI mailing list 2018.07.23:src}</column>
     </table>
     <table name="mem">
@@ -2389,6 +2647,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">взять на себя обязанности, взять на себя ответственность [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">承擔責任</column>
       <column name="definition_pt">assumir deveres, assumir responsabilidades de</column>
+      <column name="definition_fi">ottaa virka, ottaa jonkun tehtävät</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cho':v}, {Sugh:v}, {Da:v}</column>
@@ -2399,6 +2658,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2410,6 +2670,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2417,6 +2678,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2430,6 +2692,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">притворяться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">假裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fingir</column>
+      <column name="definition_fi">teeskennellä, näytellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toj:v}, {jech:v}, {Quj:v}, {reH:v}, {lIl:v}</column>
@@ -2440,6 +2703,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Использование этого слова не подразумевает никакого обмана. Это просто указывает на ролевую игру.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">使用該詞並不意味著任何欺騙。它只是表示角色扮演。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Nenhum engano é implícito pelo uso desta palavra. Simplesmente indica role-playing.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan käyttö ei tarkoita petosta. Se tarkoittaa yksinkertaisesti roolipeliä.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"The Great Pretender".</column>
       <column name="components"></column>
       <column name="examples">
@@ -2450,6 +2714,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">roleplay, role play, role-play</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2457,6 +2722,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, Sept. 2003:src}, [2] {Saarbrücken qepHom'a' 2011:src}</column>
     </table>
     <table name="mem">
@@ -2470,6 +2736,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">самозванец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">冒牌者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fingidor</column>
+      <column name="definition_fi">teeskentelijä, näyttelijä</column>
       <column name="synonyms">{DawI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2480,6 +2747,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Использование этого слова не подразумевает никакого обмана. Это просто указывает на ролевую игру.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">使用該詞並不意味著任何欺騙。它只是表示角色扮演。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Nenhum engano é implícito pelo uso desta palavra. Simplesmente indica role-playing.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan käyttö ei merkitse petosta. Se tarkoittaa yksinkertaisesti roolipeliä.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"The Great Pretender".</column>
       <column name="components">{ghet:v}, {-wI':v}</column>
       <column name="examples">
@@ -2490,6 +2758,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">actor, actress</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2497,6 +2766,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, Sept. 2003:src}, [2] {DSC announcement:src}</column>
     </table>
     <table name="mem">
@@ -2510,6 +2780,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">Гевчок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Gevchok [AUTOTRANSLATED]</column>
       <column name="definition_pt">Gevchok</column>
+      <column name="definition_fi">Gevchok</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2520,6 +2791,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Это имя воина, который в одиночку победил вторжение. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是單槍匹馬擊敗入侵力量的戰士的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um guerreiro que derrotou sozinho uma força invasora. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sen soturin nimi, joka yksin voitti hyökkäävän voiman. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} and not in the glossary.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2529,6 +2801,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2536,6 +2809,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2549,6 +2823,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">Гевчок область [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Gevchok地區 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Região de Gevchok</column>
+      <column name="definition_fi">Gevchokin alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2559,6 +2834,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">В этом регионе находится город {ruq'e'vet:n}. Он назван в честь {ghevchoq:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該區域包含{ruq'e'vet:n}市。它以{ghevchoq:n:name}命名。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta região contém a cidade de {ruq'e'vet:n}. É nomeado após {ghevchoq:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä alue sisältää {ruq'e'vet:n}-kaupungin. Se on nimetty {ghevchoq:n:name}: n mukaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} and not in the glossary.</column>
       <column name="components">{ghevchoq:n}, {Sep:n}</column>
       <column name="examples"></column>
@@ -2568,6 +2844,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2575,6 +2852,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2588,6 +2866,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">соус для гага [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">醬汁為gagh [AUTOTRANSLATED]</column>
       <column name="definition_pt">molho para gagh</column>
+      <column name="definition_fi">eräs kastike gaghille</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qagh:n}, {qagh vIychorgh:n}, {Se'tu':n}</column>
@@ -2598,6 +2877,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Существует идиома {jeD; ghevI' rur@@jeD:v, ghevI':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{jeD; ghevI' rur@@jeD:v, ghevI':n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {jeD; ghevI' rur@@jeD:v, ghevI':n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {jeD; ghevI' rur@@jeD:v, ghevI':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is "gravy".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2607,6 +2887,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2614,6 +2895,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2627,6 +2909,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">лопата [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鏟</column>
       <column name="definition_pt">pá</column>
+      <column name="definition_fi">lapio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhan:v}, {mol:v}, {SommI':n}</column>
@@ -2637,6 +2920,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2646,6 +2930,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">spade</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2653,6 +2938,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2666,6 +2952,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">жук, платяная вошь, насекомое</column>
       <column name="definition_zh_HK">蟲、蠅</column>
       <column name="definition_pt">inseto</column>
+      <column name="definition_fi">hyönteinen, ötökkä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chop:v}, {ngej:v}, {vetlh:n}</column>
@@ -2676,6 +2963,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In the "Radio Times Star Trek 30th Anniversary Special Issue", cricket (the sport) is translated as {ghew:n:nolink}. Specifically, "Cricket, please." was translated as {DaH ghew yIQuj.:sen:nolink}[3]</column>
       <column name="components"></column>
       <column name="examples">
@@ -2688,6 +2976,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">insect</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2695,6 +2984,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {PK:src}, [3] {Radio Times Star Trek 30th Anniversary Special Issue:src}</column>
     </table>
     <table name="mem">
@@ -2708,6 +2998,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">пунктуация [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">標點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pontuação</column>
+      <column name="definition_fi">välimerkit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2718,6 +3009,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghew:n}, {-mey:n}</column>
       <column name="examples"></column>
@@ -2727,6 +3019,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2734,6 +3027,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2747,6 +3041,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">быть трансформированным, трансмутированным, метаморфизированным, полностью измененным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被改造、變形、變形、完全改變 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser transformado, transmutado, metamorfoseado, totalmente alterado</column>
+      <column name="definition_fi">olla muunnettu, muuttunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choH:v}, {choH:n}</column>
@@ -2757,6 +3052,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Gregor Samsa is the main character of the Franz Kafka novella "The Metamorphosis".</column>
       <column name="components"></column>
       <column name="examples">
@@ -2767,6 +3063,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">terraform</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2774,6 +3071,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.06:src}</column>
     </table>
     <table name="mem">
@@ -2788,6 +3086,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">терраформирующее поле [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地形領域 [AUTOTRANSLATED]</column>
       <column name="definition_pt">campo de terraformação</column>
+      <column name="definition_fi">maankaltaistamiskenttä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2798,6 +3097,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Это короткий способ обозначить энергетическое поле, которое вызывает терраформирование. Более длинный способ обратиться к этой концепции будет {ghe'moHbogh HoSchem:n@@ghe':v, -moH:v, -bogh:v, HoSchem:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是引用導致地形發生的某種能量場的簡短方法。 {ghe'moHbogh HoSchem:n@@ghe':v, -moH:v, -bogh:v, HoSchem:n}是提及此概念的一種較長方法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma maneira curta de se referir a um campo de energia de algum tipo que causa a terraformação. Uma maneira mais longa de se referir a esse conceito seria {ghe'moHbogh HoSchem:n@@ghe':v, -moH:v, -bogh:v, HoSchem:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhyt tapa viitata jonkinlaiseen energiakenttään, joka saa aikaan terraformingin. Pidempi tapa viitata tähän käsitteeseen olisi {ghe'moHbogh HoSchem:n@@ghe':v, -moH:v, -bogh:v, HoSchem:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghe':v}, {chem:n:hyp}</column>
       <column name="examples"></column>
@@ -2807,6 +3107,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2814,6 +3115,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.06:src}</column>
     </table>
     <table name="mem">
@@ -2827,6 +3129,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">опера [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">歌劇</column>
       <column name="definition_pt">ópera</column>
+      <column name="definition_fi">ooppera</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}, {may' ghe'naQ:n}, {ghe'naQ nIt:n}, {jachwI'na':n}</column>
@@ -2837,6 +3140,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Пример клингонской оперы - «Актух и Мелота» (см. {'aqtu':n:name} и {mellota':n:name}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗歌劇的一個例子是“阿克圖和梅洛塔”（見{'aqtu':n:name}和{mellota':n:name}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um exemplo de ópera Klingon é "Aktuh e Melota" (ver {'aqtu':n:name} e {mellota':n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Esimerkki Klingonin oopperasta on "Aktuh and Melota" (katso {'aqtu':n:name} ja {mellota':n:name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2846,6 +3150,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2853,6 +3158,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2866,6 +3172,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">великая опера [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大歌劇</column>
       <column name="definition_pt">grande ópera</column>
+      <column name="definition_fi">suuri ooppera</column>
       <column name="synonyms"></column>
       <column name="see_also">{bom:n}, {jachwI'na':n}</column>
       <column name="notes">This is a {ghe'naQ:n} following the traditional form preferred by purists.</column>
@@ -2875,6 +3182,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Это {ghe'naQ:n}, следующий традиционной форме, предпочитаемой пуристами. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是遵循純粹主義者偏愛的傳統形式的{ghe'naQ:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um {ghe'naQ:n} seguindo a forma tradicional preferida pelos puristas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {ghe'naQ:n}, joka seuraa puristien suosimaa perinteistä muotoa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghe'naQ:n}, {nIt:v}</column>
       <column name="examples"></column>
@@ -2884,6 +3192,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2891,6 +3200,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2904,6 +3214,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">Гретор, преисподняя (место, куда уходят души обесчещенных)</column>
       <column name="definition_zh_HK">Gre'thor、地獄世界（被羞辱的精神去哪裡） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Gre'thor, submundo (para onde vão os espíritos desonrados)</column>
+      <column name="definition_fi">Gre'thor, alamaailma (minne kunniattomien henget joutuvat)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suto'vo'qor:n}, {QI'tu':n}, {qotar:n}, {Hegh Duj:n}</column>
@@ -2914,6 +3225,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Также это может быть написано {ghe''or:n:place,nolink}.</column>
       <column name="notes_zh_HK">這也寫成{ghe''or:n:place,nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também está escrito {ghe''or:n:place,nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on myös kirjoitettu {ghe''or:n:place,nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It is written {ghe''or:n:place,nolink} in {TKDA:src} and pronounced that way in {PK:src}, but is consistently written {ghe'tor:n:place,nolink} in later sources.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2931,6 +3243,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
 ▶ {Hegh Duj DatIj 'ej ghe'torDaq Duqeng.:sen:nolink} "Баржа мёртвых переправит тебя в Гретор!"[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dishonoured, hell, afterlife</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2938,6 +3251,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru">обесчещенный, ад, жизнь после смерти</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {TKDA:src}, [3] {Klingon Monopoly:src}, [4] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -2951,6 +3265,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">Когда души убегут из Гретора</column>
       <column name="definition_zh_HK">當靈魂逃離格雷索時 [AUTOTRANSLATED]</column>
       <column name="definition_pt">quando os espíritos escapam de Gre'thor</column>
+      <column name="definition_fi">kun henget pakenevat Gre'thorista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{not:adv}, {paghlogh:adv}</column>
@@ -2961,6 +3276,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru">Это похоже на земное выражение "когда свиньи полетят" или "когда рак на горе свистнет"</column>
       <column name="notes_zh_HK">這類似於人形表達“豬飛時”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é semelhante à expressão terráquea "quando os porcos voam". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on samanlainen kuin Terran-ilmaisu "kun siat lentävät". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2972,6 +3288,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
 ▶ {jIjegh ghe'torvo' narghDI' qa'pu'.:sen:nolink} "Я сдамся, когда души сбегут из Гретора!" (т.е, "Я никогда не сдамся.")</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2979,6 +3296,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.117:src}</column>
     </table>
     <table name="mem">
@@ -2992,6 +3310,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">{ghe'tor:n:place}</column>
       <column name="definition_zh_HK">{ghe'tor:n:place}</column>
       <column name="definition_pt">{ghe'tor:n:place}</column>
+      <column name="definition_fi">{ghe'tor:n:place}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3002,6 +3321,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3011,6 +3331,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3018,6 +3339,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3032,6 +3354,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">Вы принадлежите к черной дыре в преисподней! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你屬於地獄世界的黑洞！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você pertence a um buraco negro no submundo!</column>
+      <column name="definition_fi">Kuulut mustaan aukkoon alamaailmassa!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3042,6 +3365,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3051,6 +3375,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mu'qaD veS, curse warfare</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3058,6 +3383,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -3071,6 +3397,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">соглашаться, давать согласие</column>
       <column name="definition_zh_HK">允諾</column>
       <column name="definition_pt">consentimento</column>
+      <column name="definition_fi">suostua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaw':v}, {Qochbe':v}</column>
@@ -3081,6 +3408,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3090,6 +3418,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3097,6 +3426,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3110,6 +3440,7 @@ Ein allgemeiner Begriff für jede Musik spielende Gruppe (egal welcher Größe) 
       <column name="definition_ru">нос</column>
       <column name="definition_zh_HK">鼻</column>
       <column name="definition_pt">nariz</column>
+      <column name="definition_fi">nenä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhon:n}, {pur:v}, {qab:n}, {nuj:n}, {Du'ran:n}</column>
@@ -3133,6 +3464,9 @@ Det finns också ett regionalt ord {ley':n} som betyder "näsa". [AUTOTRANSLATED
       <column name="notes_pt">Existe um idioma, {boch; ghIch rur@@boch:v, ghIch:n, rur:v}.[2, p.133]
 
 Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {boch; ghIch rur@@boch:v, ghIch:n, rur:v}.[2, p.133]
+
+On myös alueellinen sana {ley':n}, joka tarkoittaa "nenä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3143,6 +3477,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3150,6 +3485,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3163,6 +3499,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">ярмарка, ярмарка, карнавал, цирк [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">公平，遊樂場，狂歡節，馬戲團 [AUTOTRANSLATED]</column>
       <column name="definition_pt">feira, parque de diversões, carnaval, circo</column>
+      <column name="definition_fi">tivoli, huvipuisto, karnevaali, sirkus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jo'ley':n}, {qut:v}</column>
@@ -3173,6 +3510,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This literally means "nose being" ({ghIch:n} + {Dep:n}). Possibly a reference to elephants or clowns.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3182,6 +3520,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3189,6 +3528,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3202,6 +3542,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">Если ты светишь мне носом, я отдам тебе нос. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">如果你擦亮我的鼻子，我會給你你的鼻子。</column>
       <column name="definition_pt">Se você polir meu nariz, eu lhe darei seu nariz.</column>
+      <column name="definition_fi">Jos kiillotat nenääni, annan sinulle sinun nenäsi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bochmoHwI':n}</column>
@@ -3212,6 +3553,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Эта идиома используется для обозначения: «Не пытайтесь ввести меня в заблуждение, если вы цените свою жизнь». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個習慣用語的意思是“如果珍惜生命，請不要誤導我”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse idioma é usado para significar "Não tente me enganar se você valoriza sua vida". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään tarkoittamaan "Älä yritä johtaa minua harhaan, jos arvotat elämääsi". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3221,6 +3563,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3228,6 +3571,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -3241,6 +3585,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">пробивать, перфорировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刺穿、穿孔 [AUTOTRANSLATED]</column>
       <column name="definition_pt">perfurar</column>
+      <column name="definition_fi">lävistää, rei'ittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIqDob:n}</column>
@@ -3251,6 +3596,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3260,6 +3606,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3267,6 +3614,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -3280,6 +3628,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">ожерелье</column>
       <column name="definition_zh_HK">頸鍊</column>
       <column name="definition_pt">colar</column>
+      <column name="definition_fi">kaulakoru</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jInaq:n}, {ghIgh:n:2}</column>
@@ -3290,6 +3639,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3299,6 +3649,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3306,6 +3657,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3319,6 +3671,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">назначение, задача, обязанность [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">任務、任務、職責 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atribuição, tarefa, dever</column>
+      <column name="definition_fi">tehtävä, komennus, toimeksianto, velvollisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baj:v}, {vum:v}, {Qu':n}, {ghIgh:n:1}</column>
@@ -3329,6 +3682,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "gig".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3338,6 +3692,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3345,6 +3700,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3358,6 +3714,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">быть грязным, быть неаккуратным</column>
       <column name="definition_zh_HK">凌亂、邋.. [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser bagunçado, desleixado</column>
+      <column name="definition_fi">olla holtiton, siivoton, hutiloiva, huolimaton, epäsiisti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{way'ar:n}</column>
@@ -3368,6 +3725,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3378,6 +3736,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3385,6 +3744,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3398,6 +3758,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">быть небрежным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">粗心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser descuidado</column>
+      <column name="definition_fi">olla huoleton, suruton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yep:v}</column>
       <column name="see_also"></column>
@@ -3408,6 +3769,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">В диалекте {ruq'e'vet:n} это слово используется в дополнение к {yepHa':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{ruq'e'vet:n}的方言中，除了{yepHa':v}以外，還使用了該詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No dialeto {ruq'e'vet:n}, esta palavra é usada além de {yepHa':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{ruq'e'vet:n}-murteessa tätä sanaa käytetään {yepHa':v}-sanan lisäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3417,6 +3779,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3424,6 +3787,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3437,6 +3801,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">пугать</column>
       <column name="definition_zh_HK">嚇驚</column>
       <column name="definition_pt">sustar</column>
+      <column name="definition_fi">pelottaa, pelästyttää, pelotella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Haj:v}, {buQ:v}, {lIm:v}, {bIt:v}</column>
@@ -3447,6 +3812,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3457,6 +3823,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3464,6 +3831,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3478,6 +3846,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">Пусть твои враги бегут в ужасе</column>
       <column name="definition_zh_HK">願你的敵人恐懼地奔跑。</column>
       <column name="definition_pt">Que seus inimigos corram com medo.</column>
+      <column name="definition_fi">Juoskoot vihollisesi peloissaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIlajneS.:sen}</column>
@@ -3488,6 +3857,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Предложение является архаичным</column>
       <column name="notes_zh_HK">這句話是過時的。在現代標準克林崗語中，它是不合語法的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta frase é arcaica. Não é gramatical no padrão moderno Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lause on arkaainen. Se on epägammaattinen nykyaikaisessa Klingon-standardissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghIj:v}, {-jaj:v}, {qet:v}, {jagh:n}, {-mey:n}</column>
       <column name="examples"></column>
@@ -3497,6 +3867,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3504,6 +3875,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.65:src}</column>
     </table>
     <table name="mem">
@@ -3517,6 +3889,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">быть средним, быть средним (среднее арифметическое, используется в математике) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">是平均值，是平均值（算術平均值，在數學中使用） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser a média aritmética (usada em matemática)</column>
+      <column name="definition_fi">olla keskimääräinen, olla (aritmeettinen) keskiarvo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{botlh:n:2}</column>
@@ -3527,6 +3900,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Mean Girls" is the name of a film.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3536,6 +3910,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">average</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3543,6 +3918,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3556,6 +3932,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">шар летать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小蠅</column>
       <column name="definition_pt">mosca glob</column>
+      <column name="definition_fi">glob-kärpänen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghew:n}</column>
@@ -3566,6 +3943,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Это маленькое раздражающее насекомое без жала, издающее легкий жужжащий звук. Существует клингонская идиома {ram; ghIlab ghew rur@@ram:v, ghIlab ghew:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種小的刺激性昆蟲，沒有刺痛，發出輕微的嗡嗡聲。有一個克林崗語，{ram; ghIlab ghew rur@@ram:v, ghIlab ghew:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um inseto pequeno e irritante, sem ferrão, que produz um leve zumbido. Existe um idioma Klingon, {ram; ghIlab ghew rur@@ram:v, ghIlab ghew:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on pieni, ärsyttävä hyönteinen, jolla ei ole pistosta, mikä antaa hieman surisevan äänen. On olemassa klingonin idioomi {ram; ghIlab ghew rur@@ram:v, ghIlab ghew:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3577,6 +3955,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3584,6 +3963,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3597,6 +3977,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">Не обращайте внимания на шариковых мух</column>
       <column name="definition_zh_HK">置之不理小蠅。</column>
       <column name="definition_pt">Não preste atenção às moscas glob.</column>
+      <column name="definition_fi">Älä kiinnitä huomiota glob-kärpäsiin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIlab ghew:n}</column>
@@ -3607,6 +3988,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghIlab ghew:n}, {-mey:n}, {tI-:v}, {buS:v}, {-Qo':v}</column>
       <column name="examples"></column>
@@ -3616,6 +3998,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3623,6 +4006,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.171:src}</column>
     </table>
     <table name="mem">
@@ -3636,6 +4020,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">"Гласность"(курс Горбачёва)</column>
       <column name="definition_zh_HK">「格拉斯諾斯」、公開性（古老的政治運動）</column>
       <column name="definition_pt">movimento político antigo, Glasnost</column>
+      <column name="definition_fi">glasnot (vanha poliittinen liike)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIvoq 'ach yI'ol.:sen}</column>
@@ -3646,6 +4031,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3655,6 +4041,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3662,6 +4049,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -3675,6 +4063,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">Гильденстерн [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吉爾登斯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Guildenstern</column>
+      <column name="definition_fi">Guildenstern</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}, {roSenQatlh:n:name}</column>
@@ -3685,6 +4074,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3694,6 +4084,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3701,6 +4092,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -3714,6 +4106,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">ссылать, изгонять</column>
       <column name="definition_zh_HK">放逐、流亡</column>
       <column name="definition_pt">exílio</column>
+      <column name="definition_fi">karkottaa?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghImwI':n}, {vuj:v}, {ruq:v}, {puch:n}</column>
@@ -3724,6 +4117,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Этот глагол можно использовать с {turmIq:n}, {qeQ:n} и {taQbang:n:2}. [2]. У клингонов нет эвфемизмов для обозначения посещения туалета, они просто говорят {taQbang ghIm:sen:nolink} и так далее. Сленговое выражение {qIvon belmoH:sen} время от времени используется, в основном, детьми или для детей.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este verbo pode ser usado com {turmIq:n}, {qeQ:n} e {taQbang:n:2}.[2] Os klingons não têm eufemismos para ir ao banheiro e diriam apenas {taQbang ghIm:sen:nolink} e assim por diante. A expressão de gíria {qIvon belmoH:sen} é usada de vez em quando, principalmente por ou para crianças.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä voidaan käyttää seuraavien kanssa: {turmIq:n}, {qeQ:n} ja {taQbang:n:2}. Slangilauseketta {qIvon belmoH:sen} käytetään aika ajoin, enimmäkseen lapset tai lapset.[2]{taQbang ghIm:sen:nolink}[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3734,6 +4128,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">deport, expel</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3741,6 +4136,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 23 (2016):src}, [3] {KLI mailing list 2019.09.20:src}</column>
     </table>
     <table name="mem">
@@ -3754,6 +4150,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">депортировать, высылать</column>
       <column name="definition_zh_HK">排氣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">exaustão</column>
+      <column name="definition_fi">lämmönpoistaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuj ghImwI':n}, {tlhuch:v}, {'och:n}, {qatlhDa':n}</column>
@@ -3764,6 +4161,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Это относится к устройству, которое рассеивает тепло. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指散發熱量的設備。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um dispositivo que dissipa calor. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa laitteeseen, joka johtaa lämpöä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Some people believed early on that this was a mistake for {tlhuchwI':n:nolink} (see {tlhuch:v}). However, {tuj ghImwI':n} actually makes sense for a mechanism that dissipates heat, and subsequently revealed information on {ghIm:v} shows that it is correct.</column>
       <column name="components">{ghIm:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3773,6 +4171,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pipe</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3780,6 +4179,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3793,6 +4193,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">монастырь, здание религиозной общины [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">修道院、宗教社群建築物</column>
       <column name="definition_pt">mosteiro, edifício(s) comunitário(s) religioso(s)</column>
+      <column name="definition_fi">luostari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIrgh:n}, {lat:n}, {ghIn pIn:n}, {bulvar:n}</column>
@@ -3803,6 +4204,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Это относится к зданию или группе зданий, включая любые сопутствующие территории, такие как сады. Это не относится к группе людей, которые там живут, работают или учатся.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">指建築物或建築物群，包括任何附屬場地，例如花園。它不是指在那裡生活，工作或學習的人群。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um edifício ou grupo de edifícios, incluindo quaisquer terrenos que o acompanham, como jardins. Não se refere ao grupo de pessoas que vive, trabalha ou estuda lá.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa rakennusta tai rakennusten ryhmää, mukaan lukien kaikki siihen liittyvät tontit, kuten puutarhat. Se ei tarkoita ihmisryhmää, joka asuu, työskentelee tai opiskelee siellä[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Plymouth Gin is produced by The Black Friars Distillery, formerly a Dominican monastery in Plymouth, England.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3812,6 +4214,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3819,6 +4222,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2010:src}, [2] {Letter from MO 2011.01.07:src} ({KLI mailing list 2011.01.16:src})</column>
     </table>
     <table name="mem">
@@ -3833,6 +4237,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">аббат, аббатство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">修道院院長、住持</column>
       <column name="definition_pt">abade, abadessa</column>
+      <column name="definition_fi">apotti, abbedissa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIn:n}, {bulvar:n}</column>
@@ -3843,6 +4248,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghIn:n}, {pIn:n:1}</column>
       <column name="examples"></column>
@@ -3852,6 +4258,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3859,6 +4266,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Facebook "Learn Klingon" group 2013.08.28:src}</column>
     </table>
     <table name="mem">
@@ -3872,6 +4280,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">суббота [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星期六</column>
       <column name="definition_pt">sábado</column>
+      <column name="definition_fi">lauantai</column>
       <column name="synonyms">{lojmItjaj:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{Hogh:n}</column>
@@ -3882,6 +4291,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">{lojmItjaj:n:nolink} обычно используется в формальных случаях, в то время как и он, и {ghInjaj:n:nolink} используются, по-видимому, без разбора, в противном случае. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{lojmItjaj:n:nolink}傾向於在正式場合使用，而{ghInjaj:n:nolink}和DONOTTRANSLATE2都被使用，否則似乎是不加區別的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">{lojmItjaj:n:nolink} tende a ser usado em ocasiões formais, enquanto tanto it quanto {ghInjaj:n:nolink} são usados, aparentemente indiscriminadamente, caso contrário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{lojmItjaj:n:nolink}: ää käytetään yleensä muodollisissa tilaisuuksissa, kun taas sekä sitä että {ghInjaj:n:nolink}: ta käytetään näennäisesti valikoimattomasti, muuten. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This refers to a line in "Being for the Benefit of Mr. Kite!" by The Beatles, which partly goes "on Saturday at Bishopsgate".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3891,6 +4301,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3898,6 +4309,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -3911,6 +4323,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">Боевое копьё, Джинтак</column>
       <column name="definition_zh_HK">戰鬥矛、Gin'tak [AUTOTRANSLATED]</column>
       <column name="definition_pt">lança de batalha, Gin'tak</column>
+      <column name="definition_fi">eräs taistelukeihän, gin'tak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQjej:n}, {ghIntaq:n:2,extcan}</column>
@@ -3921,6 +4334,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3930,6 +4344,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3937,6 +4352,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {TNG - Birthright, Part II:src}</column>
     </table>
     <!-- Note that {ghIntaq:n:2} is in the "extra" section. -->
@@ -3951,6 +4367,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">Военный трибунал</column>
       <column name="definition_zh_HK">軍法審判</column>
       <column name="definition_pt">corte marcial</column>
+      <column name="definition_fi">viedä joku sotaoikeuteen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'DIj:n}</column>
@@ -3961,6 +4378,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Объектом этого глагола является лицо, обвиняемое и подлежащее судебному разбирательству (или фактически судимое) военным трибуналом. Субъект тот, кто предъявил обвинение.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞的對像是被軍事法庭起訴並受到審判（或實際審判）的人。提出起訴的人為對象。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto desse verbo é a pessoa acusada e sujeita a julgamento (ou realmente julgado) por um tribunal militar. O sujeito é quem trouxe a acusação.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde on henkilö, jonka sotilastuomioistuin on syyttänyt häntä ja joka on oikeudenkäynnin kohteena (tai tosiasiallisesti oikeudenkäynnissä). Aihe on kuka on nostanut syytteen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3970,6 +4388,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3977,6 +4396,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -3990,6 +4410,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">потом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">然後、隨後</column>
       <column name="definition_pt">então, subsequentemente</column>
+      <column name="definition_fi">sitten, sen jälkeen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaj:adv}, {ngugh:adv}, {ngIq:n}</column>
@@ -4000,6 +4421,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Обратите внимание, что «тогда» в смысле «в то время» - это {ngugh:adv}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，“當時”意義上的“當時”是{ngugh:adv}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que "então" no sentido de "naquele momento" é {ngugh:adv}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että "silloin" merkityksessä "tuolloin" on {ngugh:adv}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4009,6 +4431,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">next, after</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4016,6 +4439,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.4, Sept. 1999:src}, [2] {s.k 1999.11.05:src} (reprinted in {HQ 8.4, p.8, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -4029,6 +4453,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">до смерти [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">至死、到死</column>
       <column name="definition_pt">para a morte</column>
+      <column name="definition_fi">kuolemaan saakka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suvchu':v}, {Hay'chu':v}</column>
@@ -4039,6 +4464,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In Semitic languages, the triconsonantal root "q-t-l" is related to killing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4048,6 +4474,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4055,6 +4482,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4068,6 +4496,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">математическая или химическая формула [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">數學或化學公式</column>
       <column name="definition_pt">fórmula matemática ou química</column>
+      <column name="definition_fi">matemaattinen tai kemiallinen kaava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI'QeD:n}, {tamlerQeD:n}, {wItte':n}</column>
@@ -4078,6 +4507,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Это написано или представлено с использованием символов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是用符號書寫或表示的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é escrito ou representado usando símbolos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjoitettu tai esitetty symboleilla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4087,6 +4517,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4094,6 +4525,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4107,6 +4539,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">отдыхать, брать отпуск</column>
       <column name="definition_zh_HK">假期、去度假 [AUTOTRANSLATED]</column>
       <column name="definition_pt">férias, tirar férias</column>
+      <column name="definition_fi">lomailla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leS:v}, {Such:v}, {leng:v}, {raQpo':n}</column>
@@ -4117,6 +4550,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4126,6 +4560,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4133,6 +4568,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4146,6 +4582,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">нисходить, снижаться, происходить</column>
       <column name="definition_zh_HK">下降</column>
       <column name="definition_pt">descender</column>
+      <column name="definition_fi">laskeutua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Sal:v}</column>
       <column name="see_also"></column>
@@ -4156,6 +4593,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Это слово не используется для сортировки.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此詞不用於排序。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa ei käytetä lajittelujärjestykseen.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">When descending, you need to drop your landing "gear".</column>
       <column name="components"></column>
       <column name="examples">
@@ -4177,6 +4615,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
 ▶ {HuDmeyvo' ghIr chaH:sen:nolink} "Они пришли из-за холмов"[2, p.118-119]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4184,6 +4623,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}, [3] {KLI mailing list 2018.02.10:src}</column>
     </table>
     <table name="mem">
@@ -4197,6 +4637,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">Грилка(женское имя)</column>
       <column name="definition_zh_HK">Grilka [AUTOTRANSLATED]</column>
       <column name="definition_pt">Grilka</column>
+      <column name="definition_fi">Grilka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4207,6 +4648,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4216,6 +4658,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4223,6 +4666,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4236,6 +4680,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">покачиваться, извиваться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">扭動、蠕動</column>
       <column name="definition_pt">agitar, contorcer-se</column>
+      <column name="definition_fi">keikkua, huojua, tutista, kiemurrella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nogh:v}, {ghargh:n}, {qagh:n}, {raHta':n}</column>
@@ -4246,6 +4691,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Это может быть использовано для описания хорошей чаши {qagh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以用來形容一碗美味的{qagh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para descrever uma boa tigela de {qagh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää kuvaamaan hyvää kulhoa {qagh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4255,6 +4701,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4262,6 +4709,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -4275,6 +4723,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">весы (животное покрытие) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鱗片</column>
       <column name="definition_pt">escamas (cobertura animal)</column>
+      <column name="definition_fi">suomut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIr:n}</column>
@@ -4285,6 +4734,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4294,6 +4744,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4301,6 +4752,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4314,6 +4766,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">Гришнарский кот</column>
       <column name="definition_zh_HK">《grishnar》貓</column>
       <column name="definition_pt">gato Grishnar</column>
+      <column name="definition_fi">grishnar-kissa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIghro':n}, {'Imyagh:excl}</column>
@@ -4324,6 +4777,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Это маленькое животное, по всей видимости, не очень злое, хотя и имеющее, возможно, пристрастие к тому, чтобы пытаться казаться более жестоким, чем оно есть на самом деле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種小動物，顯然不是很兇惡的動物，儘管它可能傾向於聽起來比實際更兇猛。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um animal pequeno, aparentemente não muito cruel, embora talvez tenha uma predileção por tentar parecer mais feroz do que realmente é. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on pieni eläin, ilmeisesti ei kovin julma, vaikka hänellä on ehkä taipumus yrittää kuulostaa kovemmalta kuin se todellisuudessa on. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4333,6 +4787,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4340,6 +4795,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}, [2] {KLI mailing list 2011.08.21:src}</column>
     </table>
     <table name="mem">
@@ -4353,6 +4809,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">открытая, плоская рука [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">張開的手</column>
       <column name="definition_pt">mão aberta e plana</column>
+      <column name="definition_fi">avoin suora kämmen?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ro':n}</column>
       <column name="see_also">{ghop:n}, {DeS:n:1}, {toch:n}, {nItlh:n}, {ghIt:n:2}</column>
@@ -4363,6 +4820,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Есть идиома {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}.[1, p.131] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語{yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}.[1, p.131] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}.[1, p.131] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}.[1, p.131] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Someone with writer's cramp might not be able to use his hand to form this.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4372,6 +4830,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4379,6 +4838,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4392,6 +4852,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">лезвие топора [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斧頭面</column>
       <column name="definition_pt">lâmina de machado</column>
+      <column name="definition_fi">kirveen terä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'obmaQ:n}, {DeS:n:2}, {ghIt:n:1}</column>
@@ -4402,6 +4863,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Есть идиома {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}.[1, p.131] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語{yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}.[1, p.131] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}.[1, p.131] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}.[1, p.131] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4411,6 +4873,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">axe blade</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4418,6 +4881,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4431,6 +4895,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">поток (например, вода), поток, излив [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">流動（例如水）、噴湧、噴口 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fluir (por exemplo, água), jorrar, espirrar</column>
+      <column name="definition_fi">virrata, kuohua, ryöpytä; sylkeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghay:v}</column>
@@ -4441,6 +4906,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4450,6 +4916,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4457,6 +4924,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4470,6 +4938,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">гейзер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">間歇噴泉</column>
       <column name="definition_pt">geyser</column>
+      <column name="definition_fi">geysir</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4480,6 +4949,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Если испускается пар, скажите {SeS ghItwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果散發出蒸汽，請說{SeS ghItwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se o vapor for emitido, diga {SeS ghItwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos höyryä vapautuu, sano sen sijaan {SeS ghItwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghIt:v}, {-wI':n}</column>
       <column name="examples"></column>
@@ -4489,6 +4959,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4496,6 +4967,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4509,6 +4981,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">рукопись [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手稿 [AUTOTRANSLATED]</column>
       <column name="definition_pt">manuscrito</column>
+      <column name="definition_fi">käsikirjoitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Se'vIr:n}, {paq:n:1h}</column>
@@ -4519,6 +4992,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The word {ghItlhHom:n:nolink} was used for the "string" variable type in Klingon Blockly.[2]</column>
       <column name="components"></column>
       <column name="examples">
@@ -4529,6 +5003,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">text</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4536,6 +5011,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <table name="mem">
@@ -4549,6 +5025,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="definition_ru">гравировать, насекать, стаить отметку, расписывать</column>
       <column name="definition_zh_HK">雕刻、切割、標記（上）、寫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gravar, incisar, marcar (em cima), escrever</column>
+      <column name="definition_fi">kirjoittaa, kaivertaa, viiltää, merkitä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hew:n}, {nan:v:1}, {tey:v:1}, {laD:v}</column>
@@ -4559,6 +5036,7 @@ Também existe uma palavra regional {ley':n} que significa "nariz". [AUTOTRANSLA
       <column name="notes_ru">Этот глагол используется, чтобы обозначить нанесение отметок на поверхности. Применяется не просто для "написания", но для любых видов нанесения отметок. Здесь идет речь, чтобы существлять физический процесс письма. Для создания композиций используйте {qon:v}.[2; 3] Другой глагол, {gher:v}, используется для создания списков и т.п[4]</column>
       <column name="notes_zh_HK">該動詞用於指示在表面上進行標記的過程。它不僅適用於書寫，而且適用於任何標記。從這個意義上說，“寫作”是指寫作的物理行為，而不是寫作的創作，而是使用{qon:v}。[2; 3]另一個動詞{gher:v}用於列表的彙編等。[4] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo é usado para indicar a realização de marcações em uma superfície. Não se aplica apenas à escrita, mas a qualquer tipo de marcação. "Escrever", neste sentido, refere-se ao ato físico de escrever, e não à criação de composições, para as quais {qon:v} é usado em seu lugar.[2; 3] Outro verbo, {gher:v}, é usado para a compilação de listas e semelhantes.[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään osoittamaan merkintöjen tekeminen pinnalle. Se ei koske vain kirjoittamista, vaan kaikenlaista merkintää. "Kirjoittaminen" tarkoittaa tässä mielessä fyysistä kirjoittamista, ei sävellysten luomista, joihin käytetään sen sijaan {qon:v}. [2; 3] Toista verbiä, {gher:v}, käytetään luetteloiden ja vastaavien kokoamiseen.[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined in {TKD:src} as "write". In {KGT:src}, it was clarified that this meant "engrave, incise, mark (upon)", that is, the phyiscal act of making marks on a surface.
 
 Writing a manuscript takes grit, and may lead to writer's cramp.</column>
@@ -4572,6 +5050,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
 ▶ {ghItlh vIghItlhta'bogh DalaD'a'?:sen:nolink} "Ты прочтешь мою рукопись?"[1, стр.172]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4579,6 +5058,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 2.4, p.18, Dec. 1993:src}, [3] {KGT p.79:src}, [4] {s.k 1998.07.09:src} (reprinted in {HQ 8.1, p.8, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -4592,6 +5072,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="definition_ru">среда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星期三</column>
       <column name="definition_pt">Quarta-feira</column>
+      <column name="definition_fi">keskiviikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hogh:n}</column>
@@ -4602,6 +5083,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This refers to a line in "Lady Madonna" by The Beatles: "Wednesday morning papers didn't come."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4611,6 +5093,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4618,6 +5101,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -4631,6 +5115,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="definition_ru">система письма [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">寫作系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sistema de escrita</column>
+      <column name="definition_fi">kirjoitusjärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIqaD:n}, {ngutlh tu'qom:n}</column>
@@ -4641,6 +5126,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghItlh:v}, {-meH:v}, {Ho'DoS:n}</column>
       <column name="examples"></column>
@@ -4650,6 +5136,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4657,6 +5144,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -4670,6 +5158,7 @@ Writing a manuscript takes grit, and may lead to writer's cramp.</column>
       <column name="definition_ru">стилус, гравер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手寫筆、雕刻師 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estilete, gravador</column>
+      <column name="definition_fi">kynä, kaivertaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4694,6 +5183,9 @@ I {TNK:src} används {ghItlhwI':n:nolink} för "penna" och {ghojmeH ghItlhwI':n:
       <column name="notes_pt">Esta palavra é usada para qualquer instrumento de escrita, bem como para qualquer pessoa que escreve.[1]
 
 Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n:nolink} é usado para "lápis" .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään mihin tahansa kirjoitusvälineeseen sekä kenelle tahansa kirjoittavalle henkilölle.[1]
+
+{TNK:src}: ssa {ghItlhwI':n:nolink}: ta käytetään "kynään" ja {ghojmeH ghItlhwI':n:nolink}: tä "lyijykynään".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The instrument/agent confusion is similar to that for the English word "printer", which can refer either to a device or to a person. This word takes the suffix {-mey:n:suff} when it refers to a device and {-pu':n:suff} when it refers to a person.</column>
       <column name="components">{ghItlh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4703,6 +5195,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pen, pencil</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4710,6 +5203,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.79:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4723,6 +5217,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="definition_ru">конечность (человека) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肢體（一個人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">membro (de uma pessoa)</column>
+      <column name="definition_fi">(henkilön) raaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DeS:n:1}, {'uS:n}</column>
@@ -4733,6 +5228,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="notes_ru">Это человек эквивалент {gham:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這相當於{gham:n}的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é a pessoa equivalente a {gham:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on henkilön {gham:n} henkilövastaava. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">An early translation of the opera {'u':src} used {QIv:n:nolink} or {qIv:n:nolink} (the capitalisation was inconsistent) in the name of a {moQbara':n} technique which involved legs and arms. Marc Okrand wanted this to make sense, but didn't want to make too drastic a change as the singers had already gotten used to singing the line.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4742,6 +5238,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4749,6 +5246,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2010.07.26:src}</column>
     </table>
     <table name="mem">
@@ -4762,6 +5260,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="definition_ru">Гбой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《G'boj》</column>
       <column name="definition_pt">G'boj</column>
+      <column name="definition_fi">G'boj</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sech:n}</column>
@@ -4772,6 +5271,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="notes_ru">Существует идиома {wov; ghI'boj Sech rur@@wov:v, ghI'boj:n, Sech:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{wov; ghI'boj Sech rur@@wov:v, ghI'boj:n, Sech:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {wov; ghI'boj Sech rur@@wov:v, ghI'boj:n, Sech:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {wov; ghI'boj Sech rur@@wov:v, ghI'boj:n, Sech:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4781,6 +5281,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4788,6 +5289,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4801,6 +5303,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="definition_ru">повелительное наклонение:ты(действие)-нам, вы(множественное число)(дейтсвие)-нам, вы(единственное число)-нам</column>
       <column name="definition_zh_HK">（命令）你、你們：我們</column>
       <column name="definition_pt">imperativo: você-nós, vocês-nós</column>
+      <column name="definition_fi">imperatiivi: sinä-meitä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ju-:v:pref}, {che-:v:pref}</column>
@@ -4813,6 +5316,8 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
 {tlhIH:n}:{maH:n:1h} = {gho-:v:pref,nolink} (пов.накл.)</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SoH:n}: {maH:n:1h} = {gho-:v:pref,nolink} (imp.)
+{tlhIH:n}: {maH:n:1h} = {gho-:v:pref,nolink} (imp.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4822,6 +5327,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4829,6 +5335,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4842,6 +5349,7 @@ Em {TNK:src}, {ghItlhwI':n:nolink} é usado para "caneta" e {ghojmeH ghItlhwI':n
       <column name="definition_ru">круг, обруч</column>
       <column name="definition_zh_HK">圈、箍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">círculo, aro</column>
+      <column name="definition_fi">ympyrä, kehä, piiri, rengas, vanne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meyrI':n}, {rutlh:n}, {rutlh:v}, {qa'vaQ:n}, {yergho:n}</column>
@@ -4866,6 +5374,9 @@ Det finns 243 {lawmey:n:nolink} i en {gho:n:nolink} eller 360 {lawrI'mey:n:nolin
       <column name="notes_pt">Existe um idioma, {vIHtaH gho:sen}.
 
 Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. (Consulte {law:n} e {lawrI':n}.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {vIHtaH gho:sen}.
+
+{gho:n:nolink}: ssa on 243 {lawmey:n:nolink}: ta tai 360 {lawrI'mey:n:nolink}: ssä. (Katso {law:n} ja {lawrI':n}.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4877,6 +5388,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
 ▶ {meyrI'Daq 'oHtaH gho'e':sen:nolink} "Круг в квадрате."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4884,6 +5396,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {qep'a' 12 (2005):src}</column>
     </table>
         <table name="mem">
@@ -4897,6 +5410,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="definition_ru">овальный [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">橢圓</column>
           <column name="definition_pt">oval</column>
+      <column name="definition_fi">soikio</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4907,6 +5421,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{gho:n}, {lang:v}</column>
           <column name="examples"></column>
@@ -4916,6 +5431,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4923,6 +5439,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -4936,6 +5453,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="definition_ru">скоросшиватель, тетрадь [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">活頁夾、筆記本 [AUTOTRANSLATED]</column>
           <column name="definition_pt">fichário, caderno</column>
+      <column name="definition_fi">kansio, muistikirja</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4946,6 +5464,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="notes_ru">Это относится не к переплетенной тетради, а скорее к переплету звонков, в который можно добавлять бумаги и извлекать их. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這不是指裝訂的筆記本，而是指可以在其中添加紙張並將其取出的鈴聲活頁夾。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso não se refere a um caderno encadernado, mas a um fichário de campainha ao qual se pode adicionar papéis e tirá-los. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei tarkoita sidottua muistikirjaa, vaan pikemminkin soittoääniä, johon voidaan lisätä papereita ja ottaa ne pois. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{gho:n}, {paq:n:1}</column>
           <column name="examples"></column>
@@ -4955,6 +5474,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4962,6 +5482,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
         </table>
         <table name="mem">
@@ -4975,6 +5496,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="definition_ru">число Пи [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">pi [AUTOTRANSLATED]</column>
           <column name="definition_pt">pi (constante matemática)</column>
+      <column name="definition_fi">pii (matemaattinen vakio)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{bav:n}, {juch:v}</column>
@@ -4985,6 +5507,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="notes_ru">Это иногда сокращается до {ghomaH:n}. Обратите внимание также на {bav:n} "окружность". Для «диаметра» используйте {juch:v} «иметь ширину». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">有時有時縮寫為{ghomaH:n}。另請注意{bav:n}“周長”。對於“直徑”，請使用{juch:v}“寬度為”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Às vezes, isso é reduzido para {ghomaH:n}. Observe também {bav:n} "circunferência". Para "diâmetro", use {juch:v} "com largura de". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lyhennetään joskus {ghomaH:n}-muotoon. Huomaa myös {bav:n} "ympärysmitta". Käytä halkaisijaa varten {juch:v}: n "leveys on". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -4994,6 +5517,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5001,6 +5525,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -5014,6 +5539,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="definition_ru">цилиндр [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">圓柱</column>
           <column name="definition_pt">cilindro</column>
+      <column name="definition_fi">sylinteri</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{gho 'Impey':n}</column>
@@ -5024,6 +5550,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="notes_ru">Это слово относится к геометрической фигуре. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這個詞指的是幾何圖形。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esta palavra se refere à figura geométrica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa geometriseen kuvioon. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{gho:n}, {tut:n:2}</column>
           <column name="examples"></column>
@@ -5033,6 +5560,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5040,6 +5568,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
         </table>
         <table name="mem">
@@ -5053,6 +5582,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="definition_ru">конус [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">圓錐體</column>
           <column name="definition_pt">cone</column>
+      <column name="definition_fi">kartio</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{gho tut:n}</column>
@@ -5063,6 +5593,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="notes_ru">Это слово относится к геометрической фигуре. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這個詞指的是幾何圖形。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esta palavra se refere à figura geométrica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa geometriseen kuvioon. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{gho:n}, {'Impey':n}</column>
           <column name="examples"></column>
@@ -5072,6 +5603,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5079,6 +5611,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
         </table>
     <table name="mem">
@@ -5092,6 +5625,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
       <column name="definition_ru">этика, добродетель</column>
       <column name="definition_zh_HK">道德、美德</column>
       <column name="definition_pt">ética, virtude</column>
+      <column name="definition_fi">etiikka, moraali, hyve</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5102,6 +5636,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
       <column name="notes_ru">Вероятно, что это обозначение слова, что является омофоном для глагола для осуществления битвы или ведения войны</column>
       <column name="notes_zh_HK">此詞與進行戰鬥或發動戰爭的動詞同音可能很重要（{ghob:v}）.[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">É provavelmente significativo que esta palavra seja homófona com o verbo para fazer batalha ou travar guerra ({ghob:v}) .[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On todennäköisesti merkittävää, että tämä sana on homofoninen taistelua tai sotaa käyvän verbin kanssa ({ghob:v}).[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5113,6 +5648,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5120,6 +5656,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {TKW p.vii:src}</column>
     </table>
     <table name="mem">
@@ -5133,6 +5670,7 @@ Existem 243 {lawmey:n:nolink} em um {gho:n:nolink} ou 360 {lawrI'mey:n:nolink}. 
       <column name="definition_ru">сражаться, бороться, вести битву, вести войну</column>
       <column name="definition_zh_HK">戰鬥、發動戰爭</column>
       <column name="definition_pt">lutar, batalhar, travar uma guerra</column>
+      <column name="definition_fi">kamppailla, taistella, käydä sotaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{may':n}, {noH:n}</column>
@@ -5171,6 +5709,11 @@ I stigande graden av våldsamhet är de verb som används för att beskriva mili
 É provavelmente significativo que esta palavra seja homófona com a palavra para ética ou virtude ({ghob:n}) .[2]
 
 Em ordem crescente de ferocidade, os verbos usados ​​para descrever confrontos militares são: {Qor:v}, {tlhaS:v}, {vay:v}, {lul:v}, {Hargh:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi viittaa konkreettiseen taisteluun. Katso sodan käymisen käsite {Qoj:v}.
+
+On luultavasti merkittävää, että tämä sana on homofoninen etiikkaa tai hyveitä koskevan sanan kanssa ({ghob:n}).
+
+Armeijan nousevassa järjestyksessä sotilaallisia yhteenottoja kuvaavia verbejä ovat: {Qor:v}, {tlhaS:v}, {vay:v}, {lul:v}, {Hargh:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5181,6 +5724,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5188,6 +5732,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {TKW p.vii:src}</column>
     </table>
     <table name="mem">
@@ -5201,6 +5746,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="definition_ru">Не нужно наслаждаться добродетелью. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">人們不需要享受美德。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Não é preciso desfrutar da virtude.</column>
+      <column name="definition_fi">Hyveellisyydestä ei tarvitse nauttia.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5211,6 +5757,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5220,6 +5767,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5227,6 +5775,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.48:src}</column>
     </table>
     <table name="mem">
@@ -5240,6 +5789,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="definition_ru">Братья сражаются друг с другом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">兄弟們互相爭鬥</column>
       <column name="definition_pt">Os irmãos lutam entre si</column>
+      <column name="definition_fi">Veljet taistelevat toisiaan vastaan (kuuluisa patsas)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5250,6 +5800,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="notes_ru">Так называется знаменитая статуя, на которой {qeylIS'e' lIjlaHbe'bogh vay':n:name} и {moratlh:n:name} сражаются друг с другом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個著名雕像的名稱，顯示{qeylIS'e' lIjlaHbe'bogh vay':n:name}和{moratlh:n:name}被困在斗爭中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma estátua famosa que mostra {qeylIS'e' lIjlaHbe'bogh vay':n:name} e {moratlh:n:name} travando uma batalha. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kuuluisan patsaan nimi, jossa {qeylIS'e' lIjlaHbe'bogh vay':n:name} ja {moratlh:n:name} on lukittu taisteluun. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghob:v}, {-chuq:v}, {loDnI':n}, {-pu':n}</column>
       <column name="examples"></column>
@@ -5259,6 +5810,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5266,6 +5818,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -5279,6 +5832,7 @@ Em ordem crescente de ferocidade, os verbos usados ​​para descrever confront
       <column name="definition_ru">Нет (ответ на вопрос)</column>
       <column name="definition_zh_HK">不（回答問題） [AUTOTRANSLATED]</column>
       <column name="definition_pt">não (resposta a uma pergunta)</column>
+      <column name="definition_fi">ei (vastaus kyllä/ei-kysymykseen)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{HIja':excl}, {HISlaH:excl}</column>
       <column name="see_also">{-'a':v:suff}, {Qo':excl}</column>
@@ -5303,6 +5857,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [AUTOTRAN
       <column name="notes_pt">Esta é a resposta negativa a uma pergunta sim / não (consulte {-'a':v}). Ao contrário da palavra "não" em inglês, não é usada como uma exclamação autônoma indicando recusa, descrença e assim por diante (para ver os quais consulte {Qo':excl}).
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kielteinen vastaus kyllä ​​/ ei-kysymykseen (katso {-'a':v}). Toisin kuin englanninkielinen sana "ei", sitä ei käytetä itsenäisenä huutomerkkinä, joka osoittaa kieltäytymistä, epäuskoa ja niin edelleen (katso {Qo':excl}).
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5312,6 +5869,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5319,6 +5877,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5332,6 +5891,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Получатель, пункт назначения</column>
       <column name="definition_zh_HK">目的地</column>
       <column name="definition_pt">Destino, destino de viagem</column>
+      <column name="definition_fi">määränpää, kohde</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leng:v}, {tlheD:v}</column>
@@ -5342,6 +5902,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5351,6 +5912,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5358,6 +5920,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5371,6 +5934,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">выслеживать, отслеживать</column>
       <column name="definition_zh_HK">跟踪、追踪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">seguir, rastrear</column>
+      <column name="definition_fi">jäljittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlha':v}, {DoS:n}</column>
@@ -5381,6 +5945,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5390,6 +5955,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5397,6 +5963,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5410,6 +5977,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Созвездие "Охотник"</column>
       <column name="definition_zh_HK">「追踪者」星座</column>
       <column name="definition_pt">a constelação "Tracker"</column>
+      <column name="definition_fi">Jäljittäjä-tähtikuvio?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'retlh:n:place}, {Hov lat:n}, {Dotrar:n}</column>
@@ -5420,6 +5988,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">{qeylIS'e' lIjlaHbe'bogh vay':n:name} предсказывал, что он вернется сюда.</column>
       <column name="notes_zh_HK">{qeylIS'e' lIjlaHbe'bogh vay':n:name}預言他會返回那裡。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">{qeylIS'e' lIjlaHbe'bogh vay':n:name} profetizou que voltaria para lá. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{qeylIS'e' lIjlaHbe'bogh vay':n:name} ennusti palaavansa sinne. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghoch:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5429,6 +5998,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Tracker</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5436,6 +6006,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru">Охотник, следопыт</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -5449,6 +6020,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">начинять, набивать, заполнять</column>
       <column name="definition_zh_HK">東東 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estofar</column>
+      <column name="definition_fi">täyttää, pakata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{teb:v}, {ngaS:v}, {buy':v}, {qorgh:v}, {tlhut:v}</column>
@@ -5459,6 +6031,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Используется, чтобы описать, как вещи помещаются внутрь рюкзака или мешка, но с незаканчивающимся свободным местом, которое могло бы {qorgh:v}.</column>
       <column name="notes_zh_HK">這用於將東西放入背包或枕頭袋中，但不阻止開口，這將是{qorgh:v}.[2]。它也不適用於動物標本剝制術或毛絨動物，請參見{tlhut:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É usado para colocar coisas dentro de uma mochila ou almofada, mas não obstruindo uma abertura, que seria {qorgh:v}.[2] Também não é usado para taxidermia ou bichos de pelúcia, para os quais ver {tlhut:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään tavaroiden asettamiseen reppuun tai tyynypussiin, mutta ei pysäyttämällä aukkoa, mikä olisi {qorgh:v}.[2]. Sitä ei myöskään käytetä taksidermiaan tai pehmoleluihin, joista ks. {tlhut:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5470,6 +6043,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5477,6 +6051,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2013:src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -5490,6 +6065,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">голос</column>
       <column name="definition_zh_HK">語音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">voz</column>
+      <column name="definition_fi">(jonkun) ääni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIch:n}, {wab:n}, {Ham:v}, {pun:v}, {ghugh:v}</column>
@@ -5500,6 +6076,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Смотрите в {QIch wab Ho'DoS:n} названия согласных и гласных клингонов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關克林崗輔音和元音的名稱，請參見{QIch wab Ho'DoS:n}下的內容。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {QIch wab Ho'DoS:n} os nomes das consoantes e vogais klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {QIch wab Ho'DoS:n}-kohdasta Klingonin konsonanttien ja vokaalien nimet. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5509,6 +6086,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5516,6 +6094,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5529,6 +6108,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">телефон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">電話</column>
       <column name="definition_pt">telefone</column>
+      <column name="definition_fi">puhelin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nav HablI':n}, {nuq mI'lIj?:sen}, {qoqyoq:n:hyp}</column>
@@ -5539,6 +6119,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Some people have taken to referring to mobile phones using {ghogh HablI' qenglu'bogh:n:nolink}. Context should make it clear if {ghogh HablI':n:nolink} refers to a mobile device.</column>
       <column name="components">{ghogh:n}, {HablI':n}</column>
       <column name="examples"></column>
@@ -5548,6 +6129,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">phone, mobile phone</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5555,6 +6137,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.2, p.20, Jun. 1996:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5568,6 +6151,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Счет, запрос оплаты</column>
       <column name="definition_zh_HK">賬單、付款請求 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conta, fatura, solicitação de pagamento</column>
+      <column name="definition_fi">lasku, maksupyyntö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qav'ap:n}, {wel:v}</column>
@@ -5578,6 +6162,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Invoice". ({ghogh:n} is "voice" and {'ot:n} is the letter "o".)</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5587,6 +6172,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">invoice</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5594,6 +6180,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5607,6 +6194,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">аргументировать, вести спор</column>
       <column name="definition_zh_HK">辯論、爭執 [AUTOTRANSLATED]</column>
       <column name="definition_pt">discutir, disputar</column>
+      <column name="definition_fi">väittää, kiistää?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngach:v}, {tlhoch:v}, {pon:v}, {Sol:v}</column>
@@ -5617,6 +6205,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Идиома {jop 'ej way':sen:idiom} выражает похожую мысль.[2]</column>
       <column name="notes_zh_HK">成語{jop 'ej way':sen:idiom}表示類似的想法。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O idioma {jop 'ej way':sen:idiom} expressa uma ideia semelhante.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Idioomi {jop 'ej way':sen:idiom} ilmaisee samanlaisen idean.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5626,6 +6215,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5633,6 +6223,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.115:src}</column>
     </table>
     <table name="mem">
@@ -5646,6 +6237,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">учиться, обучаться</column>
       <column name="definition_zh_HK">學習</column>
       <column name="definition_pt">aprender</column>
+      <column name="definition_fi">oppia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaD:v}, {DuSaQ:n}, {paQDI'norgh:n}</column>
@@ -5656,6 +6248,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5665,6 +6258,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5672,6 +6266,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5685,6 +6280,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Урок</column>
       <column name="definition_zh_HK">課</column>
       <column name="definition_pt">lição</column>
+      <column name="definition_fi">oppitunti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5695,6 +6291,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Это относится к уроку, наподобие того, что в тетради или в учебнике. Слово нельзя использовать в выражениях, наподобие "Пусть это будет тебе уроком!". Для подобных слов смотрите {ghuH:n}. Также может быть использовано, чтобы сказать "руководство о ..." {X ghojmeH mIw:n:nolink}.</column>
       <column name="notes_zh_HK">這是一本課本，就像在教科書中一樣，並不是“讓這對您來說就是一課！”（{ghuH:n}）。它也可以用來表示“關於X的教程”，例如{X ghojmeH mIw:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma lição como em um livro didático, e não no sentido de "Que isso seja uma lição para você!", Que é {ghuH:n}. Também pode ser usado para expressar "tutorial sobre X", como {X ghojmeH mIw:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on oppitunti kuten oppikirjassa, eikä merkityksessä "Olkoon tämä sinulle oppitunti!", Joka on {ghuH:n}. Sitä voidaan käyttää myös ilmaisemaan "opetusohjelma X: stä" {X ghojmeH mIw:n:nolink}-muodossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghoj:v}, {-meH:v}, {mIw:n}</column>
       <column name="examples"></column>
@@ -5704,6 +6301,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tutorial</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5711,6 +6309,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -5724,6 +6323,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">нож для мальчика [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">練習刀</column>
       <column name="definition_pt">faca de treino</column>
+      <column name="definition_fi">harjoitteluveitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5734,6 +6334,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Это буквально «нож для обучения». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這實際上是“學習刀”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é literalmente "faca para aprender". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjaimellisesti "veitsi oppimiseen". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Despite the fact that the given definition is "boy's knife", the Klingon expression has nothing to do with boys. It just happened to be the case that the protagonist of {KCD:src} was a young man.</column>
       <column name="components">{ghoj:v}, {-meH:v}, {taj:n}</column>
       <column name="examples"></column>
@@ -5743,6 +6344,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5750,6 +6352,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -5763,6 +6366,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">учить, обучать</column>
       <column name="definition_zh_HK">教導、指導</column>
       <column name="definition_pt">ensinar, instruir</column>
+      <column name="definition_fi">opettaa jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoj:v}</column>
@@ -5773,6 +6377,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Смотрите {qawmoH:v} как пример того, как использовать глагол, подобный этому.</column>
       <column name="notes_zh_HK">有關如何使用此類動詞的示例，請參見{qawmoH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja {qawmoH:v} para um exemplo de como usar um verbo como este. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {qawmoH:v} esimerkki siitä, miten tämän kaltaista verbiä käytetään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghoj:v}, {-moH:v}</column>
       <column name="examples">
@@ -5783,6 +6388,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5790,6 +6396,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -5803,6 +6410,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">учитель, наставник</column>
       <column name="definition_zh_HK">老師、教師</column>
       <column name="definition_pt">professor, mentor</column>
+      <column name="definition_fi">opettaja, mentori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'a'ghen:n}, {tel'em:n}</column>
@@ -5813,6 +6421,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Наиболее почитаемый учитель или учитель рангом выше, чем остальные учителя в том же учреждении - {ghojmoHwI' quv@@ghojmoHwI':n, quv:v} или {ghojmoHwI' Han@@ghojmoHwI':n, Han:v}. Возможно, что наивысшая ступень всего этого - {'a'ghen:n:nolink}.[2]</column>
       <column name="notes_zh_HK">一位受人尊敬的教師，其職位要比同一機構中的其他教師高，可以是{ghojmoHwI' quv@@ghojmoHwI':n, quv:v}或{ghojmoHwI' Han@@ghojmoHwI':n, Han:v}。排名最高的可能是{'a'ghen:n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um professor de alta estima, com uma classificação mais alta do que outros professores da mesma instituição, poderia ser {ghojmoHwI' quv@@ghojmoHwI':n, quv:v} ou {ghojmoHwI' Han@@ghojmoHwI':n, Han:v}. Provavelmente, a posição mais alta de todas é um {'a'ghen:n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Korkeasti arvostettu opettaja, joka on korkeampi kuin muut saman oppilaitoksen opettajat, voi olla {ghojmoHwI' quv@@ghojmoHwI':n, quv:v} tai {ghojmoHwI' Han@@ghojmoHwI':n, Han:v}. Todennäköisesti kaikkien korkein asema on {'a'ghen:n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghoj:v}, {-moH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5822,6 +6431,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5829,6 +6439,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5842,6 +6453,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">медсестра, няня, гувернантка</column>
       <column name="definition_zh_HK">護士、保姆、家庭教師 [AUTOTRANSLATED]</column>
       <column name="definition_pt">enfermeira, babá, governanta</column>
+      <column name="definition_fi">sairaanhoitaja, lastenhoitaja, kotiopettaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5852,6 +6464,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This seems to be composed of {ghoj:v} and {moq:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5861,6 +6474,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5868,6 +6482,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5881,6 +6496,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">студент</column>
       <column name="definition_zh_HK">學生</column>
       <column name="definition_pt">estudante, aluno, aprendiz</column>
+      <column name="definition_fi">opiskelija, oppilas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5891,6 +6507,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghoj:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5900,6 +6517,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5907,6 +6525,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5920,6 +6539,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Заботьтесь о ваших студентах</column>
       <column name="definition_zh_HK">關心你的學生。</column>
       <column name="definition_pt">Preocupe-se com seus alunos.</column>
+      <column name="definition_fi">Välitä opiskelijoistasi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5930,6 +6550,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5939,6 +6560,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5946,6 +6568,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.199:src}</column>
     </table>
     <table name="mem">
@@ -5959,6 +6582,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">оппонент, соперник</column>
       <column name="definition_zh_HK">對手、敵手</column>
       <column name="definition_pt">oponente, adversário</column>
+      <column name="definition_fi">vastustaja</column>
       <column name="synonyms">{jagh:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5969,6 +6593,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Goal".</column>
       <column name="components"></column>
       <column name="examples">
@@ -5980,6 +6605,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
 ▶ {ngIq gholvo' wa'maH QaS yItlhap.:sen:nolink} "Соберите 10 военнослужащих с каждого игрока."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">player</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5987,6 +6613,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6000,6 +6627,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">расслаиваться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">薄片 [AUTOTRANSLATED]</column>
       <column name="definition_pt">floco</column>
+      <column name="definition_fi">hiutale</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6010,6 +6638,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Kellogg"'s Corn Flakes.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6019,6 +6648,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6026,6 +6656,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6039,6 +6670,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">банда, группа, отряд</column>
       <column name="definition_zh_HK">樂隊、團體、派對 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bando, grupo, partido</column>
+      <column name="definition_fi">ryhmä, joukko, seurue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghom:v}, {tlhach:n}, {Hoq:n}, {boq:n:1}, {DIvI':n}, {qev:n}, {DaH:n}, {ghom'a':n}, {tlhoQ:n}</column>
@@ -6049,6 +6681,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">僅用於人群。 （單詞“ {mu'ghom:n}”是一個例外。）[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado apenas para grupos de pessoas. (A palavra {mu'ghom:n} é uma exceção.)[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään vain ihmisryhmille. (Sana {mu'ghom:n} on poikkeus.) [3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6058,6 +6691,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">team</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6065,6 +6699,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru">команда</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6079,6 +6714,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">встречать, сталкиваться, встретиться неожиданно, собираться</column>
       <column name="definition_zh_HK">相遇、相遇、聚會、約會 [AUTOTRANSLATED]</column>
       <column name="definition_pt">reunir, encontrar</column>
+      <column name="definition_fi">tavata, kohdata, kokoontua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghomHa':v}</column>
       <column name="see_also">{qIH:v}, {pIH:v:1}, {ghom:n}, {vaS:n}, {tlhop:n:2}</column>
@@ -6089,6 +6725,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Этот глагол может использоваться как с глаголом, так и без него. Если есть объект, тогда субъект встречает объект. Если нет объекта, тогда субъекты собираются или встречаются друг с другом.[2]</column>
       <column name="notes_zh_HK">該動詞可以與或不與賓語一起使用。如果有一個對象，則表明該對象正在遇到該對象。如果沒有任何物體，則各主體彼此聚集或相遇。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo pode ser usado com ou sem um objeto. Se houver um objeto, o assunto está encontrando o objeto. Se não houver objeto, os sujeitos estão se reunindo ou se encontrando.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä voidaan käyttää objektin kanssa tai ilman. Jos objektia on, kohde tapaa objektin. Jos kohdetta ei ole, koehenkilöt kokoontuvat tai kohtaavat toisiaan[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6101,6 +6738,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rendez-vous</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6108,6 +6746,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru">рандеву</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.11, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -6121,6 +6760,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">рассеивать, разбросать, разбрасывать, расходиться</column>
       <column name="definition_zh_HK">分散</column>
       <column name="definition_pt">espalhar, dispersar</column>
+      <column name="definition_fi">hajaantua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghom:v}</column>
       <column name="see_also">{rItHa':v}, {peD:v}, {ghomHa'!:sen}</column>
@@ -6131,6 +6771,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghom:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -6140,6 +6781,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6147,6 +6789,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6160,6 +6803,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">площадь, двор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">廣場、庭院</column>
       <column name="definition_pt">praça, pátio</column>
+      <column name="definition_fi">tori, aukio, piha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6170,6 +6814,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghom:v}, {-meH:v}, {yotlh:n}</column>
       <column name="examples"></column>
@@ -6179,6 +6824,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6186,6 +6832,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6199,6 +6846,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">толпа</column>
       <column name="definition_zh_HK">人群、大眾</column>
       <column name="definition_pt">multidão</column>
+      <column name="definition_fi">väkijoukko</column>
       <column name="synonyms">{qev:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{qev:v}, {qabDu' law':n:idiom}, {Dojmey:n}</column>
@@ -6209,6 +6857,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghom:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -6218,6 +6867,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6225,6 +6875,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6238,6 +6889,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">реестр, дежурный список [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">名冊、職務名冊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">escala de serviço</column>
+      <column name="definition_fi">työvuorolista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qu' poH:n}</column>
@@ -6248,6 +6900,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Это относится к дежурному списку на клингонском корабле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指Klingon船上的值班名冊。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto se refere à escala de serviço em uma nave klingon.</column>
+      <column name="notes_fi">Tämä viittaa Klingon-aluksen työvuorolistaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghom:n}, {ngoy':v}</column>
       <column name="examples"></column>
@@ -6257,6 +6910,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6264,6 +6918,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Haynes BoP Manual p.110:src}</column>
     </table>
     <table name="mem">
@@ -6277,6 +6932,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">{gho SubmaH:n}</column>
       <column name="definition_zh_HK">{gho SubmaH:n}</column>
       <column name="definition_pt">{gho SubmaH:n}</column>
+      <column name="definition_fi">{gho SubmaH:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6287,6 +6943,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6296,6 +6953,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6303,6 +6961,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6316,6 +6975,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">блеск, блеск [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">閃閃發光</column>
       <column name="definition_pt">cintilar, brilhar</column>
+      <column name="definition_fi">kimaltaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pan:v:1}, {bar:v}</column>
@@ -6326,6 +6986,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6335,6 +6996,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6342,6 +7004,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -6355,6 +7018,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">тип ножа (тонкое лезвие) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刀型（細長刀片） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de faca (lâmina fina)</column>
+      <column name="definition_fi">eräs kapea/ohut veitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taj:n}</column>
@@ -6365,6 +7029,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6374,6 +7039,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6381,6 +7047,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6394,6 +7061,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">злоупотребление</column>
       <column name="definition_zh_HK">濫用 [AUTOTRANSLATED]</column>
       <column name="definition_pt">abusar</column>
+      <column name="definition_fi">väärinkäyttö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghong:v}</column>
@@ -6404,6 +7072,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6413,6 +7082,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6420,6 +7090,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6433,6 +7104,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">злоупотреблять</column>
       <column name="definition_zh_HK">濫用 [AUTOTRANSLATED]</column>
       <column name="definition_pt">abusar, explorar</column>
+      <column name="definition_fi">käyttää väärin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghong:n}</column>
@@ -6443,6 +7115,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Это относится к жестокому обращению или эксплуатации, но не относится к физическому насилию.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指虐待或剝削，但不是指身體虐待。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a abuso ou exploração, mas não se refere a abuso físico.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa väärinkäyttöön tai hyväksikäyttöön, mutta ei tarkoita fyysistä hyväksikäyttöä[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "abuse" in {TKD:src}, and expanded to include "exploit" at {qep'a' 26 (2019):src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6452,6 +7125,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6459,6 +7133,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -6472,6 +7147,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">рука</column>
       <column name="definition_zh_HK">手</column>
       <column name="definition_pt">mão</column>
+      <column name="definition_fi">käsi, kämmen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ro':n}, {ghIt:n:1}, {qam:n}, {namwech:n}, {pogh:n}</column>
@@ -6482,6 +7158,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Части руки(о которой здесь упоминается) включают в себя {toch:n} "ладонь", {chap:n} "заднюю сторону (руки)", and {nItlh:n} "палец(цы)" (включая большой палец). Рука прикреплена к {DeS:n:1} "кисти руки" через {yeb:n:1} "запястье".</column>
       <column name="notes_zh_HK">一隻手的部分包括其{toch:n}“手掌”，{chap:n}“手背”和{nItlh:n}“手指”（包括拇指）。手通過{yeb:n:1}“手腕”連接到{DeS:n:1}“手臂”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">As partes de uma mão incluem seu {toch:n} "palma", {chap:n} "dorso (da mão)" e {nItlh:n} "dedo (s)" (incluindo o polegar). A mão é presa ao "braço" do {DeS:n:1} através do "pulso" do {yeb:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Käden osiin kuuluvat sen {toch:n} "kämmen", {chap:n} "takaosa (käden)" ja {nItlh:n} "sormet (sormet)" (peukalo mukaan lukien). Käsi on kiinnitetty {DeS:n:1} "käsivarteen" {yeb:n:1} "ranteen" kautta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Something you "grope" with. The reverse of this is {pogh:n}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6492,6 +7169,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6499,6 +7177,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -6512,6 +7191,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
           <column name="definition_ru">своего рода клинок [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">一種刀片 [AUTOTRANSLATED]</column>
           <column name="definition_pt">uma espécie de lâmina</column>
+      <column name="definition_fi">eräs teräase</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nuH bey':n}</column>
@@ -6522,6 +7202,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
           <column name="notes_ru">Это один из элементов, традиционно отображаемых на {nuH bey':n}. Это устройство для потрошения, используемое в балансе со щитом.[1] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是傳統上顯示在{nuH bey':n}上的項目之一。這是一種與盾牌平衡使用的灌腸裝置.[1] [AUTOTRANSLATED]</column>
           <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on yksi tavaroista, jotka perinteisesti näytetään {nuH bey':n}-tiedostossa. Se on suolenpoistolaite, jota käytetään tasapainossa suojan kanssa.[1] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{ghop:n}, {'etlh:n}</column>
           <column name="examples"></column>
@@ -6531,6 +7212,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6538,6 +7220,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KCD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
         </table>
     <table name="mem">
@@ -6551,6 +7234,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">астеройд</column>
       <column name="definition_zh_HK">小行星</column>
       <column name="definition_pt">asteroide</column>
+      <column name="definition_fi">asteroidi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chunDab:n}, {lIy:n}</column>
@@ -6561,6 +7245,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6570,6 +7255,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6577,6 +7263,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6590,6 +7277,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">шпионить, шпионить за</column>
       <column name="definition_zh_HK">窺探、覷步、暗中監視</column>
       <column name="definition_pt">espiar</column>
+      <column name="definition_fi">vakoilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lInDab:n}</column>
@@ -6600,6 +7288,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined as "spy" in {TKD:src} and as "spy on" in {KGT:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6609,6 +7298,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6616,6 +7306,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6629,6 +7320,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">шпион</column>
       <column name="definition_zh_HK">間諜</column>
       <column name="definition_pt">espião</column>
+      <column name="definition_fi">vakooja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lInDab:n}</column>
@@ -6639,6 +7331,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghoq:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -6648,6 +7341,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6655,6 +7349,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6668,6 +7363,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">будь свежим, будь просто убитым (мясо) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">新鮮、啱啱殺（肉）</column>
       <column name="definition_pt">ser fresco, ser recém morto (carne)</column>
+      <column name="definition_fi">olla tuore, juuri teurastettu (liha)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Soj tlhol:n}, {non:v}</column>
@@ -6678,6 +7374,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Это также относится к словам (см. {mu'mey ghoQ:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也適用於單詞（請參閱{mu'mey ghoQ:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é aplicado a palavras (consulte {mu'mey ghoQ:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sovelletaan myös sanoihin (katso {mu'mey ghoQ:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6687,6 +7384,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6694,6 +7392,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6707,6 +7406,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">быть самым последним [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">最近 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser mais recente</column>
+      <column name="definition_fi">olla viimeisin, olla tuorein</column>
       <column name="synonyms">{ret:v}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6717,6 +7417,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6726,6 +7427,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6733,6 +7435,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6746,6 +7449,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Помогите нам!</column>
       <column name="definition_zh_HK">挽救我們啊！</column>
       <column name="definition_pt">Ajude-nos!</column>
+      <column name="definition_fi">Auta meitä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6756,6 +7460,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Эта строка говорилась на клингонском языке, но не имела субтитров. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此行在克林崗語中被使用，但沒有字幕。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta linha foi falada em klingon, mas não foi legendada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä rivi puhuttiin Klingonissa, mutta sitä ei tekstitetty. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{gho-:v}, {QaH:v}</column>
       <column name="examples"></column>
@@ -6765,6 +7470,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6772,6 +7478,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -6785,6 +7492,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">ломать, нарушать, взламывать</column>
       <column name="definition_zh_HK">打破、突破、粉破、破壞</column>
       <column name="definition_pt">quebrar</column>
+      <column name="definition_fi">rikkoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIH:v:1}, {wItlh:v}</column>
@@ -6795,6 +7503,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Gore".</column>
       <column name="components"></column>
       <column name="examples">
@@ -6806,6 +7515,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6813,6 +7523,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <!-- Note that {ghor:n:2} is in the "extra" section. -->
@@ -6827,6 +7538,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Поверхность (планеты)</column>
       <column name="definition_zh_HK">星球的表面 </column>
       <column name="definition_pt">superfície (de um planeta)</column>
+      <column name="definition_fi">(planeetan) pinta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chal:n}, {muD:n:1}, {yav:n}, {bIQ beb:n}</column>
@@ -6837,6 +7549,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6846,6 +7559,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6853,6 +7567,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6866,6 +7581,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Когда?</column>
       <column name="definition_zh_HK">何時？</column>
       <column name="definition_pt">quando?</column>
+      <column name="definition_fi">milloin?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'arlogh Qoylu'pu'?:sen}</column>
@@ -6876,6 +7592,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6885,6 +7602,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6892,6 +7610,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.4:src}</column>
     </table>
     <table name="mem">
@@ -6905,6 +7624,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Когда мы уйдём?</column>
       <column name="definition_zh_HK">我們什麼時候離開？</column>
       <column name="definition_pt">Quando partimos?</column>
+      <column name="definition_fi">Milloin lähdemme?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6915,6 +7635,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6924,6 +7645,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6931,6 +7653,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -6944,6 +7667,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Когда вода станет горячей?</column>
       <column name="definition_zh_HK">水什麼時候會變咗熱？</column>
       <column name="definition_pt">Quando a água estará quente?</column>
+      <column name="definition_fi">Milloin vesi on kuumaa?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6954,6 +7678,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6963,6 +7688,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6970,6 +7696,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -6983,6 +7710,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Гормагандер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《gormagander》（太空鯨魚）</column>
       <column name="definition_pt">gormagander</column>
+      <column name="definition_fi">eräs eläin, gormagander</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh ghotI''a':n}</column>
@@ -6993,6 +7721,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="notes_ru">Это существо также называют «космический кит». Это заимствованное слово из другого языка. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種生物，也稱為“太空鯨魚”。這是另一種語言的外來詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma criatura também conhecida como "baleia espacial". Esta é uma palavra de empréstimo de outro idioma. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on olento, jota kutsutaan myös "avaruusvalaaksi". Tämä on laina toisesta kielestä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7002,6 +7731,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7009,6 +7739,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Magic to Make the Sanest Man Go Mad:src}</column>
     </table>
     <table name="mem">
@@ -7022,6 +7753,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/7_rXiSTQmAE} [A
       <column name="definition_ru">Горкон (имя одного из канцлеров)</column>
       <column name="definition_zh_HK">「戈爾康」（首相）</column>
       <column name="definition_pt">Gorkon (Chancellor)</column>
+      <column name="definition_fi">Gorkon (kansleri)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7046,6 +7778,9 @@ En av hans legendariska föregångare kallades också "Gorkon", men namnet uttal
       <column name="notes_pt">O chanceler Gorkon ({ghorqan Qang:n:nolink}) tentou fazer as pazes com a Federação na época de Kirk. Ele foi traído pelo General Chang (ver {cheng:n:name}).
 
 Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o nome foi pronunciado {ghorqon:n:name} durante sua época.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kansleri Gorkon ({ghorqan Qang:n:nolink}) yritti tehdä rauhan federaation kanssa Kirkin aikaan. Kenraali Chang petti hänet (katso {cheng:n:name}).
+
+Yksi hänen legendaarisista edeltäjistään nimettiin myös "Gorkoniksi", mutta nimi lausuttiin hänen aikanaan {ghorqon:n:name}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">He appeared in {Star Trek VI:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7055,6 +7790,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7062,6 +7798,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.07.01:src}</column>
     </table>
     <table name="mem">
@@ -7075,6 +7812,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">Горкон (легендарный)</column>
       <column name="definition_zh_HK">「戈爾康」（傳說中的祖先）</column>
       <column name="definition_pt">Gorkon (lendário)</column>
+      <column name="definition_fi">Gorkon (legendaarinen esi-isä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7085,6 +7823,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru">В {Hamlet:src} упоминается не ({ghorqan:n:name}), кто стремился заключить мир с Федерацией, а один из его предков</column>
       <column name="notes_zh_HK">{Hamlet:src}中的提法不是要尋求與聯邦和平的總理（{ghorqan:n:name}），而是他的一位傳奇祖先。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A referência em {Hamlet:src} não é para o Chanceler ({ghorqan:n:name}) que buscou a paz com a Federação, mas para um de seus ancestrais lendários.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Hamlet:src}-viite ei koske liittokanslerille ({ghorqan:n:name}), joka etsi rauhaa federaation kanssa, vaan yhteen hänen legendaarisista esi-isistään.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7094,6 +7833,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7101,6 +7841,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}, [2] {KLI mailing list 2018.07.01:src}</column>
     </table>
     <table name="mem">
@@ -7114,6 +7855,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">Горн [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《Gorn》、蜥蜴人</column>
       <column name="definition_pt">Gorn</column>
+      <column name="definition_fi">eräs laji, gorn</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7124,6 +7866,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7133,6 +7876,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7140,6 +7884,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -7153,6 +7898,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">приближаться, уходить от, приступать, идти, следовать (курсу)</column>
       <column name="definition_zh_HK">接近、離開、繼續、來、跟隨（一門課程） [AUTOTRANSLATED]</column>
       <column name="definition_pt">aproximar-se, afastar-se, prosseguir, vir, seguir (um curso)</column>
+      <column name="definition_fi">lähestyä, tulla (lähemmäksi); etääntyä, mennä pois; jatkaa, seurata (kurssia)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jaH:v}, {chol:v}, {tlha':v}, {Duv:v}, {HeD:v}, {ghoS:v:2}</column>
@@ -7163,6 +7909,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru">Это может означать как "приближение" так и "уходить от", в зависимости от присутствия существительных с суффиксами {-Daq:n} и {-vo':n}. Способ использования {ghoS:v:nolink} и других глаголов, описывающих движение, смотрите в {HQ 7.4:src}[2]. Смотрите {jaH:v} для более подробной информации.</column>
       <column name="notes_zh_HK">根據帶後綴{-Daq:n}和{-vo':n}的名詞的存在，這可能意味著“接近”或“遠離”。 {HQ 7.4:src}[2]中描述了使用{ghoS:v:nolink}和其他移動動詞的方式。有關詳細信息，請參見{jaH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode significar "aproximar-se" ou "afastar-se de" dependendo da presença de substantivos com os sufixos {-Daq:n} e {-vo':n}. A maneira de usar {ghoS:v:nolink} e outros verbos de movimento são descritos em {HQ 7.4:src}[2]. Consulte {jaH:v} para obter detalhes. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi tarkoittaa joko "lähestymistapaa" tai "mennä pois" riippuen substantiivien olemassaolosta, joiden pääte on {-Daq:n} ja {-vo':n}. Tapa käyttää {ghoS:v:nolink} ja muita liikkumisverbejä on kuvattu artikkelissa {HQ 7.4:src}[2]. Katso lisätietoja kohdasta {jaH:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7176,6 +7923,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
 ▶ {He chu' ghoS, DIvI' neHmaH.:sen}</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7183,6 +7931,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.2-12, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -7196,6 +7945,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">толкать, засовывать</column>
       <column name="definition_zh_HK">推力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">impulso</column>
+      <column name="definition_fi">työntää (alusta) eteenpäin?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoS:v:1}</column>
@@ -7206,6 +7956,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7215,6 +7966,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7222,6 +7974,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7235,6 +7988,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">Личность (гуманойд)</column>
       <column name="definition_zh_HK">人（人形） [AUTOTRANSLATED]</column>
       <column name="definition_pt">pessoa (humanoide)</column>
+      <column name="definition_fi">henkilö (humanoidi)</column>
       <column name="synonyms">{nuv:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{Dep:n}, {yoq:n}</column>
@@ -7245,6 +7999,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru">Когда это слово употребляется во множественном числе, оно больше ориентируется на людей, составляющих группу. Таким образом, {ghotpu':n@@ghot:n, -pu':n}, вероятно, будет переведен как «люди» (а не «люди»), но это не является строгим правилом.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">當這個詞為複數形式時，它會更多地關注組成該群體的個人。因此，{ghotpu':n@@ghot:n, -pu':n}可能會翻譯為“人”（而不是“人”），但這不是嚴格的規則。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kun tämä sana on monikko, se keskittyy enemmän ryhmän muodostaviin yksilöihin. Joten {ghotpu':n@@ghot:n, -pu':n} käännetään todennäköisesti "henkilöiksi" (eikä "ihmisiksi"), mutta tämä ei ole tiukka sääntö.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7270,6 +8025,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
    Связь жизни."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">persons</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7277,6 +8033,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.136-137:src}, [3] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -7290,6 +8047,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">личные дела [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">人事檔案 [AUTOTRANSLATED]</column>
       <column name="definition_pt">arquivos de pessoal</column>
+      <column name="definition_fi">henkilöstötiedostot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wey:n}</column>
@@ -7300,6 +8058,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru">Предполагается, что один личный файл будет {ghot ta:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一個人事檔案大概是一個{ghot ta:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um único arquivo pessoal provavelmente seria um {ghot ta:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksi henkilöstötiedosto olisi oletettavasti {ghot ta:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghot:n}, {-pu':n}, {ta:n}, {-mey:n}</column>
       <column name="examples"></column>
@@ -7309,6 +8068,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7316,6 +8076,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -7329,6 +8090,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">рыба, самое общее слово для рыбоподобного существа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">魚、魚類生物最常用的詞</column>
       <column name="definition_pt">peixe, palavra mais geral para criatura parecida com peixe</column>
+      <column name="definition_fi">kala, yleisin sana kalan kaltaiselle olennolle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7339,6 +8101,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru">Каждый {ghotI':n:nolink} является {bIQDep:n}, но не каждый {bIQDep:n:nolink} является {ghotI':n:nolink}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">每個{ghotI':n:nolink}都是{bIQDep:n}，但不是每個{bIQDep:n:nolink}都是{ghotI':n:nolink}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Todo {ghotI':n:nolink} é um {bIQDep:n}, mas nem todo {bIQDep:n:nolink} é um {ghotI':n:nolink}.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jokainen {ghotI':n:nolink} on {bIQDep:n}, mutta jokainen {bIQDep:n:nolink} ei ole {ghotI':n:nolink}.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is based on a joke English spelling for "fish".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7348,6 +8111,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7355,6 +8119,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}, [2] {TNK:src}, [3] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -7368,6 +8133,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">распознавать, узнавать</column>
       <column name="definition_zh_HK">認識 [AUTOTRANSLATED]</column>
       <column name="definition_pt">reconhecer</column>
+      <column name="definition_fi">tunnistaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sov:v}, {tlhoj:v}</column>
@@ -7378,6 +8144,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7387,6 +8154,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7394,6 +8162,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7407,6 +8176,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">наступить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">踩</column>
       <column name="definition_pt">pisar em (alguma coisa)</column>
+      <column name="definition_fi">astua jollekin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qam:n}, {beQmoH:v}, {tap:v}</column>
@@ -7417,6 +8187,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7426,6 +8197,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7433,6 +8205,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7446,6 +8219,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">досветовая скорость</column>
       <column name="definition_zh_HK">亞光速度</column>
       <column name="definition_pt">velocidade sub-luz</column>
+      <column name="definition_fi">alivalonnopeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hong:n}</column>
@@ -7456,6 +8230,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Someone going at sublight speed really needs to "step on" it (see {gho':v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7465,6 +8240,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7472,6 +8248,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7485,6 +8262,7 @@ Um de seus lendários antepassados ​​também foi chamado de "Gorkon", mas o 
       <column name="definition_ru">прыщи, прыщи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">痘痘 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espinha, acne</column>
+      <column name="definition_fi">näppylä, finni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jaqtala':n}</column>
@@ -7509,6 +8287,9 @@ Detta ord är främmande ursprung. Anledningen till att Klingons använder ett f
       <column name="notes_pt">Este é um tipo de mancha ou inflamação da pele que afeta os Klingons no início da puberdade.[1; 2]
 
 Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavra estranha para isso é para colocar alguma distância entre eles e algo considerado embaraçoso.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen ihon tahra tai tulehdus, joka vaikuttaa klingoneihin murrosiän aikana.
+
+Tämä sana on alkuperältään vieras. Syy siihen, miksi Klingonit käyttävät tähän ulkomaalaista sanaa, on asettaa jonkinlainen etäisyys itsensä ja kiusallisen välillä.[1; 2][3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7518,6 +8299,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gorch, pimple</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7525,6 +8307,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek Insurrection:src}, [2] {How to Speak Klingon, p.7:src}, [3] {KLI mailing list 2013.07.29:src}</column>
     </table>
     <table name="mem">
@@ -7538,6 +8321,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">фокус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">魔術技巧 [AUTOTRANSLATED]</column>
       <column name="definition_pt">truque de mágica</column>
+      <column name="definition_fi">taikatemppu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gho''ong Ho'DoS:n}, {mIn yuq:sen}, {'IDnar lIl:sen}</column>
@@ -7548,6 +8332,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{'ong:v} is "cunning", but it's not clear what the {gho':sen:nolink} part is.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7557,6 +8342,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7564,6 +8350,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
 
@@ -7578,6 +8365,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">магическая техника [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">魔術（技巧）技術 [AUTOTRANSLATED]</column>
       <column name="definition_pt">técnica mágica (truque)</column>
+      <column name="definition_fi">taikomistekniikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7588,6 +8376,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{gho''ong:n}, {Ho'DoS:n}</column>
       <column name="examples"></column>
@@ -7597,6 +8386,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">magic technique, magic trick technique</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7604,6 +8394,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
 
@@ -7618,6 +8409,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">младенец</column>
       <column name="definition_zh_HK">寶寶 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bebê</column>
+      <column name="definition_fi">vauva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yatlh:v}, {ghu:n}</column>
@@ -7628,6 +8420,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru">Это слово относится к младенцу и не должно использоваться при обращении к взрослому (кроме случаев, когда целью является оскорбление). В отличие от Стандартов Федерации, называть кого-то «ребенком» в клингоне не является признаком привязанности. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞指的是嬰兒，請勿用於稱呼成年人（除非意圖侮辱他人）。與聯邦標準不同，在克林崗州稱某人為“嬰兒”並不表示有愛心。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se refere a uma criança e não deve ser usada para se dirigir a um adulto (a menos que a intenção seja insultar). Ao contrário do Federation Standard, chamar alguém de "bebê" em Klingon não é sinal de afeto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa imeväiseen, eikä sitä tule käyttää aikuiseen (ellei tarkoituksena ole loukata). Toisin kuin Federation Standardissa, jonkun kutsuminen "vauvaksi" Klingonissa ei ole merkki kiintymyksestä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is probably the sound a Klingon baby makes. Also, "goo".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7637,6 +8430,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7644,6 +8438,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7657,6 +8452,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">бутон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">芽</column>
       <column name="definition_pt">broto</column>
+      <column name="definition_fi">nuppu, silmu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'InSong:n}, {naH:n}</column>
@@ -7667,6 +8463,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru">Это относится к цветку, фрукту или побегу до его развития. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指花朵，果實或嫩芽發育之前。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à flor, fruta ou broto antes que ela se desenvolva.</column>
+      <column name="notes_fi">Tämä viittaa kukkaan, hedelmään tai versoon ennen kuin se kehittyy. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7676,6 +8473,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7683,6 +8481,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -7696,6 +8495,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">первенец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頭生兒</column>
       <column name="definition_pt">primogênito</column>
+      <column name="definition_fi">esikoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wa'DIch:n}</column>
@@ -7706,6 +8506,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7715,6 +8516,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7722,6 +8524,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -7735,6 +8538,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">вокализировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發聲（動物）</column>
       <column name="definition_pt">vocalizar</column>
+      <column name="definition_fi">ääntää, ilmaista, tuottaa ääntä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jatlh:v}, {'Imyagh:excl}, {welwelwel:excl}, {ghughugh:v}, {Qoghogh:v}, {ghogh:n}</column>
@@ -7745,6 +8549,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru">Это относится к звуку, издаваемому животным, но не к речи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指動物發出的聲音，而不是語音。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao som emitido por um animal, mas não à fala. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa eläimen lähettämään ääniin, mutta ei puheeseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7754,6 +8559,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">singen</column>
       <column name="search_tags_fa"></column>
@@ -7761,6 +8567,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -7774,6 +8581,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">рычание [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吠聲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rosnar</column>
+      <column name="definition_fi">murista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghugh:v}, {baQa':excl}</column>
@@ -7784,6 +8592,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7794,6 +8603,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">vocal fry</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7801,6 +8611,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7814,6 +8625,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">тревога</column>
       <column name="definition_zh_HK">警戒</column>
       <column name="definition_pt">alarme</column>
+      <column name="definition_fi">hälytys, varoitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghum:n}, {ghuH:v}</column>
@@ -7824,6 +8636,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru">Это также может означать "урок" в контексте "Пусть это будет тебе уроком!"[2]</column>
       <column name="notes_zh_HK">這也意味著“讓我們為您上課！”[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode significar "lição", no sentido de "Que isso seja uma lição para você!"[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi tarkoittaa myös "oppituntia" merkityksessä "Olkoon tämä oppitunti sinulle!" [2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7833,6 +8646,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">lesson</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7840,6 +8654,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru">урок</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -7853,6 +8668,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">приготовиться к, быть предупрежденным о чем-то</column>
       <column name="definition_zh_HK">準備、警惕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prepare-se, estar alertado para</column>
+      <column name="definition_fi">valmistautua, varautua johonkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeq:v}, {ghuH:n}, {ghuS:v:1}</column>
@@ -7863,6 +8679,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru">Смотрите также суффиксы {-rup:v} и {-beH:v} для обозначения подготовки или готовности.</column>
       <column name="notes_zh_HK">另請參見後綴{-rup:v}和{-beH:v}以指示準備情況或準備情況。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou prontidão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso myös loppuliitteet {-rup:v} ja {-beH:v} valmistelun tai valmiuden osoittamiseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7875,6 +8692,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7882,6 +8700,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7895,6 +8714,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">предупреждать, предостерегать</column>
       <column name="definition_zh_HK">警告</column>
       <column name="definition_pt">alerta, avisar</column>
+      <column name="definition_fi">hälyttää, varoittaa jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghum:v}</column>
@@ -7905,6 +8725,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru">Смотрите {qawmoH:v} для примера того, как использовать глагол, как этот.</column>
       <column name="notes_zh_HK">有關如何使用此類動詞的示例，請參見{qawmoH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja {qawmoH:v} para um exemplo de como usar um verbo como este. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {qawmoH:v} esimerkki siitä, miten tämän kaltaista verbiä käytetään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ghuH:v}, {-moH:v}</column>
       <column name="examples">{ropyaH yIghuHmoH!:sen}</column>
@@ -7914,6 +8735,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7921,6 +8743,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7934,6 +8757,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">шишка (выпуклость) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">凹凸（凸起） [AUTOTRANSLATED]</column>
       <column name="definition_pt">lombada (protuberância)</column>
+      <column name="definition_fi">lommo, kolhu (ulkonema)</column>
       <column name="synonyms">{Su'nIm:n}</column>
       <column name="antonyms">{retlaw:n}</column>
       <column name="see_also">{vIlHom:n}</column>
@@ -7944,6 +8768,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to a poem which has the line: "From ghoulies and ghosties / And long-leggedy beasties / And things that go bump in the night, / Good Lord, deliver us!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7953,6 +8778,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7960,6 +8786,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -7973,6 +8800,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">тревога, сигнал тревоги</column>
       <column name="definition_zh_HK">警報</column>
       <column name="definition_pt">alarme</column>
+      <column name="definition_fi">hälytys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuH:n}, {ghum:v}</column>
@@ -7983,6 +8811,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7992,6 +8821,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7999,6 +8829,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8012,6 +8843,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">поднять тревогу, дать сигнал тревоги</column>
       <column name="definition_zh_HK">報警、發出警報</column>
       <column name="definition_pt">alarmar, soar um alarme</column>
+      <column name="definition_fi">hälyttää, antaa/laukaista hälytys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghum:n}, {ghuHmoH:v}</column>
@@ -8022,6 +8854,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8031,6 +8864,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8038,6 +8872,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8051,6 +8886,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">компьютерная программа</column>
       <column name="definition_zh_HK">程序（電腦） [AUTOTRANSLATED]</column>
       <column name="definition_pt">programar (um computador)</column>
+      <column name="definition_fi">ohjelmoida (tietokone)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{De'wI':n}, {SIm:v}</column>
@@ -8061,6 +8897,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8070,6 +8907,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8077,6 +8915,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8090,6 +8929,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="definition_ru">быть тёплым(температура)</column>
       <column name="definition_zh_HK">溫暖</column>
       <column name="definition_pt">estar morno</column>
+      <column name="definition_fi">olla lämmin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qey':v}, {bIr:v}</column>
       <column name="see_also">{tuj:v}, {Hat:n}, {buj:v}</column>
@@ -8100,6 +8940,7 @@ Esta palavra tem origem estranha. A razão pela qual os Klingons usam uma palavr
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The example makes clear that this word refers to temperature, and not to perception, emotion, or character.
 
 It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the temperature words really are about temperature and not about effect or perception, so that clothing, for example, is not said to be "hot" or "cold" in Klingon.</column>
@@ -8113,6 +8954,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
 ▶ {ghun 'Iw HIq, rap boqrat chej.} "Печень бократа такая же тёплая, как и кровавое вино."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8120,6 +8962,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 13.1, p.8, Mar. 2004:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -8133,6 +8976,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">чек, вексель, вексель (для денежных операций) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">支票，本票，借條（用於貨幣交易） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cheque, nota promissória (para operações monetárias)</column>
+      <column name="definition_fi">sekki, velkakirja (rahansiirtoja varten)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{beylI':n}, {Huch:n}, {Huq:v}, {malja':n}</column>
@@ -8143,6 +8987,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru">Клингоны не очень часто используют подобные вещи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">Klingons不再經常使用這種東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os klingons não usam esse tipo de coisa com muita frequência. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonit eivät enää käytä tällaista asiaa kovin usein. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8152,6 +8997,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cheque</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8159,6 +9005,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -8172,6 +9019,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">быть голодным</column>
       <column name="definition_zh_HK">餓</column>
       <column name="definition_pt">estar faminto, ter fome</column>
+      <column name="definition_fi">olla nälkäinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bor:v}, {'oj:v}, {qagh:n}, {Sop:v}</column>
@@ -8196,6 +9044,9 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_pt">Existe um idioma {ghung; qagh rur@@ghung:v, qagh:n, rur:v}.
 
 {ghungHa':v@@ghung:v, -Ha':v} seria algo como "não tenho mais fome" .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {ghung; qagh rur@@ghung:v, qagh:n, rur:v}.
+
+{ghungHa':v@@ghung:v, -Ha':v} olisi jotain "ei enää nälkäistä" .[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8205,6 +9056,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8212,6 +9064,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2011.11.15:src}</column>
     </table>
     <table name="mem">
@@ -8225,6 +9078,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">глотать, поглощать</column>
       <column name="definition_zh_HK">吞</column>
       <column name="definition_pt">engolir</column>
+      <column name="definition_fi">niellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhutlh:v}, {Hugh:n}, {qo'qaD:n}, {chayqa':n}</column>
@@ -8235,6 +9089,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Gulp".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8244,6 +9099,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">devour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8251,6 +9107,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8264,6 +9121,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">стих [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">詩</column>
       <column name="definition_pt">poema</column>
+      <column name="definition_fi">runo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}, {gha'tlhIq:n}, {jaghIv:n}, {'InDogh:n}, {pa'jaH:n}, {Sa:v}</column>
@@ -8274,6 +9132,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8283,6 +9142,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8290,6 +9150,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8304,6 +9165,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="definition_ru">увеличивать, усиливать, возрастать, множить, нарасти, возвышать</column>
       <column name="definition_zh_HK">增加</column>
       <column name="definition_pt">aumentar</column>
+      <column name="definition_fi">lisääntyä, kasvaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nup:v}</column>
@@ -8314,6 +9176,7 @@ It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The word {ghurmoH:v@@ghur:v, -moH:v} appears on {SkyBox 14:src} (see {nISwI' beH:n}).[2]
 
 MO confirmed at {Saarbrücken qepHom'a' 2011:src} that {ghur:v:nolink} is intransitive.</column>
@@ -8327,6 +9190,7 @@ MO confirmed at {Saarbrücken qepHom'a' 2011:src} that {ghur:v:nolink} is intran
 ▶ {jaghpu'ra' bopujmoHtaHvIS, ghur tuqmeyraj quv.} "Честь возвышается в ваших домах, также как вы ставите врагов на колени."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8334,6 +9198,7 @@ MO confirmed at {Saarbrücken qepHom'a' 2011:src} that {ghur:v:nolink} is intran
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 14:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src}), [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -8347,6 +9212,7 @@ MO confirmed at {Saarbrücken qepHom'a' 2011:src} that {ghur:v:nolink} is intran
       <column name="definition_ru">быть готовым, готовиться к запуску</column>
       <column name="definition_zh_HK">準備（發射）</column>
       <column name="definition_pt"> esteja preparado, pronto (a lançar)</column>
+      <column name="definition_fi">olla laukaisuvalmis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baH:v}, {cha:n}, {peng:n}, {qeq:v}, {ghuH:v}, {ghuS:v:2}</column>
@@ -8371,6 +9237,9 @@ Se även suffikterna {-rup:v} och {-beH:v} för indikering av förberedelse elle
       <column name="notes_pt">O objeto desse verbo é a coisa a ser lançada, geralmente torpedos. Se o objeto não for especificado explicitamente ou pelo contexto, presume-se que sejam torpedos. Além de torpedos, esse verbo pode ser usado para foguetes, mísseis, feixes de energia ou qualquer outra coisa que vá de um ponto a outro. Também é usado para descrever a ação de puxar para trás a faixa elástica de um estilingue, ou o abaixamento de uma lança em uma posição horizontal para atacar (ver {ghuS:v:2}). Este verbo nunca leva o sufixo {-rup:v}. ({TKD 4.2.2:src})
 
 Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou prontidão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin tarkoitus on käynnistettävä asia, yleensä torpedot. Jos kohdetta ei ole määritelty nimenomaisesti tai kontekstin mukaan, sen oletetaan olevan torpedot. Torpedojen lisäksi tätä verbiä voidaan käyttää raketteihin, ohjuksiin, energiapalkkeihin tai mihin tahansa muuhun pisteestä toiseen. Sitä käytetään myös kuvaamaan toimintoa, jolla vedetään ritsa-joustavan nauhan taakse, tai keihään laskemista vaakasuoraan asentoon hyökätä varten (katso {ghuS:v:2}). Tämä verbi ei koskaan ota loppuliitettä {-rup:v}. ({TKD 4.2.2:src})
+
+Katso myös loppuliitteet {-rup:v} ja {-beH:v} valmistelun tai valmiuden osoittamiseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Even though the definition starts with "be", this is not a stative verb. The subject is a person getting ready to use a device to launch something, not the device itself.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8381,6 +9250,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8388,6 +9258,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek I:src}</column>
     </table>
     <table name="mem">
@@ -8401,6 +9272,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="definition_ru">ниже (копье) к горизонтали для атаки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">降低（矛）到水平攻擊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mais baixo (lança) para horizontal para atacar</column>
+      <column name="definition_fi">laskea keihäs vaakasuoraan asentoon ennen hyökkäystä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQjej:n}, {moy'bI':n}, {chuH:v:1}, {ghuS:v:1}</column>
@@ -8411,6 +9283,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="notes_ru">Этот глагол может использоваться для описания подготовки любого вида метательного оружия, например, оттягивания резинки рогатки. На звездолете он используется почти исключительно для обозначения торпед (см. {ghuS:v:1}).[1, p.64] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞可用於描述任何種類的射彈武器的準備情況，例如拉回彈弓的鬆緊帶。在星際飛船上，它幾乎專門用於指魚雷（請參閱{ghuS:v:1}）。[1, p.64] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse verbo pode ser usado para descrever a preparação de qualquer tipo de arma de projétil, como puxar o elástico de um estilingue. Em uma nave estelar, é usado quase exclusivamente para se referir a torpedos (consulte {ghuS:v:1}).[1, p.64] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä voidaan käyttää kuvaamaan kaikenlaisten ammuksen aseiden valmistelua, kuten ritsaen elastisen nauhan vetämistä takaisin. Tähtialuksella sitä käytetään melkein yksinomaan viittaamaan torpedoihin (katso {ghuS:v:1}).[1, p.64] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8420,6 +9293,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">spear, slingshot</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8427,6 +9301,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8440,6 +9315,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="definition_ru">прогнозировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">預測</column>
       <column name="definition_pt">prever</column>
+      <column name="definition_fi">ennustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'aq:v}, {qut:v}, {loy:v}</column>
@@ -8450,6 +9326,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="notes_ru">Это относится к прогнозированию на основе своих чувств или просто дикой догадки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指根據一個人的感覺進行預測或只是一個瘋狂的猜測。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à previsão com base nos sentimentos de alguém ou apenas em um palpite. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ennustamiseen tunteiden tai vain villin arvauksen perusteella. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The term "gut feeling" refers to one's intuition.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8459,6 +9336,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8466,6 +9344,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -8479,6 +9358,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="definition_ru">рекрут</column>
       <column name="definition_zh_HK">新兵</column>
       <column name="definition_pt">recrutar</column>
+      <column name="definition_fi">alokas, uusi jäsen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{muvmoH:v}, {muv:v}, {Sap:v}</column>
@@ -8489,6 +9369,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8498,6 +9379,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8505,6 +9387,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8518,6 +9401,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="definition_ru">черт(ругательство), проклятие(ругательство)</column>
       <column name="definition_zh_HK">肏蛋（粗口）</column>
       <column name="definition_pt">xingamento Klingon, caramba</column>
+      <column name="definition_fi">eräs kirosana, hitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuy'cha':excl}</column>
@@ -8528,6 +9412,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{ghuy' po'qu'!:sen}</column>
@@ -8537,6 +9422,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8544,6 +9430,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.13, Dec. 1999:src}, [2] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -8557,6 +9444,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="definition_ru">Он хорош черт возьми!</column>
       <column name="definition_zh_HK">肏蛋！他很勁！</column>
       <column name="definition_pt">Caraca, ele é bom!</column>
+      <column name="definition_fi">Hitto, hän on hyvä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8567,6 +9455,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghuy':excl}, {po':v}, {-qu':v}</column>
       <column name="examples"></column>
@@ -8576,6 +9465,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8583,6 +9473,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -8596,6 +9487,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="definition_ru">ругательное слово, гораздо сильнее, чем "черт возьми"</column>
       <column name="definition_zh_HK">咒罵、強於“愚弄” [AUTOTRANSLATED]</column>
       <column name="definition_pt">palavrão, muito mais forte do que "danado"</column>
+      <column name="definition_fi">eräs voimakas kirosana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghay'cha':excl}, {ghuy':excl}</column>
@@ -8606,6 +9498,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is only noted as a curse in {TKD:src}. The explanation that it's a lot stronger than "darn it" comes from {CK:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8615,6 +9508,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">darn it, damn it</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8622,6 +9516,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -8635,6 +9530,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="definition_ru">ситуация</column>
       <column name="definition_zh_HK">情況</column>
       <column name="definition_pt">situação</column>
+      <column name="definition_fi">tilanne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8645,6 +9541,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8656,6 +9553,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8663,6 +9561,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8676,6 +9575,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="definition_ru">пункт в списке, пункт списка</column>
       <column name="definition_zh_HK">列表中的項目 [AUTOTRANSLATED]</column>
       <column name="definition_pt">item em uma lista</column>
+      <column name="definition_fi">luettelon kohta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{natlIS:n}, {tetlh:n}</column>
@@ -8686,6 +9586,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8695,6 +9596,7 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8702,5 +9604,6 @@ Consulte também os sufixos {-rup:v} e {-beH:v} para indicar a preparação ou p
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>

--- a/mem-05-H.xml
+++ b/mem-05-H.xml
@@ -1493,7 +1493,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Сражаться, бороться, биться (существенная конфронтация)</column>
       <column name="definition_zh_HK">戰鬥、戰鬥（主要對抗） [AUTOTRANSLATED]</column>
       <column name="definition_pt">luta, batalha (grande confronto)</column>
-      <column name="definition_fi">kamppailla, taistella (suuressa yhteenotossa)</column>
+      <column name="definition_fi">taistella (suuressa yhteenotossa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suv:v}, {may':n}</column>

--- a/mem-05-H.xml
+++ b/mem-05-H.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {H:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{H:sen:nolink}</column>
       <column name="definition_pt">a consoante {H:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {H:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">быть гладким, быть плавным, быть без затруднений, быть однородным</column>
       <column name="definition_zh_HK">順利 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser suave, ser liso</column>
+      <column name="definition_fi">olla sileä, olla tasainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghegh:v}, {vIl:v:1}</column>
       <column name="see_also">{tlher:v}, {'Ich:v}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -68,6 +74,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -75,6 +82,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.179:src}</column>
     </table>
     <table name="mem">
@@ -88,6 +96,7 @@
       <column name="definition_ru">У твоей матери плоский лоб!</column>
       <column name="definition_zh_HK">你媽媽額頭很光滑！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sua mãe tem a testa lisa!</column>
+      <column name="definition_fi">Äidilläsi on sileä otsa!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mu'qaD veS:n}</column>
@@ -98,6 +107,7 @@
       <column name="notes_ru">Является классическим оскорблением</column>
       <column name="notes_zh_HK">這是經典的侮辱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um insulto clássico. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on klassinen loukkaus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hab:v}, {SoS:n}, {-lI':n}, {Quch:n}</column>
       <column name="examples"></column>
@@ -107,6 +117,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mu'qaD veS, curse warfare</column>
       <column name="search_tags_de">mu'qaD veS, Wettfluchen</column>
       <column name="search_tags_fa"></column>
@@ -114,6 +125,7 @@
       <column name="search_tags_ru">mu'qaD veS, проклятие</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -127,6 +139,7 @@
       <column name="definition_ru">устройство для передачи данных</column>
       <column name="definition_zh_HK">數據收發設備 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dispositivo de envio e recebimento de dados</column>
+      <column name="definition_fi">tiedonsiirtolaite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -137,6 +150,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{ghogh HablI':n}, {nav HablI':n}, {teS HablI':n}</column>
@@ -146,6 +160,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -153,6 +168,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -166,6 +182,7 @@
       <column name="definition_ru">быть развитым(ой)</column>
       <column name="definition_zh_HK">發展（例如、文明） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desenvolvido (por exemplo, a civilização)</column>
+      <column name="definition_fi">olla kehittynyt (esim. sivilisaatio)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lutlh:v}</column>
       <column name="see_also">{tayqeq:n}, {'Itlh:v}</column>
@@ -176,6 +193,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Something "hatch"es and develops.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -185,6 +203,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">civilisation</column>
       <column name="search_tags_de">Zivilisation</column>
       <column name="search_tags_fa"></column>
@@ -192,6 +211,7 @@
       <column name="search_tags_ru">цивилизация</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -205,6 +225,7 @@
       <column name="definition_ru">изучение, исследование</column>
       <column name="definition_zh_HK">學習、讀書</column>
       <column name="definition_pt">estudar</column>
+      <column name="definition_fi">opiskella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoj:v}, {laD:v}, {DuSaQ:n}, {paQDI'norgh:n}, {yejHaD:n}</column>
@@ -215,6 +236,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Studying is "hard".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -224,6 +246,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -231,6 +254,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -244,6 +268,7 @@
       <column name="definition_ru">смеяться</column>
       <column name="definition_zh_HK">笑</column>
       <column name="definition_pt">rir</column>
+      <column name="definition_fi">nauraa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mon:v}, {qotlh:v:1}, {tlhaQ:v}</column>
@@ -254,6 +279,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It's what it sounds like.</column>
       <column name="components"></column>
       <column name="examples">
@@ -265,6 +291,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -272,6 +299,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -285,6 +313,7 @@
       <column name="definition_ru">Только дураки смеются, пока умирают воины</column>
       <column name="definition_zh_HK">戰士死亡之時，只有傻瓜會笑。</column>
       <column name="definition_pt">Somente os tolos riem enquanto os guerreiros morrem.</column>
+      <column name="definition_fi">Soturien kuollessa vain tyhmät nauravat.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -295,6 +324,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hagh:v}, {qoH:n}, {-pu':n}, {neH:adv}, {Hegh:v}, {-taH:v}, {-vIS:v}, {SuvwI':n}, {-pu':n}</column>
       <column name="examples"></column>
@@ -304,6 +334,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">replacement proverb</column>
       <column name="search_tags_de">Ersatzsprichwort</column>
       <column name="search_tags_fa"></column>
@@ -311,6 +342,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -324,6 +356,7 @@
       <column name="definition_ru">вымочить, вымачивать, намочить, впитывать, замачивать, смачивать, мокнуть</column>
       <column name="definition_zh_HK">浸泡、浸透</column>
       <column name="definition_pt">ensopar, encharcar</column>
+      <column name="definition_fi">liottaa, kastella läpimäräksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIQ:v}, {HaH:v:2}, {Qal:v}</column>
@@ -348,6 +381,9 @@
       <column name="notes_pt">O objeto é a coisa que está sendo encharcada ou encharcada.
 
 {HaH'egh:v@@HaH:v:1, -'egh:v} é usado para se referir a beber muito ou tomar banho.[1, p.91] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on liotettu tai kasteltu asia.
+
+{HaH'egh:v@@HaH:v:1, -'egh:v}: llä tarkoitetaan paljon juomista tai uimista.[1, p.91] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -357,6 +393,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bathe</column>
       <column name="search_tags_de">baden</column>
       <column name="search_tags_fa"></column>
@@ -364,6 +401,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -377,6 +415,7 @@
       <column name="definition_ru">Маринуйте [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">醃 [AUTOTRANSLATED]</column>
       <column name="definition_pt">marinar</column>
+      <column name="definition_fi">marinoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chanDoq:n}, {'Iw:n}, {vIychorgh:n}, {voDleH Ha'DIbaH:n}, {HaH:v:1}</column>
@@ -387,6 +426,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -396,6 +436,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -403,6 +444,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -416,6 +458,7 @@
       <column name="definition_ru">опасаться, страшиться, бояться</column>
       <column name="definition_zh_HK">恐怕</column>
       <column name="definition_pt">ter medo</column>
+      <column name="definition_fi">pelätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIj:v}, {lIm:v}, {bIt:v}</column>
@@ -426,6 +469,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -435,6 +479,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -442,6 +487,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -455,6 +501,7 @@
       <column name="definition_ru">нога (пища)</column>
       <column name="definition_zh_HK">腿（作為食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">perna (servida como alimento)</column>
+      <column name="definition_fi">jalka (tarjoiltuna ruokana)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -465,6 +512,7 @@
       <column name="notes_ru">Слово, используется носителями языка высшего класса для {gham:n} служащего едой</column>
       <column name="notes_zh_HK">這個詞被上流社會的說話者用來作為{gham:n}的食物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada pelos oradores da classe alta para {gham:n} servidos como alimento. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käyttävät ylemmän luokan puhujat {gham:n}-ruokana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -474,6 +522,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -481,6 +530,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -494,6 +544,7 @@
       <column name="definition_ru">ласкоподобное животное [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鼬鼠般的動物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">animal tipo doninha</column>
+      <column name="definition_fi">eräs lumikon kaltainen eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -504,6 +555,7 @@
       <column name="notes_ru">Это животное, найденное на {Qo'noS:n}, похоже на ласку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種在{Qo'noS:n}上發現的動物，有點像鼬鼠。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um animal encontrado em {Qo'noS:n} que é uma espécie de doninha. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {Qo'noS:n}: stä löydetty eläin, joka on tavallaan lumikon kaltainen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{vav:n} "father", or colloquially "pop", and {jaH:v} "go" together make "pop goes the weasel".
 
 The request was for a musteloid (otter-like or wolverine-like animal).</column>
@@ -515,6 +567,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">otter, wolverine, musteloid</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -522,6 +575,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -535,6 +589,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">источник, родник, исходник, первопричина, исток</column>
       <column name="definition_zh_HK">來源</column>
       <column name="definition_pt">fonte</column>
+      <column name="definition_fi">lähde</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mung:n}, {nompuq:n}</column>
@@ -545,6 +600,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -554,6 +610,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -561,6 +618,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -574,6 +632,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">быть пористым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">多孔 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser poroso</column>
+      <column name="definition_fi">olla huokoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bum:v}, {betgham:n}</column>
@@ -584,6 +643,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -593,6 +653,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -600,6 +661,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -613,6 +675,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">быть высоким (в поле) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">高（球場） [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar alto (em tom)</column>
+      <column name="definition_fi">olla korkea (äänenkorkeudeltaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pun:v}</column>
       <column name="see_also">{wab:n}, {ghogh:n}, {QoQ:n}, {HaS:v}</column>
@@ -623,6 +686,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это может означать высокий голос или высокую ноту в музыке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能表示聲音很高，或音樂中的聲音很高。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode se referir a uma voz alta ou uma nota alta na música. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata korkeaan ääniin tai korkeaan nuottiin musiikissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">To "ham it up" is to do something ridiculous as to make people laugh.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -632,6 +696,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -639,6 +704,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -652,6 +718,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Гамлет</column>
       <column name="definition_zh_HK">哈姆雷特</column>
       <column name="definition_pt">Aldeia</column>
+      <column name="definition_fi">Hamlet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taH pagh taHbe'.:sen}</column>
@@ -662,6 +729,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Название известной пьесы, автором которой является {wIlyam SeQpIr:n:name}, а также имя одноименного протагониста.</column>
       <column name="notes_zh_HK">這是{wIlyam SeQpIr:n:name}著名戲劇的名稱，也是其同名主角的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma peça famosa de {wIlyam SeQpIr:n:name}, e também o nome de seu protagonista homônimo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {wIlyam SeQpIr:n:name}: n kuuluisan näytelmän nimi ja samannimisen päähenkilön nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -671,6 +739,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -678,6 +747,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -691,6 +761,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">рана, боль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傷口、疼痛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ferida</column>
+      <column name="definition_fi">haava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ban:v}, {mIvwa':n}, {moqtay':n}, {Hampong DIr:n}</column>
@@ -701,6 +772,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это рана или рана, по крайней мере, с некоторым истиранием, а не просто синяк. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是傷口或酸痛，至少有一些磨損，而不僅僅是瘀傷。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma ferida ou ferida com pelo menos alguma abrasão, não apenas uma contusão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on haava tai kipeä, jossa on ainakin jonkin verran hankausta, ei vain mustelmia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -710,6 +782,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -717,6 +790,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
         <table name="mem">
@@ -730,6 +804,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="definition_ru">парша [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">痂皮</column>
           <column name="definition_pt">crosta (de machucado/ferida)</column>
+      <column name="definition_fi">rupi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -740,6 +815,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="notes_ru">Для множественного числа используется {-mey:n}, даже если струп все еще прикреплен. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">對於復數，即使結the仍然附著，也使用{-mey:n}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Para o plural, {-mey:n} é usado mesmo se a crosta ainda estiver anexada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Monikkomuodossa {-mey:n} käytetään, vaikka rupi on edelleen kiinni. [AUTOTRANSLATED]</column>
           <column name="hidden_notes">When it was first revealed, the {DIr:sen:nolink} was accidentally dropped. This was corrected in the Q &amp; A session.</column>
           <column name="components">{Hampong:n}, {DIr:n}</column>
           <column name="examples"></column>
@@ -749,6 +825,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -756,6 +833,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -769,6 +847,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">йодль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">約德爾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">yodel (uma forma de canto)</column>
+      <column name="definition_fi">jodlata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ham:v}, {pun:v}, {bom:v}</column>
@@ -779,6 +858,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это глагол с двумя слогами и сленгом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個兩個音節的動詞，它是語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um verbo de duas sílabas e é uma gíria. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kaksisavuinen verbi, ja se on slangi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was confirmed intransitive during the Q &amp; A session.</column>
       <column name="components">{Ham:v}, {pun:v}</column>
       <column name="examples"></column>
@@ -788,6 +868,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -795,6 +876,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -808,6 +890,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">быть учёным, учёным, эрудированным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">學習、學術、博學 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser aprendido, acadêmico, erudito</column>
+      <column name="definition_fi">olla oppinut, koulutettu, sivistynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{po':v}, {'um:v}, {Hen:v}</column>
@@ -818,6 +901,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -827,6 +911,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -834,6 +919,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -847,6 +933,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">клетка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">細胞</column>
       <column name="definition_pt">célula (biologia)</column>
+      <column name="definition_fi">solu (biologiassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lerup:n}</column>
@@ -857,6 +944,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это относится к биологической единице. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指生物單位。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a uma unidade biológica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa biologiseen yksikköön. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Handy" is slang for "cell phone".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -866,6 +954,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -873,6 +962,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -886,6 +976,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">гондола корабля, кабина самолета</column>
       <column name="definition_zh_HK">機艙（引擎）</column>
       <column name="definition_pt">nacele</column>
+      <column name="definition_fi">naselli, poimuajomoottorin kotelo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}, {Som:n}</column>
@@ -896,6 +987,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -905,6 +997,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -912,6 +1005,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -925,6 +1019,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">дело, материя, вопрос, предмет, материал</column>
       <column name="definition_zh_HK">物質</column>
       <column name="definition_pt">matéria</column>
+      <column name="definition_fi">aine (fysiikassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rugh:n}, {ngI':v}</column>
@@ -935,6 +1030,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -944,6 +1040,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mass</column>
       <column name="search_tags_de">Masse</column>
       <column name="search_tags_fa"></column>
@@ -951,6 +1048,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -964,6 +1062,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="definition_ru">репликатор [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">複製 [AUTOTRANSLATED]</column>
           <column name="definition_pt">replicador</column>
+      <column name="definition_fi">replikaattori</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Soj choHwI':n}</column>
@@ -974,6 +1073,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Hap:n}, {choH:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -983,6 +1083,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -990,6 +1091,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
         </table>
         <table name="mem">
@@ -1003,6 +1105,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="definition_ru">физика [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">物理</column>
           <column name="definition_pt">física</column>
+      <column name="definition_fi">fysiikka</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{'otlhQeD:n}, {DI'ruj QeD:n}, {Haptej:n}</column>
@@ -1013,6 +1116,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Hap:n}, {QeD:n}</column>
           <column name="examples"></column>
@@ -1022,6 +1126,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1029,6 +1134,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 26 (2019):src}</column>
         </table>
         <table name="mem">
@@ -1042,6 +1148,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="definition_ru">физик [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">物理學家 [AUTOTRANSLATED]</column>
           <column name="definition_pt">físico</column>
+      <column name="definition_fi">fyysikko</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{HapQeD:n}, {tej:n}, {'otlhtej:n}</column>
@@ -1052,6 +1159,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word does not appear in canon, but is an obvious construction based on {HapQeD:n:nolink}.</column>
           <column name="components">{Hap:n}, {tej:n}</column>
           <column name="examples"></column>
@@ -1061,6 +1169,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1068,6 +1177,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -1081,6 +1191,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">хирургия, операционная</column>
       <column name="definition_zh_HK">手術</column>
       <column name="definition_pt">cirurgia</column>
+      <column name="definition_fi">leikkaus (lääketieteessä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Haq:v:1}</column>
@@ -1091,6 +1202,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Hack".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1100,6 +1212,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1107,6 +1220,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1120,6 +1234,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">оперировать кого-то </column>
       <column name="definition_zh_HK">做手術、開力</column>
       <column name="definition_pt">realizar cirurgias (em)</column>
+      <column name="definition_fi">leikata (lääketieteessä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Haq:n}, {Haq:v:2}</column>
@@ -1130,6 +1245,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Слово имеет негативный оттенок в Клингонской культуре.[1]</column>
       <column name="notes_zh_HK">這個詞在克林崗文化中具有負面含義。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra tem uma conotação negativa na cultura klingon.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä sanalla on negatiivinen merkitys klingonikulttuurissa.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Hack".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1139,6 +1255,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1146,6 +1263,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.151:src}</column>
     </table>
     <table name="mem">
@@ -1159,6 +1277,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">вмешиваться (ситуация) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">介入（情況） [AUTOTRANSLATED]</column>
       <column name="definition_pt">intervir em (uma situação)</column>
+      <column name="definition_fi">puuttua (tilanteeseen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mun:v}, {nIS:v}, {Haq:v:1}</column>
@@ -1169,6 +1288,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это слово имеет отрицательный оттенок в клингонской культуре.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞在克林崗文化中具有負面含義。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra tem uma conotação negativa na cultura klingon.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä sanalla on negatiivinen merkitys klingonikulttuurissa.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1178,6 +1298,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1185,6 +1306,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.151:src}</column>
     </table>
     <table name="mem">
@@ -1198,6 +1320,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Скальпель</column>
       <column name="definition_zh_HK">解剖刀、手術刀</column>
       <column name="definition_pt">bisturi</column>
+      <column name="definition_fi">leikkausveitsi, skalpelli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1208,6 +1331,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Haq:n}, {taj:n}</column>
       <column name="examples"></column>
@@ -1217,6 +1341,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1224,6 +1349,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1237,6 +1363,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Хирург</column>
       <column name="definition_zh_HK">外科醫生 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cirurgião</column>
+      <column name="definition_fi">kirurgi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{petqaD:n}, {tuj muvwI':n}, {'uD Haqtaj:n}</column>
@@ -1247,6 +1374,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это доктор (см. {Qel:n:1h}), который проводит операцию (см. {Haq:v:1}).[2]</column>
       <column name="notes_zh_HK">這是一名進行手術（請參閱{Haq:v:1}）的醫生（請參閱{Qel:n:1h}）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um médico (consulte {Qel:n:1h}) que realiza cirurgia (consulte {Haq:v:1}) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lääkäri (ks.{Qel:n:1h}), joka suorittaa leikkauksen (ks.{Haq:v:1}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Haq:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1256,6 +1384,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1263,6 +1392,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {s.k 1998.10.20:src}</column>
     </table>
     <table name="mem">
@@ -1276,6 +1406,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Сахарин</column>
       <column name="definition_zh_HK">糖精 [AUTOTRANSLATED]</column>
       <column name="definition_pt">saccharin</column>
+      <column name="definition_fi">sakariini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{na'ran:n}, {Su'ghar qut:n}</column>
@@ -1286,6 +1417,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Marc Okrand decided to put this word into {TKD:src} because he thought artificial sweetener would be something that would be around in the future.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1295,6 +1427,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1302,6 +1435,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2019.09.26:src}</column>
     </table>
     <table name="mem">
@@ -1316,6 +1450,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">верить, считать(быть в чем-то уверенным), быть убежденным в чем-то</column>
       <column name="definition_zh_HK">相信 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acreditar</column>
+      <column name="definition_fi">uskoa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hon:v}</column>
       <column name="see_also">{DIch:n}, {voq:v}, {loy:v}, {Sov:v}</column>
@@ -1326,6 +1461,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1335,6 +1471,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1342,6 +1479,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1355,6 +1493,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Сражаться, бороться, биться (существенная конфронтация)</column>
       <column name="definition_zh_HK">戰鬥、戰鬥（主要對抗） [AUTOTRANSLATED]</column>
       <column name="definition_pt">luta, batalha (grande confronto)</column>
+      <column name="definition_fi">kamppailla, taistella (suuressa yhteenotossa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suv:v}, {may':n}</column>
@@ -1365,6 +1504,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">В порядке убывания свирепости, используются следующие глаголы, для описания военных противостояний: {Qor:v}, {tlhaS:v}, {vay:v}, {lul:v}, {Hargh:v:nolink}.</column>
       <column name="notes_zh_HK">按照兇猛的升序，用於描述軍事對抗的動詞是：{Qor:v}、{tlhaS:v}、{vay:v}、{lul:v}、{Hargh:v:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Armeijan nousevassa järjestyksessä sotilaallisia yhteenottoja kuvaavia verbejä ovat: {Qor:v}, {tlhaS:v}, {vay:v}, {lul:v}, {Hargh:v:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Armageddon (Har Megiddo).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1374,6 +1514,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1381,6 +1522,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1394,6 +1536,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">расстройство, инвалидность, синдром, состояние [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">障礙，殘疾，綜合症，狀況 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desordem, incapacidade, síndrome, condição</column>
+      <column name="definition_fi">häiriö, vamma, oireyhtymä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1404,6 +1547,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это относится к состоянию здоровья, которое влияет на человека психически или физически. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是諸如醫療狀況之類的東西，會在心理上或身體上影響某人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a algo como uma condição médica que afeta alguém mentalmente ou fisicamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa sellaiseen sairauteen, joka vaikuttaa henkisesti tai fyysisesti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Americans with Disabilities Act of 1990 was authored by Senator Tom Harkin.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1413,6 +1557,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1420,6 +1565,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1433,6 +1579,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">радуга [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">彩虹</column>
       <column name="definition_pt">arco Iris</column>
+      <column name="definition_fi">sateenkaari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIS:v}, {yutlhegh:n}</column>
@@ -1443,6 +1590,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Over the Rainbow" was composed by Harold Arlen and its lyrics were written by E.Y. Harburg.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1452,6 +1600,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1459,6 +1608,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -1472,6 +1622,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">писк [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">guincho</column>
+      <column name="definition_fi">kirskua, kitistä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ham:v}</column>
@@ -1482,6 +1633,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это используется не только для животных. Его также можно использовать для звука, который издает старая дверь или деревянный сундук, когда вы ее открываете, если это своего рода высокий звук. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不僅用於動物。如果它是一種高音調，也可以用於打開舊門或木箱時發出的聲音。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado não apenas para animais. Também pode ser usado para o som que uma porta velha ou um baú de madeira faz quando você a abre, se for uma espécie de tom agudo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä ei käytetä vain eläimille. Sitä voidaan käyttää myös äänelle, jonka vanha ovi tai puinen arkku antaa, kun avaat sen, jos se on eräänlainen korkea. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1491,6 +1643,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1498,6 +1651,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -1511,6 +1665,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Дисплей</column>
       <column name="definition_zh_HK">畫面顯示 [AUTOTRANSLATED]</column>
       <column name="definition_pt">exibição visual</column>
+      <column name="definition_fi">näyttölaite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaSta jIH:n}, {cha':v}, {wIy:n}</column>
@@ -1521,6 +1676,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">請注意，{jIH:n:2}是指設備，而{HaSta:n:nolink}是指顯示在其上的視覺信息。還要與{wIy:n}進行對比，也可以在{jIH:n:2}上顯示它。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que {jIH:n:2} se refere ao dispositivo, enquanto {HaSta:n:nolink} se refere às informações visuais exibidas nele. Compare isso também com {wIy:n}, que também pode ser exibido em um {jIH:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että {jIH:n:2} viittaa laitteeseen, kun taas {HaSta:n:nolink} viittaa siinä näkyviin visuaalisiin tietoihin. Kontrastaa tämä myös {wIy:n}: een, joka voidaan näyttää myös {jIH:n:2}: llä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Interesting coincidence: in the Spanish phrase "Hasta la vista" ("see you later"), "la vista" means "the view".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1530,6 +1686,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1537,6 +1694,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1550,6 +1708,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Телевидение</column>
       <column name="definition_zh_HK">電視</column>
       <column name="definition_pt">televisão</column>
+      <column name="definition_fi">televisio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1560,6 +1719,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HaSta:n}, {jIH:n:2}</column>
       <column name="examples"></column>
@@ -1569,6 +1729,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">TV</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1576,6 +1737,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -1589,6 +1751,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">{HaSta much:n}</column>
       <column name="definition_zh_HK">{HaSta much:n}</column>
       <column name="definition_pt">{HaSta much:n}</column>
+      <column name="definition_fi">{HaSta much:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1599,6 +1762,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HaSta jIH:n}, {much:n}</column>
       <column name="examples"></column>
@@ -1608,6 +1772,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1615,6 +1780,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -1628,6 +1794,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">ТВ шоу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">電視節目</column>
       <column name="definition_pt">TV show</column>
+      <column name="definition_fi">televisio-ohjelma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1638,6 +1805,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HaSta:n}, {much:n}</column>
       <column name="examples"></column>
@@ -1647,6 +1815,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">television show</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1654,6 +1823,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -1667,6 +1837,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">видео, видеозапись</column>
       <column name="definition_zh_HK">視頻、視覺顯示記錄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vídeo, registro de exibição visual</column>
+      <column name="definition_fi">video, visuaalinen nauhoite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wab ta:n}</column>
@@ -1677,6 +1848,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HaSta:n}, {ta:n}</column>
       <column name="examples"></column>
@@ -1686,6 +1858,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1693,6 +1866,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.25:src}</column>
     </table>
     <table name="mem">
@@ -1706,6 +1880,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">быть незаконным</column>
       <column name="definition_zh_HK">非法</column>
       <column name="definition_pt">ser ilegal</column>
+      <column name="definition_fi">olla laitonta</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mub:v}</column>
       <column name="see_also"></column>
@@ -1716,6 +1891,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In slang, stolen goods are said to be "hot".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1725,6 +1901,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1732,6 +1909,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1745,6 +1923,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">температура</column>
       <column name="definition_zh_HK">溫度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">temperatura</column>
+      <column name="definition_fi">lämpötila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gheH:v}, {SImyon:n}, {tuj:v}, {bIr:v}, {ghun:v:2}, {Qey':v}, {tuj:n}</column>
@@ -1755,6 +1934,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Hot".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1764,6 +1944,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1771,6 +1952,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1784,6 +1966,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Страна, местность</column>
       <column name="definition_zh_HK">國家、農村 [AUTOTRANSLATED]</column>
       <column name="definition_pt">campo, interior</column>
+      <column name="definition_fi">maaseutu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{veng:n}</column>
       <column name="see_also">{yotlh:n}</column>
@@ -1794,6 +1977,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1803,6 +1987,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rural</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1810,6 +1995,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru">сельская местность</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1823,6 +2009,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">быть случайным, произвольным, непредсказуемым, случайным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">隨機，任意，不可預測，偶然 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser aleatório, arbitrário, imprevisível, fortuito</column>
+      <column name="definition_fi">olla satunnainen, mielivaltainen, arvaamaton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuD:v:2}, {mI' nagh:n}</column>
@@ -1833,6 +2020,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Для «случайных» в смысле чисел, например, при броске костей, используйте {'al:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於數字意義上的“隨機”，例如擲骰子時，請使用{'al:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para "aleatório" no sentido de números, como ao jogar dados, use {'al:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Käytä "satunnaista" numeroiden mielessä, kuten heittäessäsi noppaa, käyttämällä sen sijaan {'al:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"How?"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1842,6 +2030,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1849,6 +2038,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1862,6 +2052,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">бежать, убираться(уходить откуда-то)</column>
       <column name="definition_zh_HK">逃離</column>
       <column name="definition_pt">fugir, sair</column>
+      <column name="definition_fi">paeta jostakin, päästä pois jostakin</column>
       <column name="synonyms">{HeD:v}</column>
       <column name="antonyms">{yong:v}</column>
       <column name="see_also">{lel:v}, {nargh:v:2}</column>
@@ -1872,6 +2063,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1882,6 +2074,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">run away from</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1889,6 +2082,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1902,6 +2096,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">территория или район за пределами чего-то</column>
       <column name="definition_zh_HK">區域以外 [AUTOTRANSLATED]</column>
       <column name="definition_pt">área além</column>
+      <column name="definition_fi">alue ulkopuolella, alue takana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{retlh:n}, {joj:n}</column>
@@ -1912,6 +2107,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1921,6 +2117,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1928,6 +2125,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1941,6 +2139,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">кувыркаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">翻筋斗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cambalhota</column>
+      <column name="definition_fi">tehdä kuperkeikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1951,6 +2150,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Это контролируемый бросок. Если человек катится случайно, глагол использовать {ron:v:1}. Если кто-то катится вниз по склону (как бревно), см. {tetlh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是受控輥。如果某人隨意滾動，則使用的動詞為{ron:v:1}。如果有人從小山上滾下來（例如原木），請參閱{tetlh:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on ohjattu rulla. Jos henkilö liikkuu sattumanvaraisesti, käytettävä verbi on {ron:v:1}. Jos joku liikkuu mäkeä alas (kuten tukki), katso {tetlh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1960,6 +2160,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">roll</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1967,6 +2168,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -1980,6 +2182,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">ведро [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">桶 [AUTOTRANSLATED]</column>
       <column name="definition_pt">balde</column>
+      <column name="definition_fi">ämpäri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaSwI':n}, {DoQmIv:n}</column>
@@ -1990,6 +2193,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="notes_ru">Обычно это круглый (так что это может быть {'Ib rutlh:n@@'Ib:n, rutlh:v}) и переносимый (поэтому это не {qegh:n}) .[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它通常是圓形的（因此可能是{'Ib rutlh:n@@'Ib:n, rutlh:v}）並且是便攜式的（因此它不是{qegh:n}）。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Geralmente, é redondo (portanto, pode ser um {'Ib rutlh:n@@'Ib:n, rutlh:v}) e portátil (portanto, não é um {qegh:n}).[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tyypillisesti pyöreä (joten se voi olla {'Ib rutlh:n@@'Ib:n, rutlh:v}) ja kannettava (joten se ei ole {qegh:n}).[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Hyacinth Bucket is a character on the British sitcom "Keeping Up Appearances" (who insists that her surname is to be pronounced "bouquet").</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1999,6 +2203,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2006,6 +2211,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2019,6 +2225,7 @@ The request was for a musteloid (otter-like or wolverine-like animal).</column>
       <column name="definition_ru">Дуэль, поединок</column>
       <column name="definition_zh_HK">決鬥</column>
       <column name="definition_pt">duelar</column>
+      <column name="definition_fi">käydä kaksintaistelu jonkun kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha' qabDu':n}, {vItHay':n}, {qab:n}, {baj:v}</column>
@@ -2039,6 +2246,9 @@ För att gå med på duellen, säg {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Jag d
       <column name="notes_pt">Para desafiar alguém para um duelo, diga {qablIj HI'ang!:sen} (geralmente abreviado para {HI'ang!:sen:nolink}). Diz-se que a parte que lança o desafio {qabDaj 'ang:sen@@qab:n, -Daj:n, 'ang:v} "mostra sua cara". O ato de lançar o desafio é {poQ:v}, que é a abreviação de {qab legh 'e' poQ:sen@@qab:n, legh:v, 'e':n, poQ:v} "Ele exige ver um rosto". Bater no adversário com as costas da mão ({chap:n}) ao lançar o desafio é exigir um duelo até a morte ({Hay'chu':v}) .[2]
 
 Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não escondo" (ou o mais longo {qabwIj vISo'be':sen} "Eu não escondo meu rosto"). A parte desafiada é então chamada de {'angchu':sen@@'ang:v, -chu':v} (abreviação de {qab 'angchu':sen@@qab:n, 'ang:v, -chu':v}). Aceita-se um desafio ({qab 'ang:sen@@qab:n, 'ang:v}) para provar sua honra ({quv tob:sen@@quv:n, tob:v}) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Haasta joku kaksintaisteluun sano {qablIj HI'ang!:sen} (tämä lyhennetään usein sanaan {HI'ang!:sen:nolink}) Haasteen antaneesta osapuolesta sanotaan, että {qabDaj 'ang:sen@@qab:n, -Daj:n, 'ang:v} "hän näyttää kasvonsa". Haasteen antaminen on {poQ:v}, joka on lyhenne sanoista {qab legh 'e' poQ:sen@@qab:n, legh:v, 'e':n, poQ:v} "Hän vaatii kasvojen näkymistä". Vastustajan lyöminen kädellä ({chap:n}) haasteen antamisen yhteydessä on vaatia kaksintaistelua kuolemaan ({Hay'chu':v}).
+
+Hyväksy kaksintaistelu sanomalla {vISo'be':sen@@vI-:v, So':v:1, -be':v} "En piilota sitä" (tai pidempi {qabwIj vISo'be':sen} "En piilota kasvoni"). Haasteteltava osapuoli sanotaan sitten {'angchu':sen@@'ang:v, -chu':v} (lyhenne sanoista {qab 'angchu':sen@@qab:n, 'ang:v, -chu':v}). Yksi hyväksyy haasteen ({qab 'ang:sen@@qab:n, 'ang:v}) osoittaakseen kunniansa ({quv tob:sen@@quv:n, tob:v}).[2][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2048,6 +2258,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2055,6 +2266,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.68:src}</column>
     </table>
         <table name="mem">
@@ -2068,6 +2280,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
           <column name="definition_ru">дуэль до смерти [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">決鬥致死 [AUTOTRANSLATED]</column>
           <column name="definition_pt">duelar até a morte</column>
+      <column name="definition_fi">taistella kaksintaistelu kuolemaan asti jonkun kanssa</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{ghIqtal:excl}, {Suvchu':v}, {chap:n}</column>
@@ -2078,6 +2291,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Hay':v}, {-chu':v:suff}</column>
           <column name="examples"></column>
@@ -2087,6 +2301,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2094,6 +2309,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.49:src}</column>
         </table>
     <table name="mem">
@@ -2107,6 +2323,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="definition_ru">Пойдем, пошли, вперед</column>
       <column name="definition_zh_HK">我們走了、來吧 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vamos lá, vamos</column>
+      <column name="definition_fi">mennään, tule</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tugh:excl}</column>
@@ -2117,6 +2334,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2126,6 +2344,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2133,6 +2352,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2146,6 +2366,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="definition_ru">мясо, животное</column>
       <column name="definition_zh_HK">肉、動物</column>
       <column name="definition_pt">carne, animal</column>
+      <column name="definition_fi">liha, eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghab:n}, {'oynot:n}, {Hom:n:1}, {Somraw:n}, {Saj:n}, {namwech:n}, {lem:n}, {Ha'DIbaH:n:2}</column>
@@ -2156,6 +2377,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="notes_ru">Для описания различных способов приготовления мяса, смотрите {wamwI' Ha'DIbaH:n}, {voDleH Ha'DIbaH:n}, и {qeyvaq Ha'DIbaH:n}. Также может использоваться, как легкое оскорбление</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Para diferentes maneiras pelas quais a carne pode ser preparada, consulte {wamwI' Ha'DIbaH:n}, {voDleH Ha'DIbaH:n} e {qeyvaq Ha'DIbaH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso eri tavoista lihan valmistamiseksi {wamwI' Ha'DIbaH:n}, {voDleH Ha'DIbaH:n} ja {qeyvaq Ha'DIbaH:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A lip movement match for "animal".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2165,6 +2387,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2172,6 +2395,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2185,6 +2409,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="definition_ru">собака, шавка, жалкий человек</column>
       <column name="definition_zh_HK">狗、禽獸、下等人</column>
       <column name="definition_pt">cachorro, "porco", pessoa inferior</column>
+      <column name="definition_fi">heittiö, sika, alempi henkilö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'DIbaH:n:1}</column>
@@ -2195,6 +2420,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2204,6 +2430,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2211,6 +2438,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2224,6 +2452,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="definition_ru">Не убивай животное, если не намерен его съесть!</column>
       <column name="definition_zh_HK">除非你打算吃它，否則不要殺死動物。</column>
       <column name="definition_pt">Não mate um animal a menos que você pretenda comê-lo.</column>
+      <column name="definition_fi">Älä tapa eläintä, ellet aio syödä sitä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2234,6 +2463,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Ha'DIbaH:n:1}, {Da-:v}, {Sop:v}, {'e':n}, {Da-:v}, {Hech:v}, {-be':v}, {-chugh:v}, {yI-:v}, {HoH:v}, {-Qo':v}</column>
       <column name="examples"></column>
@@ -2243,6 +2473,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2250,6 +2481,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.163:src}</column>
     </table>
     <table name="mem">
@@ -2263,6 +2495,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="definition_ru">Бургер, гамбургер</column>
       <column name="definition_zh_HK">漢堡包</column>
       <column name="definition_pt">hambúrguer</column>
+      <column name="definition_fi">hampurilainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamburgh:n}</column>
@@ -2273,6 +2506,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="notes_ru">Это то, что Клингоны называют земной пищей</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族食物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de comida terráquea. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-ruokaksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Ha'DIbaH:n:1}, {ghIH:v:1}, {tIr ngogh:n}, {je:conj}</column>
       <column name="examples"></column>
@@ -2282,6 +2516,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sandwich</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2289,6 +2524,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="search_tags_ru">сендвич, бутерброд</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -2303,6 +2539,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="definition_ru">штапель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">訂書釘、釘書針</column>
       <column name="definition_pt">Grampo</column>
+      <column name="definition_fi">niitti, paperiliitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'on vevwI':n}</column>
@@ -2313,6 +2550,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="notes_ru">Это относится к маленькому кусочку металла, который скрепляет листы бумаги. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指將紙片固定在一起的小金屬片。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao pequeno pedaço de metal que mantém as folhas de papel juntas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa pieneen metallipalaan, joka pitää paperiarkut yhdessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2322,6 +2560,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2329,6 +2568,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2342,6 +2582,7 @@ Para concordar com o duelo, diga {vISo'be':sen@@vI-:v, So':v:1, -be':v} "Eu não
       <column name="definition_ru">стэплер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">訂書機 [AUTOTRANSLATED]</column>
       <column name="definition_pt">grampeador</column>
+      <column name="definition_fi">nitoja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIqDob:n}</column>
@@ -2366,6 +2607,9 @@ För att använda en sådan enhet kan man {qIp:v}, {'uy:v} eller {ngaH:v} den, b
       <column name="notes_pt">O objeto de {vev:v} é {Ha'on:n}. Os papéis grampeados são o objeto de {rar:v}.[1]
 
 Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do dispositivo específico.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{vev:v}: n kohde on {Ha'on:n}. Yhdistetyt paperit ovat {rar:v}.[1]-objektin kohteita
+
+Tällaisen laitteen käyttämiseksi voi {qIp:v}, {'uy:v} tai {ngaH:v} sen tietystä laitteesta riippuen.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Ha'on:n}, {vev:v}, {-wI':n}</column>
       <column name="examples"></column>
@@ -2375,6 +2619,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2382,6 +2627,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2395,6 +2641,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="definition_ru">перевязь, орденская лента</column>
       <column name="definition_zh_HK">baldric、腰帶 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sash, faixa</column>
+      <column name="definition_fi">olkanauha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'quj nge':sen:idiom}, {mong Ha'quj:n}</column>
@@ -2405,6 +2652,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="notes_ru">В древние времена использовалась для ношения меча. Сейчас это символ {tuq:n}.</column>
       <column name="notes_zh_HK">在遠古時代，這支撐了一把劍。現在它像徵著一個人的{tuq:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Nos tempos antigos, isso sustentava uma espada. Agora é simbólico do {tuq:n} de alguém. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Muinaisina aikoina tämä tuki miekkaa. Nyt se on symbolinen {tuq:n}: lle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2416,6 +2664,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
 ▶ {qorDu'Daj tuq 'oS Ha'quj'e' tuQbogh wo'rIv. tuQtaHvIS Hem. ghaHvaD quHDaj qawmoH.:sen:nolink} "Перевязь, которую носит Ворф, является символом его семьи. Он носит её гордо, как  напоминание о его наследии."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2423,6 +2672,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 20:src} (reprinted in {HQ 5.2, p.14, Jun. 1996:src})</column>
     </table>
     <table name="mem">
@@ -2436,6 +2686,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="definition_ru">Задеть(ущемить) чью-то гордость</column>
       <column name="definition_zh_HK">傷到一個人的驕傲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ferir o orgulho</column>
+      <column name="definition_fi">loukata jonkun ylpeyttä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'quj:n}, {le'yo':n}, {nur:n}</column>
@@ -2446,6 +2697,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="notes_ru">Выражение {Ha'qujlIj nge':sen:nolink} "сними свою перевязь" значит "ущеми свою гордость".</column>
       <column name="notes_zh_HK">{Ha'qujlIj nge':sen:nolink}表示“拿走腰帶”的意思是“傷了你的自尊心”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A expressão {Ha'qujlIj nge':sen:nolink} "tire sua faixa" significa "ferir seu orgulho". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Lauseke {Ha'qujlIj nge':sen:nolink} "ota pois puitteesi" tarkoittaa "haavata ylpeyttäsi". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2455,6 +2707,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2462,6 +2715,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.123:src}</column>
     </table>
     <table name="mem">
@@ -2475,6 +2729,7 @@ Para usar tal dispositivo, pode-se {qIp:v}, {'uy:v} ou {ngaH:v}, dependendo do d
       <column name="definition_ru">курс, маршрут</column>
       <column name="definition_zh_HK">當然、路線 [AUTOTRANSLATED]</column>
       <column name="definition_pt">curso, rota</column>
+      <column name="definition_fi">kurssi, reitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeDon:n}, {tIgh:n}</column>
@@ -2499,6 +2754,9 @@ En fysisk väg (som man kan se och gå) på skulle vara en {taw:n}.[2] [AUTOTRAN
       <column name="notes_pt">Esta palavra só pode se referir a uma rota física, e não a uma rota espiritual ou metafórica. "O Caminho Klingon", por exemplo, é {tlhIngan tIgh:n:nolink}.
 
 Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi viitata vain fyysiseen reittiin, ei henkiseen tai metaforiseen reittiin. Esimerkiksi "Klingon Way" on {tlhIngan tIgh:n:nolink}.
+
+Fyysinen polku (jonka voi nähdä ja kävellä) olisi {taw:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2511,6 +2769,7 @@ Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">way, path</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2518,6 +2777,7 @@ Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATE
       <column name="search_tags_ru">путь</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2531,6 +2791,7 @@ Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATE
       <column name="definition_ru">намереваться, хотеть(иметь намерение)</column>
       <column name="definition_zh_HK">打算、意思是 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pretender, significar</column>
+      <column name="definition_fi">aikoa, suunnitella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngoQ:n}, {nab:v}, {QuS:v}</column>
@@ -2541,6 +2802,7 @@ Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2552,6 +2814,7 @@ Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2559,6 +2822,7 @@ Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2572,6 +2836,7 @@ Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATE
       <column name="definition_ru">отступать</column>
       <column name="definition_zh_HK">撤退</column>
       <column name="definition_pt">retirar</column>
+      <column name="definition_fi">vetäytyä</column>
       <column name="synonyms">{Haw':v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{DoH:v}, {Duv:v}, {chol:v}, {ghoS:v:1}, {HeDchu':v}</column>
@@ -2582,6 +2847,7 @@ Um caminho físico (que se pode ver e andar) seria um {taw:n}.[2] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Head" off.
 
 This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
@@ -2593,6 +2859,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2600,6 +2867,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2613,6 +2881,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">полностью отступить, осуществить полный вывод</column>
       <column name="definition_zh_HK">完成撤退、完全退出</column>
       <column name="definition_pt">recuar perfeitamente, fazer uma retirada completa</column>
+      <column name="definition_fi">vetäytyä kokonaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2623,6 +2892,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HeD:v}, {-chu':v}</column>
       <column name="examples"></column>
@@ -2632,6 +2902,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">retreat</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2639,6 +2910,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru">отступать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.49:src}</column>
     </table>
     <table name="mem">
@@ -2652,6 +2924,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">параллельный курс</column>
       <column name="definition_zh_HK">平行路線</column>
       <column name="definition_pt">curso paralelo</column>
+      <column name="definition_fi">rinnakkaiskurssi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{He:n}, {Don:v}</column>
@@ -2662,6 +2935,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Head-on".</column>
       <column name="components">{He:n}, {Don:v}</column>
       <column name="examples"></column>
@@ -2671,6 +2945,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2678,6 +2953,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2691,6 +2967,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Умирать</column>
       <column name="definition_zh_HK">死</column>
       <column name="definition_pt">morrer</column>
+      <column name="definition_fi">kuolla</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yIn:v}</column>
       <column name="see_also">{bogh:v}, {HoH:v}, {jub:v}, {jubbe':v}</column>
@@ -2701,6 +2978,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">Фактически {yIn:v} может быть использована транзитивно. Как и {Hegh:v:nolink}.</column>
       <column name="notes_zh_HK">可以交替使用{yIn:v}的事實表明{Hegh:v:nolink}也可以。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Se tosiasia, että {yIn:v}: tä voidaan käyttää väliaikaisesti, viittaa siihen, että {Hegh:v:nolink} voi olla myös. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2734,6 +3012,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2741,6 +3020,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2754,6 +3034,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Смерть</column>
       <column name="definition_zh_HK">死亡</column>
       <column name="definition_pt">morte</column>
+      <column name="definition_fi">kuolema</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIn:n}</column>
@@ -2764,6 +3045,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2776,6 +3058,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2783,6 +3066,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2796,6 +3080,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Смертельный вой</column>
       <column name="definition_zh_HK">死嚎 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uivo da morte</column>
+      <column name="definition_fi">kuoleman ulvonta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Heghtay:n}, {bey:n}, {beyHom bey bey'a' jachtaH:sen}</column>
@@ -2806,6 +3091,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hegh:n}, {bey:n}</column>
       <column name="examples">
@@ -2823,6 +3109,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
    Когда клингонский воин умирает или его убивают, другие клингоны могут исполнять церемониальный вой или крик, как часть клингонского смертельного ритуала. Глаза павшего клингона открыты, и остальные рычат в нарастающем объеме. По природе этот вой скорее победоносный, нежели печальный. Также служит предупреждением другим умершим, что идет клингонский воин"[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2830,6 +3117,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 31:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -2844,6 +3132,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Баржа мёртвых</column>
       <column name="definition_zh_HK">死者的駁船</column>
       <column name="definition_pt">Barcaça dos Mortos</column>
+      <column name="definition_fi">Kuolleiden vene</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qotar:n}, {ghe'tor:n}</column>
@@ -2854,6 +3143,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hegh:n}, {Duj:n:1}</column>
       <column name="examples">
@@ -2865,6 +3155,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
 ▶ {Hegh Duj DatIj 'ej ghe'torDaq Duqeng.:sen:nolink} "Баржа мертвых переправит тебя в Гретор!"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2872,6 +3163,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2885,6 +3177,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Единственное достижение дурака это смерть</column>
       <column name="definition_zh_HK">傻瓜的唯一成就就是死亡。</column>
       <column name="definition_pt">A única conquista de um tolo é a morte.</column>
+      <column name="definition_fi">Tyhmä saavuttaa vain kuoleman.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2895,6 +3188,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hegh:n}, {neH:adv}, {chav:v}, {qoH:n}</column>
       <column name="examples"></column>
@@ -2904,6 +3198,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2911,6 +3206,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.115:src}</column>
     </table>
     <table name="mem">
@@ -2924,6 +3220,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">ритуальное самоубийство</column>
       <column name="definition_zh_HK">儀式自殺、自殺禮</column>
       <column name="definition_pt">ritual de suicídio</column>
+      <column name="definition_fi">rituaalinen itsemurha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2934,6 +3231,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">Это также может быть написано как {Heghba':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也可以寫為{Heghba':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser escrito como {Heghba':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voidaan kirjoittaa myös nimellä {Heghba':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It is written {Heghba':n:nolink} in the novel "Sarek".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2943,6 +3241,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2950,6 +3249,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Sarek:src}</column>
     </table>
     <table name="mem">
@@ -2963,6 +3263,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">{Heghbat:n}</column>
       <column name="definition_zh_HK">{Heghbat:n}</column>
       <column name="definition_pt">{Heghbat:n}</column>
+      <column name="definition_fi">{Heghbat:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2973,6 +3274,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2982,6 +3284,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2989,6 +3292,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Sarek:src}</column>
     </table>
     <table name="mem">
@@ -3002,6 +3306,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Когда воин умирает, его дух вырывается</column>
       <column name="definition_zh_HK">當一個戰士死去時，他的靈魂逃脫了。</column>
       <column name="definition_pt">Quando um guerreiro morre, seu espírito escapa.</column>
+      <column name="definition_fi">Kun soturi kuolee, hänen henkensä pakenee.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{narghbe'chugh SuvwI' qa' taH may'.:sen}</column>
@@ -3012,6 +3317,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">Глагол {nargh:v:2} означает "сбегать", но он также значит "появляться" (см. {nargh:v:1}).</column>
       <column name="notes_zh_HK">動詞{nargh:v:2}的意思是“轉義”，但它（或在語音上相同的單詞）也意味“出現”（請參閱{nargh:v:1}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O verbo {nargh:v:2} significa "escape", mas (ou uma palavra foneticamente idêntica) também significa "aparecer" (consulte {nargh:v:1}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbi {nargh:v:2} tarkoittaa "paeta", mutta se (tai foneettisesti identtinen sana) tarkoittaa myös "näkyvää" (katso {nargh:v:1}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hegh:v}, {-DI':v}, {SuvwI':n}, {nargh:v:2}, {SuvwI':n}, {qa':n}</column>
       <column name="examples"></column>
@@ -3021,6 +3327,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3028,6 +3335,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.145:src}</column>
     </table>
     <table name="mem">
@@ -3041,6 +3349,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Смерть это опыт, который передается лучше всего</column>
       <column name="definition_zh_HK">死亡之經驗最佳是分享的。</column>
       <column name="definition_pt">A morte é uma experiência melhor compartilhada.</column>
+      <column name="definition_fi">Kuolema on parasta jaettuna.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3051,6 +3360,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A version of this phrase with the typo {QaQpu':sen:nolink} (instead of {QaQqu':sen:nolink}) seems to have propagated online.</column>
       <column name="components">{Hegh:v}, {-lu':v}, {-DI':v}, {mob:v:1}, {-be':v}, {-lu':v}, {-chugh:v}, {QaQ:v}, {-qu':v}, {Hegh:n}, {wanI':n}</column>
       <column name="examples"></column>
@@ -3060,6 +3370,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3067,6 +3378,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.73:src}</column>
     </table>
     <table name="mem">
@@ -3080,6 +3392,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Это хороший день, чтобы умереть!</column>
       <column name="definition_zh_HK">今天是死的好日子。</column>
       <column name="definition_pt">É um bom dia para morrer.</column>
+      <column name="definition_fi">Tänään on hyvä päivä kuolla.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mova' 'aqI' ruStaq.:excl}</column>
@@ -3090,6 +3403,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3099,6 +3413,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3106,6 +3421,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.69:src}</column>
     </table>
     <table name="mem">
@@ -3119,6 +3435,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">быть фатальным, быть смертельным, быть роковым</column>
       <column name="definition_zh_HK">是致命的（至） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser fatal (para)</column>
+      <column name="definition_fi">olla kohtalokas, kuolettava, tappava jollekulle; tappaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoH:v}</column>
@@ -3129,6 +3446,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The definition in {TKD:src} only says "be fatal", but it's clear that the verb takes an object since it is formed using {-moH:v}.</column>
       <column name="components">{Hegh:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -3138,6 +3456,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3145,6 +3464,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3158,6 +3478,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Смертельный ритуал</column>
       <column name="definition_zh_HK">死亡儀式</column>
       <column name="definition_pt">ritual de morte</column>
+      <column name="definition_fi">kuolemarituaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SonchIy:n}, {nol:n}, {'aQvoH:n}</column>
@@ -3168,6 +3489,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">Смотрите под {Hegh bey:n} для описания этого ритуала. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請參閱“ {Hegh bey:n}”下有關此儀式的說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {Hegh bey:n} para obter uma descrição desse ritual. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso tämän rituaalin kuvaus kohdasta {Hegh bey:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hegh:n}, {tay:n:2}</column>
       <column name="examples"></column>
@@ -3177,6 +3499,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3184,6 +3507,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3197,6 +3521,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">край, грань, кромка</column>
       <column name="definition_zh_HK">邊緣</column>
       <column name="definition_pt">beira, beirada</column>
+      <column name="definition_fi">reuna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{veH:n}, {vuS:v}, {ghangwI':n}</column>
@@ -3207,6 +3532,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">В {TNK:src}, {bIQ'a' HeH:n} используется, как "берег моря". В {paq'batlh:src}, {ngeng HeH:n} используется, как "берег озера".</column>
       <column name="notes_zh_HK">在{TNK:src}中，{bIQ'a' HeH:n}用於翻譯“海灘”。在{paq'batlh:src}中，{ngeng HeH:n}用於翻譯“湖岸”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No {TNK:src}, {bIQ'a' HeH:n} é usado para traduzir "praia". No {paq'batlh:src}, {ngeng HeH:n} é usado para traduzir "lakeshore". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{TNK:src}: ssä {bIQ'a' HeH:n}: ta käytetään kääntämään "ranta". {paq'batlh:src}: ssa {ngeng HeH:n}: ää käytetään kääntämään "järvenranta". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3216,6 +3542,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">border</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3223,6 +3550,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru">граница</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3236,6 +3564,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">грабить, отнимать, разбойничать</column>
       <column name="definition_zh_HK">搶</column>
       <column name="definition_pt">roubar</column>
+      <column name="definition_fi">ryöstää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIH:v}, {HeS:v}</column>
@@ -3246,6 +3575,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3255,6 +3585,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3262,6 +3593,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3275,6 +3607,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">быть гордым, быть величавым</column>
       <column name="definition_zh_HK">值得驕傲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser orgulhoso</column>
+      <column name="definition_fi">olla ylpeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nur:n}, {jeQ:v}, {tuH:v}, {tlhIngan:n}, {le'yo':n}</column>
@@ -3285,6 +3618,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">Используется в контексте восхищения. Для описания высокомерия, смотрите {nguq:v}.</column>
       <column name="notes_zh_HK">這是一個令人欽佩的特質，不帶有傲慢的內涵，對此請參見{nguq:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é uma característica admirável e não carrega conotações de arrogância, para as quais veja {nguq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ihailtava piirre, eikä sillä ole ylimielisyyttä, josta ks. {nguq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Ahem!"</column>
       <column name="components"></column>
       <column name="examples">
@@ -3295,6 +3629,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3302,6 +3637,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3315,6 +3651,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Клингоны гордая раса и мы намерены продолжать быть гордыми</column>
       <column name="definition_zh_HK">克林崗人是一種自豪的民族，和我們打算繼續自豪。</column>
       <column name="definition_pt">Os klingons são uma raça orgulhosa, e pretendemos continuar orgulhosos.</column>
+      <column name="definition_fi">Klingonit ovat ylpeä laji, ja aiomme pysyä sellaisena.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3325,6 +3662,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3334,6 +3672,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3341,6 +3680,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.13:src}</column>
     </table>
     <table name="mem">
@@ -3354,6 +3694,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">быть опытным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有經驗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser experimentado</column>
+      <column name="definition_fi">olla kokenut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'um:v}, {Han:v}</column>
@@ -3364,6 +3705,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">Это означает «опытный» в смысле вовлеченности, знакомства, знакомства или практической работы с определенной областью знаний или типом навыка.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著在參與，接觸，熟悉或親身處理給定的知識或技能類型方面具有“經驗”。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto significa "experiente" no sentido de envolvimento, exposição, familiaridade, ou lidar de forma prática com uma determinada área de conhecimento ou tipo de habilidade.[1]</column>
+      <column name="notes_fi">Tämä tarkoittaa "kokenutta" siinä mielessä, että osallistuu tiettyyn osa-alueeseen tai taitotyyppiin, altistuu siihen, tuntee sen tai käyttää sitä käytännössä.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3373,6 +3715,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3380,6 +3723,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3393,6 +3737,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">кнут [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鞭子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chicote</column>
+      <column name="definition_fi">piiska</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3403,6 +3748,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">Для глагола "кнут" используйте {Qach:v}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於動詞“ whip”，請使用{Qach:v}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para o verbo "chicote", use {Qach:v}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Käytä verbiä "piiska" käyttämällä sanaa {Qach:v}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">One evades ({jun:v}) this if one is experienced ({Hen:v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3412,6 +3758,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3419,6 +3766,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3432,6 +3780,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">Генрих V</column>
       <column name="definition_zh_HK">亨利五世</column>
       <column name="definition_pt">Henrique V</column>
+      <column name="definition_fi">Henrik V</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIvDaq pogh cha':sen}, {'o 'oghlu'meH qul:sen}</column>
@@ -3442,6 +3791,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="notes_ru">Это имя персонажа из пьесы {wIlyam SeQpIr:n:name}, а также имя персонажа.</column>
       <column name="notes_zh_HK">這是{wIlyam SeQpIr:n:name}劇中角色的名稱，也是劇本本身的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um personagem de uma peça de {wIlyam SeQpIr:n:name} e também o nome da peça em si. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {wIlyam SeQpIr:n:name}-näytelmän hahmon nimi ja myös näytelmän nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3451,6 +3801,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3458,6 +3809,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.126:src}</column>
     </table>
     <table name="mem">
@@ -3471,6 +3823,7 @@ This word is listed among other militaristic terminology in the body of {KGT:src
       <column name="definition_ru">палец (отверстия, струны инструмента) для изменения звука [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手指（孔、樂器弦）改變聲音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dedilhar (orifícios, cordas do instrumento) para variar o som</column>
+      <column name="definition_fi">koskea sormella puhallinsoittimen ilma-aukkoihin tai kielisoittimen kieliin soittaessa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meSchuS:n}, {may'ron:n}, {DIron:n}, {qung:n}, {chu':v:3}, {nItlh:n}</column>
@@ -3495,6 +3848,9 @@ Se under {nItlh:n} för de verb som är förknippade med var och en av fingrarna
       <column name="notes_pt">Esta palavra é aplicada a {SuSDeq:n} e {HurDagh:n}.[1]
 
 Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään malleihin {SuSDeq:n} ja {HurDagh:n}.[1]
+
+Katso sormiin liittyvät verbit kohdasta {nItlh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3504,6 +3860,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3511,6 +3868,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3524,6 +3882,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">hail (weather) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">冰雹</column>
       <column name="definition_pt">granizo (tempo)</column>
+      <column name="definition_fi">sataa (rakeita tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuch 'aplom:n}, {peD:v}, {jev:v:1}, {SIS:v}, {muD Dotlh:n}</column>
@@ -3534,6 +3893,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined as "hail" among other weather words. The "weather" clarification was added to distinguish it from the communication sense of "hail" ({rI':v}).
 
 "Heck" is a euphemism for "hell", which sounds like "hail".</column>
@@ -3545,6 +3905,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3552,6 +3913,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3565,6 +3927,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">исполнять, подчиняться, соглашаться что-либо исполнить</column>
       <column name="definition_zh_HK">執行 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cumprir</column>
+      <column name="definition_fi">noudattaa, totella, myöntyä, antaa periksi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'om:v}</column>
       <column name="see_also">{pab:v}, {jIj:v}, {chut:n}, {bIv:v}, {lob:v}, {wem:v}</column>
@@ -3575,6 +3938,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3584,6 +3948,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3591,6 +3956,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3604,6 +3970,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">лекарство</column>
       <column name="definition_zh_HK">醫</column>
       <column name="definition_pt">medicamento</column>
+      <column name="definition_fi">lääke</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vor:v}, {Qel:n:1h}, {tar:n}, {ngej:v}, {Sev:n}, {Hergh QaywI':n}, {'enteD:n}, {'enteD:n}</column>
@@ -3614,6 +3981,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3624,6 +3992,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">drug</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3631,6 +4000,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3644,6 +4014,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">фармацевт, химик, аптекарь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">藥劑師、化學家、藥劑師 [AUTOTRANSLATED]</column>
       <column name="definition_pt">farmacêutico, químico</column>
+      <column name="definition_fi">farmaseutti, apteekkari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamlerQeD:n}</column>
@@ -3654,6 +4025,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hergh:n}, {ngevwI':n}</column>
       <column name="examples"></column>
@@ -3663,6 +4035,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">drugstore</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3670,6 +4043,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -3683,6 +4057,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">конвой медицинской помощи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">醫療救援車隊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comboio de assistência médica</column>
+      <column name="definition_fi">lääkeapusaattue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3693,6 +4068,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hergh:n}, {qeng:v}, {-bogh:v}, {yo':n}</column>
       <column name="examples">
@@ -3703,6 +4079,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3710,6 +4087,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3723,6 +4101,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">шприц, гипошприц</column>
       <column name="definition_zh_HK">低氣動、低氣壓 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Hypospray</column>
+      <column name="definition_fi">lääkeruisku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3733,6 +4112,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru">Может быть сокращено до {HerghwI':n:nolink}.</column>
       <column name="notes_zh_HK">這也縮短為{HerghwI':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é reduzido para {HerghwI':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lyhennetään myös muotoon {HerghwI':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hergh:n}, {Qay:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3742,6 +4122,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hypospray, needle</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3749,6 +4130,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3762,6 +4144,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">{Hergh QaywI':n}</column>
       <column name="definition_zh_HK">{Hergh QaywI':n}</column>
       <column name="definition_pt">{Hergh QaywI':n}</column>
+      <column name="definition_fi">{Hergh QaywI':n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3772,6 +4155,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3781,6 +4165,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3788,6 +4173,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3801,6 +4187,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">совершить преступление</column>
       <column name="definition_zh_HK">犯罪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cometer um crime</column>
+      <column name="definition_fi">tehdä rikos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qop:v}, {yem:v}, {DIS:v}, {Hej:v}, {HeS:n}</column>
@@ -3811,6 +4198,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3820,6 +4208,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3827,6 +4216,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3840,6 +4230,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">преступление</column>
       <column name="definition_zh_HK">犯罪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">crime</column>
+      <column name="definition_fi">rikos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeS:v}</column>
@@ -3850,6 +4241,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3859,6 +4251,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3866,6 +4259,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3879,6 +4273,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">преступник</column>
       <column name="definition_zh_HK">刑事 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Criminoso</column>
+      <column name="definition_fi">rikollinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qop:v}, {jIvvo':n}</column>
@@ -3889,6 +4284,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">R. Hess was a famous war criminal.</column>
       <column name="components">{HeS:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3898,6 +4294,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3905,6 +4302,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3918,6 +4316,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">получать, принимать</column>
       <column name="definition_zh_HK">接收 [AUTOTRANSLATED]</column>
       <column name="definition_pt">receber</column>
+      <column name="definition_fi">vastaanottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngeH:v}</column>
@@ -3928,6 +4327,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3938,6 +4338,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3945,6 +4346,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3958,6 +4360,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">Статуя</column>
       <column name="definition_zh_HK">雕像</column>
       <column name="definition_pt">estátua</column>
+      <column name="definition_fi">patsas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nan:v:1}, {tey:v:1}, {ghItlh:v}, {nagh:n}, {'Iw 'Ip ghomey:n}, {Habnagh:n:extcan}</column>
@@ -3968,6 +4371,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru">Есть идиома {tam; Hew rur}.</column>
       <column name="notes_zh_HK">有一個成語，{tam; Hew rur}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {tam; Hew rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {tam; Hew rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">One "hew"s a statue.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3977,6 +4381,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3984,6 +4389,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3997,6 +4403,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">скульптор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雕塑家</column>
       <column name="definition_pt">escultor</column>
+      <column name="definition_fi">kuvanveistäjä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIStaq:n:name}</column>
@@ -4007,6 +4414,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hew:n}, {chenmoHwI':n}</column>
       <column name="examples"></column>
@@ -4016,6 +4424,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4023,6 +4432,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4036,6 +4446,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">вести бой или сражаться с собственной группой</column>
       <column name="definition_zh_HK">與自己的團體作戰或戰鬥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">batalhar ou lutar contra o próprio grupo</column>
+      <column name="definition_fi">taistella omaa ryhmää vastaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4046,6 +4457,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru">Глагол обозначает сражение против своей собственной группы, а не с предполагаемым врагом.[1]</column>
       <column name="notes_zh_HK">該動詞表示與自己的團體作戰，而不是與所謂的敵人作戰。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo indica lutar contra o próprio grupo, e não o suposto inimigo.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi osoittaa taistelun omaa ryhmää vastaan ​​eikä oletettua vihollista vastaan[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This may have been a back-fit for a mispronunciation of {Hegh:v}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4056,6 +4468,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">infighting</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4063,6 +4476,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru">распри, борьба, междоусобица</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -4076,6 +4490,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">атом</column>
       <column name="definition_zh_HK">原子</column>
       <column name="definition_pt">átomo</column>
+      <column name="definition_fi">atomi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {'o'rIS:n}, {yugh:v}, {pay'an:n}, {ngIng:v}, {ruS:v}, {tat:n}</column>
@@ -4086,6 +4501,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru">Компоненты атома могут включать {yomIj:n}, {valtIn:n}, and {tem:n}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Os componentes de um átomo podem incluir {yomIj:n}, {valtIn:n} e {tem:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Atomin komponentit voivat sisältää {yomIj:n}, {valtIn:n} ja {tem:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Atomium is a famous building in Heysel, Brussels.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4095,6 +4511,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4102,6 +4519,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -4115,6 +4533,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">пахнуть, испускать запах</column>
       <column name="definition_zh_HK">聞到、散發出異味 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cheirar, emitir odor</column>
+      <column name="definition_fi">haista, tuoksua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{He'So':v}, {largh:v}, {pIw:n}</column>
@@ -4125,6 +4544,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4134,6 +4554,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">emit odour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4141,6 +4562,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru">испускать запах</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4154,6 +4576,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">вонять, смердеть</column>
       <column name="definition_zh_HK">臭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">feder</column>
+      <column name="definition_fi">haista, tuoksua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{He':v}, {largh:v}, {pIw:n}</column>
@@ -4164,6 +4587,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru">Это слово относится к выделения запаха. Она не имеет смысла "дурной запах"</column>
       <column name="notes_zh_HK">這個詞是指氣味的散發。它沒有英語中“臭味”一詞的慣用意義“非常不好”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se à emissão de odor. Ele não tem o senso idiomático de "ser muito ruim", como a palavra "fedor" em inglês. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa hajupäästöihin. Sillä ei ole idiomaattista merkitystä "olla erittäin huono", kuten sana "haiseva" tekee englanniksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4173,6 +4597,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4180,6 +4605,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4193,6 +4619,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">повелительное наклонение: ты(действие)-мне, вы (множественное) число(действие)-мне</column>
       <column name="definition_zh_HK">（命令）你、你們：我</column>
       <column name="definition_pt">imperativo: você-eu</column>
+      <column name="definition_fi">imperatiivi: sinä/te-minua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cho-:v:pref}, {tu-:v:pref}</column>
@@ -4205,6 +4632,8 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
 {tlhIH:n}:{jIH:n:1h} = {HI-:v:pref,nolink} (пов.накл.)</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SoH:n}: {jIH:n:1h} = {HI-:v:pref,nolink} (imp.)
+{tlhIH:n}: {jIH:n:1h} = {HI-:v:pref,nolink} (imp.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4214,6 +4643,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4221,6 +4651,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4234,6 +4665,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">пистолет, револьвер</column>
       <column name="definition_zh_HK">手槍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">revólver</column>
+      <column name="definition_fi">käsituliase, pistooli, revolveri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{beH:n}, {pu'HIch:n}</column>
@@ -4244,6 +4676,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4253,6 +4686,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gun</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4260,6 +4694,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru">ружьё</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4274,6 +4709,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">шлюз</column>
       <column name="definition_zh_HK">氣閘 [AUTOTRANSLATED]</column>
       <column name="definition_pt">câmara de ar</column>
+      <column name="definition_fi">ilmalukko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lojmIt:n}</column>
@@ -4284,6 +4720,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4293,6 +4730,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4300,6 +4738,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4313,6 +4752,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="definition_ru">потеть, потеть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">流汗、出汗</column>
       <column name="definition_pt">suar, transpirar</column>
+      <column name="definition_fi">hiki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuynIj:n}</column>
@@ -4323,6 +4763,7 @@ Veja em {nItlh:n} para os verbos associados a cada um dos dedos. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Hidrosis".
 
 This was explicitly noted not to take an object.</column>
@@ -4334,6 +4775,7 @@ This was explicitly noted not to take an object.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4341,6 +4783,7 @@ This was explicitly noted not to take an object.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4354,6 +4797,7 @@ This was explicitly noted not to take an object.</column>
       <column name="definition_ru">меню</column>
       <column name="definition_zh_HK">菜單、選單</column>
       <column name="definition_pt">cardápio</column>
+      <column name="definition_fi">ruokalista, menu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qe':n}, {vun:v}, {tetlh:n}, {mem:n}, {buv:n}</column>
@@ -4364,6 +4808,7 @@ This was explicitly noted not to take an object.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4373,6 +4818,7 @@ This was explicitly noted not to take an object.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4380,6 +4826,7 @@ This was explicitly noted not to take an object.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4394,6 +4841,7 @@ This was explicitly noted not to take an object.</column>
       <column name="definition_ru">драться грязно, драться нечестными способами</column>
       <column name="definition_zh_HK">打得很髒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lutar sujo</column>
+      <column name="definition_fi">taistella epärehellisesti, likaisia keinoja käyttäen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suv:v}, {toj:v}</column>
@@ -4404,6 +4852,7 @@ This was explicitly noted not to take an object.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4413,6 +4862,7 @@ This was explicitly noted not to take an object.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4420,6 +4870,7 @@ This was explicitly noted not to take an object.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4433,6 +4884,7 @@ This was explicitly noted not to take an object.</column>
       <column name="definition_ru">Идите сюда"</column>
       <column name="definition_zh_HK">過來！</column>
       <column name="definition_pt">Venha aqui!</column>
+      <column name="definition_fi">Tule tänne!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4449,6 +4901,9 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
 Смотрите, как Гаурон говорит это: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "Tule minua kohti!"
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{HI-:v}, {ghoS:v:1}</column>
       <column name="examples"></column>
@@ -4458,6 +4913,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4465,6 +4921,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -4478,6 +4935,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="definition_ru">доставлять, перевозить, осуществлять транспортировку товаров</column>
       <column name="definition_zh_HK">交貨、運輸貨物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">entregar, transportar mercadorias</column>
+      <column name="definition_fi">toimittaa, kuljettaa kauppatavaraa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lup:v}, {qeng:v}, {Qay:v}</column>
@@ -4488,6 +4946,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{HIj:v:nolink} is used for transporting goods, whereas it seems that {lup:v} is used for transporting people.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4499,6 +4958,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
 ▶ {yIHmey DaHIj'a'? ghobe', yIHmey vIHIjbe'.:sen@@yIH:n, -mey:n, Da-:v, HIj:v, -'a':v, ghobe':excl, yIH:n, -mey:n, vI-:v, HIj:v, -be':v} "Вы перевозите трибблов? Нет. Я не перевожу трибблов."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4506,6 +4966,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -4519,6 +4980,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="definition_ru">штамп, почтовая марка</column>
       <column name="definition_zh_HK">郵票</column>
       <column name="definition_pt">carimbo, selo postal</column>
+      <column name="definition_fi">postimerkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIn 'echletHom:n}, {nav qatwI':n}, {toqwIn:n}</column>
@@ -4529,6 +4991,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HIj:v}, {-meH:v}, {chaw':n}</column>
       <column name="examples"></column>
@@ -4538,6 +5001,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4545,6 +5009,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4558,6 +5023,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/Wq5mvIWRSKc}</col
       <column name="definition_ru">да, верно (ответ на вопрос да\нет)</column>
       <column name="definition_zh_HK">是的、是的（回答是/否問題） [AUTOTRANSLATED]</column>
       <column name="definition_pt">sim, verdadeiro (resposta à pergunta sim / não)</column>
+      <column name="definition_fi">kyllä (vastaus kyllä/ei-kysymykseen)</column>
       <column name="synonyms">{HISlaH:excl}</column>
       <column name="antonyms">{ghobe':excl}</column>
       <column name="see_also">{-'a':v:suff}, {lu':excl}, {luq:excl}</column>
@@ -4582,6 +5048,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/KArQlviVXMk} [AUTOTRAN
       <column name="notes_pt">Esta é a resposta positiva a uma pergunta sim / não (consulte {-'a':v}). Ao contrário da palavra em inglês "sim", ela não é usada como uma exclamação autônoma indicando percepção, alegria e assim por diante (para ver {toH:excl} e {Qapla'!:sen}). Para uma exclamação indicando conformidade, como em resposta a um comando, consulte {lu':excl}.
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on positiivinen vastaus kyllä ​​/ ei-kysymykseen (katso {-'a':v}). Toisin kuin englanninkielinen sana "kyllä", sitä ei käytetä itsenäisenä huutomerkkinä, joka osoittaa oivallusta, iloa ja niin edelleen (katso {toH:excl} ja {Qapla'!:sen}). Katso huutomerkki, joka osoittaa vaatimustenmukaisuuden, kuten vastauksena komentoon, kohdasta {lu':excl}.
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/KArQlviVXMk} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Looks like a combination of the Japanese and German affirmative answers ("hai" and "ja").</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4591,6 +5060,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4598,6 +5068,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4611,6 +5082,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">Поднимайте меня на борт!</column>
       <column name="definition_zh_HK">傳送我來艦上！</column>
       <column name="definition_pt">Teletransporte-me a bordo!</column>
+      <column name="definition_fi">Siirrä minut kyytiin! (siirtimellä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jol yIchu'!:sen}</column>
@@ -4621,6 +5093,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HI-:v}, {jol:v}</column>
       <column name="examples"></column>
@@ -4630,6 +5103,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4637,6 +5111,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -4650,6 +5125,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">пошаговые инструкции [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">分步說明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">instruções passo-a-passo</column>
+      <column name="definition_fi">vaiheittaiset ohjeet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIw:n}, {qurme':n}</column>
@@ -4660,6 +5136,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru">Это единственное число. {HIl'aDmey:n@@HIl'aD:n, -mey:n} будет означать несколько наборов инструкций. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是單數。 {HIl'aDmey:n@@HIl'aD:n, -mey:n}表示幾組指令。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é singular. {HIl'aDmey:n@@HIl'aD:n, -mey:n} significaria vários conjuntos de instruções. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksikkö. {HIl'aDmey:n@@HIl'aD:n, -mey:n} tarkoittaisi useita komentosarjoja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{HIlaD:sen@@HI-:v, laD:v} means "read me!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4669,6 +5146,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">formula, recipe</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4676,6 +5154,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4689,6 +5168,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">Униформа</column>
       <column name="definition_zh_HK">制服 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uniforme</column>
+      <column name="definition_fi">virkapuku, univormu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sut:n}, {SeQ:v}</column>
@@ -4699,6 +5179,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru">Относится к боевой униформе</column>
       <column name="notes_zh_HK">這是指戰鬥中穿的衣服。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se às roupas usadas na batalha. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa taistelussa käytettyihin vaatteisiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In English slang, "hip" means fashionable in the context of clothing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4708,6 +5189,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4715,6 +5197,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4728,6 +5211,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">Ликер, эль, пиво, вино</column>
       <column name="definition_zh_HK">酒、啤酒、啤酒、葡萄酒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">licor, cerveja, vinho, cerveja ale</column>
+      <column name="definition_fi">olut, viini, viina</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qegh:n}, {chech:v}, {'uH:v}, {pIchSIv:n}, {'enteD:n}</column>
@@ -4738,6 +5222,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru">Типы {HIq:n} включают {baqghol:n}, {chechtlhutlh:n} и {wornagh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{HIq:n}的類型包括{baqghol:n}，{chechtlhutlh:n}和{wornagh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os tipos de {HIq:n} incluem {baqghol:n}, {chechtlhutlh:n} e {wornagh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{HIq:n}-tyypit sisältävät {baqghol:n}, {chechtlhutlh:n} ja {wornagh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Hic"cup.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4754,6 +5239,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">alcohol</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4761,6 +5247,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru">алкоголь</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4774,6 +5261,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">Чтобы найти эль, идите в бар!</column>
       <column name="definition_zh_HK">要找到啤酒，請進入酒吧。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Para encontrar cerveja Ale, entre em um bar.</column>
+      <column name="definition_fi">Oluen löytämiseksi mene baariin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4784,6 +5272,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4793,6 +5282,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4800,6 +5290,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.181:src}</column>
     </table>
     <table name="mem">
@@ -4813,6 +5304,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">пивная кружка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">啤酒杯</column>
       <column name="definition_pt">caneca de cerveja</column>
+      <column name="definition_fi">oluttuoppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4823,6 +5315,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HIq:n}, {HIvje':n}</column>
       <column name="examples"></column>
@@ -4832,6 +5325,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4839,6 +5333,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -4852,6 +5347,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">застрять (физически привязанный к чему-либо) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">卡住（物理上固定在某物上） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficar preso (preso fisicamente a alguma coisa)</column>
+      <column name="definition_fi">olla liimautunut, olla kiinnittynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngam:v}, {Hum:v}, {nguD:v}</column>
@@ -4862,6 +5358,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru">Здесь описывается, как наклейка наклеивается на конверт или пачка плевания прикрепляется к стене. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這描述了郵票是如何粘貼到信封上或一堆吐痰如何粘貼到牆上的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso descreve como um carimbo está preso a um envelope ou um maço de espeto preso à parede. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kuvaa kuinka leima tarttuu kirjekuoreen tai sylkeä on kiinni seinään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "be stuck" with an explanation, along with a bunch of other words which can be translated into various senses of "be stuck" in English.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4871,6 +5368,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4878,6 +5376,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4891,6 +5390,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">быть сжатым (как в воздухе) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被壓縮（如空氣中） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser comprimido (como no ar)</column>
+      <column name="definition_fi">olla tiivistetty, puristettu, paineistettu, pakattu (kaasusta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rewve':n}, {lay:n:2h}, {ngI':v}</column>
@@ -4901,6 +5401,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Hiss".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4910,6 +5411,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4917,6 +5419,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4930,6 +5433,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">Come with me! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">跟我來！</column>
       <column name="definition_pt">Venha comigo!</column>
+      <column name="definition_fi">Tule mukaani!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4940,6 +5444,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru">Эта строка говорилась на клингонском языке, но не имела субтитров. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此行在克林崗語中被使用，但沒有字幕。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta linha foi falada em klingon, mas não foi legendada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä rivi puhuttiin Klingonissa, mutta sitä ei tekstitetty. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{HI-:v}, {tlhej:v}</column>
       <column name="examples"></column>
@@ -4949,6 +5454,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4956,6 +5462,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -4969,6 +5476,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">черный эль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">黑麥酒</column>
       <column name="definition_pt">cerveja ale preta</column>
+      <column name="definition_fi">musta ale</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4979,6 +5487,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru">Это известно как туристический напиток. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這被稱為旅遊飲料。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é conhecido como uma bebida turística. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tunnetaan turistijuomana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{HIq:n}, {qIj:v}</column>
       <column name="examples"></column>
@@ -4988,6 +5497,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4995,6 +5505,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -5008,6 +5519,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">Да, верно (ответ на вопрос да\нет)</column>
       <column name="definition_zh_HK">是的、是的（回答是/否問題） [AUTOTRANSLATED]</column>
       <column name="definition_pt">sim, verdadeiro (resposta à pergunta sim / não)</column>
+      <column name="definition_fi">kyllä (vastaus kyllä/ei-kysymykseen)</column>
       <column name="synonyms">{HIja':excl}</column>
       <column name="antonyms">{ghobe':excl}</column>
       <column name="see_also">{-'a':v:suff}, {lu':excl}, {luq:excl}</column>
@@ -5018,6 +5530,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru">Является разновидностью {HIja':excl}.</column>
       <column name="notes_zh_HK">這是{HIja':excl}的變體。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma variante do {HIja':excl}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {HIja':excl}-muunnos. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5027,6 +5540,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5034,6 +5548,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5047,6 +5562,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">атаковать, нападать</column>
       <column name="definition_zh_HK">攻擊</column>
       <column name="definition_pt">ataque</column>
+      <column name="definition_fi">hyökätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hub:v}, {weH:v}, {yot:v}, {yov:v}</column>
@@ -5057,6 +5573,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5068,6 +5585,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5075,6 +5593,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -5088,6 +5607,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">Только дураки не нападают!</column>
           <column name="definition_zh_HK">只有傻瓜之不攻擊。</column>
           <column name="definition_pt">Apenas tolos não atacam.</column>
+      <column name="definition_fi">Vain tyhmät eivät hyökkää.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5098,6 +5618,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HIv:v}, {-be':v}, {qoH:n}, {-pu':n}, {neH:adv}</column>
           <column name="examples"></column>
@@ -5107,6 +5628,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5114,6 +5636,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.113:src}</column>
         </table>
         <table name="mem">
@@ -5127,6 +5650,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">Дистанция атаки</column>
           <column name="definition_zh_HK">射程、攻擊範圍</column>
           <column name="definition_pt">raio de ataque</column>
+      <column name="definition_fi">hyökkäyskantama?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5137,6 +5661,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HIv:n:hyp,nolink}, {chuq:n}</column>
           <column name="examples">
@@ -5147,6 +5672,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5154,6 +5680,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 8.4, p.12, Dec. 1999:src}, [2] {Star Trek V:src}</column>
         </table>
         <table name="mem">
@@ -5167,6 +5694,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">истребитель</column>
           <column name="definition_zh_HK">攻擊戰鬥機（船隻） [AUTOTRANSLATED]</column>
           <column name="definition_pt">Cruzador de ataque (embarcação)</column>
+      <column name="definition_fi">hyökkäysalus</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5177,6 +5705,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HIv:n:hyp,nolink}, {Duj:n:1}</column>
           <column name="examples"></column>
@@ -5186,6 +5715,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5193,6 +5723,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -5206,6 +5737,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">курс атаки</column>
           <column name="definition_zh_HK">攻擊航向</column>
           <column name="definition_pt">Curso de ataque</column>
+      <column name="definition_fi">hyökkäyskurssi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5216,6 +5748,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HIv:n:hyp,nolink}, {He:n}</column>
           <column name="examples"></column>
@@ -5225,6 +5758,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5232,6 +5766,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Star Trek V:src}</column>
         </table>
         <table name="mem">
@@ -5245,6 +5780,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">Корабль включает маскировку, чтобы атаковать</column>
           <column name="definition_zh_HK">一艘船為了攻擊而斗篷。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Uma nave se esconde para atacar.</column>
+      <column name="definition_fi">Alus verhoutuu hyökätäkseen.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5255,6 +5791,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HIv:v}, {-meH:v}, {Duj:n:1}, {So':v:1}, {-lu':v}</column>
           <column name="examples"></column>
@@ -5264,6 +5801,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5271,6 +5809,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.182:src}</column>
         </table>
         <table name="mem">
@@ -5284,6 +5823,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">честь-атака [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">榮譽攻擊 [AUTOTRANSLATED]</column>
           <column name="definition_pt">ataque de honra</column>
+      <column name="definition_fi">kunniahyökkäys?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{HubneS:v}, {Suvchu':v}</column>
@@ -5294,6 +5834,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru">При использовании с глаголом {HIv:v} суффикс {-neS:v:suff} указывает, что самоубийство является частью плана атаки. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">與動詞{HIv:v}一起使用時，後綴{-neS:v:suff}表示自殺是攻擊計劃的一部分。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Quando usado com o verbo {HIv:v}, o sufixo {-neS:v:suff} indica que o suicídio faz parte do plano de ataque. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun sitä käytetään verbin {HIv:v} kanssa, loppuliite {-neS:v:suff} osoittaa, että itsemurha on osa hyökkäyssuunnitelmaa. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{HIv:v}, {-neS:v}</column>
           <column name="examples"></column>
@@ -5303,6 +5844,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">honour-attack</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5310,6 +5852,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.49:src}</column>
         </table>
         <table name="mem">
@@ -5323,6 +5866,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">Фек'лр снова наносит удар. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">Fek'lhr再次罷工。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">O Fek'lhr ataca novamente.</column>
+      <column name="definition_fi">Fek'lhr iskee jälleen.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{veqlargh:n}</column>
@@ -5333,6 +5877,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -5342,6 +5887,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">replacement proverb</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5349,6 +5895,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {PK:src}</column>
         </table>
     <table name="mem">
@@ -5362,6 +5909,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">стекло тумблера</column>
       <column name="definition_zh_HK">杯</column>
       <column name="definition_pt">copo (de vidro)</column>
+      <column name="definition_fi">juomalasi, muki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5372,6 +5920,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{Dargh HIvje':n}, {HIq HIvje':n}</column>
@@ -5381,6 +5930,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mug, cup, stein</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5388,6 +5938,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -5401,6 +5952,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">застольная песня</column>
           <column name="definition_zh_HK">喝酒歌 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Canto de bebedeiras</column>
+      <column name="definition_fi">juomalaulu</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{bom:n}</column>
@@ -5411,6 +5963,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HIvje':n}, {bom:n}</column>
           <column name="examples"></column>
@@ -5420,6 +5973,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5427,6 +5981,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
     <table name="mem">
@@ -5440,6 +5995,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">Диктатор</column>
       <column name="definition_zh_HK">獨裁者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ditador</column>
+      <column name="definition_fi">diktaattori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HI''a':n}</column>
@@ -5450,6 +6006,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{HI'tlher:n:name,nolink} was a lumpy dictator.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5459,6 +6016,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5466,6 +6024,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -5479,6 +6038,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="definition_ru">Тиран</column>
           <column name="definition_zh_HK">暴君 [AUTOTRANSLATED]</column>
           <column name="definition_pt">tirano</column>
+      <column name="definition_fi">tyranni</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5489,6 +6049,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi">{paq'batlh:n}: ssä {molor:n:name}: ta kutsutaan kaikkialla {HI''a':n:nolink} "tyranniksi". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{HI':n}, {-'a':n:suff}</column>
           <column name="examples"></column>
@@ -5498,6 +6059,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5505,6 +6067,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {paq'batlh:src}</column>
         </table>
     <table name="mem">
@@ -5518,6 +6081,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="definition_ru">Диктаторство, диктат</column>
       <column name="definition_zh_HK">專政 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ditadura</column>
+      <column name="definition_fi">diktatuuri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5528,6 +6092,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/KArQlviVXMk} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{HItoy'.:sen:nolink}
 
 There's no evidence that {tuy:n:nolink} exists as an independent word or component.</column>
@@ -5539,6 +6104,7 @@ There's no evidence that {tuy:n:nolink} exists as an independent word or compone
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5546,6 +6112,7 @@ There's no evidence that {tuy:n:nolink} exists as an independent word or compone
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5559,6 +6126,7 @@ There's no evidence that {tuy:n:nolink} exists as an independent word or compone
       <column name="definition_ru">зевать, зиять</column>
       <column name="definition_zh_HK">打哈欠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bocejar</column>
+      <column name="definition_fi">haukotella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qong:v}, {Doy':v}</column>
@@ -5569,6 +6137,7 @@ There's no evidence that {tuy:n:nolink} exists as an independent word or compone
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {boH:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5578,6 +6147,7 @@ There's no evidence that {tuy:n:nolink} exists as an independent word or compone
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5585,6 +6155,7 @@ There's no evidence that {tuy:n:nolink} exists as an independent word or compone
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5598,6 +6169,7 @@ There's no evidence that {tuy:n:nolink} exists as an independent word or compone
       <column name="definition_ru">все, каждый, всякий</column>
       <column name="definition_zh_HK">所有、一切、每個</column>
       <column name="definition_pt">todos, tudo, todas as coisas, cada</column>
+      <column name="definition_fi">kaikki, jokainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pagh:n:1}</column>
       <column name="see_also">{'op:n}, {HochHom:n}, {ngIq:n}, {HochDIch:n}, {Hochlogh:adv}</column>
@@ -5622,6 +6194,9 @@ Om {Hoch:n:nolink} följer ett substantiv betyder det "hela X" .[3; 4] Observera
       <column name="notes_pt">Se {Hoch:n:nolink} for seguido por um substantivo que é explicitamente plural, significa "todos os X", considerados coletivamente. Se o substantivo a seguir não estiver explicitamente no plural, significa "cada X", considerado individualmente.[2]
 
 Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe que isso é diferente de {naQ:v} após um substantivo, que significa "um X completo". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos {Hoch:n:nolink}: n jälkeen on substantiivi, joka on nimenomaisesti monikko, se tarkoittaa "kaikkia X: itä" yhdessä otettuna. Jos seuraava substantiivi ei ole nimenomaisesti monikko, se tarkoittaa "kukin X" erikseen tarkasteltuna.
+
+Jos {Hoch:n:nolink} seuraa substantiivia, se tarkoittaa "kaikki X: tä".[2][3; 4]{naQ:v} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5667,6 +6242,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
    Followed her cry for Kahless."[2, p.186-187]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5674,6 +6250,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 5.2, p.11, Jun. 1996:src}, [3] {KGT p.155:src}, [4] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -5687,6 +6264,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">конец, окончание, завершение, граница, последний пункт списка</column>
       <column name="definition_zh_HK">結束、列表中的最後一項 [AUTOTRANSLATED]</column>
       <column name="definition_pt">final, último item de uma lista</column>
+      <column name="definition_fi">luettelon viimeinen kohta</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wa'DIch:n}</column>
       <column name="see_also">{paghDIch:n}, {Qav:v}</column>
@@ -5697,6 +6275,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="notes_ru">Первым элементом в списке слов (например) будет {mu' wa'DIch:n@@mu':n, wa'DIch:n}, в то время как можно сказать {mu' HochDIch:n@@mu':n, HochDIch:n} для последнего слова в списке или использовать специальный термин для конца списка, {natlIS:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">單詞列表中的第一項（例如）將是{mu' wa'DIch:n@@mu':n, wa'DIch:n}，而單詞中的最後一個單詞可能是{mu' HochDIch:n@@mu':n, HochDIch:n}，或者列表結尾使用特殊術語{natlIS:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O primeiro item de uma lista de palavras (por exemplo) seria {mu' wa'DIch:n@@mu':n, wa'DIch:n}, enquanto alguém poderia dizer {mu' HochDIch:n@@mu':n, HochDIch:n} para a última palavra da lista ou usar um termo especial para o final de uma lista, {natlIS:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sanaluettelon (esim.) Ensimmäinen kohde olisi {mu' wa'DIch:n@@mu':n, wa'DIch:n}, kun taas voisi sanoa {mu' HochDIch:n@@mu':n, HochDIch:n} luettelon viimeiselle sanalle tai käyttää erityistä termiä luettelon loppuun {natlIS:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hoch:n}, {-DIch:n:num,suff}</column>
       <column name="examples"></column>
@@ -5706,6 +6285,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5713,6 +6293,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.177:src}, [2] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -5726,6 +6307,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">большая часть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大部分、多數</column>
       <column name="definition_pt">maior parte</column>
+      <column name="definition_fi">suurin osa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'op:n}, {bID:n}</column>
@@ -5736,6 +6318,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The sentence from {SkyBox 15:src} seems to have the {wa'DIch:n} in the wrong place. Also, the second occurrence of {vatlh DIS poH:n} is missing a space.</column>
       <column name="components">{Hoch:n}, {-Hom:n}</column>
       <column name="examples">
@@ -5749,6 +6332,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5756,6 +6340,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 15:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -5769,6 +6354,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">всегда, всегда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">總是如此 [AUTOTRANSLATED]</column>
       <column name="definition_pt">todos as vezes, sempre</column>
+      <column name="definition_fi">aina, joka kerta</column>
       <column name="synonyms">{reH:adv}</column>
       <column name="antonyms">{paghlogh:adv}</column>
       <column name="see_also"></column>
@@ -5779,6 +6365,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="notes_ru">Это решительная альтернатива для {reH:adv}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{reH:adv}的重要替代方案。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma alternativa enfática ao {reH:adv}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on painava vaihtoehto {reH:adv}: lle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hoch:n}, {-logh:n:num,suff}</column>
       <column name="examples">
@@ -5789,6 +6376,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5796,6 +6384,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.178:src}</column>
     </table>
     <table name="mem">
@@ -5810,6 +6399,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">универсальный переводчик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">萬能翻譯機</column>
       <column name="definition_pt">tradutor universal</column>
+      <column name="definition_fi">universaalikääntäjä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5820,6 +6410,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The example sentence was MO's reply to the interviewer who asked him to choose his favourite Star Trek technology. He chose the transporter beam ({jol:n}).</column>
       <column name="components">{Hoch:n}, {Hol:n}, {-mey:n}, {mugh:v}, {-wI':v}</column>
       <column name="examples">
@@ -5830,6 +6421,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5837,6 +6429,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Air &amp; Space Magazine, August 2016:src}</column>
     </table>
     <table name="mem">
@@ -5850,6 +6443,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">Пожалейте воина, который убивает всех своих врагов. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">可憐殺死他所有敵人的戰士。</column>
       <column name="definition_pt">Tenha pena do guerreiro que mata todos os seus inimigos.</column>
+      <column name="definition_fi">Sääli soturia, joka on tappanut kaikki vihollisensa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5860,6 +6454,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="notes_ru">Это знаменитая строка из стихотворения Gontrok {lu qeng:n:name,nolink}. Идиоматическое выражение {Hoch jaghpu'Daj HoHpu':sen:nolink} «Он / она убил всех своих врагов» означает, что человек ведет бессмысленную, пустую жизнь, в которой нет проблем. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是G'trok的一首詩{lu qeng:n:name,nolink}的著名詩句。慣用語{Hoch jaghpu'Daj HoHpu':sen:nolink}“他/她殺死了所有敵人”意味著一個人過著毫無意義，空虛的生活，沒有任何挑戰。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma frase famosa do poema {lu qeng:n:name,nolink} de G'trok. A expressão idiomática {Hoch jaghpu'Daj HoHpu':sen:nolink} "Ele / ela matou todos os seus inimigos" significa que uma pessoa leva uma vida vazia, sem sentido, sem desafios. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kuuluisa rivi G'trokin runosta {lu qeng:n:name,nolink}. Idiomaattinen ilmaus {Hoch jaghpu'Daj HoHpu':sen:nolink} "Hän on tappanut kaikki vihollisensa" tarkoittaa, että henkilö elää merkityksetöntä, tyhjää elämää, josta ei ole haastetta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hoch:n}, {jagh:n}, {-pu':n}, {-Daj:n}, {HoH:v}, {-bogh:v}, {SuvwI':n}, {yI-:v}, {vup:v}</column>
       <column name="examples"></column>
@@ -5869,6 +6464,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5876,6 +6472,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.107:src}</column>
     </table>
     <table name="mem">
@@ -5889,6 +6486,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">рассмотреть каждую возможность [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">考慮每種可能性 [AUTOTRANSLATED]</column>
       <column name="definition_pt">considerar todas as possibilidades</column>
+      <column name="definition_fi">pohtia jokaista vaihtoehtoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5899,6 +6497,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="notes_ru">Это идиоматическое выражение, основанное на гомофонии слов {nuH:n:1} и {nuH:n:2}, означает «рассмотреть каждую возможность» или «рассмотреть каждую возможность». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語表達是基於單詞{nuH:n:1}和{nuH:n:2}的諧音，意思是“考慮每種可能性”或“考慮每種選擇”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática, baseada na homofonia das palavras {nuH:n:1} e {nuH:n:2}, significa "considerar todas as possibilidades" ou "considerar todas as opções". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaus, joka perustuu sanojen {nuH:n:1} ja {nuH:n:2} homofoniaan, tarkoittaa "harkitsemaan kaikkia mahdollisuuksia" tai "harkitsemaan kaikkia vaihtoehtoja". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5910,6 +6509,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">option, possibility, choice</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5917,6 +6517,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.108:src}</column>
     </table>
     <table name="mem">
@@ -5930,6 +6531,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">Съешь все, или ты умрешь без чести. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">如果你不吃哂一切，你的死而會沒有榮譽。</column>
       <column name="definition_pt">Coma tudo ou você morrerá sem honra.</column>
+      <column name="definition_fi">Syö kaikki tai kuolet ilman kunniaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5940,6 +6542,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="notes_ru">Это примерно как сказать: «Ешь, ешь!» [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就像在說：“吃，吃！” [AUTOTRANSLATED]</column>
       <column name="notes_pt">É mais ou menos como dizer: "Coma, coma!" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on karkeasti kuin sanoa: "Syö, syö!" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hoch:n}, {Da-:v}, {Sop:v}, {-be':v}, {-chugh:v}, {batlh:adv}, {bI-:v}, {Hegh:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -5949,6 +6552,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">QI'lop, Eat everything or you will die without honour.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5956,6 +6560,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -5969,6 +6574,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">Охватите все возможности.</column>
       <column name="definition_zh_HK">抓住所有機會。</column>
       <column name="definition_pt">Capture todas as oportunidades.</column>
+      <column name="definition_fi">Nappaa kaikki mahdollisuudet.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -5980,6 +6586,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="notes_ru">Это означает «использовать все возможности» (взятые вместе), а не «использовать каждую возможность» (рассматриваемую индивидуально) .[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著“捕獲所有機會”（集體獲得），而不是“捕獲每個機會”（單獨考慮）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "capturar todas as oportunidades" (coletivamente) e não "capturar cada oportunidade" (considerada individualmente).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "vangitse kaikki mahdollisuudet" (otetaan yhdessä) eikä "vangita kaikkia mahdollisuuksia" (tarkastellaan erikseen).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5989,6 +6596,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5996,6 +6604,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.51:src}, [2] {HQ 5.2, p.11, Jun. 1996:src}</column>
     </table>
     <table name="mem">
@@ -6009,6 +6618,7 @@ Se {Hoch:n:nolink} segue um substantivo, significa "todos de X" .[3; 4] Observe 
       <column name="definition_ru">Капитан</column>
       <column name="definition_zh_HK">艦長</column>
       <column name="definition_pt">capitão</column>
+      <column name="definition_fi">kapteeni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6033,6 +6643,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/9CTfqKn383I} [AUTOTRAN
       <column name="notes_pt">Este é o 5º lugar do {yaS:n}.
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/9CTfqKn383I} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {yaS:n}: n 5. sijoitus.
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/9CTfqKn383I} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Head of Department".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6042,6 +6655,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/9CTfqKn383I} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6049,6 +6663,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/9CTfqKn383I} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6062,6 +6677,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/9CTfqKn383I} [A
       <column name="definition_ru">Неделя (клингонская)</column>
       <column name="definition_zh_HK">週（克林崗日曆）</column>
       <column name="definition_pt">semana (Klingon)</column>
+      <column name="definition_fi">(klingonien) viikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIS:n:2}, {jar:n}, {jaj:n}, {'ISjaH:n}, {tera' poH:n}</column>
@@ -6088,6 +6704,15 @@ If an alien calendar contains more than six days, additional days are numbered b
 Если инопланетный календарь состоит более чем из 6 дней, дополнительные дни нумеруются начиная с {wa':n:num}. Таким образом, "Воскресенье" будет {jaj wa':n}. Восьмой день недели {jaj cha':n:nolink}, и так далее.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingon-viikolla on kuusi päivää, jotka ovat:
+▶ {DaSjaj:n} "maanantai"
+▶ {povjaj:n} "tiistai"
+▶ {ghItlhjaj:n} "keskiviikko"
+▶ {loghjaj:n} "torstai"
+▶ {buqjaj:n} "perjantai"
+▶ {lojmItjaj:n} tai {ghInjaj:n} "lauantai"
+
+Jos ulkomaalaisen kalenteri sisältää yli kuusi päivää, lisäpäivät numeroidaan {wa':n:num}: lla. Siten "sunnuntai" olisi {jaj wa':n}. Kahdeksan päivän viikkoa käyttävän {lenmaq:n}: n viikon kahdeksas päivä on nimeltään {jaj cha':n:nolink} ja niin edelleen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6097,6 +6722,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6104,6 +6730,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -6117,6 +6744,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="definition_ru">anniversary (measured in weeks) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">每週紀念日</column>
       <column name="definition_pt">aniversário (medido em semanas)</column>
+      <column name="definition_fi">anniversary (measured in weeks) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DISjaj:n}, {jarjaj:n}</column>
@@ -6127,6 +6755,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hogh:n}, {jaj:n}</column>
       <column name="examples"></column>
@@ -6136,6 +6765,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6143,6 +6773,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -6156,6 +6787,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="definition_ru">убить, убивать, умерщвлять, добивать</column>
       <column name="definition_zh_HK">殺</column>
       <column name="definition_pt">matar</column>
+      <column name="definition_fi">tappaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hegh:v}, {HeghmoH:v}, {chot:v}, {muH:v}, {HoH:n}, {peq:v}, {wID:v}, {ghab:v}, {jIb:v}</column>
@@ -6166,6 +6798,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6176,6 +6809,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6183,6 +6817,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6196,6 +6831,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="definition_ru">Убийство</column>
       <column name="definition_zh_HK">謀殺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">matança</column>
+      <column name="definition_fi">tappaminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoH:v}</column>
@@ -6206,6 +6842,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6215,6 +6852,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6222,6 +6860,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
         <table name="mem">
@@ -6235,6 +6874,7 @@ If an alien calendar contains more than six days, additional days are numbered b
           <column name="definition_ru">Ромуланский зонд убийца</column>
           <column name="definition_zh_HK">羅慕蘭獵人殺手探測器 [AUTOTRANSLATED]</column>
           <column name="definition_pt">sonda Romulano caçadora-assassina</column>
+      <column name="definition_fi">romuluslainen metsästäjä-tappajaluotain</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -6245,6 +6885,7 @@ If an alien calendar contains more than six days, additional days are numbered b
           <column name="notes_ru">Это сокращенный вариант слова {romuluSngan Sambogh 'ej HoHbogh nejwI':n}.</column>
           <column name="notes_zh_HK">這是{romuluSngan Sambogh 'ej HoHbogh nejwI':n}的縮寫。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso é abreviação de {romuluSngan Sambogh 'ej HoHbogh nejwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhyt sanalle {romuluSngan Sambogh 'ej HoHbogh nejwI':n}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{HoH:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -6254,6 +6895,7 @@ If an alien calendar contains more than six days, additional days are numbered b
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6261,6 +6903,7 @@ If an alien calendar contains more than six days, additional days are numbered b
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KCD:src}</column>
         </table>
         <table name="mem">
@@ -6274,6 +6917,7 @@ If an alien calendar contains more than six days, additional days are numbered b
           <column name="definition_ru">совершить самоубийство</column>
           <column name="definition_zh_HK">自殺</column>
           <column name="definition_pt">cometer suicídio</column>
+      <column name="definition_fi">tehdä itsemurha</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{jIb'egh:v}</column>
@@ -6284,6 +6928,7 @@ If an alien calendar contains more than six days, additional days are numbered b
           <column name="notes_ru">Это просто глагол {HoH:v} с суффиксом {-'egh:v}.[2]</column>
           <column name="notes_zh_HK">這只是帶後綴{-'egh:v}.[2]的動詞{HoH:v} [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este é simplesmente o verbo {HoH:v} com o sufixo {-'egh:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksinkertaisesti verbi {HoH:v}, jonka pääte on {-'egh:v}.[2] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{HoH:v}, {-'egh:v}</column>
           <column name="examples"></column>
@@ -6293,6 +6938,7 @@ If an alien calendar contains more than six days, additional days are numbered b
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6300,6 +6946,7 @@ If an alien calendar contains more than six days, additional days are numbered b
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}, [2] {msn 1997.11.30:src} (repeated in {s.k 1998.02.23:src})</column>
         </table>
     <table name="mem">
@@ -6313,6 +6960,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="definition_ru">быть осторожным, быть осмотрительным, быть предусмотрительным</column>
       <column name="definition_zh_HK">小心、慎重</column>
       <column name="definition_pt">ter cuidado</column>
+      <column name="definition_fi">olla varovainen, olla tarkkaavainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yep:v}, {tera'ngan:n}</column>
@@ -6323,6 +6971,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6332,6 +6981,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6339,6 +6989,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6352,6 +7003,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="definition_ru">подросток, подросток, подросток, молодежь, молодые взрослые [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">青少年，少年，青少年，青年，年輕成人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">adolescente, jovem, adulto jovem</column>
+      <column name="definition_fi">teini, nuori, nuori aikuinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puq:n}, {nen:v}</column>
@@ -6362,6 +7014,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="notes_ru">На сленге это слово {yaD:n:3}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">語是{yaD:n:3}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma gíria para isso é {yaD:n:3}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Slangitermi tälle on {yaD:n:3}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6371,6 +7024,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6378,6 +7032,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6391,6 +7046,7 @@ If an alien calendar contains more than six days, additional days are numbered b
       <column name="definition_ru">Язык(речь)</column>
       <column name="definition_zh_HK">語言、文字</column>
       <column name="definition_pt">língua</column>
+      <column name="definition_fi">kieli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jatlh:v}, {ngan:n}, {Hol Sar:n}</column>
@@ -6415,6 +7071,9 @@ Identifieraren är vanligtvis ett land, region eller politisk enhet av något sl
       <column name="notes_pt">Em Klingon, os nomes das línguas são formados anexando {Hol:n:nolink} a um identificador para a língua. Por exemplo, "Klingon" (o idioma) é {tlhIngan Hol:n}, e {tlhIngan:n} por si só não se refere ao idioma, mas a uma pessoa ou pessoas.
 
 O identificador é geralmente um país, região ou unidade política de algum tipo. Por exemplo, o Federation Standard (ou seja, "Inglês") é {DIvI' Hol:n}. {tlhIngan Hol:n:nolink} é na verdade uma forma abreviada de {tlhIngan wo' Hol:n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonissa kielten nimet muodostetaan liittämällä {Hol:n:nolink} kielen tunnisteeseen. Esimerkiksi "Klingon" (kieli) on {tlhIngan Hol:n}, ja {tlhIngan:n} ei itsessään viittaa kieleen, vaan henkilöön tai ihmisiin.
+
+Tunniste on yleensä maa, alue tai jonkinlainen poliittinen yksikkö. Esimerkiksi Federation Standard (eli "englanti") on {DIvI' Hol:n}. {tlhIngan Hol:n:nolink} on oikeastaan ​​lyhennetty {tlhIngan wo' Hol:n:nolink}-muoto.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6424,6 +7083,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6431,6 +7091,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2012.04.01:src}</column>
     </table>
         <table name="mem">
@@ -6444,6 +7105,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="definition_ru">свежий язык [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">新鮮的語言</column>
           <column name="definition_pt">linguagem nova (ou seja, linguagem coloquial)</column>
+      <column name="definition_fi">slangi, puhekieli</column>
           <column name="synonyms">{mu'mey ghoQ:n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -6454,6 +7116,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="notes_ru">Этот термин используется младшими клингонами для обозначения того, как они предпочитают говорить. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">年輕的克林崗人使用此術語來指稱他們喜歡說話的方式。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esse termo é usado pelos klingons mais jovens para se referir à maneira como eles preferem falar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nuoremmat klingonit käyttävät tätä termiä viittaamaan tapaan, jolla he haluavat puhua. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Hol:n}, {ghoQ:v:1}</column>
           <column name="examples"></column>
@@ -6463,6 +7126,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6470,6 +7134,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.35:src}</column>
         </table>
         <table name="mem">
@@ -6483,6 +7148,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="definition_ru">диалект [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">話（方言）</column>
           <column name="definition_pt">dialeto</column>
+      <column name="definition_fi">murre</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Sep Hol Sar:n}, {ta' Hol:n}</column>
@@ -6493,6 +7159,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Hol:n}, {Sar:n}</column>
           <column name="examples"></column>
@@ -6502,6 +7169,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6509,6 +7177,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2018.02.25:src}</column>
         </table>
         <table name="mem">
@@ -6522,6 +7191,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="definition_ru">лингвистика</column>
           <column name="definition_zh_HK">語言學</column>
           <column name="definition_pt">linguística</column>
+      <column name="definition_fi">kielitiede</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Holtej:n}</column>
@@ -6532,6 +7202,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="notes_ru">Это также название журнала {tlhIngan Hol yejHaD:n}.</column>
           <column name="notes_zh_HK">這也是{tlhIngan Hol yejHaD:n}期刊的名稱。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este também é o nome do diário do {tlhIngan Hol yejHaD:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on myös {tlhIngan Hol yejHaD:n}-päiväkirjan nimi. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Hol:n}, {QeD:n}</column>
           <column name="examples"></column>
@@ -6541,6 +7212,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6548,6 +7220,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}, [2] {HQ 2.2, p.12, Jun. 1993:src}</column>
         </table>
         <table name="mem">
@@ -6561,6 +7234,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="definition_ru">лингвист [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">語言學家</column>
           <column name="definition_pt">linguista</column>
+      <column name="definition_fi">kielitieteilijä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{HolQeD:n}, {tej:n}</column>
@@ -6571,6 +7245,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This term does not appear in canon, but is an obvious construction from {HolQeD:n}. (It was revealed at {Saarbrücken qepHom'a' 2019:src} that if a {QeD:n:nolink} exists, then there is generally a corresponding {tej:n:nolink}.)
 
 {Holtej:n:name,nolink} is also the Klingon name of linguist and Klingonist d'Armond Speers.</column>
@@ -6582,6 +7257,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">Hol tej</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6589,6 +7265,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -6602,6 +7279,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">Кость</column>
       <column name="definition_zh_HK">骨</column>
       <column name="definition_pt">osso</column>
+      <column name="definition_fi">luu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nobmeD:n}, {qal'aq:n}, {pIp:n}, {melchoQ:n}, {Somraw:n}, {Ha'DIbaH:n:1}, {petqaD:n}, {'an'or:n}</column>
@@ -6612,6 +7290,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru">Типы костей включают {joQ:n:1}, {DughrI':n} и {Ho':n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">骨骼的類型包括{joQ:n:1}，{DughrI':n}和{Ho':n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os tipos de ossos incluem {joQ:n:1}, {DughrI':n} e {Ho':n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Luutyyppejä ovat {joQ:n:1}, {DughrI':n} ja {Ho':n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6621,6 +7300,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6628,6 +7308,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6641,6 +7322,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">слабый, грубый, тощий, худой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">弱者、矮子、骨瘦如柴、骨瘦如柴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fraco, raquítico, magricela, magrela</column>
+      <column name="definition_fi">heikko, pieni, laiha henkilö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-Hom:n}</column>
@@ -6651,6 +7333,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6660,6 +7343,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6667,6 +7351,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6680,6 +7365,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">использовать второй палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">使用第二個腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">use o segundo dedo do pé</column>
+      <column name="definition_fi">käyttää toista varvasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaD:n:1}</column>
@@ -6690,6 +7376,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru">Из-за гомофонии с {Hom:n:2} наведение второго пальца на кого-то (обычно противника или врага), в то время как другие пальцы указывают вниз, считается оскорбительным жестом. Это означает, что один считает другого человека слабым. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">由於與{Hom:n:2}的諧音，將一個人的第二個腳趾指向某個人（通常是對手或敵人），而另一個腳趾指向下方，則被視為侮辱性手勢。它表示一個人認為另一個人很虛弱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Devido à homofonia com o {Hom:n:2}, apontar o segundo dedo do pé para alguém (normalmente um oponente ou um inimigo), enquanto os outros dedos apontam para baixo, é considerado um gesto ofensivo. Significa que um considera a outra pessoa fraca. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Hom:n:2}: n kanssa käydyn homofonian takia toisen varpaan osoittaminen jollekin (tyypillisesti vastustajalle tai viholliselle), kun taas toiset varpaat osoittavat alaspäin, katsotaan loukkaavaksi eleeksi. Se tarkoittaa, että toinen pitää toista ihmistä heikkona. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This little piggy stayed home.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6700,6 +7387,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6707,6 +7395,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
         <table name="mem">
@@ -6720,6 +7409,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="definition_ru">второй палец [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">第二個腳趾 [AUTOTRANSLATED]</column>
           <column name="definition_pt">segundo dedo do pé</column>
+      <column name="definition_fi">toinen varvas</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{yaD:n:1}</column>
@@ -6730,6 +7420,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This little piggy stayed home.</column>
           <column name="components">{Hom:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -6739,6 +7430,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6746,6 +7438,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
         </table>
     <table name="mem">
@@ -6759,6 +7452,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">хрящ [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">軟骨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cartilagem</column>
+      <column name="definition_fi">rusto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6769,6 +7463,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru">Это относится к типу плотной несосудистой ткани, обычно обнаруживаемой на концах суставов, грудной клетки, уха, носа и между межпозвоночными дисками. Это компонент {ngat:n:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指一種密集的，非血管組織，通常在關節，肋骨，耳朵，鼻子和椎間盤之間的末端發現。它是{ngat:n:2}的成分。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um tipo de tecido denso não vascular, geralmente encontrado no final das articulações, na caixa torácica, na orelha, no nariz e entre os discos intervertebrais. É um ingrediente do {ngat:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tietyn tyyppiseen tiheään, ei-verisuoniseen kudokseen, joka yleensä löytyy nivelten, rintakehän, korvan, nenän ja nikamien välisten levyjen päästä. Se on {ngat:n:2}: n ainesosa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's not clear if {HomHap:n:nolink} exists as an independent word.</column>
       <column name="components">{Hom:n:1}, {Hap:n}, {tun:v}</column>
       <column name="examples"></column>
@@ -6778,6 +7473,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6785,6 +7481,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6798,6 +7495,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">сомневаться, колебаться, подозревать</column>
       <column name="definition_zh_HK">懷疑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dúvida</column>
+      <column name="definition_fi">epäillä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Har:v}</column>
       <column name="see_also">{DIch:n}</column>
@@ -6808,6 +7506,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru">Данный глагол можно использовать с {'e':n:pro}.[2]</column>
       <column name="notes_zh_HK">該動詞可以將{'e':n:pro}作為對象。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä verbi voi ottaa objektiksi {'e':n:pro}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Hon"est doubt.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6819,6 +7518,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
 ▶ {tlhIngan Hol Dajatlh 'e' vIHon.:sen:nolink} "Я сомневаюсь, что ты говоришь на Клингонском."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6826,6 +7526,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.07.01:src} (reprinted in {HQ 7.2, p.8, Jun. 1998:src})</column>
     </table>
     <table name="mem">
@@ -6839,6 +7540,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">импульсная энергия</column>
       <column name="definition_zh_HK">脈衝力</column>
       <column name="definition_pt">força de impulso</column>
+      <column name="definition_fi">impulssivoima</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIv:n:hyp}, {gho'Do:n}</column>
@@ -6849,6 +7551,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6858,6 +7561,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6865,6 +7569,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6878,6 +7583,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">импульсные термоядерные двигатели [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">脈衝聚變推進器</column>
       <column name="definition_pt">propulsores de fusão por impulso</column>
+      <column name="definition_fi">impulssifuusiomoottorit?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hong:n}, {boq:n:2}, {chuyDaH:n}</column>
@@ -6888,6 +7594,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hong:n}, {boq:n:2}, {chuyDaH:n}</column>
       <column name="examples"></column>
@@ -6897,6 +7604,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6904,6 +7612,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6917,6 +7626,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">импульсный драйв [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">脈衝引擎、脈衝驅動</column>
       <column name="definition_pt">motores de impulso</column>
+      <column name="definition_fi">impulssiajo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIvghor:n}</column>
@@ -6927,6 +7637,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hong:n}, {ghor:n:2,hyp}</column>
       <column name="examples"></column>
@@ -6936,6 +7647,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6943,6 +7655,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6956,6 +7669,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">система импульсного привода [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">脈衝驅動系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sistema de acionamento de impulso</column>
+      <column name="definition_fi">impulssiajojärjestelmä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6966,6 +7680,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hongghor:n}, {pat:n}</column>
       <column name="examples"></column>
@@ -6975,6 +7690,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6982,6 +7698,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6995,6 +7712,7 @@ O identificador é geralmente um país, região ou unidade política de algum ti
       <column name="definition_ru">быть удаленным, быть далёким</column>
       <column name="definition_zh_HK">遠</column>
       <column name="definition_pt">ser remoto, longe</column>
+      <column name="definition_fi">olla kaukainen, olla kaukana</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Sum:v}</column>
       <column name="see_also">{DoH:v}, {chuq:n}</column>
@@ -7019,6 +7737,9 @@ I Klingon kallas "deep space" {logh Hop:n}, bokstavligen, "far space" .[3] [AUTO
       <column name="notes_pt">Este verbo é usado da mesma forma que {Sum:v} (envolve o conceito de dêixis) .[2]
 
 Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaço distante" .[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään samalla tavalla kuin {Sum:v} (siihen liittyy deixiksen käsite).
+
+Klingonissa "syvä avaruus" on nimeltään {logh Hop:n}, kirjaimellisesti "kaukaa tilaa".[2][3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's just a "hop" away.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7028,6 +7749,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7035,6 +7757,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.9-10, Dec. 1998:src}, [3] {SkyBox 99:src}</column>
     </table>
     <table name="mem">
@@ -7048,6 +7771,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="definition_ru">экспедиция</column>
       <column name="definition_zh_HK">遠征 [AUTOTRANSLATED]</column>
       <column name="definition_pt">expedição</column>
+      <column name="definition_fi">tutkimusmatka, retkikunta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghom:n}, {Saqghom:n}, {tIjwI'ghom:n}, {leng:n}, {jey:n}, {Qu':n}</column>
@@ -7058,6 +7782,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7067,6 +7792,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7074,6 +7800,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7087,6 +7814,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="definition_ru">трикодер</column>
       <column name="definition_zh_HK">的tricorder [AUTOTRANSLATED]</column>
       <column name="definition_pt">tricorder</column>
+      <column name="definition_fi">trikorderi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HotlhwI':n}</column>
@@ -7097,6 +7825,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The pun seems to be {Hoq:n} "expedition" = "trek", and {ra':v:1} "order", and hence "trekorder" = "tricorder". Another theory says that the "Expedition" is a model of adult tricycle ("trike").</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7106,6 +7835,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7113,6 +7843,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7126,6 +7857,7 @@ Em Klingon, "espaço profundo" é denominado {logh Hop:n}, literalmente, "espaç
       <column name="definition_ru">быть удостоенным лжи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被虛假地稱讚、是虛假的光榮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser honrado falsamente, ser falsamente honrado</column>
+      <column name="definition_fi">olla virheellisesti kunnioitettu?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DavHam:n}, {Qaq:v}, {quv:v}, {batlh:n}, {mIl:v}, {quvHa':v}</column>
@@ -7172,6 +7904,13 @@ Essa palavra é usada em lugares onde {quv:v} pode ser usado, mas quando a honra
 É diferente de {quvHa':v} porque indica que alguém exigiu respeito imerecido ou imerecido. Um guerreiro que mostra covardia na batalha é um {SuvwI' quvHa':n:nolink}. Aquele que esconde sua covardia, é premiado por sua bravura (ou seja, torna-se conhecido como {SuvwI' quv:n:nolink}) e, posteriormente, é descoberto que é uma fraude, é um {SuvwI' HoQ:n:nolink}.
 
 Não use essa palavra levianamente, pois ela tem conotações muito ruins na sociedade Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin käyttö merkitsee petosta.
+
+Tätä sanaa käytetään paikoissa, joissa saatetaan käyttää {quv:v}-sanaa, mutta kun kunnia havaittiin olevan laiton. Esimerkiksi {Duy quv:n:nolink}, joka osoittautuu vakoojaksi, kutsutaan {Duy HoQ:n:nolink}: ksi.
+
+Se eroaa {quvHa':v}: stä siinä, että se osoittaa, että on vaadittu kunnioitusta, joka on ansaitsematon tai ansaitsematon. Taistelussa pelkuruutta osoittava soturi on {SuvwI' quvHa':n:nolink}. {SuvwI' HoQ:n:nolink} on se, joka kätkee pelkuruutensa, palkitaan rohkeudesta (eli tunnetaan nimellä {SuvwI' quv:n:nolink}) ja jonka myöhemmin havaitaan olevan petos.
+
+Älä käytä tätä sanaa kevyesti, koska sillä on erittäin huono merkitys Klingonin yhteiskunnassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Hoax".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7181,6 +7920,7 @@ Não use essa palavra levianamente, pois ela tem conotações muito ruins na soc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be honoured falsely, be falsely honourable</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7188,6 +7928,7 @@ Não use essa palavra levianamente, pois ela tem conotações muito ruins na soc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, p.8, Sept. 2003:src}</column>
     </table>
     <table name="mem">
@@ -7201,6 +7942,7 @@ Não use essa palavra levianamente, pois ela tem conotações muito ruins na soc
       <column name="definition_ru">Горацио [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">霍雷肖</column>
       <column name="definition_pt">Horatio</column>
+      <column name="definition_fi">Horatio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -7211,6 +7953,7 @@ Não use essa palavra levianamente, pois ela tem conotações muito ruins na soc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7220,6 +7963,7 @@ Não use essa palavra levianamente, pois ela tem conotações muito ruins na soc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7227,6 +7971,7 @@ Não use essa palavra levianamente, pois ela tem conotações muito ruins na soc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -7240,6 +7985,7 @@ Não use essa palavra levianamente, pois ela tem conotações muito ruins na soc
       <column name="definition_ru">быть сильным</column>
       <column name="definition_zh_HK">堅強</column>
       <column name="definition_pt">ser forte</column>
+      <column name="definition_fi">olla vahva</column>
       <column name="synonyms"></column>
       <column name="antonyms">{puj:v}</column>
       <column name="see_also">{'Iw:n}, {HoS:n:1}, {HoSghaj:v}</column>
@@ -7264,6 +8010,9 @@ Detta verb används också för vanliga polygoner och polyeder. [2] [AUTOTRANSLA
       <column name="notes_pt">Existe um idioma, {HoS; 'Iw rur:sen@@HoS:v, 'Iw:n, rur:v}.
 
 Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {HoS; 'Iw rur:sen@@HoS:v, 'Iw:n, rur:v}.
+
+Tätä verbiä käytetään myös tavallisille monikulmioille ja polyhedeille.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7275,6 +8024,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
 ▶ {vagh reD mey' HoS:n@@vagh reD mey':n, HoS:v} "обычный пятиугольник"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7282,6 +8032,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -7295,6 +8046,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">сила, энергия, </column>
       <column name="definition_zh_HK">力量、能量</column>
       <column name="definition_pt">força, energia, poder</column>
+      <column name="definition_fi">vahvuus, energia, voima</column>
       <column name="synonyms"></column>
       <column name="antonyms">{puj:n:1h}</column>
       <column name="see_also">{HoS:v}</column>
@@ -7305,6 +8057,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Horse" power. The character of Eric "Hoss" Cartwright on the TV show "Bonanza" has a reputation for being strong.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7316,6 +8069,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7323,6 +8077,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -7336,6 +8091,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">транстатор</column>
           <column name="definition_zh_HK">態變機</column>
           <column name="definition_pt">conversor de energia</column>
+      <column name="definition_fi">transtaattori, energiamuunnin?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7346,6 +8102,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru">Это устройство, что преобразует одну форму энергии в другую.</column>
           <column name="notes_zh_HK">這是一種將能量從一種形式轉換為另一種形式的設備。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este é um dispositivo que altera a energia de uma forma para outra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on laite, joka muuttaa energiaa muodosta toiseen. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{HoS:n:1}, {choH:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -7355,6 +8112,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7362,6 +8120,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 1.3, Sept. 1992:src}</column>
         </table>
         <table name="mem">
@@ -7375,6 +8134,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">генератор энергии [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">發力機、發電機</column>
           <column name="definition_pt">gerador de energia</column>
+      <column name="definition_fi">energian generaattori</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{lIngwI':n}, {woj choHwI':n}, {HoS waw':n}, {HoSHal:n}</column>
@@ -7385,6 +8145,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HoS:n:1}, {lIngwI':n}</column>
           <column name="examples"></column>
@@ -7394,6 +8155,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7401,6 +8163,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {CK:src}</column>
         </table>
         <table name="mem">
@@ -7414,6 +8177,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">You are a total waste of good energy! [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">你是一個完全浪費能量的人！</column>
           <column name="definition_pt">Você é um total desperdício de boa energia!</column>
+      <column name="definition_fi">Olet hyvän energian täyttä tuhlausta!</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7424,6 +8188,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HoS:n:1}, {lI':v:1}, {Da-:v}, {lo':v}, {-Ha':v}, {-chu':v}</column>
           <column name="examples"></column>
@@ -7433,6 +8198,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">mu'qaD veS, curse warfare</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7440,6 +8206,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {PK:src}</column>
         </table>
         <table name="mem">
@@ -7453,6 +8220,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">канал передачи энергии [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">動力傳輸管道</column>
           <column name="definition_pt">canal de transferência de energia</column>
+      <column name="definition_fi">energiansiirtokaapeli</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7463,6 +8231,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HoS:n:1}, {Qay:v}, {-meH:v}, {'och:n}</column>
           <column name="examples"></column>
@@ -7472,6 +8241,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7479,6 +8249,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -7492,6 +8263,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">щитовидная железа [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">甲狀腺 [AUTOTRANSLATED]</column>
           <column name="definition_pt">tireoide</column>
+      <column name="definition_fi">kilpirauhanen</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7502,6 +8274,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HoS:n:1}, {voveng:n}</column>
           <column name="examples"></column>
@@ -7511,6 +8284,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7518,6 +8292,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -7531,6 +8306,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">энергетический объект [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">能源設施 [AUTOTRANSLATED]</column>
           <column name="definition_pt">instalação de energia</column>
+      <column name="definition_fi">energialaitos</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{tlhIlHal:n}, {laSvargh:n}, {HoSHal:n}, {HoS lIngwI':n}</column>
@@ -7541,6 +8317,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru">{pIraqSIS:n} - важный энергетический объект клингона. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">{pIraqSIS:n}是重要的克林崗州能源設施。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">O {pIraqSIS:n} é uma importante instalação de energia de Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{pIraqSIS:n} on tärkeä Klingonin energialaitos. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{HoS:n:1}, {waw':n}</column>
           <column name="examples">
@@ -7551,6 +8328,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">energy production facility</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7558,6 +8336,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Klingon Monopoly:src}</column>
         </table>
         <table name="mem">
@@ -7571,6 +8350,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">энергетическое поле</column>
           <column name="definition_zh_HK">能量場</column>
           <column name="definition_pt">campo de energia</column>
+      <column name="definition_fi">energiakenttä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{ghe'chem:n}, {peQchem:n}, {pIvchem:n}, {Surchem:n}, {tlhamchem:n}</column>
@@ -7581,6 +8361,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{HoS:n:1}, {chem:n:hyp}</column>
           <column name="examples"></column>
@@ -7590,6 +8371,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7597,6 +8379,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
     <table name="mem">
@@ -7610,6 +8393,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">амплитуда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">振幅 [AUTOTRANSLATED]</column>
       <column name="definition_pt">amplitude</column>
+      <column name="definition_fi">amplitudi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaDvay':n}</column>
@@ -7620,6 +8404,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это относится к величине волны (например, электромагнитной волны). Это буквально означает «сила» (см. {HoS:n:1}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指波（例如電磁波）的大小。這字面意思是“實力”（請參閱{HoS:n:1}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à magnitude de uma onda (como uma onda eletromagnética). Isso significa literalmente "força" (consulte {HoS:n:1}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa aallon (kuten sähkömagneettisen aallon) suuruuteen. Tämä tarkoittaa kirjaimellisesti "voimaa" (katso {HoS:n:1}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7629,6 +8414,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">magnitude</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7636,6 +8422,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7650,6 +8437,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">энергетические сущности</column>
       <column name="definition_zh_HK">能量眾生 [AUTOTRANSLATED]</column>
       <column name="definition_pt">seres energéticos</column>
+      <column name="definition_fi">energiaolennot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7660,6 +8448,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Не ясно, является ли это слово грамматически единственным или множественным числом. Одно энергетическое существо - {HoS Dep:n:nolink} (см. {HoS:n:1}, {Dep:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">目前尚不清楚這個詞是語法上的單數還是複數。一種能量是{HoS Dep:n:nolink}（請參閱{HoS:n:1}，{Dep:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não está claro se essa palavra é gramaticalmente singular ou plural. Um ser de energia é um {HoS Dep:n:nolink} (consulte {HoS:n:1}, {Dep:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei ole selvää, onko tämä sana kieliopillisesti yksikkö vai monikko. Yksi energiaolento on {HoS Dep:n:nolink} (katso {HoS:n:1}, {Dep:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7669,6 +8458,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7676,6 +8466,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7689,6 +8480,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">быть мощным, быть могущественным</column>
       <column name="definition_zh_HK">要有力量 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser poderoso</column>
+      <column name="definition_fi">olla voimakas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mupwI':n}</column>
@@ -7699,6 +8491,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{HoS:n:1}, {ghaj:v}</column>
       <column name="examples"></column>
@@ -7708,6 +8501,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7715,6 +8509,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7728,6 +8523,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">источник энергии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">能源</column>
       <column name="definition_pt">fonte de energia</column>
+      <column name="definition_fi">energialähde</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoS waw':n}, {HoS lIngwI':n}, {'ul 'aplo':n}</column>
@@ -7738,6 +8534,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Термин {HoS Hal:n:nolink} (с пробелом) также появился в каноне. Смотрите пример под {nISwI' beH:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">佳能中也出現了術語{HoS Hal:n:nolink}（帶空格）。請參閱{nISwI' beH:n}下的示例。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O termo {HoS Hal:n:nolink} (com um espaço) também apareceu no cânone. Veja o exemplo em {nISwI' beH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Termi {HoS Hal:n:nolink} (välilyönnillä) on esiintynyt myös kaanonissa. Katso esimerkki kohdasta {nISwI' beH:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{HoS:n:1}, {Hal:n}</column>
       <column name="examples">
@@ -7748,6 +8545,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7755,6 +8553,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -7768,6 +8567,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">трогать, прикасаться, чуствовать</column>
       <column name="definition_zh_HK">觸摸、感覺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tocar, sentir</column>
+      <column name="definition_fi">koskea, koskettaa, tuntea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIch:v}</column>
@@ -7778,6 +8578,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It feels "hot" to the touch.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7787,6 +8588,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7794,6 +8596,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7807,6 +8610,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">базальт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">玄武岩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">basalto</column>
+      <column name="definition_fi">basaltti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nagh:n}, {lIvrI':n}</column>
@@ -7817,6 +8621,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это относится к типу твердых магматических пород, которые очень распространены в океанической коре. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指一種堅硬的火成岩，在大洋地殼中非常常見。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um tipo de rocha ígnea dura, muito comum na crosta oceânica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa eräänlaiseen kovaan magmakivikiviin, joka on hyvin yleistä valtameren kuoressa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Basalt comes from an ancient Greek word meaning "touchstone" ({Hot:v} + {nagh:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7826,6 +8631,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7833,6 +8639,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7846,6 +8653,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">проектировать, отразить что-то(на экране)</column>
       <column name="definition_zh_HK">項目、穿上（屏幕） [AUTOTRANSLATED]</column>
       <column name="definition_pt">projetar, colocar em (tela)</column>
+      <column name="definition_fi">projisoida (näytölle), panna (näytölle)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7856,6 +8664,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Имеется омофон {Hotlh:v:2} прпедполагающий, что глагол относится к совмещенному действию захвата и показа изображения.</column>
       <column name="notes_zh_HK">諧音的{Hotlh:v:2}表示此動詞是指捕獲和顯示圖像的組合動作。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {Hotlh:v:2} homofônico sugere que esse verbo se refere ao ato combinado de capturar e exibir uma imagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Homofoninen {Hotlh:v:2} viittaa siihen, että tämä verbi viittaa sekä kuvan sieppaamiseen että näyttämiseen yhdessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7866,6 +8675,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7873,6 +8683,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7886,6 +8697,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">сканировать, искать</column>
       <column name="definition_zh_HK">掃描 [AUTOTRANSLATED]</column>
       <column name="definition_pt">varredura</column>
+      <column name="definition_fi">skannata, tutkata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuD:v}</column>
@@ -7896,6 +8708,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Гомофонный {Hotlh:v:1} предполагает, что этот глагол относится к объединенному акту захвата и отображения изображения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">諧音的{Hotlh:v:1}表示此動詞是指捕獲和顯示圖像的組合動作。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {Hotlh:v:1} homofônico sugere que esse verbo se refere ao ato combinado de capturar e exibir uma imagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Homofoninen {Hotlh:v:1} viittaa siihen, että tämä verbi viittaa sekä kuvan sieppaamiseen että näyttämiseen yhdessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7907,6 +8720,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7914,6 +8728,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7927,6 +8742,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">сканер</column>
       <column name="definition_zh_HK">掃描器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">scanner</column>
+      <column name="definition_fi">skanneri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hoqra':n}, {noch:n}</column>
@@ -7937,6 +8753,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hotlh:v:2}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7946,6 +8763,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7953,6 +8771,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7966,6 +8785,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">звезда(астрономическое тело)</column>
       <column name="definition_zh_HK">恆星</column>
       <column name="definition_pt">estrela (astronomia)</column>
+      <column name="definition_fi">tähti</column>
       <column name="synonyms">{jul:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{bav:v}, {yuQ:n}, {maS:n}, {Dotrar:n}</column>
@@ -7976,6 +8796,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Относится к астрономическому телу, а не к геометрической фигуре, для которой смотрите {DujtlhuQ:n}.</column>
       <column name="notes_zh_HK">這是指天文物體，而不是幾何圖形，對此請參見{DujtlhuQ:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um corpo astronômico, e não à figura geométrica, para a qual veja {DujtlhuQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tähtitieteelliseen kappaleeseen, ei geometriseen kuvioon, josta katso {DujtlhuQ:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined in {TKD:src} only as "star". The "astronomy" part was added for clarification.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7985,6 +8806,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7992,6 +8814,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8005,6 +8828,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">A day without secrets is like a night without stars. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沒有秘密的一天就像一個沒有星星的夜晚。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Um dia sem segredos é como uma noite sem estrelas.</column>
+      <column name="definition_fi">Salaisuukseton päivä on kuin tähdetön yö.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8015,6 +8839,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {ghaj:v}, {-be':v}, {-bogh:v}, {ram:n}, {rur:v}, {pegh:n}, {ghaj:v}, {-be':v}, {-bogh:v}, {jaj:n}</column>
       <column name="examples"></column>
@@ -8024,6 +8849,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">secrecy proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8031,6 +8857,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -8044,6 +8871,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">звездный храм [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星龕</column>
       <column name="definition_pt">santuário das estrelas</column>
+      <column name="definition_fi">tähtipyhäkkö?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8054,6 +8882,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это символическое представление созвездия {ghochwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{ghochwI':n}星座的象徵性表示。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma representação simbólica da constelação {ghochwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on symbolinen esitys {ghochwI':n}-tähdistöstä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {lat:n}</column>
       <column name="examples"></column>
@@ -8063,6 +8892,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8070,6 +8900,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -8083,6 +8914,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">Звёздный путь</column>
       <column name="definition_zh_HK">星空奇遇記</column>
       <column name="definition_pt">Jornada nas Estrelas</column>
+      <column name="definition_fi">Star Trek</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'aH:n}</column>
@@ -8100,6 +8932,14 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on suosittu televisio-franchising-nimi. Se sisältää seuraavat sarjat:
+▶ Alkuperäinen sarja
+▶ Animaatiosarja
+▶ Seuraava sukupolvi ({puq poH veb:n})
+▶ Deep Space Nine ({logh Hop Hut tengchaH:n})
+▶ Voyager ({vo'yajer:n:name})
+▶ Yritys ({'entepray':n:name})
+▶ Löytö ({DISqa'vI'rIy:n:name}) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {leng:n}</column>
       <column name="examples"></column>
@@ -8109,6 +8949,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8116,6 +8957,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -8129,6 +8971,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">Трекнология [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星空奇遇記科技</column>
       <column name="definition_pt">Treknologia</column>
+      <column name="definition_fi">treknologia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8139,6 +8982,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это фраза вне вселенной, которая не происходит от клингонской культуры.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個非普遍的短語，並非來自克林崗文化。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma frase fora do universo que não vem da cultura klingon.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maailmankaikkeuden ulkopuolella oleva lause, joka ei tule klingonikulttuurista.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It really ought to be {Hov leng cham:n:nolink}, but canon is canon.</column>
       <column name="components">{Hov leng:n}, {QeD:n}</column>
       <column name="examples"></column>
@@ -8148,6 +8992,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8155,6 +9000,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -8168,6 +9014,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">Ты приветствуешь звезды</column>
       <column name="definition_zh_HK">你向星星致敬。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você saúda as estrelas.</column>
+      <column name="definition_fi">Tervehdit tähtiä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lay':v}, {'Ip:v}, {voq:v}, {ngoy':v}</column>
@@ -8178,6 +9025,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Эта идиома означает "Я доверяю тебе" или "Я знаю, что ты сдержишь свое слово".</column>
       <column name="notes_zh_HK">這是一個成語，意為“我相信你”或“我知道你會尊重你的話”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um idioma que significa "eu confio em você" ou "eu sei que você honrará sua palavra". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sanasto, joka tarkoittaa "Luotan sinuun" tai "Tiedän, että kunnioitat sanasi". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {-mey:n:suff}, {Da-:v:pref}, {van:v:1}</column>
       <column name="examples"></column>
@@ -8187,6 +9035,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8194,6 +9043,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.83:src}</column>
     </table>
     <table name="mem">
@@ -8207,6 +9057,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">звездная дата [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星曆 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Data estrelar</column>
+      <column name="definition_fi">tähtipäivämäärä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera' poH:n}</column>
@@ -8217,6 +9068,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {poH:n}</column>
       <column name="examples">
@@ -8227,6 +9079,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8234,6 +9087,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Star Trek The Exhibition:src} invitation</column>
     </table>
     <table name="mem">
@@ -8247,6 +9101,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">астрономия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">天文學</column>
       <column name="definition_pt">astronomia</column>
+      <column name="definition_fi">tähtitiede</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hovtej:n}, {Hov tut:n}</column>
@@ -8257,6 +9112,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {QeD:n}</column>
       <column name="examples"></column>
@@ -8266,6 +9122,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8273,6 +9130,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -8286,6 +9144,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">Звездная система</column>
       <column name="definition_zh_HK">星系 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sistema estelar</column>
+      <column name="definition_fi">tähtijärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dotrar:n}</column>
@@ -8296,6 +9155,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {tay':v}</column>
       <column name="examples"></column>
@@ -8305,6 +9165,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">solar system</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8312,6 +9173,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8325,6 +9187,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">астроном [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">天文學家</column>
       <column name="definition_pt">astrônomo</column>
+      <column name="definition_fi">tähtitieteilijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HovQeD:n}, {tej:n}, {Hov tut:n}</column>
@@ -8335,6 +9198,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {tej:n}</column>
       <column name="examples"></column>
@@ -8344,6 +9208,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8351,6 +9216,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -8364,6 +9230,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">телескоп [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">望遠鏡</column>
       <column name="definition_pt">telescópio</column>
+      <column name="definition_fi">teleskooppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HovQeD:n}, {Hovtej:n}, {chuq'a' leghwI':n}</column>
@@ -8374,6 +9241,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это повседневный термин. Есть более технический термин, но Мальц не помнил, что это было. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是日常用語。還有一個技術術語，但Maltz不記得它是什麼。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o termo cotidiano. Existe um termo mais técnico, mas Maltz não se lembrava do que era. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on jokapäiväinen termi. On teknisempi termi, mutta Maltz ei muista mitä se oli. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hov:n}, {tut:n:1}</column>
       <column name="examples"></column>
@@ -8383,6 +9251,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8390,6 +9259,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -8403,6 +9273,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">be refined, be fancy, be sophisticated (pertaining to culture) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">精緻，花哨，精緻（與文化有關） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser refinado, ser chique, ser sofisticado (pertencente à cultura)</column>
+      <column name="definition_fi">olla hienostunut (liittyy kulttuuriin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meHghem:n}</column>
@@ -8413,6 +9284,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Hoity-toity". Also comedic inversion of "hoi polloi", meaning "the common people".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8422,6 +9294,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8429,6 +9302,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8442,6 +9316,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">поздравлять</column>
       <column name="definition_zh_HK">祝賀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">felicitar</column>
+      <column name="definition_fi">onnitella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{van'a':n}, {'ev:v}</column>
@@ -8452,6 +9327,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8461,6 +9337,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8468,6 +9345,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8481,6 +9359,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">восхищаться, восторгаться</column>
       <column name="definition_zh_HK">欣賞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">admirar</column>
+      <column name="definition_fi">ihailla, kunnioittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sub:n}, {vuv:v}, {Ho':n:2}</column>
@@ -8491,6 +9370,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8500,6 +9380,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8507,6 +9388,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8520,6 +9402,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">зуб</column>
       <column name="definition_zh_HK">牙齒</column>
       <column name="definition_pt">dente</column>
+      <column name="definition_fi">hammas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuj:n}, {wuS:n}, {ghapqa':n}, {repnuj:n}, {Hom:n:1}</column>
@@ -8530,6 +9413,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Отдельно от дословного перевода, как части тела, это слово может использоваться, чтобы описать "зубы" на зубчатом колесе или цепном колесе</column>
       <column name="notes_zh_HK">除了其作為身體部位的字面含義外，該詞還可以用於指代g子或鏈輪上的“牙齒”（請參見{Ho':n:3}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Além de seu significado literal como parte do corpo, essa palavra também pode ser usada para se referir aos "dentes" de uma roda dentada ou de uma roda dentada (consulte {Ho':n:3}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen lisäksi, että kirjaimellisesti tarkoitetaan ruumiinosaa, tätä sanaa voidaan käyttää myös viittaamaan hammaspyörän tai ketjupyörän "hampaisiin" (katso {Ho':n:3}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8540,6 +9424,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8547,6 +9432,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8560,6 +9446,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">идол, достойный подражания, заслуживающий уважения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">偶像、值得模仿的人、值得尊重的東西 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ídolo, alguém digno de emulação, algo que merece respeito</column>
+      <column name="definition_fi">idoli, joku jota ihailla tai kunnioittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sub:n}, {Ho':v}</column>
@@ -8570,6 +9457,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это слово следует грамматическим правилам, соответствующим его буквальному значению (см. {Ho':n:1}). Он принимает множественный суффикс {-Du':n:suff} и притяжательные суффиксы, такие как {-wIj:n:suff}, даже когда он относится к человеку или людям. [1, p.152] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞遵循適合其字面意思的語法規則（請參閱{Ho':n:1}）。即使是一個人或多個人，它也要使用複數後綴{-Du':n:suff}和所有格後綴，例如{-wIj:n:suff}。[1, p.152] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra segue as regras gramaticais apropriadas ao seu significado literal (consulte {Ho':n:1}). Leva o sufixo plural {-Du':n:suff} e sufixos possessivos, como {-wIj:n:suff}, mesmo quando se refere a uma pessoa ou pessoas.[1, p.152] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana noudattaa kieliopillisia sääntöjä, jotka sopivat sen kirjaimelliseen merkitykseen (katso {Ho':n:1}). Se vie monikon {-Du':n:suff} ja omistavien jälkiliitteiden kuten {-wIj:n:suff}, vaikka se viittaa henkilöön tai ihmisiin.[1, p.152] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined in the {KGT:src} word list only as "idol". The expanded definition above is from p.152.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8579,6 +9467,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8586,6 +9475,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8599,6 +9489,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">зубчатый зуб, зуб звездочки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">齒齒、鏈輪齒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dente da roda dentada</column>
+      <column name="definition_fi">hammasrattaan hammas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8609,6 +9500,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это слово принимает суффикс множественного числа {-Du':n:suff}, даже если это не часть тела.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">即使不是身體部位，該詞也帶有復數後綴{-Du':n:suff}。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sana vie monikon {-Du':n:suff}, vaikka se ei olisikaan runko-osa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8618,6 +9510,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8625,6 +9518,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}, [2] {KLI mailing list 2018.12.02:src}</column>
     </table>
     <table name="mem">
@@ -8638,6 +9532,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">зубчатое колесо, звездочка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">齒輪、鏈輪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">roda dentada</column>
+      <column name="definition_fi">hammasratas, hammaspyörä, ketjupyörä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8648,6 +9543,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Ho':n:3}, {rutlh:n}</column>
       <column name="examples"></column>
@@ -8657,6 +9553,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gear</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8664,6 +9561,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8677,6 +9575,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">зубная щетка</column>
       <column name="definition_zh_HK">牙刷</column>
       <column name="definition_pt">escova de dente</column>
+      <column name="definition_fi">hammasharja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8687,6 +9586,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Ho':n:1}, {teywI':n}</column>
       <column name="examples"></column>
@@ -8696,6 +9596,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8703,6 +9604,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8716,6 +9618,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">зубчатый клинок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鋸齒狀刀片 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lâmina serrilhada</column>
+      <column name="definition_fi">sahalaitainen terä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8726,6 +9629,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это относится к зубчатому лезвию, найденному на {qutluch:n}. [1, p.61] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指在{qutluch:n}.[1, p.61]上找到的鋸齒狀刀片 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à lâmina serrilhada encontrada em um {qutluch:n}.[1, p.61] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa hammastettuun terään, joka löytyy {qutluch:n}.[1, p.61] -laitteesta [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Ho':n:1}, {'etlh:n}</column>
       <column name="examples"></column>
@@ -8735,6 +9639,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8742,6 +9647,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8755,6 +9661,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">зубная паста</column>
       <column name="definition_zh_HK">牙膏</column>
       <column name="definition_pt">pasta de dentes</column>
+      <column name="definition_fi">hammastahna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8765,6 +9672,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Ho':n:1}, {-Du':n}, {Say'moHwI' tlhagh:n}</column>
       <column name="examples"></column>
@@ -8774,6 +9682,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8781,6 +9690,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8794,6 +9704,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">You have some stuffed to'baj leg in your teeth. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你的牙齒裡有一些塞滿了腿的東西。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você tem alguma perna de to'baj nos dentes.</column>
+      <column name="definition_fi">Sinulla on täytettyä tobbajin jalkaa hampaissasi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8804,6 +9715,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Ho':n:1}, {-Du':n}, {-lIj:n}, {-Daq:n}, {to'baj:n}, {'uS:n}, {-Hom:n}, {lu-:v}, {ghoD:v}, {-lu':v}, {-bogh:v}, {tu'lu':v}</column>
       <column name="examples"></column>
@@ -8813,6 +9725,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">QI'lop</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8820,6 +9733,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -8833,6 +9747,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">зубная боль</column>
       <column name="definition_zh_HK">牙疼</column>
       <column name="definition_pt">dor de dente</column>
+      <column name="definition_fi">hammassärky</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8843,6 +9758,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Существует клингонская идиома {Sagh; Ho''oy' rur@@Sagh:v, Ho''oy':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個克林崗語，{Sagh; Ho''oy' rur@@Sagh:v, Ho''oy':n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma Klingon, {Sagh; Ho''oy' rur@@Sagh:v, Ho''oy':n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On olemassa klingonin idioomi {Sagh; Ho''oy' rur@@Sagh:v, Ho''oy':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Ho':n:1}, {'oy':n}</column>
       <column name="examples"></column>
@@ -8852,6 +9768,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8859,6 +9776,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8872,6 +9790,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">система(подход), метод, способ, образ действий, техника</column>
       <column name="definition_zh_HK">系統、方法、方式、技術 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sistema, método, maneira, técnica</column>
+      <column name="definition_fi">järjestelmä, menetelmä, tapa, tekniikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8882,6 +9801,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Обратите внимание, что это относится к «системе» в смысле способа что-то сделать. Для физической (или подобной физике) системы см. {pat:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，這在某種意義上是指“系統”。有關物理（或類似物理的）系統，請參閱{pat:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que isso se refere a um "sistema" no sentido de uma maneira de fazer alguma coisa. Para um sistema físico (ou físico), consulte {pat:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä viittaa "järjestelmään" tavalla, jolla tehdään jotain. Fyysisen (tai fyysisen kaltaisen) järjestelmän osalta katso {pat:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In Ancient Greek, "ὁδός" (hodós) means "method".</column>
       <column name="components"></column>
       <column name="examples">
@@ -8893,6 +9813,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">way</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8900,6 +9821,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -8914,6 +9836,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">зоопарк</column>
       <column name="definition_zh_HK">動物園</column>
       <column name="definition_pt">jardim zoológico</column>
+      <column name="definition_fi">eläintarha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8924,6 +9847,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Dr. Seuss wrote "If I Ran the Zoo" and "Horton Hears a Who!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8933,6 +9857,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8940,6 +9865,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8953,6 +9879,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">{Hu'ma:excl}</column>
       <column name="definition_zh_HK">{Hu'ma:excl}</column>
       <column name="definition_pt">{Hu'ma:excl}</column>
+      <column name="definition_fi">{Hu'ma:excl}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8963,6 +9890,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8972,6 +9900,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8979,6 +9908,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8992,6 +9922,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">защищать, оборонять, отстаивать</column>
       <column name="definition_zh_HK">保衛</column>
       <column name="definition_pt">defender</column>
+      <column name="definition_fi">puolustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qan:v}, {'om:v}, {HIv:v}, {Hub:n}</column>
@@ -9002,6 +9933,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9011,6 +9943,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9018,6 +9951,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9031,6 +9965,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">защита, оборона, укрепления, оборонительные сооружения</column>
       <column name="definition_zh_HK">防禦</column>
       <column name="definition_pt">defesa</column>
+      <column name="definition_fi">puolustus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hub:v}</column>
@@ -9041,6 +9976,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
       <column name="components"></column>
       <column name="examples">
@@ -9051,6 +9987,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9058,6 +9995,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -9071,6 +10009,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">{tlhIngan Hubbeq:n}</column>
           <column name="definition_zh_HK">{tlhIngan Hubbeq:n}</column>
           <column name="definition_pt">{tlhIngan Hubbeq:n}</column>
+      <column name="definition_fi">{tlhIngan Hubbeq:n}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9081,6 +10020,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This does not appear in {TKDA:src} by itself, but only as part of {tlhIngan Hubbeq:n:nolink}.</column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -9090,6 +10030,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9097,6 +10038,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKDA:src}</column>
         </table>
         <table name="mem">
@@ -9110,6 +10052,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="definition_ru">защищать честь [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">捍衛榮譽 [AUTOTRANSLATED]</column>
           <column name="definition_pt">defender-honra</column>
+      <column name="definition_fi">kunniapuolustaa?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{HIvneS:v}, {Suvchu':v}</column>
@@ -9120,6 +10063,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="notes_ru">При использовании с глаголом {Hub:v} суффикс {-neS:v:suff} указывает, что самоубийство является частью плана защиты. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">與動詞{Hub:v}一起使用時，後綴{-neS:v:suff}表示自殺是防禦計劃的一部分。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Quando usado com o verbo {Hub:v}, o sufixo {-neS:v:suff} indica que o suicídio faz parte do plano de defesa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun sitä käytetään verbin {Hub:v} kanssa, loppuliite {-neS:v:suff} osoittaa, että itsemurha on osa puolustussuunnitelmaa. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Hub:v}, {-neS:v}</column>
           <column name="examples"></column>
@@ -9129,6 +10073,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">honour-defend</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9136,6 +10081,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.49:src}</column>
         </table>
     <table name="mem">
@@ -9149,6 +10095,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">деньги</column>
       <column name="definition_zh_HK">錢</column>
       <column name="definition_pt">dinheiro</column>
+      <column name="definition_fi">raha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIp:n}, {DeQ:n}, {DarSeq:n}, {chep:v}, {mIp:v}, {Huch nav:n}, {Huch jengva':n}, {beylI':n}, {ghunta:n}, {'ewro:n}</column>
@@ -9159,6 +10106,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9169,6 +10117,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9176,6 +10125,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -9189,6 +10139,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">кредитная карта [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">信用卡</column>
       <column name="definition_pt">cartão de crédito</column>
+      <column name="definition_fi">luottokortti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9199,6 +10150,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Huch:n}, {chaw':n}</column>
       <column name="examples"></column>
@@ -9208,6 +10160,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9215,6 +10168,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -9228,6 +10182,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">монета [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">硬幣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">moeda</column>
+      <column name="definition_fi">kolikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Huch nav:n}, {Huch:n}, {jengva':n}</column>
@@ -9238,6 +10193,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это буквально означает «денежная тарелка». За ним часто, но не всегда, следует {-Hom:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“錢盤”。它通常但不總是緊隨其後的是{-Hom:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "placa de dinheiro". Geralmente, mas nem sempre, é seguido por {-Hom:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "rahalautasta". Sitä seuraa usein, mutta ei aina, {-Hom:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Huch ngop:n:inhpl}</column>
       <column name="examples"></column>
@@ -9247,6 +10203,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9254,6 +10211,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -9267,6 +10225,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">банкнота, бумажные деньги [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鈔票、紙幣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">notas, papel-moeda</column>
+      <column name="definition_fi">seteli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Huch jengva':n}</column>
@@ -9277,6 +10236,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Huch:n}, {nav:n}</column>
       <column name="examples"></column>
@@ -9286,6 +10246,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9293,6 +10254,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -9306,6 +10268,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">Не доверяй ференги, который возвращает деньги</column>
       <column name="definition_zh_HK">不要相信那些還錢的Ferengi。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Não confie no Ferengi que devolve o dinheiro.</column>
+      <column name="definition_fi">Älä luota Ferengiin, joka palauttaa rahaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9316,6 +10279,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">There is a grammatical error with this sentence. It should be {tIvoqQo':sen@@tI-:v, voq:v, -Qo':v} rather than {yIvoqQo':sen:nolink}.</column>
       <column name="components">{Huch:n}, {nobHa':v}, {-bogh:v}, {verengan:n}, {-pu':n}, {-'e':n}, {yI-:v}, {voq:v}, {-Qo':v}</column>
       <column name="examples"></column>
@@ -9325,6 +10289,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9332,6 +10297,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.189:src}</column>
     </table>
     <table name="mem">
@@ -9345,6 +10311,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">монеты [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">硬幣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">moedas</column>
+      <column name="definition_fi">kolikot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9355,6 +10322,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это буквально означает «денежные тарелки». За ним часто, но не всегда, следует {-Hom:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“錢盤”。它通常但不總是緊隨其後的是{-Hom:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "placas de dinheiro". Geralmente, mas nem sempre, é seguido por {-Hom:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "rahalautoja". Sitä seuraa usein, mutta ei aina, {-Hom:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Huch jengva':n:inhps}</column>
       <column name="examples"></column>
@@ -9364,6 +10332,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9371,6 +10340,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -9384,6 +10354,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">экономика [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">經濟學</column>
       <column name="definition_pt">economia</column>
+      <column name="definition_fi">taloustiede</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9394,6 +10365,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это слово не имеет (известного) не сленгового аналога. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該詞沒有（已知）非-語對應詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra não possui contrapartida (conhecida) que não seja gíria. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä sanalla ei ole (tunnettua) ei-slangia vastaavaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Presumably, an economist would be a {Huchtej:n@@Huch:n, tej:n}, but this word has never appeared in canon.</column>
       <column name="components">{Huch:n}, {QeD:n}</column>
       <column name="examples"></column>
@@ -9403,6 +10375,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9410,6 +10383,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9423,6 +10397,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">гора, холм</column>
       <column name="definition_zh_HK">山</column>
       <column name="definition_pt">montanha, colina</column>
+      <column name="definition_fi">vuori, mäki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'ghey:n}, {qoj:n}, {qulHuD:n}, {Do'ol HuD:n}</column>
@@ -9433,6 +10408,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Mt. Hood is the name of a mountain in northern Oregon.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9442,6 +10418,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9449,6 +10426,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9462,6 +10440,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">Черные холмы</column>
       <column name="definition_zh_HK">黑山</column>
       <column name="definition_pt">as colinas negras</column>
+      <column name="definition_fi">Mustat kukkulat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9472,6 +10451,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是{SaqSub:n}和{QIStaq:n}之間的地理特徵的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on maantieteellisen ominaisuuden nimi {SaqSub:n} ja {QIStaq:n} välillä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{HuD:n:1}, {qIj:v}</column>
       <column name="examples"></column>
@@ -9481,6 +10461,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9488,6 +10469,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.72-73:src}</column>
     </table>
     <table name="mem">
@@ -9501,6 +10483,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">Плоский горный район [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">平山區</column>
       <column name="definition_pt">Distrito de Flat Mountain</column>
+      <column name="definition_fi">Tasaisten vuorten vyöhyke</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9511,6 +10494,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это район внутри {Sa'Qej Sep:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{Sa'Qej Sep:n}內部的區域。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um distrito dentro do {Sa'Qej Sep:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on piiri {Sa'Qej Sep:n}: n sisällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{HuD:n:1}, {beQ:v}, {yoS:n}</column>
       <column name="examples"></column>
@@ -9520,6 +10504,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9527,6 +10512,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9540,6 +10526,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">сарай, лачуга [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">棚屋</column>
       <column name="definition_pt">galpão, barraco</column>
+      <column name="definition_fi">vaja, katos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qach:n}</column>
@@ -9550,6 +10537,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Это обычно используется для хранения вещей, в отличие от {raywal:n}, который предназначен для использования людьми, хотя между ними есть частичное совпадение.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它通常用於存儲事物，這與供人使用的{raywal:n}不同，儘管它們之間存在重疊。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä käytetään tyypillisesti tavaroiden varastointiin, toisin kuin {raywal:n}, joka on tarkoitettu ihmisten käyttöön, vaikka niiden välillä onkin päällekkäisyyksiä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Radio Shack".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9559,6 +10547,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9566,6 +10555,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -9579,6 +10569,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">HuDyuQ (планета) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">山星（星球）</column>
       <column name="definition_pt">HuDyuQ (planeta)</column>
+      <column name="definition_fi">HuDyuQ (planeetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taD:n:place}</column>
@@ -9589,6 +10580,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru">Название горной планеты. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">山區星球的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O nome de um planeta montanhoso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vuoristoisen planeetan nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{HuD:n:1}, {yuQ:n}</column>
       <column name="examples"></column>
@@ -9598,6 +10590,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9605,6 +10598,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -9619,6 +10613,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">грудь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">乳房 [AUTOTRANSLATED]</column>
       <column name="definition_pt">seio</column>
+      <column name="definition_fi">rinta</column>
       <column name="synonyms">{ngob'at:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{ngech:n:2}</column>
@@ -9629,6 +10624,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9638,6 +10634,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9645,6 +10642,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9658,6 +10656,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">глотка, горло, жерло</column>
       <column name="definition_zh_HK">喉嚨</column>
       <column name="definition_pt">garganta</column>
+      <column name="definition_fi">kurkku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghup:v}, {qo'qaD:n}, {chayqa':n}</column>
@@ -9668,6 +10667,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9678,6 +10678,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9685,6 +10686,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9698,6 +10700,7 @@ Este verbo também é usado para polígonos regulares e poliedros.[2] [AUTOTRANS
       <column name="definition_ru">тина, слизь, муть</column>
       <column name="definition_zh_HK">粘液 [AUTOTRANSLATED]</column>
       <column name="definition_pt">baba, bile, mucus</column>
+      <column name="definition_fi">lima, sappi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{char:v}, {quy'Ip:n}, {chej:n}, {'enDeq:n}</column>
@@ -9722,6 +10725,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [AUTOTRAN
       <column name="notes_pt">Dependendo do contexto, essa palavra também pode ser listada como "bile" ou "fel".
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Asiayhteydestä riippuen tämä sana voidaan myös kiiltää "sappena" tai "sappena".
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9731,6 +10737,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bile, gall</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9738,6 +10745,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9751,6 +10759,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">быть странным, быть незнакомым</column>
       <column name="definition_zh_HK">陌生</column>
       <column name="definition_pt">ser estranho</column>
+      <column name="definition_fi">olla outo, vieras</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jum:v}, {taQ:v}</column>
@@ -9761,6 +10770,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru">Это означает «странный», как в незнакомом.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著像陌生人一樣“奇怪”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "estranho", como não é familiar.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "outoa" kuin tuntemattomassa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9770,6 +10780,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">unfamiliar</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9777,6 +10788,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru">незнакомый</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -9790,6 +10802,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">заряжать, производить зарядку</column>
       <column name="definition_zh_HK">充電） [AUTOTRANSLATED]</column>
       <column name="definition_pt">carregar (para cima)</column>
+      <column name="definition_fi">ladata (laite, ase tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loj:v}, {rIH:v}, {'ul 'aplo':n}</column>
@@ -9800,6 +10813,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru">Некто сперва заряжает ({Huj:v:2,nolink}) устройство, перед его включением ({rIH:v}).</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Um primeiro carrega ({Huj:v:2,nolink}) um dispositivo antes de energizá-lo ({rIH:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ensimmäinen lataa ({Huj:v:2,nolink}) laitteen ennen virran kytkemistä ({rIH:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9809,6 +10823,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9816,6 +10831,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9829,6 +10845,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">быть липким, быть клейким, быть липучим</column>
       <column name="definition_zh_HK">粘 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser pegajoso</column>
+      <column name="definition_fi">olla tahmea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{char:v}, {HIr:v}</column>
@@ -9839,6 +10856,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">When it's "hum"id you feel sticky.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9848,6 +10866,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9855,6 +10874,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9868,6 +10888,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">Человек(вид)</column>
       <column name="definition_zh_HK">人、人類、智人</column>
       <column name="definition_pt">humano</column>
+      <column name="definition_fi">ihminen (laji)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera'ngan:n}, {tera':n}</column>
@@ -9878,6 +10899,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru">Обратите внимание, что человек ({Human:n:nolink}) является членом местного разумного вида Земли ({tera':n:place}), тогда как Терран ({tera'ngan:n}) относится к любому обитателю планеты. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，人類（{Human:n:nolink}）是地球上土著感知物種（{tera':n:place}）的成員，而人族（{tera'ngan:n}）則是指地球上的任何居民。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que um humano ({Human:n:nolink}) é um membro das espécies sencientes da Terra ({tera':n:place}), enquanto o terráqueo ({tera'ngan:n}) se refere a qualquer habitante do planeta. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että ihminen ({Human:n:nolink}) on maan alkuperäiskansojen tuntevien lajien ({tera':n:place}) jäsen, kun taas Terran ({tera'ngan:n}) viittaa mihin tahansa planeetan asukkaaseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9887,6 +10909,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Terran</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9894,6 +10917,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru">землянин, человек</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9907,6 +10931,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">существо, похожее на {ghargh:n}, но с множеством шатких ног [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">似{ghargh:n}的多足蟲類</column>
       <column name="definition_pt">uma criatura como um {ghargh:n}, mas com muitas pernas enroladas</column>
+      <column name="definition_fi">eräs {ghargh:n}:ia muistuttava olento, jolla on paljon liikkuvia jalkoja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghargh:n}</column>
@@ -9917,6 +10942,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9926,6 +10952,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">centipede, millipede</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9933,6 +10960,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -9947,6 +10975,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">Хрун, тип животного [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《khrun》（動物類型）</column>
       <column name="definition_pt">Khrun, um tipo de animal</column>
+      <column name="definition_fi">eräs eläin, khrun</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sargh:n}, {ba'qIn:n}</column>
@@ -9957,6 +10986,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru">Это животное известно своей скоростью. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種動物以速度著稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este animal é conhecido por sua velocidade. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä eläin tunnetaan nopeudestaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9967,6 +10997,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">horse</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9974,6 +11005,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, [2] {paq'batlh p.130-131:src}</column>
     </table>
     <table name="mem">
@@ -9987,6 +11019,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">безопасность, охрана, защита, надежность</column>
       <column name="definition_zh_HK">警衛、保安人員</column>
       <column name="definition_pt">segurança</column>
+      <column name="definition_fi">turvallisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pegh:n}, {ghan'Iq:n}, {qop:v}, {chut:n}</column>
@@ -9997,6 +11030,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10007,6 +11041,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10014,6 +11049,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -10027,6 +11063,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">наказывать, карать, расправляться, наказать</column>
       <column name="definition_zh_HK">懲治 [AUTOTRANSLATED]</column>
       <column name="definition_pt">punir</column>
+      <column name="definition_fi">rangaista</column>
       <column name="synonyms">{bIj:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{bIj:n}, {jIb:v}, {rup:v}</column>
@@ -10037,6 +11074,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10046,6 +11084,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10053,6 +11092,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10066,6 +11106,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">совершать сделку</column>
       <column name="definition_zh_HK">辦理</column>
       <column name="definition_pt">transacionar</column>
+      <column name="definition_fi">tehdä kauppaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{malja':n}, {Suy:n}, {tlhong:v}, {ghunta:n}</column>
@@ -10076,6 +11117,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10086,6 +11128,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10093,6 +11136,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10106,6 +11150,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">вне [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">外面、出便</column>
       <column name="definition_pt">lado de fora</column>
+      <column name="definition_fi">ulkopuolella, ulkopuoli</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qoD:n}, {Hur'Iq:n}, {reD:n:1}, {yor:n}, {pIrmuS:n}</column>
       <column name="see_also"></column>
@@ -10116,6 +11161,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10125,6 +11171,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">exterior</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10132,6 +11179,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10146,6 +11194,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/tAK-hgXMH-M} [A
       <column name="definition_ru">stringed instrument (general term) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">弦樂器（總稱） [AUTOTRANSLATED]</column>
       <column name="definition_pt">instrumento de cordas (termo geral)</column>
+      <column name="definition_fi">kielisoitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10180,6 +11229,11 @@ En {HurDagh:n:nolink} spelas vanligtvis inte med en båge, men en {ngItHel:n} ka
 Os tipos de {HurDagh:n:nolink} incluem o {Supghew:n} (pequeno), o {leSpal:n} (médio) e o {tIngDagh:n} (grande).
 
 Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} pode ser puxado, dedilhado ou curvado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleinen termi jousille tarkoitetulle soittimelle ({SIrgh:n}), jonka voi joko repiä ({pang:v}) tai lyödä ({yach:v:2}). Äänen vaihtelemiseksi yhdellä "sormella" ({Heng:v}) merkkijonoja (kosketa niitä eri kohdissa, kun kynsitään tai lyötään).
+
+{HurDagh:n:nolink}-tyypit sisältävät {Supghew:n} (pieni), {leSpal:n} (keskikoko) ja {tIngDagh:n} (suuri).
+
+{HurDagh:n:nolink}: tä ei yleensä pelata jousella, mutta {ngItHel:n}: tä voidaan kynsiä, lyödä tai kumartaa.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10189,6 +11243,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">harp</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10196,6 +11251,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -10209,6 +11265,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="definition_ru">быть темным, быть мрачным</column>
       <column name="definition_zh_HK">黑</column>
       <column name="definition_pt">ser escuro</column>
+      <column name="definition_fi">olla pimeä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wov:v}</column>
       <column name="see_also">{nguv:v}, {QIb:n}, {qIj:v}</column>
@@ -10219,6 +11276,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10228,6 +11286,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10235,6 +11294,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10248,6 +11308,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="definition_ru">солёный огурец</column>
       <column name="definition_zh_HK">泡菜（黃瓜） [AUTOTRANSLATED]</column>
       <column name="definition_pt">picles (pepino)</column>
+      <column name="definition_fi">(suola)kurkku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaH:v:2}, {peb'ot:n}</column>
@@ -10258,6 +11319,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="notes_ru">Это полностью маринованный {peb'ot:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個完全醃製的{peb'ot:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um {peb'ot:n} totalmente marinado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on täysin marinoitu {peb'ot:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Gherkin".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10267,6 +11329,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cucumber</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10274,6 +11337,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="search_tags_ru">огурец</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -10287,6 +11351,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
           <column name="definition_ru">подводная лодка, дирижабль [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">潛艇，飛艇 [AUTOTRANSLATED]</column>
           <column name="definition_pt">submarino, dirigível</column>
+      <column name="definition_fi">sukellusvene, ilmalaiva</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{weSjech ba'Suq Duj:n}, {'oq:v}, {luS:v}</column>
@@ -10297,6 +11362,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
           <column name="notes_ru">В империи клингонов есть корабли, которые могут летать и погружаться под воду. Относится ли это конкретно к подводной лодке или дирижаблю, зависит от контекста. Чтобы дифференцировать их, подводная лодка была бы {bIQ Hurgh Duj:n@@bIQ:n, Hurgh Duj:n}, а дирижабль был бы {muD Hurgh Duj:n@@muD:n:1, Hurgh Duj:n}.[1]. {Hurgh Duj:n:nolink}, как правило, имеет двигатель для тяги.[2] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt">O Império Klingon tem navios que podem voar e submergir debaixo d'água. Se isso se refere especificamente a um submarino ou a um dirigível depende do contexto. Para diferenciá-los, um submarino seria um {bIQ Hurgh Duj:n@@bIQ:n, Hurgh Duj:n} e um dirigível seria um {muD Hurgh Duj:n@@muD:n:1, Hurgh Duj:n}.[1] A {Hurgh Duj:n:nolink} normalmente possui um motor de propulsão.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin imperiumissa on aluksia, jotka voivat sekä lentää että upota veden alle. Tarkoittaako tämä nimenomaan sukellusvenettä vai välähdystä, riippuu asiayhteydestä. Niiden erottamiseksi sukellusvene olisi {bIQ Hurgh Duj:n@@bIQ:n, Hurgh Duj:n} ja välähdys olisi {muD Hurgh Duj:n@@muD:n:1, Hurgh Duj:n}.[1] {Hurgh Duj:n:nolink}: ssä on tyypillisesti moottori työntövoimaa varten.[2] [AUTOTRANSLATED]</column>
           <column name="hidden_notes">This word and information about it were revealed in conversation during the {qepHom:src}.</column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -10306,6 +11372,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de">Unterseeboot</column>
           <column name="search_tags_fa"></column>
@@ -10313,6 +11380,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}, [2] {KLI mailing list 2020.04.21:src}</column>
         </table>
     <table name="mem">
@@ -10326,6 +11394,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="definition_ru">посторонний, иностранец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">外人、外國人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estrangeiro, de fora</column>
+      <column name="definition_fi">ulkopuolinen, ulkomaalainen</column>
       <column name="synonyms">{nov:n}</column>
       <column name="antonyms">{Sung:n}</column>
       <column name="see_also">{Hur'Iqngan:n}, {Hur:n}</column>
@@ -10336,6 +11405,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Possibly derived from {Hur:n} and {'Iq:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10345,6 +11415,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10352,6 +11423,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10365,6 +11437,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="definition_ru">Hur'q (person) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">赫爾克（人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Hur'q (pessoa)</column>
+      <column name="definition_fi">hur'qlainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hur'Iq:n}, {ngan:n}</column>
@@ -10375,6 +11448,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="notes_ru">Существует идиома {wIH; Hur'Iqngan rur@@wIH:v, Hur'Iqngan:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{wIH; Hur'Iqngan rur@@wIH:v, Hur'Iqngan:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {wIH; Hur'Iqngan rur@@wIH:v, Hur'Iqngan:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {wIH; Hur'Iqngan rur@@wIH:v, Hur'Iqngan:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10384,6 +11458,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10391,6 +11466,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10404,6 +11480,7 @@ Um {HurDagh:n:nolink} geralmente não é tocado com um arco, mas um {ngItHel:n} 
       <column name="definition_ru">вешать, развесить, свисать, увешивать</column>
       <column name="definition_zh_HK">掛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pendurar</column>
+      <column name="definition_fi">ripustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10428,6 +11505,9 @@ Detta används inte för att "exekvera genom att hänga", vilket är {jIb:v}. [A
       <column name="notes_pt">Isso é usado, por exemplo, para pendurar um casaco em um cabide ou roupas em um varal. Mas não é usado para uma aranha pendurada em um fio de seda ou um par de sapatos pendurado por seus cadarços em uma linha de alta tensão, que é {tlhep:v}.
 
 Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään esimerkiksi takin ripustamiseen koukkuun tai vaatteiden pyykkinarulle. Mutta sitä ei käytetä hämähäkkiin, joka roikkuu silkkilangasta, tai kenkäpariin, joka roikkuu nauhojensa avulla sähköverkosta, joka on {tlhep:v}.
+
+Tätä ei käytetä tarkoittamaan "suorita ripustamalla", mikä on {jIb:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's confirmed this takes an object.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10437,6 +11517,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10444,6 +11525,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -10457,6 +11539,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">Гус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">胡斯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Huss</column>
+      <column name="definition_fi">Huss</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'atrom:n:name}</column>
@@ -10467,6 +11550,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru">{HuS 'atrom puqbe':sen:nolink} "Гус, дочь А'Трома" [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{HuS 'atrom puqbe':sen:nolink}“胡斯，A'trom的女兒” [AUTOTRANSLATED]</column>
       <column name="notes_pt">{HuS 'atrom puqbe':sen:nolink} "Huss, filha de A'trom" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{HuS 'atrom puqbe':sen:nolink} "Huss, A'tromin tytär" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10476,6 +11560,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10483,6 +11568,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10496,6 +11582,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">девять</column>
       <column name="definition_zh_HK">九</column>
       <column name="definition_pt">nove</column>
+      <column name="definition_fi">yhdeksän</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10506,6 +11593,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10515,6 +11603,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">9th</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10522,6 +11611,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -10535,6 +11625,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="definition_ru">девятый</column>
           <column name="definition_zh_HK">第九</column>
           <column name="definition_pt">nono</column>
+      <column name="definition_fi">yhdeksäs</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -10545,6 +11636,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Hut:n:num}, {-DIch:n:num,suff}</column>
           <column name="examples"></column>
@@ -10554,6 +11646,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10561,6 +11654,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -10574,6 +11668,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="definition_ru">девяносто [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">九十 [AUTOTRANSLATED]</column>
           <column name="definition_pt">noventa</column>
+      <column name="definition_fi">yhdeksänkymmentä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -10584,6 +11679,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Hut:n:num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -10593,6 +11689,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10600,6 +11697,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -10613,6 +11711,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">слишком много людей или вещей в одном месте одновременно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一次到位的人太多 [AUTOTRANSLATED]</column>
       <column name="definition_pt">muitas pessoas ou coisas em um lugar ao mesmo tempo</column>
+      <column name="definition_fi">liikaa asioita tai ihmisiä yhdessä paikassa kerralla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iq:v}</column>
@@ -10623,6 +11722,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru">Этот термин используется как игра слов, заменяя проклятие {Qu'vatlh:excl} в ситуациях, когда это уместно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該詞用作文字遊戲，在適當的情況下代替{Qu'vatlh:excl}詛咒。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo é usado como um jogo de palavras, substituindo a maldição {Qu'vatlh:excl} nas situações em que é apropriado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä termiä käytetään sanaleikkinä, korvaamalla kirous {Qu'vatlh:excl} tilanteissa, joissa se on tarkoituksenmukaista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word was disclosed during a congested drive on Interstate 95 (i.e., {Hut:n}, {vagh:n:1,num}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10632,6 +11732,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10639,6 +11740,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.3, p.13, Sept. 2002:src}</column>
     </table>
     <table name="mem">
@@ -10652,6 +11754,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">nerve (anatomy, physiology) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">神經（解剖學、生理學） [AUTOTRANSLATED]</column>
       <column name="definition_pt">nervo (anatomia, fisiologia)</column>
+      <column name="definition_fi">hermo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hutvav rarwI':n}</column>
@@ -10662,6 +11765,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10671,6 +11775,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10678,6 +11783,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -10691,6 +11797,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">нервный синапс [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">神經突觸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sinapse neural</column>
+      <column name="definition_fi">hermosynapsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hutvav:n}</column>
@@ -10701,6 +11808,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10710,6 +11818,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10717,6 +11826,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -10730,6 +11840,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">гвоздь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">釘 [AUTOTRANSLATED]</column>
       <column name="definition_pt">unha</column>
+      <column name="definition_fi">naula</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hut'In vIl:n}, {mupwI':n}, {wIl:n}, {Hut'In tIq:n}</column>
@@ -10740,6 +11851,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru">Это относится к небольшому, обычно металлическому, шипу, обычно используемому для крепления дерева. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指通常用於固定木材的小釘子（通常為金屬釘）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um pequeno espigão, geralmente de metal, normalmente usado para prender madeira. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa pieneen, yleensä metalliseen piikkiin, jota tyypillisesti käytetään puun kiinnittämiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the industrial rock band "Nine Inch Nails".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10749,6 +11861,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10756,6 +11869,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.08.13:src}</column>
     </table>
     <table name="mem">
@@ -10769,6 +11883,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">ткацкая палочка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">編織棒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vara de tecelagem</column>
+      <column name="definition_fi">kudinpuikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10779,6 +11894,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru">Это буквально означает «длинный гвоздь» и относится к палочкам, используемым в некоторых формах плетения (см. {nIq:v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“長指甲”，是指在某些形式的編織中使用的棍棒（請參閱{nIq:v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso literalmente significa "unha longa" e refere-se aos palitos usados ​​em algumas formas de tecelagem (consulte {nIq:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "pitkää kynsiä" ja viittaa joissakin kudontamuotoissa käytettyihin keppeihin (katso {nIq:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hut'In:n}, {tIq:v}</column>
       <column name="examples"></column>
@@ -10788,6 +11904,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">knitting needle, crochet hook</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10795,6 +11912,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.10.28:src}</column>
     </table>
     <table name="mem">
@@ -10808,6 +11926,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">винт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">parafuso</column>
+      <column name="definition_fi">ruuvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hut'In:n}, {veragh:n}, {voD:v}</column>
@@ -10818,6 +11937,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The "Phillips-head" screw and screwdriver are named for Henry F. Phillips.</column>
       <column name="components">{Hut'In:n}, {vIl:v:1}</column>
       <column name="examples"></column>
@@ -10827,6 +11947,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10834,6 +11955,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.08.13:src}</column>
     </table>
     <table name="mem">
@@ -10847,6 +11969,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">байт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">字節 [AUTOTRANSLATED]</column>
       <column name="definition_pt">byte</column>
+      <column name="definition_fi">tavu (tiedon yksikkö)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{San'on:n}</column>
@@ -10857,6 +11980,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru">Это единица информации в информатике. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是計算機科學中的信息單元。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma unidade de informação em ciência da computação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tietojenkäsittelytieteen tietoyksikkö. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">John Hutton played Claude Shannon in the 2018 film "The Bit Player".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10866,6 +11990,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10873,6 +11998,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -10886,6 +12012,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">не хватать, быть без, не иметь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">缺乏、沒有、沒有 [AUTOTRANSLATED]</column>
       <column name="definition_pt">faltar, estar sem, não ter</column>
+      <column name="definition_fi">olla ilman, puuttua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghaj:v}</column>
       <column name="see_also"></column>
@@ -10896,6 +12023,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10906,6 +12034,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10913,6 +12042,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {TKW p.59:src}</column>
     </table>
     <table name="mem">
@@ -10926,6 +12056,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">быть чистым, быть незатрудненным</column>
       <column name="definition_zh_HK">要清楚、不要阻礙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser claro, não obstruído</column>
+      <column name="definition_fi">olla selkeä, ei-hämärä, ei-samea, läpinäkyvä, näköesteetön?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{waQ:v}</column>
@@ -10936,6 +12067,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10945,6 +12077,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10952,6 +12085,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10965,6 +12099,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">{qu':v:2,slang}</column>
       <column name="definition_zh_HK">{qu':v:2,slang}</column>
       <column name="definition_pt">{qu':v:2,slang}</column>
+      <column name="definition_fi">{qu':v:2,slang}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10975,6 +12110,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10984,6 +12120,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10991,6 +12128,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.161:src}</column>
     </table>
     <table name="mem">
@@ -11004,6 +12142,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">гул [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">哼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cantarolar</column>
+      <column name="definition_fi">surista, hurista, kehrätä, hyräillä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:v}, {'uq:v}</column>
@@ -11014,6 +12153,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru">Это может быть использовано как для пения без слов, так и для звука, производимого (не огромным) двигателем. Это также используется для звука кошки (мурлыканье). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這既可以用於無聲唱歌，也可以用於引擎（不是很大）發出的聲音。它也用於發出貓的聲音。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado tanto para cantar sem palavras quanto para o som que um mecanismo (não enorme) produz. Também é usado para o som de um gato (ronronar). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää sekä sanattomaan laulamiseen että (ei valtavan) moottorin ääniin. Sitä käytetään myös kissan ääniin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11023,6 +12163,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">purr</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11030,6 +12171,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -11043,6 +12185,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">быть острым, пикантным, горячим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">辛辣辛辣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser picante, ser quente</column>
+      <column name="definition_fi">olla mausteinen, pikantti, tulinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mum:v}</column>
@@ -11053,6 +12196,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11062,6 +12206,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11069,6 +12214,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -11082,6 +12228,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">бровь</column>
       <column name="definition_zh_HK">眉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sobrancelha</column>
+      <column name="definition_fi">kulmakarva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn:n}, {Quch:n}</column>
@@ -11092,6 +12239,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru">Существует идиома {val; Huy' rur}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{val; Huy' rur}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {val; Huy' rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {val; Huy' rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11101,6 +12249,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11108,6 +12257,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -11121,6 +12271,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">лоб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">額頭</column>
       <column name="definition_pt">testa</column>
+      <column name="definition_fi">otsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quch:n}</column>
@@ -11131,6 +12282,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word seems to be composed of {Huy':n} and {Dung:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11140,6 +12292,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11147,6 +12300,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -11160,6 +12314,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">дней назад</column>
       <column name="definition_zh_HK">（幾）日前</column>
       <column name="definition_pt">dias atrás</column>
+      <column name="definition_fi">... päivää sitten</column>
       <column name="synonyms"></column>
       <column name="antonyms">{leS:n}</column>
       <column name="see_also">{jaj:n}, {ret:n}</column>
@@ -11170,6 +12325,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The fact that this is homophonous with {Hu':v} may have to do with how many times one has gotten up (from sleep) since the day in question. Note that {leS:n:nolink} is also homophonous with {leS:v}.</column>
       <column name="components"></column>
       <column name="examples">{wa'Hu':n}, {cha'Hu':n}</column>
@@ -11179,6 +12335,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11186,6 +12343,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -11199,6 +12357,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">вставать, подниматься, усиливать</column>
       <column name="definition_zh_HK">起身</column>
       <column name="definition_pt">Levantar-se</column>
+      <column name="definition_fi">nousta ylös (sängystä, maasta tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ba':v}, {Qam:v}, {Qot:v}, {tor:v:1}, {vem:v}, {woH:v}</column>
@@ -11209,6 +12368,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{yIHu'!:sen}</column>
@@ -11218,6 +12378,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11225,6 +12386,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -11238,6 +12400,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">ммм [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嗯，嗯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ah!</column>
+      <column name="definition_fi">öö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11248,6 +12411,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru">Это слово наполнителя. Иногда это {Hu'mI:sen:nolink}, а иногда просто {Hu:sen:nolink}. Еще одна пауза вокализации - это просто низкий тон {ghghgh:sen:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個補語。有時是{Hu'mI:sen:nolink}，有時只是{Hu:sen:nolink}。另一個暫停發聲只是低調的{ghghgh:sen:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra de preenchimento. Às vezes é {Hu'mI:sen:nolink} e às vezes apenas {Hu:sen:nolink}. Outra vocalização de pausa é apenas um {ghghgh:sen:nolink} em tons baixos.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on täytesana. Se on joskus {Hu'mI:sen:nolink} ja joskus vain {Hu:sen:nolink}. Toinen taukovokaalisointi on vain matalan sävyn {ghghgh:sen:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The character Ralph Kramden on the TV show "The Honeymooners" would say this when at a loss for words.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11257,6 +12421,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ghghgh, hmm, uhh, filler word</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11264,6 +12429,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
         <table name="mem">
@@ -11277,6 +12443,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="definition_ru">{Hu'ma:excl}</column>
           <column name="definition_zh_HK">{Hu'ma:excl}</column>
           <column name="definition_pt">{Hu'ma:excl}</column>
+      <column name="definition_fi">{Hu'ma:excl}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -11287,6 +12454,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -11296,6 +12464,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -11303,6 +12472,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 26 (2019):src}</column>
         </table>
     <table name="mem">
@@ -11316,6 +12486,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="definition_ru">общее оскорбление</column>
       <column name="definition_zh_HK">一般粗口</column>
       <column name="definition_pt">invectivo geral</column>
+      <column name="definition_fi">eräs kirosana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11326,6 +12497,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11335,6 +12507,7 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11342,5 +12515,6 @@ Isso não é usado para significar "executar por suspensão", que é {jIb:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>

--- a/mem-06-j.xml
+++ b/mem-06-j.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {j:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{j:sen:nolink}</column>
       <column name="definition_pt">a consoante {j:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {j:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">обслуживать(подавать еду)</column>
       <column name="definition_zh_HK">提供食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">servir (comida)</column>
+      <column name="definition_fi">tarjoilla (ruokaa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vun:v}, {vut:v}, {jabwI':n}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">передавать данные</column>
       <column name="definition_zh_HK">數據傳輸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transmissão de dados</column>
+      <column name="definition_fi">tiedonsiirto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIn:n:1}, {lab:v}, {lI':v:2}, {nav QIn:n}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is often used to refer to email among Klingonists.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mail, email, e-mail</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">чтобы обслуживать</column>
       <column name="definition_zh_HK">為了服務 [AUTOTRANSLATED]</column>
       <column name="definition_pt">para servir</column>
+      <column name="definition_fi">eräs kirja, Tarjoilemiseksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -136,6 +149,7 @@
       <column name="notes_ru">Это название книги рецептов, автором которой является J'puq.[1, стр.86]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on J'puqin keittokirjan nimi.[1, p.86] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The name "J'puq" is a reference to Julia Child ({puq:n}). It also alludes to "puke" and makes fun of the use of French in otherwise English-language cookbooks.
 
 The title of the book may be a reference to the Twilight Zone episode "To Serve Man".</column>
@@ -147,6 +161,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -154,6 +169,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -167,6 +183,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="definition_ru">сервер еды, официант, официантка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">服務生、侍應生、侍者</column>
       <column name="definition_pt">garçom</column>
+      <column name="definition_fi">tarjoilija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chom:n}, {tebwI':n}, {vutwI':n}</column>
@@ -177,6 +194,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="notes_ru">Это обязанность {jabwI':n:nolink} к {qaw:v} заказа. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">É dever do {jabwI':n:nolink} a {qaw:v} a ordem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{jabwI':n:nolink} on velvollinen {qaw:v} tilaamaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jab:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -186,6 +204,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -193,6 +212,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -206,6 +226,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="definition_ru">кричать, выкрикивать, выплакиваться, гомонить, накричать, вопить</column>
       <column name="definition_zh_HK">尖叫、喊叫、喊叫、大叫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gritar, berrar</column>
+      <column name="definition_fi">huutaa, kiljua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bey:n}, {SaQ:v}</column>
@@ -216,6 +237,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -226,6 +248,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -233,6 +256,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -246,6 +270,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="definition_ru">Мастер крика</column>
       <column name="definition_zh_HK">吶喊大師 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mestre do Grito</column>
+      <column name="definition_fi">huutomestari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghe'naQ:n}</column>
@@ -256,6 +281,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="notes_ru">Это традиционная роль рассказчика в Клингонской опере.</column>
       <column name="notes_zh_HK">這是克林崗歌劇的傳統敘述者角色。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o papel tradicional de narrador na ópera klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on perinteinen kertojan rooli Klingonin oopperassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jach:v}, {-wI':v}, {-na':n}</column>
       <column name="examples"></column>
@@ -265,6 +291,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -272,6 +299,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.xvii,xxii,40-41:src}</column>
     </table>
     <table name="mem">
@@ -285,6 +313,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="definition_ru">Слушай клич воина</column>
       <column name="definition_zh_HK">聽到戰士的叫聲！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ouça o guerreiro gritar!</column>
+      <column name="definition_fi">Kuule soturin huuto!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -295,6 +324,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jach:v}, {SuvwI':n}, {'e':n}, {yI-:v}, {Qoy:v}</column>
       <column name="examples"></column>
@@ -304,6 +334,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -311,6 +342,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.195:src}</column>
     </table>
     <table name="mem">
@@ -324,6 +356,7 @@ The title of the book may be a reference to the Twilight Zone episode "To Serve 
       <column name="definition_ru">бросать, швырять [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">四處亂竄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">jogar ao redor, arremessar</column>
+      <column name="definition_fi">heitellä, viskellä ympäriinsä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhur:v}</column>
       <column name="see_also">{vo':v}, {woD:v:1}</column>
@@ -348,6 +381,9 @@ Att jonglera, det vill säga att kasta föremål i luften och fånga dem i ett r
       <column name="notes_pt">Isso significa atirar ou arremessar algo como um projétil.[1, p.91]
 
 Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítmico, é {jaDchu':v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa heittää tai heittää jotain ammuksen kaltaista.[1, p.91]
+
+Jongleeraaminen eli esineiden heittäminen ilmaan ja kiinniottaminen rytmikkäässä muodossa on {jaDchu':v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -357,6 +393,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -364,6 +401,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -377,6 +415,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">juggle (objects, not tasks) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">玩雜耍（對象、而不是任務） [AUTOTRANSLATED]</column>
       <column name="definition_pt">malabarismo (com objetos)</column>
+      <column name="definition_fi">jonglöörata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -387,6 +426,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">For another example where {-chu':v} on a verb of motion indicates a rhythmic pattern, see {lerchu':v}.</column>
       <column name="components">{jaD:v}, {-chu':v}</column>
       <column name="examples"></column>
@@ -396,6 +436,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -403,6 +444,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -416,6 +458,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">враг</column>
       <column name="definition_zh_HK">敵人</column>
       <column name="definition_pt">inimigo</column>
+      <column name="definition_fi">vihollinen</column>
       <column name="synonyms">{ghol:n}</column>
       <column name="antonyms">{jup:n}</column>
       <column name="see_also"></column>
@@ -426,6 +469,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -435,6 +479,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -442,6 +487,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -455,6 +501,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">Чтобы победить врага, будь готов сражаться в одиночку</column>
       <column name="definition_zh_HK">為了戰勝敵人，準備獨自戰鬥。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Para derrotar o inimigo, esteja pronto para lutar sozinho.</column>
+      <column name="definition_fi">Voittaaksesi vihollisen valmistaudu taistelemaan yksin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -465,6 +512,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jagh:n}, {Da-:v}, {jey:v}, {-meH:v}, {nIteb:adv}, {yI-:v}, {Suv:v}, {-rup:v}</column>
       <column name="examples"></column>
@@ -474,6 +522,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">replacement proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -481,6 +530,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru">поговорка</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -494,6 +544,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">Пусть желчь завоеванного врага наполнит твои руки.</column>
       <column name="definition_zh_HK">願被征服敵人的膽汁填滿你的手。</column>
       <column name="definition_pt">Que a bílis dos vencidos encha suas mãos.</column>
+      <column name="definition_fi">Täyttäköön kukistettujen sappi kätesi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -504,6 +555,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -513,6 +565,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -520,6 +573,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -533,6 +587,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">Focus on the enemy! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">專注於敵人！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Foco no inimigo!</column>
+      <column name="definition_fi">Keskity viholliseen!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -543,6 +598,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was the winning replacement proverb entry, submitted by Rich Yampell ({Qanqor:n:name,nolink}), in the proverbs competition at {qep'a' 21 (2014):src}.</column>
       <column name="components">{jagh:n}, {yI-:v}, {buS:v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -552,6 +608,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">replacement proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -559,6 +616,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 21 (2014):src}</column>
     </table>
     <table name="mem">
@@ -572,6 +630,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">вражеский командир</column>
       <column name="definition_zh_HK">敵人指揮官 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comandante inimigo</column>
+      <column name="definition_fi">vihollisen komentaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -582,6 +641,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jagh:n}, {la':n}</column>
       <column name="examples"></column>
@@ -591,6 +651,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -598,6 +659,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -611,6 +673,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">ритм [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">韻律 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ritm</column>
+      <column name="definition_fi">rytmi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IngSav:n}, {'ISQIm:n}, {ghuQ:n}, {QoQ:n}, {bom:n}</column>
@@ -621,6 +684,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Backwards of {vIghaj:sen@@vI-:v, ghaj:v} "I have it", a reference to the George Gershwin jazz standard "I've Got Rhythm".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -630,6 +694,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -637,6 +702,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -650,6 +716,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">идти, ходить куда-то, переходить, отправляться</column>
       <column name="definition_zh_HK">走</column>
       <column name="definition_pt">ir</column>
+      <column name="definition_fi">mennä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoS:v:1}, {chegh:v}, {leng:v}</column>
@@ -660,6 +727,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="notes_ru">Если глагольный префикс указывает на объект, тогда субъект идет в направлении, связанном с объектом, который отмечен постфиксом {-Daq:n}. Если глагольный префикс не указывает на объект, тогда направление не задано. В этом случае существительное, отмеченое {-Daq:n:nolink}, указывает место, куда идет "идущий".[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Se o prefixo do verbo indicar um objeto, o sujeito está indo para um destino associado ao objeto, que pode ser marcado com {-Daq:n}. Se o prefixo do verbo não indicar nenhum objeto, o destino não será especificado. Nesse caso, um substantivo marcado com {-Daq:n:nolink} indica o local onde o "ir" está ocorrendo.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos verbin etuliite osoittaa objektin, kohde menee kohteeseen liittyvään kohteeseen, joka voidaan merkitä {-Daq:n}-merkinnällä. Jos verbin etuliite ei osoita mitään objektia, kohde on määrittelemätön. Tällöin {-Daq:n:nolink}: lla merkitty substantiivi osoittaa sijainnin, jossa "menee".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Some canon sentences don't seem to follow the grammar described in {HQ 7.4:src}, instead using a prefix indicating no object to indicate travel to the destination marked with {-Daq:n:nolink}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -677,6 +745,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
 ▶ {Ha', ... wIjaH!:sen} "Давай, пойдем ... !"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -684,6 +753,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -697,6 +767,7 @@ Fazer malabarismos, isto é, jogar objetos no ar e pegá-los em um padrão rítm
       <column name="definition_ru">День (от рассвета до рассвета)</column>
       <column name="definition_zh_HK">日、天（從黎明到黎明）</column>
       <column name="definition_pt">dia (do amanhecer ao amanhecer)</column>
+      <column name="definition_fi">vuorokausi, päivä (mukaanlukien yö)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaHjaj:n}, {DIS:n:2}, {Hogh:n}, {jar:n}, {'ISjaH:n}, {tera' poH:n}</column>
@@ -719,6 +790,11 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
 Для обозначения "сколько то дней назад" и "сколько-то дней спустя", смотрите {Hu':n} и {leS:n}, соответственно.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin päivä menee aamusta aamuun. Katso päivän se osa, jonka aikana on päivänvaloa, katso {pem:n} (jonka vastakohta on yö, {ram:n}).
+
+Osat on {jaj:n:nolink} ovat: {pem:n} "päivällä", {jajlo':n} "Dawn", {po:n} "huomenta", {pemjep:n} "keskipäivän", {DungluQ:n} "keskipäivällä", {pov:n} "iltapäivällä", {ram:n} "yö", {ramjep:n:1} "Midnight".
+
+Katso "päivät sitten" ja "päivät nyt" kohdat {Hu':n} ja {leS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -728,6 +804,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -735,6 +812,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -748,6 +826,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">Воскресенье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星期日</column>
       <column name="definition_pt">domingo</column>
+      <column name="definition_fi">sunnuntai</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera' poH:n}</column>
@@ -758,6 +837,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru">Неделя клингонов ({Hogh:n}) содержит шесть дней. Дни после шестого в календарях пришельцев просто нумеруются, начиная с {wa':n:num}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">A semana Klingon ({Hogh:n}) contém seis dias. Os dias além do sexto em calendários estrangeiros são simplesmente numerados, começando em {wa':n:num}.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingon-viikko ({Hogh:n}) sisältää kuusi päivää. Muukalaiskalentereilla kuudennen jälkeen olevat päivät on yksinkertaisesti numeroitu alkaen {wa':n:num}.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">According to Maltz, the numbering of Sunday as "day one" may have been to cater to Americans, who view it as the first day of the week.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -767,6 +847,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -774,6 +855,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek The Exhibition:src}, [2] {KLI mailing list 2012.04.01:src}, [3] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -787,6 +869,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">рассвет</column>
       <column name="definition_zh_HK">黎明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alvorecer</column>
+      <column name="definition_fi">aamunkoitto</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhom:n}</column>
       <column name="see_also">{po:n}, {pem:n}, {choS:n}</column>
@@ -797,6 +880,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -806,6 +890,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -813,6 +898,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -826,6 +912,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">Восход [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">日出 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nascer do Sol</column>
+      <column name="definition_fi">auringonnousu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -836,6 +923,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru">Это относится к визуальному явлению на небе, а не к техническому моменту восхода солнца. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指天空中的視覺現象，而不是日出時的技術瞬間。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao fenômeno visual no céu, não ao momento técnico do nascer do sol. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa taivaan visuaaliseen ilmiöön, ei auringonnousun tekniseen hetkeen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jajlo':n}, {chum:v}</column>
       <column name="examples"></column>
@@ -845,6 +933,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -852,6 +941,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -865,6 +955,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">A noisy animal (not a bird) known for making a ruckus at dawn, like a Terran rooster. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種吵鬧的動物（不是鳥），在黎明時發出騷動，就像人族公雞一樣。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Um animal barulhento (não um pássaro) conhecido por fazer zaragata ao amanhecer, como um galo terráqueo.</column>
+      <column name="definition_fi">eräs aamunkoitteessa pitämästään melusta tunnettu eläin (ei lintu)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uSgheb:n}</column>
@@ -875,6 +966,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru">Глагол {jach:v} может описывать, что делает {jajlo' Qa':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">O verbo {jach:v} pode descrever o que um {jajlo' Qa':n:nolink} faz. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbi {jach:v} voi kuvata mitä {jajlo' Qa':n:nolink} tekee. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jajlo':n}, {Qa':n:1}</column>
       <column name="examples"></column>
@@ -884,6 +976,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -891,6 +984,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}, [2] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -904,6 +998,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">сегодня</column>
       <column name="definition_zh_HK">本日、今日</column>
       <column name="definition_pt">hoje</column>
+      <column name="definition_fi">tämä päivä, tänään</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -914,6 +1009,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru">До тех пор, пока {DaHjaj:n:nolink} и {jajvam:n:nolink} означают "сегодня", они не совсем взаимозаменяемые.[2] Смотрите подробности {DaHjaj:n}.</column>
       <column name="notes_zh_HK">儘管{DaHjaj:n:nolink}和{jajvam:n:nolink}均表示“今天”，但它們並不是可互換的。[2]有關詳細信息，請參見{DaHjaj:n}下的內容。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Vaikka sekä {DaHjaj:n:nolink} että {jajvam:n:nolink} tarkoittavat "tänään", ne eivät ole täysin keskenään vaihdettavissa.[2] Katso lisätietoja kohdasta {DaHjaj:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jaj:n}, {-vam:n}</column>
       <column name="examples"></column>
@@ -923,6 +1019,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -930,6 +1027,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW:src}, [2] {msn 1997.06.29:src}</column>
     </table>
     <table name="mem">
@@ -943,6 +1041,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">представь, представь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">想像、意想、假想</column>
       <column name="definition_pt">imaginar, prever</column>
+      <column name="definition_fi">kuvitella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qub:v}, {'Ir:v:1}, {'ergh:v}</column>
@@ -953,6 +1052,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru">Для контрафактного (или «irrealis») выражения используется фраза {... net jalchugh:sen:nolink} «если кто-то воображает, что ...», «если он воображает, что ...» ..[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kontrafaktuaalisen (tai "irrealis") lausunnon kohdalla käytetään ilmaisua {... net jalchugh:sen:nolink} "jos kuvitellaan, että ...", "jos luuletaan, että ...".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">J.L. are John Lennon's initials.</column>
       <column name="components"></column>
       <column name="examples">
@@ -965,6 +1065,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">counterfactual, irrealis, subjunctive</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -972,6 +1073,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -985,6 +1087,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">устройство</column>
       <column name="definition_zh_HK">設備、器具</column>
       <column name="definition_pt">dispositivo</column>
+      <column name="definition_fi">laite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SommI':n}, {vIqraq:n}, {jom:v}, {jo':n}, {mIqta':n}, {jan:n:2}</column>
@@ -995,6 +1098,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1006,6 +1110,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">machine, mechanism</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1013,6 +1118,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru">машина, механизм</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1026,6 +1132,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">музыкальный инструмент</column>
       <column name="definition_zh_HK">樂器</column>
       <column name="definition_pt">instrumento musical</column>
+      <column name="definition_fi">soitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jan:n:1}</column>
@@ -1036,6 +1143,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru">Это сокращенная форма для {QoQ jan:n}, но этот термин редко сокращается.</column>
       <column name="notes_zh_HK">{QoQ jan:n}的縮寫，但該術語很少被縮寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é abreviação de {QoQ jan:n}, mas esse termo raramente é abreviado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhyt sanalle {QoQ jan:n}, mutta termiä lyhennetään harvoin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1045,6 +1153,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1052,6 +1161,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1065,6 +1175,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">slope (mathematical term) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斜率（數學項） [AUTOTRANSLATED]</column>
       <column name="definition_pt">inclinação (termo matemático)</column>
+      <column name="definition_fi">kaltevuus (matemaattinen termi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'ghey:n}, {lav:v}</column>
@@ -1075,6 +1186,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to the song "Sloop John B".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1084,6 +1196,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1091,6 +1204,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1104,6 +1218,7 @@ För "dagar sedan" och "dagar från nu", se {Hu':n} respektive {leS:n}. [AUTOTRA
       <column name="definition_ru">Жан-Люк Пикар</column>
       <column name="definition_zh_HK">「让吕克·皮卡尔」</column>
       <column name="definition_pt">Jean-Luc Picard</column>
+      <column name="definition_fi">Jean-Luc Picard</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1128,6 +1243,9 @@ I Klingon går titlar i allmänhet efter namnet, så "Captain Jean-Luc Picard" s
       <column name="notes_pt">Este é o nome do {HoD:n} do {'entepray':n:name} durante o tempo de {puq poH veb:n}.
 
 Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc Picard" seria {janluq pIqarD HoD:n@@janluq pIqarD:n, HoD:n}. Observe que {pIqarD:n:nolink} não segue a fonologia Klingon adequada, pois é um nome estranho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {'entepray':n:name}: n {HoD:n}-nimi {puq poH veb:n}-aikaan.
+
+Klingonissa otsikot ovat yleensä nimen perässä, joten "kapteeni Jean-Luc Picard" olisi {janluq pIqarD HoD:n@@janluq pIqarD:n, HoD:n}. Huomaa, että {pIqarD:n:nolink} ei noudata oikeaa Klingon-fonologiaa, koska se on ulkomaalainen nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1137,6 +1255,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1144,6 +1263,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.3, Sept. 1996:src}, [2] {SkyBox 25:src}</column>
     </table>
     <table name="mem">
@@ -1157,6 +1277,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="definition_ru">свидетель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">見證人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">testemunha</column>
+      <column name="definition_fi">todistaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nguHwI':n}</column>
@@ -1167,6 +1288,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="notes_ru">Это относится к человеку, который видел или был частью события. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指已經看過事件或參與事件的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa que viu ou participou de um evento. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, joka on nähnyt tapahtuman tai ollut osa sitä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The 1981 film "Eyewitness" was released in the UK as "The Janitor". The film starred Christopher Plummer (among others).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1176,6 +1298,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">eyewitness</column>
       <column name="search_tags_de">Augenzeuge</column>
       <column name="search_tags_fa"></column>
@@ -1183,6 +1306,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -1196,6 +1320,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="definition_ru">отвечать, реагировать, откликаться</column>
       <column name="definition_zh_HK">回答、回复</column>
       <column name="definition_pt">responder, replicar</column>
+      <column name="definition_fi">vastata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghel:v}, {tlhob:v}</column>
@@ -1206,6 +1331,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">There is contradictory information regarding whether this is a "verb of speech". (See {jatlh:v} for an explanation.) In {HQ 7.4:src}, it is said not to be, but its usage in the {paq'batlh:src} suggests otherwise.[2; 3]</column>
       <column name="components"></column>
       <column name="examples">
@@ -1250,6 +1376,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
    Они отвечают, что оно изогнуто в виде полумесяца."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">respond</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1257,6 +1384,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="search_tags_ru">отвечать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}, [3] {paq'batlh p.138-139:src}</column>
     </table>
     <table name="mem">
@@ -1270,6 +1398,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="definition_ru">быть смелым, быть храбрым, быть дерзким</column>
       <column name="definition_zh_HK">大膽</column>
       <column name="definition_pt">ser ousado</column>
+      <column name="definition_fi">olla rohkea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yoH:v}</column>
@@ -1280,6 +1409,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="notes_ru">Чтобы описать «жирный» шрифт, см. {pI':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">要描述“粗體”字體，請參閱{pI':v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para descrever uma fonte "bold", consulte {pI':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat kuvata "lihavoitua" kirjasinta, katso {pI':v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Jack".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1289,6 +1419,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1296,6 +1427,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1309,6 +1441,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="definition_ru">взбодрить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">壯膽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">encorajar</column>
+      <column name="definition_fi">rohkaista, kannustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1319,6 +1452,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso é dito da música.[1, p.71] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sanotaan musiikista.[1, p.71] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jaq:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -1328,6 +1462,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1335,6 +1470,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1348,6 +1484,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="definition_ru">половое созревание, джак'тала [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">青春期、jak'tahla [AUTOTRANSLATED]</column>
       <column name="definition_pt">puberdade, jak'tahla</column>
+      <column name="definition_fi">murrosikä, jak'tahla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gho'rIch:n}</column>
@@ -1358,6 +1495,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1367,6 +1505,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1374,6 +1513,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek Insurrection:src}, [2] {KLI mailing list 2013.07.29:src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1387,6 +1527,7 @@ Em Klingon, os títulos geralmente vêm após o nome, então "Capitão Jean-Luc 
       <column name="definition_ru">быть глубоким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">深</column>
       <column name="definition_pt">ser profundo</column>
+      <column name="definition_fi">olla syvä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jaQHa':v}</column>
       <column name="see_also">{Saw':v}</column>
@@ -1411,6 +1552,9 @@ Observera att i Klingon kallas "deep space" {logh Hop:n}, bokstavligen, "far spa
       <column name="notes_pt">Esta palavra significa "profundo" no sentido físico.
 
 Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalmente, "espaço distante". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana tarkoittaa "syvää" fyysisessä mielessä.
+
+Huomaa, että Klingonissa "syvää avaruutta" kutsutaan {logh Hop:n}, kirjaimellisesti "kaukana avaruutena". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Jacques Cousteau was a renowned deep-sea diver.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1420,6 +1564,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1427,6 +1572,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -1440,6 +1586,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">быть мелким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">淺</column>
       <column name="definition_pt">ser raso</column>
+      <column name="definition_fi">olla matala (ei syvä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jaQ:v}</column>
       <column name="see_also">{Saw':v}</column>
@@ -1450,6 +1597,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru">Для "мелкого" в метафорическом смысле, см. {SaS:v:2,slang}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於隱喻意義上的“淺”，請參閱{SaS:v:2,slang}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para "superficial" em um sentido metafórico, consulte {SaS:v:2,slang}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso "matala" metaforisessa mielessä kohdasta {SaS:v:2,slang}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jaQ:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -1459,6 +1607,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1466,6 +1615,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -1479,6 +1629,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">месяц(Клингонское исчисление)</column>
       <column name="definition_zh_HK">月（克林崗日曆）</column>
       <column name="definition_pt">mês (Klingon)</column>
+      <column name="definition_fi">(klingonien) kuukausi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maS:n}, {DIS:n:2}, {Hogh:n}, {jaj:n}, {'ISjaH:n}, {tera' poH:n}</column>
@@ -1489,6 +1640,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru">Для "месяцев назад" и "месяцев спустя", смотрите {wen:n} и {waQ:n}, соответственно.</column>
       <column name="notes_zh_HK">有關“幾個月前”和“從現在開始的幾個月”，請分別參閱{wen:n}和{waQ:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para "meses atrás" e "meses a partir de agora", consulte {wen:n} e {waQ:n}, respectivamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso "kuukausia sitten" ja "kuukausien kuluttua" kohdat {wen:n} ja {waQ:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1498,6 +1650,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1505,6 +1658,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1518,6 +1672,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">anniversary (measured in months) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">每月紀念日</column>
       <column name="definition_pt">aniversário (medido em meses)</column>
+      <column name="definition_fi">vuosipäivä (mitattuna kuukausina) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DISjaj:n}, {Hoghjaj:n}</column>
@@ -1528,6 +1683,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jar:n}, {jaj:n}</column>
       <column name="examples"></column>
@@ -1537,6 +1693,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1544,6 +1701,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -1557,6 +1715,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">лоб</column>
       <column name="definition_zh_HK">額頭</column>
       <column name="definition_pt">testa</column>
+      <column name="definition_fi">otsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quch:n}</column>
@@ -1567,6 +1726,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1576,6 +1736,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1583,6 +1744,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1596,6 +1758,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">иначе, различно</column>
       <column name="definition_zh_HK">不同 [AUTOTRANSLATED]</column>
       <column name="definition_pt">diferentemente</column>
+      <column name="definition_fi">eri tavalla, toisin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jaSHa':adv}</column>
       <column name="see_also">{pIm:v}, {motlh:v}, {roD:adv}</column>
@@ -1606,6 +1769,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Compare with {rap:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1615,6 +1779,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1622,6 +1787,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1635,6 +1801,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">аналогично, так же точно так же [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">類似地、同樣地、以相同的方式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">da mesma forma, da mesma maneira</column>
+      <column name="definition_fi">samalla tavalla</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jaS:adv}</column>
       <column name="see_also">{rap:v}, {-Ha':v:suff}</column>
@@ -1645,6 +1812,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Apparently, MO had originally rejected this as a word in 2000, but had changed his mind by 2009.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1654,6 +1822,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1661,6 +1830,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 19 (2012):src} ({KLI mailing list 2012.08.30:src}), [2] {Saarbrücken qepHom'a' 2013:src} ({KLI mailing list 2014.01.15:src})</column>
     </table>
     <table name="mem">
@@ -1674,6 +1844,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">язык(орган)</column>
       <column name="definition_zh_HK">舌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">língua</column>
+      <column name="definition_fi">kieli (anatomiassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuj:n}, {mum:v}, {roS:v:1}</column>
@@ -1684,6 +1855,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1693,6 +1865,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1700,6 +1873,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1713,6 +1887,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">говорить бессвязно, бормотать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">說話語無倫次、咕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falar incoerentemente, murmurar</column>
+      <column name="definition_fi">puhua epäselvästi, mutista, mumista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jatlh:v}, {jat Hol:n}</column>
@@ -1723,6 +1898,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Speaking in "tongues".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1732,6 +1908,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1739,6 +1916,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1752,6 +1930,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">быть неуклюжим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">笨手笨腳 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desajeitado</column>
+      <column name="definition_fi">olla kömpelö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1762,6 +1941,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru">В диалекте {ruq'e'vet:n} это слово используется вместо {Soy':v:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{ruq'e'vet:n}方言中，使用此詞代替{Soy':v:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{ruq'e'vet:n}-murteessa tätä sanaa käytetään {Soy':v:1}-sanan sijaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1771,6 +1951,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1778,6 +1959,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1791,6 +1973,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">тарабарщина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">胡言亂語 [AUTOTRANSLATED]</column>
       <column name="definition_pt">algaraviada</column>
+      <column name="definition_fi">siansaksa</column>
       <column name="synonyms">{laqlaq:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{jat:v:1}, {laq:v:2}, {Dap:n}, {chatlh:n:2}</column>
@@ -1801,6 +1984,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Glossolalia is also known as speaking in tongues ({jat:n}).</column>
       <column name="components">{jat:n}, {Hol:n}</column>
       <column name="examples"></column>
@@ -1810,6 +1994,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1817,6 +2002,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1830,6 +2016,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">духовное владение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">精神佔有 [AUTOTRANSLATED]</column>
       <column name="definition_pt">possessão espiritual</column>
+      <column name="definition_fi">henkien riivaus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1840,6 +2027,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="notes_ru">Согласно легенде, это духи мертвых, которые обладают живыми. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據傳說，這些是擁有生命的死者靈魂。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Segundo a lenda, estes são espíritos dos mortos que possuem os vivos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Legendan mukaan nämä ovat kuolleiden henkiä, joilla on elävä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1849,6 +2037,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1856,6 +2045,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -1869,6 +2059,7 @@ Observe que em Klingon, "espaço profundo" é chamado de {logh Hop:n}, literalme
       <column name="definition_ru">говорить, разговаривать, высказывать, высказываться, сказать</column>
       <column name="definition_zh_HK">說、話、講</column>
       <column name="definition_pt">falar, dizer</column>
+      <column name="definition_fi">puhua, sanoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hol:n}, {SoQ:n}, {ja':v}, {jat:v:1}, {jaw:v}, {ghugh:v}, {rIch:v}</column>
@@ -1927,6 +2118,15 @@ For expressing "read aloud" (e.g., a book), something like {paq mu'mey jatlh:sen
 
 為了表達“大聲朗讀”（例如，一本書），類似{paq mu'mey jatlh:sen:nolink}的方法將起作用。[6] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän verbin tyypillinen kohde on puhuttu, joka voi olla kieli tai luento. Kuuntelija on epäsuora objekti ja se on merkitty tunnuksella {-vaD:n}.[3; 4]
+
+"Etuliitetemppua" voidaan käyttää tämän verbin kanssa: jos verbin etuliite osoittaa ensimmäisen tai toisen henkilön objektin, kyseinen henkilö on epäsuora esine eli henkilö, jolle aihe puhuu.
+
+Verbiä {jatlh:v:nolink} käytetään myös suoraa lainausta annettaessa, jolloin verbin etuliitettä, joka osoittaa, ettei mitään objektia käytetä (paitsi jos käytetään "etuliitteen temppua"). Lainaus voi tulla ennen tai jälkeen lauseen {jatlh:v:nolink}.[3]
+
+Tämä on yksi harvoista "verbeistä puhetta" Klingonissa. Klingonissa lainauksiin on aina liitettävä yksi näistä verbeistä.[4]
+
+Ilmaisun "lukea ääneen" (esim. Kirjan) toiminnalle jotain {paq mu'mey jatlh:sen:nolink}: ta voisi toimia.[3][6] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TKD:src}, this is defined in the K-E word list as "say", and listed in the E-K word list under "speak". In {TKDA:src}, it is defined in both word lists as "say".
 
 In the {msn:src} newsgroup message, it says only that the verb prefix indicating no object is used for a direct quotation if the speaker is first or second person.[3] It's left unclear if {lu-:v:pref} should be used if the speakers are third-person and plural, but the rule seems to be that a quotation is not treated grammatically as the object of the verb.</column>
@@ -1951,6 +2151,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
 ▶ {tlhIngan Hol bIjatlh.:sen:nolink} "Ты говоришь, 'Клингонский язык'."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">talk</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1958,6 +2159,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKDA:src}, [3] {msn 1997.06.29:src}, [4] {HQ 7.4, Dec. 1998:src}, [5] {ENT - Affliction:src}, [6] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -1971,6 +2173,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="definition_ru">неправильно говорить, говорить неправильно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">說錯話，說錯話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falar errado</column>
+      <column name="definition_fi">sanoa väärin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1981,6 +2184,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in the word lists in {TKD:src}, but is used as an example in the book.</column>
       <column name="components">{jatlh:v}, {-Ha':v}</column>
       <column name="examples">
@@ -1991,6 +2195,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1998,6 +2203,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2011,6 +2217,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="definition_ru">шесть</column>
       <column name="definition_zh_HK">六</column>
       <column name="definition_pt">seis</column>
+      <column name="definition_fi">kuusi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jav:n:2} (musical tone)</column>
@@ -2021,6 +2228,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2030,6 +2238,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2037,6 +2246,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -2050,6 +2260,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
           <column name="definition_ru">шестой</column>
           <column name="definition_zh_HK">第六</column>
           <column name="definition_pt">sexto</column>
+      <column name="definition_fi">kuudes</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2060,6 +2271,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{jav:n:1,num}, {-DIch:n:num,suff}</column>
           <column name="examples"></column>
@@ -2069,6 +2281,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">6th</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2076,6 +2289,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -2089,6 +2303,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
           <column name="definition_ru">шестьдесят [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">六十</column>
           <column name="definition_pt">sessenta</column>
+      <column name="definition_fi">kuusikymmentä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2099,6 +2314,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{jav:n:1,num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -2108,6 +2324,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2115,6 +2332,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -2128,6 +2346,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="definition_ru">шестой тон неатонической музыкальной гаммы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">第六音非音階音階 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sexto tom da escala musical não-eletrônica</column>
+      <column name="definition_fi">nonatoonisen musiikkiasteikon kuudes sävel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jav:n:1} (number)</column>
@@ -2138,6 +2357,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin musiikkiasteikon sävyt (katso {yutlhegh:n}) ovat: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}, {vagh:n:2}, {jav:n:2,nolink}, {Soch:n:2}, {chorgh:n:2}, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DOT{yu:n:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2147,6 +2367,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2154,6 +2375,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2167,6 +2389,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="definition_ru">заключенный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">囚犯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prisioneiro</column>
+      <column name="definition_fi">vanki</column>
       <column name="synonyms">{qama':n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2177,6 +2400,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In the TV show "The Prisoner", the main character is number six ({jav:n:1}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2186,6 +2410,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2193,6 +2418,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2206,6 +2432,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="definition_ru">вирус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">病毒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vírus</column>
+      <column name="definition_fi">virus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lerup:n}</column>
@@ -2216,6 +2443,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{jav:n:1} in Roman numerals is "VI", and Tim Russ played Tuvok. VI + Russ = virus.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2225,6 +2453,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2232,6 +2461,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2245,6 +2475,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="definition_ru">болтать, вести непринужденную беседу, вести разговор</column>
       <column name="definition_zh_HK">聊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bate-papo</column>
+      <column name="definition_fi">jutella, rupatella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jatlh:v}</column>
@@ -2255,6 +2486,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2264,6 +2496,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2271,6 +2504,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2284,6 +2518,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="definition_ru">господин, леди [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">主、女士 [AUTOTRANSLATED]</column>
       <column name="definition_pt">senhor, senhora</column>
+      <column name="definition_fi">herra, rouva</column>
       <column name="synonyms">{joH:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2294,6 +2529,7 @@ In the {msn:src} newsgroup message, it says only that the verb prefix indicating
       <column name="notes_ru">Неизвестно, есть ли разница между этим словом и {joH:n}.[2, p.41]. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">未知此單詞和{joH:n}.[2, p.41]之間是否有區別 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não se sabe se há alguma diferença entre esta palavra e {joH:n}.[2, p.41] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei tiedetä, onko tämän sanan ja {joH:n}.[2, p.41]: n välillä eroa [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word came about as an onscreen mispronunciation of {joH:n:nolink}.
 
 In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. However, {KGT:src} expanded the definition of {joH:n:nolink} to include "lady". Though not explicitly stated, this extension applies to {jaw:n:nolink} as well.</column>
@@ -2305,6 +2541,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2312,6 +2549,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2325,6 +2563,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="definition_ru">интенсивно</column>
       <column name="definition_zh_HK">激烈的（in罵） [AUTOTRANSLATED]</column>
       <column name="definition_pt">intensamente (invectivo)</column>
+      <column name="definition_fi">eräs kirosana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2335,6 +2574,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="notes_ru">Это наречие всегда приходит в конце предложения и превращает все это в оскорбительное. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個副詞總是出現在句子的結尾，並且將整個事物變成指責。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse adverbial sempre aparece no final de uma frase e transforma a coisa toda em invectiva. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä adverbi tulee aina lauseen loppuun ja muuttaa koko asian invektiiviseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2344,6 +2584,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2351,6 +2592,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2365,6 +2607,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="definition_ru">сказать, рассказывать, сообщать, отчитываться</column>
       <column name="definition_zh_HK">報告</column>
       <column name="definition_pt">dizer, reportar</column>
+      <column name="definition_fi">sanoa, kertoa, ilmoittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SovmoH:v}, {QoymoH:v}, {'otHa':v}</column>
@@ -2375,6 +2618,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="notes_ru">Это один из нескольких "речевых глаголов" в Клингонском.[2] (Смотрите {jatlh:v} для пояснения.)</column>
       <column name="notes_zh_HK">這是Klingon.[2]中的少數“語音動詞”之一（有關說明，請參閱{jatlh:v}。） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um dos poucos "verbos da fala" em Klingon.[2] (Veja {jatlh:v} para uma explicação.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksi harvoista "verbeistä puhetta" kielessä Klingon.[2] (Katso selitys {jatlh:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the {HolQeD:src} interview, Will Martin suggested that a typical direct object of this verb is the person addressed. This was not contradicted by Marc Okrand, but not explicitly affirmed, either.[2]</column>
       <column name="components"></column>
       <column name="examples">
@@ -2386,6 +2630,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
 ▶ {nuja'rup.:sen:nolink} "Они готовы рассказать нам."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2393,6 +2638,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -2406,6 +2652,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="definition_ru">обсуждать, дискутировать, совещаться</column>
       <column name="definition_zh_HK">討論、商量 [AUTOTRANSLATED]</column>
       <column name="definition_pt">discutir, conferir</column>
+      <column name="definition_fi">keskustella, neuvotella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIch:v}</column>
@@ -2416,6 +2663,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="notes_ru">Глагол составлен из {ja':v} плюс суффикс {-chuq:v}[1, стр.66]. Невзирая на это, похоже, что он может принимать тему обсуждения как объект,хотя точная грамматика неясна.[3]</column>
       <column name="notes_zh_HK">該動詞由{ja':v}和後綴{-chuq:v}[1, p.66]組成。儘管如此，儘管確切的語法尚不清楚，但似乎可以將討論的主題作為其對象。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo é composto de {ja':v} mais o sufixo {-chuq:v}[1, p.66]. Apesar disso, parece que pode tomar o tópico da discussão como seu objeto, embora a gramática exata não seja clara.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi koostuu sanasta {ja':v} plus pääte {-chuq:v}[1, p.66]. Tästä huolimatta näyttää siltä, ​​että se voi ottaa keskustelunaiheen kohteeksi, vaikka tarkka kielioppi on epäselvä.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ja':v}, {-chuq:v}</column>
       <column name="examples">
@@ -2429,6 +2677,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
 ▶ {quv HIja'chuqQo'!:sen:nolink} "Не говори со мной о чести!"[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2436,6 +2685,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {PK:src}, [3] {paq'batlh p.156-157:src}</column>
     </table>
     <table name="mem">
@@ -2449,6 +2699,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="definition_ru">Название древней церемонии посвящения</column>
       <column name="definition_zh_HK">繼承儀式（古代） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ritual de sucessão (antigo)</column>
+      <column name="definition_fi">muinainen vallanperimysrituaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ja'chuq:v}, {SonchIy:n}, {cho'tay:n:hyp}</column>
@@ -2459,6 +2710,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="notes_ru">церемония выполянется кандидатами во время ритуала посвящения (смотрите {cho'tay:n:hyp}).</column>
       <column name="notes_zh_HK">這是候選人在接任儀式中舉行的儀式（請參閱{cho'tay:n:hyp}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma cerimônia realizada pelos candidatos durante o Rito de Sucessão (veja {cho'tay:n:hyp}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on seremonia, jonka ehdokkaat suorittavat perintöriitin aikana (katso {cho'tay:n:hyp}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2470,6 +2722,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
 ▶ {ja'chuq Dalopchu'. Qang Damoj.:sen:nolink} "Завершите ритуал посвящения, чтобы стать канцлером."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Rite of Succession</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2477,6 +2730,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2490,6 +2744,7 @@ In {TKD:src} this word is defined as "lord" only, same as {joH:n:nolink}. Howeve
       <column name="definition_ru">также, и(объединяет существительные)</column>
       <column name="definition_zh_HK">還有、（加入名詞） [AUTOTRANSLATED]</column>
       <column name="definition_pt">também, e (juntando substantivos)</column>
+      <column name="definition_fi">myös, ja (yhdistää substantiivilausekkeita)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joq:conj}, {'ej:conj}, {je:adv}</column>
@@ -2512,6 +2767,9 @@ Förutom substantiv kan {je:sen:nolink} också följa ett verb. Se {je:adv}. [AU
       <column name="notes_pt">Isto segue o substantivo final.
 
 Além de substantivos, {je:sen:nolink} também pode seguir um verbo. Consulte {je:adv}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä seuraa lopullista substantiivia.
+
+Substantiivien lisäksi {je:sen:nolink} voi seurata myös verbiä. Katso {je:adv}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2530,6 +2788,7 @@ Além de substantivos, {je:sen:nolink} também pode seguir um verbo. Consulte {j
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2537,6 +2796,7 @@ Além de substantivos, {je:sen:nolink} também pode seguir um verbo. Consulte {j
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox cards:src}, [3] {SkyBox 3:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src}), [4] {paq'batlh p.102-103:src}, [5] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2551,6 +2811,7 @@ Além de substantivos, {je:sen:nolink} também pode seguir um verbo. Consulte {j
       <column name="definition_ru">также (следует за глаголом)</column>
       <column name="definition_zh_HK">也（遵循它修改的動詞） [AUTOTRANSLATED]</column>
       <column name="definition_pt">também (segue o verbo que ele modifica)</column>
+      <column name="definition_fi">myös</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{je:conj}, {vabDot:adv}</column>
@@ -2561,6 +2822,7 @@ Além de substantivos, {je:sen:nolink} também pode seguir um verbo. Consulte {j
       <column name="notes_ru">Когда {je:adv:nolink} следует за глаголом, то это означает "также, тоже". {qaleghpu' je:sen:nolink} значит "Я также тебя видел"[1]</column>
       <column name="notes_zh_HK">當{je:adv:nolink}在動詞後面時，它的意思是“也”。 {qaleghpu' je:sen:nolink}的意思是“我也看到了您，我也看到了您”，並且英語中的含義不明確。 （這可能表示“我和其他人看到了您”或“我看到了您和其他人”。）[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando {je:adv:nolink} segue um verbo, significa "também também". {qaleghpu' je:sen:nolink} significa "Eu também vi você, também vi" e, como em inglês, seu significado é ambíguo. (Pode significar "eu e outros vi você" ou "eu vi você e outros".)[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun {je:adv:nolink} seuraa verbiä, se tarkoittaa "myös". {qaleghpu' je:sen:nolink} tarkoittaa "minä näin sinut, minä näin sinut myös", ja kuten englannissa, sen merkitys on epäselvä. (Se voi tarkoittaa "minä ja muut näin sinut" tai "minä näin sinut ja muut".) [1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is considered a noun conjunction, rather than an adverbial, in {TKD:src}.
 
 The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:nolink}.</column>
@@ -2581,6 +2843,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2588,6 +2851,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 5.3:src}, [2] {CK:src}, [3] {PK:src}, [4] {msn 1996.11.10:src}, [5] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -2601,6 +2865,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="definition_ru">маскировать, делать неузнаваемым, скрывать</column>
       <column name="definition_zh_HK">偽裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">disfarçar</column>
+      <column name="definition_fi">naamioida, naamioitua?, puvustaa, pukeutua?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toj:v}, {ghet:v}, {jech:n}</column>
@@ -2611,6 +2876,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2620,6 +2886,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2627,6 +2894,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2640,6 +2908,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="definition_ru">маскировка, сокрытие, обман, личина</column>
       <column name="definition_zh_HK">偽裝、服裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">disfarce, traje</column>
+      <column name="definition_fi">valeasu, naamiaispuku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jech:v}, {Sut:n}, {qur'ep:n}</column>
@@ -2650,6 +2919,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{much jech:n}, {qab jech:n}</column>
@@ -2659,6 +2929,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2666,6 +2937,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2679,6 +2951,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="definition_ru">быть толстым, быть плотным, быть вязким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">厚、密、粘稠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser grosso, ser denso, ser viscoso</column>
+      <column name="definition_fi">olla paksu, tiheä, sakea, olla viskoosinen (nesteestä?)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghevI':n}, {taS:n}</column>
@@ -2689,6 +2962,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="notes_ru">Существует идиома {jeD; ghevI' rur@@jeD:v, ghevI':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{jeD; ghevI' rur@@jeD:v, ghevI':n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {jeD; ghevI' rur@@jeD:v, ghevI':n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {jeD; ghevI' rur@@jeD:v, ghevI':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2698,6 +2972,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2705,6 +2980,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2718,6 +2994,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="definition_ru">сдаваться в плен, капитулировать</column>
       <column name="definition_zh_HK">投降、放棄</column>
       <column name="definition_pt">render-se, desistir</column>
+      <column name="definition_fi">antautua, luovuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bup:v}, {luj:v}, {baq:v}, {jey:v}</column>
@@ -2728,6 +3005,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2739,6 +3017,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2746,6 +3025,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2759,6 +3039,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="definition_ru">Клингоны не сдаются</column>
       <column name="definition_zh_HK">克林崗人不會投降。</column>
       <column name="definition_pt">Os klingons não se rendem.</column>
+      <column name="definition_fi">Klingonit eivät antaudu.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2769,6 +3050,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2778,6 +3060,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2785,6 +3068,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.89:src}</column>
     </table>
     <table name="mem">
@@ -2798,6 +3082,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="definition_ru">Завоеванный субъект</column>
       <column name="definition_zh_HK">投咗降者</column>
       <column name="definition_pt">pessoa conquistada</column>
+      <column name="definition_fi">valloitettu, valloitetut henkilöt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2808,6 +3093,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="notes_ru">Завоеванные люди: больше чем рабы, но меньше чем граждане. Этот статус дан оккупированным в тех мирах, что завоевала Клингонская империя.</column>
       <column name="notes_zh_HK">被征服的人民：這種地位賦予克林崗帝國征服的世界，而不是奴隸，而不是公民。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Pessoas conquistadas: mais que escravos, menos que cidadãos, esse status é dado aos ocupantes de mundos conquistados pelo Império Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Valloitetut ihmiset: enemmän kuin orjia, vähemmän kuin kansalaisia, tämä asema annetaan Klingonin imperiumin valloittamien maailmojen asukkaille. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jegh:v}, {-pu':v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2817,6 +3103,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2824,6 +3111,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -2837,6 +3125,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="definition_ru">быть рассеянным</column>
       <column name="definition_zh_HK">開小差 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser distraído</column>
+      <column name="definition_fi">olla (henkisesti) poissaoleva, olla ajatuksissaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dach:v:2}</column>
@@ -2847,6 +3136,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2856,6 +3146,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2863,6 +3154,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2876,6 +3168,7 @@ The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:n
       <column name="definition_ru">быть острым</column>
       <column name="definition_zh_HK">利（刃）</column>
       <column name="definition_pt">ser afiado</column>
+      <column name="definition_fi">olla terävä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jejHa':v}, {Qung:v}</column>
       <column name="see_also"></column>
@@ -2900,6 +3193,9 @@ Det finns också ett formspråk, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [A
       <column name="notes_pt">A expressão idiomática {jej pach@@jej:v, pach:n} "a garra é afiada" significa "a comida é picante (ou seja, boa)".
 
 Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Idiomaattinen ilmaus {jej pach@@jej:v, pach:n} "kynsi on terävä" tarkoittaa "ruoka on pistävä (eli hyvä)".
+
+Siellä on myös idioomi {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2909,6 +3205,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">delicious</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2916,6 +3213,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2929,6 +3227,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="definition_ru">быть затупленным, быть туповатым, быть тупым(характеристика клинка)</column>
       <column name="definition_zh_HK">鈍（刃）</column>
       <column name="definition_pt">ser monótono, sem corte (de lâminas)</column>
+      <column name="definition_fi">olla tylsä (terästä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jej:v}</column>
       <column name="see_also">{naH taj:n}, {Qung:v}</column>
@@ -2939,6 +3238,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="notes_ru">Идиоматическое выражение {jejHa' pach} "коготь тупой" означает "еда мягкая (это плохо)".</column>
       <column name="notes_zh_HK">慣用語{jejHa' pach}“爪子鈍”表示“食物無味（即不好）”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A expressão idiomática {jejHa' pach} "a garra é chata" significa "a comida é branda (ou seja, ruim)". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Idiomaattinen ilmaisu {jejHa' pach} "kynsi on tylsä" tarkoittaa "ruoka on lempeä (eli huono)". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jej:v}, {-Ha':v}</column>
       <column name="examples">{'etlh QorghHa'lu'chugh ragh 'etlh nIvqu' 'ej jejHa'choH.:sen}</column>
@@ -2948,6 +3248,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">undelicious</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2955,6 +3256,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="search_tags_ru">невкусная</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2968,6 +3270,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="definition_ru">трясти, дрожать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">搖晃、顫抖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agitar, tremer</column>
+      <column name="definition_fi">vapista, tutista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qom:v:1}, {tav:v}, {wal:v}</column>
@@ -2978,6 +3281,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Jello".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2987,6 +3291,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2994,6 +3299,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3007,6 +3313,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="definition_ru">iodine (element) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">碘（元素） [AUTOTRANSLATED]</column>
       <column name="definition_pt">iodo (elemento)</column>
+      <column name="definition_fi">jodi (alkuaine)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3017,6 +3324,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Iodine gel is used for washing wounds.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3026,6 +3334,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3033,6 +3342,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -3046,6 +3356,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="definition_ru">чувствовать, чувствовать, воспринимать, обнаруживать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">感覺、感覺、感知、發現 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sentir, perceber, detectar</column>
+      <column name="definition_fi">aistia, tuntea, havaita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noch:n}, {tIw:v}</column>
@@ -3056,6 +3367,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="notes_ru">Это может означать «чувствовать» в значении «ощущать» что-то (как может быть Betazoid), но это также может быть использовано для машины, которая обнаруживает что-то. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能意味著“感覺”到“感知”某物的含義（例如Betazoid可能），但是它也可以用於檢測某物的機器。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode significar "sentir" no sentido de "sentir" algo (como um Betazoid), mas também pode ser usado para uma máquina que detecta algo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi tarkoittaa "tuntea" tarkoittaa "aistia" jotain (kuten Betazoid saattaa), mutta sitä voidaan käyttää myös koneelle, joka havaitsee jotain. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TOS - The Empath:src}, "Gem" was the nickname given by Dr. McCoy to an empath.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3065,6 +3377,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3072,6 +3385,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Si Vis Pacem, Para Bellum:src}</column>
     </table>
     <table name="mem">
@@ -3085,6 +3399,7 @@ Também existe um idioma, {jej; Daqtagh rur@@jej:v, Daqtagh:n, rur:v}. [AUTOTRAN
       <column name="definition_ru">Джеймс Т. Кирк</column>
       <column name="definition_zh_HK">「詹姆斯·T·柯克」</column>
       <column name="definition_pt">James T. Kirk</column>
+      <column name="definition_fi">James T. Kirk</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3109,6 +3424,9 @@ Observera att {jemS:n:nolink} och {qIrq:n:nolink} inte följer korrekt Klingon-f
       <column name="notes_pt">Este é o nome do {HoD:n} do {'entepray':n:name}. Seu primeiro oficial é {SIpoq:n:name}.
 
 Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon adequada, pois são parte de um nome estranho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {'entepray':n:name}: n {HoD:n}-nimi. Hänen ensimmäinen upseeri on {SIpoq:n:name}.
+
+Huomaa, että {jemS:n:nolink} ja {qIrq:n:nolink} eivät noudata oikeaa klingonifonologiaa, koska ne ovat osa ulkomaalaisten nimeä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3118,6 +3436,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3125,6 +3444,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -3138,6 +3458,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">замок, крепость</column>
       <column name="definition_zh_HK">城堡、堡壘</column>
       <column name="definition_pt">castelo, fortaleza</column>
+      <column name="definition_fi">linna, linnoitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{waw':n}, {DuHmor:n}</column>
@@ -3148,6 +3469,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru">Это здание, построенное для защиты или укрепления. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一棟為保護或設防而建造的建築物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um edifício construído para proteção ou fortificação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on rakennus, joka on rakennettu suojelua tai linnoitusta varten. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Himeji Castle is a famous landmark in Japan.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3157,6 +3479,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3164,6 +3487,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.01:src}</column>
     </table>
     <table name="mem">
@@ -3178,6 +3502,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">быть высоким, быть высшим</column>
       <column name="definition_zh_HK">要高 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser alto</column>
+      <column name="definition_fi">olla korkea</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'eS:v}</column>
       <column name="see_also">{woch:v}, {'ab:v}, {'Iv:n:2h}</column>
@@ -3188,6 +3513,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru">Это слово нельзя применять к описанию размеров людей.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3197,6 +3523,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3204,6 +3531,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3219,6 +3547,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">нелетающая водная птица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不會飛的水生鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pássaro aquático que não voa</column>
+      <column name="definition_fi">eräs lentokyvytön vesilintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -3229,6 +3558,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru">Клингон признал бы терранского пингвина ДОНОТТРАНСЛАЙТОМ. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗人會把人族企鵝認作是{tera' jentu':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um Klingon reconheceria um pinguim terráqueo como um {tera' jentu':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingon tunnustaisi Terran-pingviinin DONOTTRANSLATE-kieleksi1.{tera' jentu':n:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Gentoo".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3238,6 +3568,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">penguin</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3245,6 +3576,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Twitter 2013.08.11:src}</column>
     </table>
     <table name="mem">
@@ -3258,6 +3590,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">тарелка для еды</column>
       <column name="definition_zh_HK">碟（單數）</column>
       <column name="definition_pt">prato (para comer)</column>
+      <column name="definition_fi">lautaset</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{De' jengva':n}, {Huch jengva':n}</column>
@@ -3268,6 +3601,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru">Это также можно использовать для обозначения блюдца (см. {Dargh HIvje':n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也可以用來指碟（參見{Dargh HIvje':n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser usado para se referir a um pires (consulte {Dargh HIvje':n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää myös viittaamaan lautaseen (katso {Dargh HIvje':n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngop:n:inhpl}</column>
       <column name="examples"></column>
@@ -3277,6 +3611,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dish</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3284,6 +3619,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3297,6 +3633,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">выступать из [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">突然出現 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sobressair de (algo)</column>
+      <column name="definition_fi">pistää esiin, törröttää jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DuQ:v:1}</column>
@@ -3307,6 +3644,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru">Объект - это вещь, из которой выступает объект. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對像是對像從中突出的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é a coisa da qual o sujeito se sobressai. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on asia, josta kohde ulkonee. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3318,6 +3656,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3325,6 +3664,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.06.18:src}, [3] {FTG:src}</column>
     </table>
     <table name="mem">
@@ -3338,6 +3678,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">дубинка, дубинка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">俱樂部、大棒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">taco, cacetete</column>
+      <column name="definition_fi">nuija, pamppu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghanjaq:n}, {Qach:v}</column>
@@ -3348,6 +3689,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a "Black Jack".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3357,6 +3699,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3364,6 +3707,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3377,6 +3721,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">быть самоуверенным, быть самонадеянным</column>
       <column name="definition_zh_HK">要自信 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser autoconfiante</column>
+      <column name="definition_fi">olla itsevarma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hem:v}</column>
@@ -3387,6 +3732,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "jerk"?</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3396,6 +3742,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">confident</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3403,6 +3750,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3416,6 +3764,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">surge (aircraft suddenly moves forward or backward) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">激增（飛機突然向前或向後移動） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser espasmódico (aeronaves de repente avançam ou recuam)</column>
+      <column name="definition_fi">nykiä, syöksyä? (lentokoneesta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dav:v:2}, {Der:v:2}, {jIm:v:2}, {lol:v:2}, {ron:v:2}, {tor:v:2}, {'or:v}</column>
@@ -3426,6 +3775,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru">Этот глагол не имеет никакого известного значения вне контекста описания ориентации самолета.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在飛機姿態描述的上下文之外，該動詞沒有已知的含義。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo não tem significado conhecido fora do contexto das descrições de atitude da aeronave.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä verbillä ei ole tunnettua merkitystä lentokoneen asennekuvausten ulkopuolella[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A sudden "jerk".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3435,6 +3785,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3442,6 +3793,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}, [2] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -3455,6 +3807,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">спазм [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">痙攣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espasmo</column>
+      <column name="definition_fi">kouristaa, kouristella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghan'ach:n}</column>
@@ -3465,6 +3818,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru">Причинять что-то к спазму {jerghmoH:v@@jergh:v, -moH:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">引起痙攣的是{jerghmoH:v@@jergh:v, -moH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Causar algo a espasmo é {jerghmoH:v@@jergh:v, -moH:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{jerghmoH:v@@jergh:v, -moH:v} aiheuttaa jotain kouristuksia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Jerk".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3474,6 +3828,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3481,6 +3836,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3494,6 +3850,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="definition_ru">участвовать, принимать участие</column>
       <column name="definition_zh_HK">參加 [AUTOTRANSLATED]</column>
       <column name="definition_pt">participar</column>
+      <column name="definition_fi">osallistua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3504,6 +3861,7 @@ Observe que {jemS:n:nolink} e {qIrq:n:nolink} não seguem a fonologia Klingon ad
       <column name="notes_ru">Этот глагол не берет объект и обычно находится во фразе, следующей за фразой, говорящей о том, в чем участвует субъект {jeS:v:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞不帶賓語，通常在說{jeS:v:nolink}的主題正在參與的短語之後的短語中。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse verbo não aceita um objeto e geralmente está em uma frase após uma frase que diz em que o sujeito de {jeS:v:nolink} está participando.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi ei vie kohdetta, ja se on yleensä lauseessa, joka seuraa lausetta, jossa sanotaan, mihin {jeS:v:nolink}-aihe osallistuu.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3522,6 +3880,7 @@ All of the following can be translated as "I participate in the {qepHom@@qep:n, 
       </column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3529,6 +3888,7 @@ All of the following can be translated as "I participate in the {qepHom@@qep:n, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3542,6 +3902,7 @@ All of the following can be translated as "I participate in the {qepHom@@qep:n, 
       <column name="definition_ru">зарегистрироваться (на мероприятие) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">註冊（活動） [AUTOTRANSLATED]</column>
       <column name="definition_pt">inscrever-se (para um evento)</column>
+      <column name="definition_fi">ilmoittautua (tapahtumaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3552,6 +3913,7 @@ All of the following can be translated as "I participate in the {qepHom@@qep:n, 
       <column name="notes_ru">Это буквально означает «добровольно участвовать». Его можно использовать, даже если регистрация не совсем добровольная. Он используется как для подписки на что-то заранее, так и для принятия решения о месте для участия в мероприятии, которое должно начаться. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這從字面上意味著“自願參加”。即使註冊並非完全出於自願，也可以使用它。它既可以用於預先註冊某些東西，也可以用於當場決定要參加的活動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "voluntário para participar". Pode ser usado mesmo que a inscrição não seja totalmente voluntária. É usado tanto para se inscrever com antecedência ou para decidir no local para participar de um evento que está prestes a começar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "vapaaehtoista osallistumaan". Sitä voidaan käyttää, vaikka rekisteröityminen ei olekaan täysin vapaaehtoista. Sitä käytetään sekä ilmoittautumiseen johonkin etukäteen että paikan päällä päättämiseen osallistumisesta alkavaan tapahtumaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3561,6 +3923,7 @@ All of the following can be translated as "I participate in the {qepHom@@qep:n, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3568,6 +3931,7 @@ All of the following can be translated as "I participate in the {qepHom@@qep:n, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -3581,6 +3945,7 @@ All of the following can be translated as "I participate in the {qepHom@@qep:n, 
       <column name="definition_ru">шторм, буря, гроза</column>
       <column name="definition_zh_HK">風暴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tempestade</column>
+      <column name="definition_fi">myrskytä, ukkostaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{muD Dotlh:n}, {SIS:v}, {SuS:n}, {muD:n:2}, {raw:v}, {tuD:v}, {pe'bIl:n}, {Heq:v}, {cheq:v}, {vung:v}</column>
@@ -3605,6 +3970,9 @@ Detta verb används i Sonnet 116, där dess uttryckliga ämne är {muD:n:nolink}
       <column name="notes_pt">Esta é uma palavra meteorológica, em vez de militar. Isso é esclarecido pelo {jev:v:2} homófono. (Para o significado militar de "tempestade", considere {yov:v}.)
 
 Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sääsana, ei sotilaallinen sana. Tämän tekee selväksi homofoninen {jev:v:2}. (Tarkastellaan "myrskyn" sotilaallista merkitystä {yov:v}.)
+
+Tätä verbiä käytetään sonetissa 116, jossa sen nimenomainen aihe on {muD:n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3614,6 +3982,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3621,6 +3990,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2012.03.19:src}</column>
     </table>
     <table name="mem">
@@ -3634,6 +4004,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">хрипеть, шумно дышать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">喘息、大聲呼吸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chiar, respirar ruidosamente</column>
+      <column name="definition_fi">huohottaa, puuskuttaa, hengittää äänekkäästi</column>
       <column name="synonyms">{tlhov:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{wuD:v}, {pur:v}, {rech:v}, {tlhuH:v:1}, {chuy:v}</column>
@@ -3644,6 +4015,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru">Обратите внимание на однотонный {jev:v:1}. Очевидно, клингоны рассматривают штормы как форму хрипов или шумного дыхания атмосферой. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">注意諧音的{jev:v:1}。顯然，克林崗斯人將風暴看作是大氣中喘息或嘈雜呼吸的一種形式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe o {jev:v:1} homofônico. Aparentemente, os klingons veem as tempestades como uma forma de respiração ofegante ou barulhenta pela atmosfera. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa homofoninen {jev:v:1}. Klingonit pitävät myrskyjä ilmeisesti hengityksen vinkuna tai meluisena hengityksenä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3653,6 +4025,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3660,6 +4033,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -3673,6 +4047,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">побеждать, нанести поражение, уничтожать, разбивать врага</column>
       <column name="definition_zh_HK">打敗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">derrotar</column>
+      <column name="definition_fi">kukistaa, voittaa (vihollinen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jegh:v}, {chargh:v}, {yay:n:2}</column>
@@ -3683,6 +4058,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sounds like the Hindi for victory.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3693,6 +4069,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3700,6 +4077,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3713,6 +4091,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">маршрут</column>
       <column name="definition_zh_HK">行程</column>
       <column name="definition_pt">itinerário</column>
+      <column name="definition_fi">matkareitti, matkasuunnitelma tai -ohjelma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hoq:n}, {leng:n}, {leng:v}</column>
@@ -3723,6 +4102,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3732,6 +4112,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3739,6 +4120,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3752,6 +4134,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">банка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">锡</column>
       <column name="definition_pt">latão, estanho</column>
+      <column name="definition_fi">tina</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}</column>
@@ -3762,6 +4145,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3771,6 +4155,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3778,6 +4163,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3791,6 +4177,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">бронза [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">青銅</column>
       <column name="definition_pt">bronze</column>
+      <column name="definition_fi">pronssi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}, {Sorpuq:n}</column>
@@ -3801,6 +4188,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jey':n}, {Sorpuq:n}</column>
       <column name="examples"></column>
@@ -3810,6 +4198,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3817,6 +4206,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3830,6 +4220,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">двуглавый топор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雙刃斧</column>
       <column name="definition_pt">machado de duas cabeças</column>
+      <column name="definition_fi">kaksipäinen tai kaksiteräinen kirves</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'obmaQ:n}, {jey'naS ghoqwI':n}</column>
@@ -3840,6 +4231,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru">Существует идиома {yuD; jey'naS rur@@yuD:v, jey'naS:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{yuD; jey'naS rur@@yuD:v, jey'naS:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {yuD; jey'naS rur@@yuD:v, jey'naS:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {yuD; jey'naS rur@@yuD:v, jey'naS:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Janus" is a two-faced Roman god.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3849,6 +4241,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">axe</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3856,6 +4249,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3869,6 +4263,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">двойной агент [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雙重代理人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agente duplo</column>
+      <column name="definition_fi">kaksoisagentti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'o'wen:n}</column>
@@ -3879,6 +4274,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru">Это буквально означает «двуглавый топор-шпион». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“雙頭斧頭間諜”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "espião de machado de duas cabeças". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "kaksapäistä kirvesvakoja". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jey'naS:n}, {ghoqwI':n}</column>
       <column name="examples"></column>
@@ -3888,6 +4284,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3895,6 +4292,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -3908,6 +4306,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">покупать</column>
       <column name="definition_zh_HK">買、購買 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comprar, adquirir</column>
+      <column name="definition_fi">ostaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngev:v}, {DIl:v}, {tlhong:v}, {je':v:2}</column>
@@ -3918,6 +4317,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3929,6 +4329,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3936,6 +4337,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3949,6 +4351,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">кормить кого-то, обогащать дух</column>
       <column name="definition_zh_HK">餵（別人）、充實精神 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alimentar (outra pessoa), enriquecer o espírito</column>
+      <column name="definition_fi">ruokkia jotakuta, rikastaa henkeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sop:v}, {Soj:n:1}, {qa':n}, {je':v:1}</column>
@@ -3959,6 +4362,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3970,6 +4374,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3977,6 +4382,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -3991,6 +4397,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">счетчик, верстак [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">櫃檯，工作台 [AUTOTRANSLATED]</column>
       <column name="definition_pt">balcão, bancada</column>
+      <column name="definition_fi">tiski, työpöytä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{raS:n}</column>
@@ -4001,6 +4408,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru">Это рабочее место, прикрепленное к стене. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是附著在牆上的工作空間。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um espaço de trabalho preso à parede. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on seinään kiinnitetty työtila. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A "jeton" is a token used as a "counter" (in the sense of counting things).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4010,6 +4418,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4017,6 +4426,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4030,6 +4440,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">Я(действие)</column>
       <column name="definition_zh_HK">我：無</column>
       <column name="definition_pt">Eu-nenhum</column>
+      <column name="definition_fi">minä-ei kukaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ma-:v:pref}, {vI-:v:pref}</column>
@@ -4040,6 +4451,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{jIH:n:1h}: {pagh:n:1h} = {jI-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4049,6 +4461,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4056,6 +4469,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4069,6 +4483,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">волосы</column>
       <column name="definition_zh_HK">頭髮</column>
       <column name="definition_pt">cabelo (na cabeça)</column>
+      <column name="definition_fi">hiukset</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIp:v}, {SIrgh:n}, {veD:n}, {qur'ep:n}, {wan:v}, {tIy:v}</column>
@@ -4079,6 +4494,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru">Это относится только к волосам на верхней части головы, а не на лице (смотрите {rol:n} и {loch:n}) или теле (сотрите {pob:n}).[2]</column>
       <column name="notes_zh_HK">這僅是指頭頂的頭髮，而不是指面部毛髮（請參見{rol:n}和{loch:n}）或體毛（請參見{pob:n}）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se apenas aos cabelos na parte superior da cabeça, e não aos pêlos faciais (consulte {rol:n} e {loch:n}) ou pêlos do corpo (consulte {pob:n}).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa vain pään yläosassa oleviin hiuksiin, ei kasvojen hiuksiin (katso {rol:n} ja {loch:n}) tai vartalokarvoihin (katso {pob:n}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The "cut of someone's jib" is an idiom referring to their appearance.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4089,6 +4505,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4096,6 +4513,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
         <table name="mem">
@@ -4110,6 +4528,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
           <column name="definition_ru">расческа, гребень</column>
           <column name="definition_zh_HK">梳 [AUTOTRANSLATED]</column>
           <column name="definition_pt">pente</column>
+      <column name="definition_fi">kampa</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4120,6 +4539,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{jIb:n}, {Ho':n:1}, {-Du':n}</column>
           <column name="examples"></column>
@@ -4129,6 +4549,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4136,6 +4557,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -4149,6 +4571,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
           <column name="definition_ru">щетка для волос</column>
           <column name="definition_zh_HK">髮刷 [AUTOTRANSLATED]</column>
           <column name="definition_pt">escova de cabelo</column>
+      <column name="definition_fi">hiusharja</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4159,6 +4582,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{jIb:n}, {yachwI':n}</column>
           <column name="examples"></column>
@@ -4168,6 +4592,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">brush</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4175,6 +4600,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
     <table name="mem">
@@ -4188,6 +4614,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="definition_ru">казнить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吊死執行 [AUTOTRANSLATED]</column>
       <column name="definition_pt">executar por enforcamento</column>
+      <column name="definition_fi">hirttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIj:v}, {Hup:v}, {HuS:v}, {muH:v}, {HoH:v}</column>
@@ -4198,6 +4625,7 @@ Este verbo é usado no Soneto 116, onde seu sujeito explícito é {muD:n:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Maltz thought maybe an early form of torture or execution was hanging people by their hair, but he wasn't sure about this and may have just been reacting to the homophony.
 
 A "gibbet" is a structure used for public execution. It's also a term for the projecting arm of a crane, another word for which is the "jib".</column>
@@ -4209,6 +4637,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">lynch</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4216,6 +4645,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
         <table name="mem">
@@ -4229,6 +4659,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
           <column name="definition_ru">покончить жизнь самоубийством через повешение [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">吊死自殺 [AUTOTRANSLATED]</column>
           <column name="definition_pt">cometer suicídio por enforcamento</column>
+      <column name="definition_fi">hirttäytyä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{HoH'egh:v}</column>
@@ -4239,6 +4670,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
           <column name="notes_ru">Это просто глагол {jIb:v} с суффиксом {-'egh:v}. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這只是帶後綴{-'egh:v}的動詞{jIb:v}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso é simplesmente o verbo {jIb:v} com o sufixo {-'egh:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksinkertaisesti verbi {jIb:v}, jonka pääte on {-'egh:v}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes">This was defined as "suicide by hanging" but it's clearly a verb.</column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -4248,6 +4680,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4255,6 +4688,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
         </table>
     <table name="mem">
@@ -4268,6 +4702,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
       <column name="definition_ru">Я готов(а) страдать.</column>
       <column name="definition_zh_HK">我準備了受苦。</column>
       <column name="definition_pt">Estou pronto para sofrer.</column>
+      <column name="definition_fi">Olen valmis kärsimään.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4278,6 +4713,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
       <column name="notes_ru">Это сказано Ворфом во время ритуала посвящения.</column>
       <column name="notes_zh_HK">這是沃爾夫（在克林崗）在《提升儀式》中所說的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso foi falado por Worf (em Klingon) durante seu Rito de Ascensão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän puhui Worf (Klingonissa) ylösnousemusriitin aikana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4287,6 +4723,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4294,6 +4731,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNG - The Icarus Factor:src}</column>
     </table>
     <table name="mem">
@@ -4307,6 +4745,7 @@ A "gibbet" is a structure used for public execution. It's also a term for the pr
       <column name="definition_ru">Я</column>
       <column name="definition_zh_HK">我</column>
       <column name="definition_pt">eu</column>
+      <column name="definition_fi">minä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-wIj:n}, {-wI':n}, {... 'oH pongwIj'e'.:sen}</column>
@@ -4343,6 +4782,20 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
 Глагольный префикс повелительного наклонения, когда {jIH:n:1h,nolink} является объектом {HI-:v:pref}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän pronominin monikko on {maH:n:1h,pro}.
+
+Verbien etuliitteet, kun aihe {jIH:n:1h,nolink} on:
+▶ {jIH:n:1h,nolink}: {pagh:n:1h} = {jI-:v:pref}
+▶ {jIH:n:1h,nolink}: {SoH:n} = {qa-:v:pref}
+▶ {jIH:n:1h,nolink}: {tlhIH:n} = {Sa-:v:pref}
+▶ {jIH:n:1h,nolink}: {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n} = {vI-:v:pref}
+
+Verbien etuliitteet, kun {jIH:n:1h,nolink} on objekti:
+▶ {SoH:n}: {jIH:n:1h,nolink} = {cho-:v:pref}
+▶ {tlhIH:n}: {jIH:n:1h,nolink} = {tu-:v:pref}
+▶ {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n}: {jIH:n:1h,nolink} = {mu-:v:pref}
+
+Pakollinen verbin etuliite, kun kohde on {jIH:n:1h,nolink}, on {HI-:v:pref}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4354,6 +4807,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4361,6 +4815,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4374,6 +4829,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="definition_ru">экран</column>
       <column name="definition_zh_HK">查看屏幕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tela de visualização</column>
+      <column name="definition_fi">näyttö, monitori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaSta jIH:n}</column>
@@ -4384,6 +4840,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="notes_ru">Заметьте, что {jIH:n:2,nolink} относится к устройству, в то время как {HaSta:n} относится к графиеской информации, отображенной на нем.{HaSta:n} и {wIy:n} среди видов, которые могт быть показаны на {jIH:n:2,nolink}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Huomaa, että {jIH:n:2,nolink} viittaa laitteeseen, kun taas {HaSta:n} viittaa siinä näkyviin visuaalisiin tietoihin. {HaSta:n} ja {wIy:n} kuuluvat näkymiin, jotka voidaan näyttää {jIH:n:2,nolink}-ohjelmassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4393,6 +4850,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4400,6 +4858,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4413,6 +4872,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="definition_ru">Монитор</column>
       <column name="definition_zh_HK">監控 [AUTOTRANSLATED]</column>
       <column name="definition_pt">monitorar</column>
+      <column name="definition_fi">valvoa, tarkkailla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bej:v:1}</column>
@@ -4423,6 +4883,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4434,6 +4895,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
 ▶ {jolbogh ghom wa'DIch DamuvlaHmeH De' DaneHchugh, Se'vam yIjIHtaH!:sen:nolink} "Оставайтесь на связи для получения информации, каким образом вы можете быть в числе первых, кого поднимут на борт!"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4441,6 +4903,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {Star Trek The Experience:src}</column>
     </table>
     <table name="mem">
@@ -4454,6 +4917,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="definition_ru">быть совместным, кооперироваться</column>
       <column name="definition_zh_HK">合作</column>
       <column name="definition_pt">ser cooperativo, cooperar</column>
+      <column name="definition_fi">olla yhteistyöhaluinen, tehdä yhteistyötä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeQ:v}, {yeq:v}, {yuQjIjDIvI':n}</column>
@@ -4464,6 +4928,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="notes_ru">Субъектом являются кооперирующиеся группы</column>
       <column name="notes_zh_HK">主題是合作方。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O assunto são as partes que colaboraram. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Aihe on yhteistyössä toimineet osapuolet. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from E-K side of {TKD:src}, and furthermore the K-E side defines it as "cooperate". However, {KGT:src} clarifies that this word means "be cooperative".</column>
       <column name="components"></column>
       <column name="examples">
@@ -4477,6 +4942,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
   "Сёстры из дома Дюраса, Лурса и Бетор, постоянно ищут высокого положения для дома Дюраса внутри клингонского высшего совета. В конце, сёстры выступили против Гаурона, зайдя так далеко, что работали с ромуланскими группировками, чтобы усилить власть."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4484,6 +4950,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {SkyBox 26:src}</column>
     </table>
     <table name="mem">
@@ -4497,6 +4964,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="definition_ru">The stars will talk before I will. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星星會在我說話之前說話。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">As estrelas vão falar antes de mim.</column>
+      <column name="definition_fi">Ennen kuin puhun, tähdet puhuvat.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4507,6 +4975,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4516,6 +4985,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">secrecy proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4523,6 +4993,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -4536,6 +5007,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="definition_ru">Сосед</column>
       <column name="definition_zh_HK">鄰居</column>
       <column name="definition_pt">vizinho</column>
+      <column name="definition_fi">naapuri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4546,6 +5018,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a private joke referring to a specific person.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4555,6 +5028,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">neighbour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4562,6 +5036,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4575,6 +5050,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="definition_ru">Я принимаю эту честь или дословно "Я принимаю твою честь"</column>
       <column name="definition_zh_HK">我接受，你的榮譽。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu aceito, sua honra</column>
+      <column name="definition_fi">Minun on kunnia hyväksyä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIj qet jaghmeyjaj.:sen}</column>
@@ -4585,6 +5061,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="notes_ru">Это сказано, чтобы принять просьбу стать чьим-то {cha'DIch:n:2}.</column>
       <column name="notes_zh_HK">說這是為了接受成為某人的{cha'DIch:n:2}的請求。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é solicitado para aceitar uma solicitação para se tornar {cha'DIch:n:2} de alguém. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä puhutaan hyväksymään pyyntö tulla jonkun {cha'DIch:n:2}-nimeksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4594,6 +5071,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4601,6 +5079,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNG - Sins of the Father:src}</column>
     </table>
     <table name="mem">
@@ -4614,6 +5093,7 @@ The imperative verb prefix when {jIH:n:1h,nolink} is the object is {HI-:v:pref}.
       <column name="definition_ru">пожимание плечами [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聳聳肩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">shrug</column>
+      <column name="definition_fi">kohauttaa olkapäitään</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4638,6 +5118,9 @@ Detta verb kan också tillämpas på flygplan, för vilka se {jIm:v:2}. [AUTOTRA
       <column name="notes_pt">Este verbo se refere a um movimento dos ombros.
 
 Este verbo também pode ser aplicado a aeronaves, para as quais consulte {jIm:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi viittaa hartioiden liikkumiseen.
+
+Tätä verbiä voidaan soveltaa myös lentokoneisiin, joista ks. {jIm:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4650,6 +5133,7 @@ Este verbo também pode ser aplicado a aeronaves, para as quais consulte {jIm:v:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4657,6 +5141,7 @@ Este verbo também pode ser aplicado a aeronaves, para as quais consulte {jIm:v:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -4670,6 +5155,7 @@ Este verbo também pode ser aplicado a aeronaves, para as quais consulte {jIm:v:
       <column name="definition_ru">тяга (самолет поднимается или опускается без качки) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">升起（飛機上升或下降而不投球） [AUTOTRANSLATED]</column>
       <column name="definition_pt">levantamento e abaixamento (de uma aeronave sem inclinação; queda)</column>
+      <column name="definition_fi">saada tai menettää korkeutta (lentokoneesta, joka ei nyöki)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dav:v:2}, {Der:v:2}, {jer:v}, {lol:v:2}, {ron:v:2}, {tor:v:2}, {'or:v}, {nech:v}</column>
@@ -4680,6 +5166,7 @@ Este verbo também pode ser aplicado a aeronaves, para as quais consulte {jIm:v:
       <column name="notes_ru">Это просто глагол {jIm:v:1}, применяемый к самолету. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是應用於飛機的動詞{jIm:v:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é apenas o verbo {jIm:v:1} aplicado à aeronave. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain verbi {jIm:v:1}, jota sovelletaan lentokoneisiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This may be a reference to the maneuver used by Kirk in {Star Trek II:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4689,6 +5176,7 @@ Este verbo também pode ser aplicado a aeronaves, para as quais consulte {jIm:v:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4696,6 +5184,7 @@ Este verbo também pode ser aplicado a aeronaves, para as quais consulte {jIm:v:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -4709,6 +5198,7 @@ Este verbo também pode ser aplicado a aeronaves, para as quais consulte {jIm:v:
       <column name="definition_ru">желание [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">願望</column>
       <column name="definition_pt">desejar</column>
+      <column name="definition_fi">toivoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chabal:n}</column>
@@ -4733,6 +5223,9 @@ För att uttrycka en önskan om att något ska hända, se {-jaj:v}. [AUTOTRANSLA
       <column name="notes_pt">O objeto deste verbo é geralmente uma frase e não pode ser uma coisa.[1]
 
 Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde on yleensä lause, eikä se voi olla juttu.[1]
+
+Jos haluat ilmaista toiveesi tapahtumisesta, katso {-jaj:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A reference to the genie (or jinn) of Arabian mythology.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4743,6 +5236,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4750,6 +5244,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -4763,6 +5258,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">амулет, символизирующий совершеннолетие девушки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">象徵著女孩成年的護身符 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Amuleto que simboliza a maturidade de uma menina</column>
+      <column name="definition_fi">tytön aikuistumista symboloiva amuletti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIgh:n:1}</column>
@@ -4773,6 +5269,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4782,6 +5279,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4789,6 +5287,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4802,6 +5301,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">J'naii (планета) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吉奈（行星） [AUTOTRANSLATED]</column>
       <column name="definition_pt">J'naii (planeta)</column>
+      <column name="definition_fi">J'naii (planeetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jInay'ngan:n}</column>
@@ -4812,6 +5312,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4821,6 +5322,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4828,6 +5330,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
         <table name="mem">
@@ -4841,6 +5344,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
           <column name="definition_ru">J'naii (человек) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">吉奈（人） [AUTOTRANSLATED]</column>
           <column name="definition_pt">J'naii (pessoa)</column>
+      <column name="definition_fi">J'naii (henkilö)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{jInay':n}</column>
@@ -4851,6 +5355,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This was confirmed during the Q &amp; A session.</column>
           <column name="components">{jInay':n}, {ngan:n}</column>
           <column name="examples"></column>
@@ -4860,6 +5365,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4867,6 +5373,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -4880,6 +5387,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">тип хлеба [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">麵包類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de pão</column>
+      <column name="definition_fi">eräs leipätyyppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIr ngogh:n}</column>
@@ -4890,6 +5398,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4899,6 +5408,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4906,6 +5416,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4919,6 +5430,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">Проект</column>
       <column name="definition_zh_HK">事業、項目、計劃</column>
       <column name="definition_pt">projeto</column>
+      <column name="definition_fi">projekti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4929,6 +5441,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4938,6 +5451,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4945,6 +5459,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4958,6 +5473,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">студия, рабочее пространство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">工作室、工作區 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estúdio, espaço de trabalho</column>
+      <column name="definition_fi">studio, työtila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4968,6 +5484,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jInmol:n}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -4977,6 +5494,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4984,6 +5502,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4997,6 +5516,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">штраф, взыскание</column>
       <column name="definition_zh_HK">罰款 [AUTOTRANSLATED]</column>
       <column name="definition_pt">multa, penalidade</column>
+      <column name="definition_fi">rangaistus</column>
       <column name="synonyms">{bIj:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{rup:v}</column>
@@ -5007,6 +5527,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5016,6 +5537,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5023,6 +5545,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5036,6 +5559,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">вращать, вертеть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">旋轉</column>
       <column name="definition_pt">girar, rodopiar</column>
+      <column name="definition_fi">pyöriä, kieppua</column>
       <column name="synonyms">{DIng:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{jIrmoH:v:1}, {jIr:excl}</column>
@@ -5046,6 +5570,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">MO confirmed at {Saarbrücken qepHom'a' 2011:src} that {jIr:v:nolink} is intransitive. (This was already known from the existence of {jIrmoH:v:1,nolink}.)</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5055,6 +5580,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5062,6 +5588,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5075,6 +5602,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">батлет(меч Клингона)</column>
       <column name="definition_zh_HK">旋轉bat'leth、導致bat'leth旋轉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">girar bat'leth, fazer o bat'leth girar</column>
+      <column name="definition_fi">kieputtaa bat'lethia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{betleH:n}, {jop:v:1}, {baQ:v:1}, {way':v}, {chaQ:v}, {ngol:v}, {lev:v}, {DIj:v:1}</column>
@@ -5085,6 +5613,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jIr:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -5094,6 +5623,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5101,6 +5631,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5114,6 +5645,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">кривошип [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">曲柄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">manivelar (causar rotação)</column>
+      <column name="definition_fi">kammeta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QaplaStep:n}</column>
@@ -5124,6 +5656,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jIr:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -5133,6 +5666,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5140,6 +5674,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5155,6 +5690,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">Whoop-dee-doo!, La-dee-dah!, Who cares?!, Big deal! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">哇哇哇哇！La-dee-dah！，誰在乎？！，大不了！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Não importa. Quem se importa? Desinteressante</column>
+      <column name="definition_fi">Yhdentekevää!, Ketä kiinnostaa?, Ihan sama. ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jISaHbe'.:sen}, {jIr:v}</column>
@@ -5165,6 +5701,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru">Это используется, чтобы выразить, что кто-то не совсем впечатлен тем, что кто-то только что сказал. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是用來表達人們對剛才所說的話並沒有完全的印象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para expressar que alguém não está exatamente impressionado com o que alguém acabou de dizer. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään ilmaisemaan, että joku ei juuri ole vaikuttunut siitä, mitä joku juuri sanoi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Jeer".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5174,6 +5711,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5181,6 +5719,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5194,6 +5733,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">Меня не волнует, меня не заботит</column>
       <column name="definition_zh_HK">我不在乎。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu não me importo.</column>
+      <column name="definition_fi">En välitä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIr:excl}</column>
@@ -5204,6 +5744,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jI-:v}, {SaH:v:2}, {-be':v}</column>
       <column name="examples"></column>
@@ -5213,6 +5754,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5220,6 +5762,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -5233,6 +5776,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">мумия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">木乃伊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mamãe</column>
+      <column name="definition_fi">muumio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pel'aQ:n:2}, {'Impey':n}, {nev'aQ:n}, {nebeylI':n}, {jItuj'ep ngutlh:n}</column>
@@ -5243,6 +5787,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to Imhotep ({jItuj:sen@@jI-:v, tuj:v} means "I'm hot").</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5252,6 +5797,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5259,6 +5805,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5272,6 +5819,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">глиф мумификации [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">木乃伊字形 [AUTOTRANSLATED]</column>
       <column name="definition_pt">glifo de mumificação</column>
+      <column name="definition_fi">muumiointimerkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5282,6 +5830,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jItuj'ep:n}, {ngutlh:n}</column>
       <column name="examples"></column>
@@ -5291,6 +5840,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5298,6 +5848,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5311,6 +5862,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">быть неосведомленным</column>
       <column name="definition_zh_HK">無知</column>
       <column name="definition_pt">ser ignorante</column>
+      <column name="definition_fi">olla tietämätön, olla kouluttamaton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Sov:v}</column>
       <column name="see_also"></column>
@@ -5321,6 +5873,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5330,6 +5883,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5337,6 +5891,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5350,6 +5905,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">преступник, злодей, злоумышленник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">犯罪、惡棍、犯罪分子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">criminoso, vilão, malfeitor</column>
+      <column name="definition_fi">rikollinen, roisto, pahantekijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIvo':n}</column>
@@ -5360,6 +5916,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru">Это слово похоже на {HeSwI':n}, которое используется для обозначения того, кто нарушает закон. Это слово обозначает, кроме того, быть злым.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此詞類似於{HeSwI':n}，該詞用於指稱違反法律的人。這個詞還意味著邪惡。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra é semelhante a {HeSwI':n}, que é usada para se referir a alguém que viola uma lei. Além disso, esta palavra denota ser maligna.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on samanlainen kuin {HeSwI':n}, jota käytetään viittaamaan johonkin, joka rikkoo lakia. Tämä sana merkitsee lisäksi sitä, että se on paha.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The German subtitles, and apparently an earlier version of the English subtitles, use "terrorist" to translate this word.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5370,6 +5927,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">terrorist</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5377,6 +5935,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -5390,6 +5949,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">У меня болит голова</column>
       <column name="definition_zh_HK">我頭痛。</column>
       <column name="definition_pt">Estou com dor de cabeça.</column>
+      <column name="definition_fi">Päätäni särkee.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5400,6 +5960,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jI-:v}, {wuQ:v}</column>
       <column name="examples"></column>
@@ -5409,6 +5970,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5416,6 +5978,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -5429,6 +5992,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">быть умами, несладкими, земными [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鮮味鹹土 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser umami (um dos cinco gostos básicos do paladar humano), saboroso, ser terroso</column>
+      <column name="definition_fi">olla umaminmakuinen, olla suolainen, olla multainen?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mum:v}</column>
@@ -5439,6 +6003,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The umami taste comes from glutamate, the "G" in "MSG".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5448,6 +6013,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5455,6 +6021,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5468,6 +6035,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">Я понимаю.</column>
       <column name="definition_zh_HK">我明白。</column>
       <column name="definition_pt">Compreendo.</column>
+      <column name="definition_fi">Ymmärrän.</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jIyajbe'.:sen}</column>
       <column name="see_also">{bIyaj'a'?:sen}, {choyaj'a'?:sen}</column>
@@ -5478,6 +6046,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru">Смотрите, как Гаурон говорит это: {YouTube video:url:http://youtu.be/BU7q3h2D9Mk}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/BU7q3h2D9Mk} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/BU7q3h2D9Mk} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/BU7q3h2D9Mk} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jI-:v}, {yaj:v}</column>
       <column name="examples"></column>
@@ -5487,6 +6056,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5494,6 +6064,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -5507,6 +6078,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">Я не понимаю.</column>
       <column name="definition_zh_HK">我不明白。</column>
       <column name="definition_pt">Eu não entendo.</column>
+      <column name="definition_fi">En ymmärrä.</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jIyaj.:sen}</column>
       <column name="see_also">{bIyaj'a'?:sen}, {choyaj'a'?:sen}, {QIt yIjatlh!:sen}</column>
@@ -5517,6 +6089,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jI-:v}, {yaj:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -5526,6 +6099,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5533,6 +6107,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -5546,6 +6121,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">воспаление [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">炎 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inflamação</column>
+      <column name="definition_fi">tulehdus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhaw:v}</column>
@@ -5556,6 +6132,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5565,6 +6142,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5572,6 +6150,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5585,6 +6164,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">толкование, глоссарий, перевод</column>
       <column name="definition_zh_HK">翻譯、光澤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tradução, observação</column>
+      <column name="definition_fi">käännös, tulkinta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mugh:v}</column>
@@ -5595,6 +6175,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru">Это не «определение», как можно найти в словаре, но быстрый тег, чтобы дать представление о том, что означает слово. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不是像在字典中那樣的“定義”，而是一個快速的標籤，可讓您了解單詞的含義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não é "definição", como seria encontrado em um dicionário, mas uma tag rápida para dar uma idéia do significado de uma palavra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei ole "määritelmä", kuten löytyy sanakirjasta, mutta pikalappu antaa käsityksen siitä, mitä sana tarkoittaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"G" ({jIy:sen:nolink}) + "loss" ({weS:v})</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5604,6 +6185,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5611,6 +6193,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -5624,6 +6207,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">ручка, ручка, дверная ручка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">把手、把手、門把手 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alça, empurrador, maçaneta da porta</column>
+      <column name="definition_fi">kahva, nuppi, ovenkahva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lojmIt:n}</column>
@@ -5634,6 +6218,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to the composer George Frideric Handel.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5643,6 +6228,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5650,6 +6236,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -5663,6 +6250,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">ресурсы</column>
       <column name="definition_zh_HK">資源（眾數）</column>
       <column name="definition_pt">recursos</column>
+      <column name="definition_fi">resurssit, varannot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIl:v}, {tlhIl:n}</column>
@@ -5673,6 +6261,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Sup:n:inhps}</column>
       <column name="examples"></column>
@@ -5682,6 +6271,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5689,6 +6279,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5702,6 +6293,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">зигзаг, быть зазубренным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">之字形、鋸齒狀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ziguezaguear, ser irregular</column>
+      <column name="definition_fi">olla siksakinmuotoinen, olla rosoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wan:v}</column>
       <column name="see_also">{wanHa':v}</column>
@@ -5712,6 +6304,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5722,6 +6315,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5729,6 +6323,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5742,6 +6337,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">быть вредным, быть губительным</column>
       <column name="definition_zh_HK">有害</column>
       <column name="definition_pt">ser prejudicial</column>
+      <column name="definition_fi">olla haitallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIH:v:1}</column>
@@ -5752,6 +6348,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5761,6 +6358,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5768,6 +6366,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5781,6 +6380,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">наклоняться, нагибаться, сутулиться</column>
       <column name="definition_zh_HK">哈腰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">curvar, dobrar</column>
+      <column name="definition_fi">kyyristyä, kumartua, koukistua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tor:v:1}, {'ung:v}, {'eS:v}</column>
@@ -5791,6 +6391,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of "dodge".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5800,6 +6401,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dodge, duck</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5807,6 +6409,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5820,6 +6423,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">квадрант</column>
       <column name="definition_zh_HK">象限儀</column>
       <column name="definition_pt">quadrante</column>
+      <column name="definition_fi">kvadrantti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh:n}, {qIb:n}</column>
@@ -5830,6 +6434,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5839,6 +6444,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5846,6 +6452,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5859,6 +6466,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="definition_ru">Леди, Лорд (титул для главы дома)</column>
       <column name="definition_zh_HK">女士、主（房子頭銜） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Senhora, Senhor (título do chefe da casa)</column>
+      <column name="definition_fi">lady, lordi (huoneen/suvun johtajan titteli)</column>
       <column name="synonyms">{jaw:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{qaH:n}, {tuq:n}, {chuQun:n}</column>
@@ -5869,6 +6477,7 @@ Para expressar o desejo de que algo aconteça, consulte {-jaj:v}. [AUTOTRANSLATE
       <column name="notes_ru">В Клингонском языке титулы идут после имени</column>
       <column name="notes_zh_HK">在克林崗，名稱後面是標題。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em Klingon, os títulos seguem o nome. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonissa otsikot ovat nimen perässä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TKD:src}, this was defined as "lord". In {KGT:src}, this was expanded to "Lady, female head of house" and "Lord, male head of house".
 
 In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, Princess of Wales) is translated as {Day joH:n:nolink}.[3]</column>
@@ -5881,6 +6490,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5888,6 +6498,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {Radio Times Star Trek 30th Anniversary Special Issue:src}</column>
     </table>
     <table name="mem">
@@ -5901,6 +6512,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">территория между чем-то</column>
       <column name="definition_zh_HK">之間、中間</column>
       <column name="definition_pt">área entre</column>
+      <column name="definition_fi">välissä, välinen alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{botlh:n:1}, {qoD:n}, {bIng:n}, {Dung:n}, {retlh:n}, {tlhop:n:1}, {'em:n}, {Hay:n:2h}, {qubbID:n}</column>
@@ -5911,6 +6523,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Для территории внутри объекта, смотрите {qoD:n} или {botlh:n:1}. Смотрите также {lurgh:n} для других слов, относящихся к пространственным направлениям.</column>
       <column name="notes_zh_HK">有關對象內的區域，請參見{qoD:n}或{botlh:n:1}。另請參閱{lurgh:n}以獲取與空間方向有關的其他字詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para a área dentro de um objeto, consulte {qoD:n} ou {botlh:n:1}. Consulte também {lurgh:n} para outras palavras relacionadas a direções espaciais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohteen sisällä oleva alue, katso {qoD:n} tai {botlh:n:1}. Katso myös {lurgh:n} muista paikkatietoihin liittyvistä sanoista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5920,6 +6533,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">middle, center, centre</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5927,6 +6541,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru">середина, центр</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5940,6 +6555,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">консул</column>
       <column name="definition_zh_HK">領事 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cônsul</column>
+      <column name="definition_fi">konsuli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghar:v}, {gharwI':n}, {Duy'a':n}</column>
@@ -5950,6 +6566,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is someone who is between ({joj:n}) two parties and says "okay" ({lu':excl}) to both of them.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5959,6 +6576,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5966,6 +6584,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5979,6 +6598,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">поднимать на борт</column>
       <column name="definition_zh_HK">傳送上來（艦上）</column>
       <column name="definition_pt">teletransportar (a bordo)</column>
+      <column name="definition_fi">siirtää kyytiin (siirtimellä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qol:v}</column>
       <column name="see_also">{jol:n}</column>
@@ -5989,6 +6609,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6003,6 +6624,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
 ▶ {jolbogh ghom wa'DIch DamuvlaHmeH De' DaneHchugh, Se'vam yIjIHtaH!:sen:nolink} "Оставайтесь на связи для получения информации, каким образом вы можете быть в числе первых, кого поднимут на борт!"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">beam aboard</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6010,6 +6632,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek The Experience:src}</column>
     </table>
     <table name="mem">
@@ -6023,6 +6646,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">транспортирующий луч, луч транспортера</column>
       <column name="definition_zh_HK">傳送光束</column>
       <column name="definition_pt">feixe de teletransporte</column>
+      <column name="definition_fi">siirrinsäde</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jol:v}, {Qol:v}</column>
@@ -6033,6 +6657,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is better known as a "transporter beam", but {TKD:src} uses "transport beam" consistently.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6043,6 +6668,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">transporter beam</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6050,6 +6676,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru">луч транспортера</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6063,6 +6690,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">система транспортера</column>
       <column name="definition_zh_HK">傳送裝置系統</column>
       <column name="definition_pt">sistema transportador</column>
+      <column name="definition_fi">siirrinjärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIH:v}, {chu':v:2}</column>
@@ -6073,6 +6701,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jol:n}, {pat:n}</column>
       <column name="examples">
@@ -6084,6 +6713,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6091,6 +6721,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6104,6 +6735,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">комната транспортера</column>
       <column name="definition_zh_HK">傳送室</column>
       <column name="definition_pt">sala de transporte</column>
+      <column name="definition_fi">siirrinhuone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6114,6 +6746,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jol:n}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -6123,6 +6756,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6130,6 +6764,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6143,6 +6778,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">Иди в транспортаторную</column>
       <column name="definition_zh_HK">到傳送室！</column>
       <column name="definition_pt">Vá para a sala de transporte!</column>
+      <column name="definition_fi">Mene siirrinhuoneeseen!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6153,6 +6789,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jolpa':n}, {yI-:v}, {jaH:v}</column>
       <column name="examples"></column>
@@ -6162,6 +6799,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6169,6 +6807,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}, [2] {TKD p.73:src}</column>
     </table>
     <table name="mem">
@@ -6182,6 +6821,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">ионизатор транспортаторного блока</column>
       <column name="definition_zh_HK">轉運單元電離器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ionizador da unidade transportadora</column>
+      <column name="definition_fi">siirrinyksikön ionisaattori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tat:n}</column>
@@ -6192,6 +6832,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is defined as "transporter ionizer unit" in {TKD:src}, but this is certainly a transposition of "transporter unit ionizer", a component of the transporter system mentioned in {TOS - The Enemy Within:src}.</column>
       <column name="components">{jol:n}, {voy':n:hyp,nolink}</column>
       <column name="examples"></column>
@@ -6201,6 +6842,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">transporter ionizer unit</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6208,6 +6850,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6221,6 +6864,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">панель управления транспортером</column>
       <column name="definition_zh_HK">運輸車控制面板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">painel de controle do transportador</column>
+      <column name="definition_fi">siirtimen ohjauspaneeli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6231,6 +6875,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jol:n}, {SeHlaw:n}</column>
       <column name="examples">
@@ -6242,6 +6887,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
 ▶ {jol SeHlaw lItHa'!@@jol SeHlaw:n, lItHa':v} "Уйди от этой панели управления транспортером!"[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6249,6 +6895,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -6262,6 +6909,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">Активировать луч транспортера!</column>
       <column name="definition_zh_HK">開始傳送！</column>
       <column name="definition_pt">Ative o feixe de transporte!</column>
+      <column name="definition_fi">Aktivoi siirrin!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIjol!:sen}</column>
@@ -6272,6 +6920,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Смотрите, как это говорит Гаурон: {YouTube video:url:http://youtu.be/Tvtfxst0IJ8}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/Tvtfxst0IJ8} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/Tvtfxst0IJ8} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/Tvtfxst0IJ8} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jol:n}, {yI-:v}, {chu':v:2}</column>
       <column name="examples"></column>
@@ -6281,6 +6930,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6288,6 +6938,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}, [2] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -6301,6 +6952,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">установить (устройство) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">安裝</column>
       <column name="definition_pt">instalar (um dispositivo)</column>
+      <column name="definition_fi">asentaa (laite)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jan:n:1}, {mutlh:v}</column>
@@ -6311,6 +6963,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6320,6 +6973,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6327,6 +6981,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6340,6 +6995,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">захватывать, добывать что-то(как трофей), пленять</column>
       <column name="definition_zh_HK">俘獲、捕獲</column>
       <column name="definition_pt">capturar</column>
+      <column name="definition_fi">vangita</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jonHa':v}</column>
       <column name="see_also">{nargh:v:2}, {bIghHa':n}, {tlhur:v}</column>
@@ -6350,6 +7006,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Глагол используется в просторечии с {'eb:n} чтобы выразить идею "использования подвернувшейся возможности".[2] Он может использоваться для рыбалки (в дополнение к охоте) .[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞與{'eb:n}口語化地表達了“抓住機會”的概念。[2]可以用於釣魚（除了狩獵）。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo é usado coloquialmente com {'eb:n} para expressar a idéia de "aproveitar uma oportunidade" .[2] Ele pode ser usado para pescar (além de caçar) .[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään puhekielessä {'eb:n}: n kanssa ajatuksen ilmaisemisesta "mahdollisuuden tarttumisesta" .[2] Sitä voidaan käyttää kalastukseen (metsästyksen lisäksi).[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6362,6 +7019,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6369,6 +7027,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.e 1998.01.18:src}, [3] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6382,6 +7041,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">отпускать кого-то, освобождать</column>
       <column name="definition_zh_HK">釋放</column>
       <column name="definition_pt">lançar</column>
+      <column name="definition_fi">vapauttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jon:v}</column>
       <column name="see_also"></column>
@@ -6392,6 +7052,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jon:v}, {-Ha':v}</column>
       <column name="examples">{yIjonHa'!:sen}</column>
@@ -6401,6 +7062,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6408,6 +7070,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -6421,6 +7084,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">технический офицер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">輪機長</column>
       <column name="definition_pt">oficial de engenharia</column>
+      <column name="definition_fi">konepäällikkö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jonwI':n}, {jonta' pa':n}, {jonSeH yaH:n}</column>
@@ -6431,6 +7095,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jon:n:hyp}, {pIn:n:1}</column>
       <column name="examples"></column>
@@ -6440,6 +7105,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6447,6 +7113,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6460,6 +7127,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">контроль двигателя [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發動機控制 [AUTOTRANSLATED]</column>
       <column name="definition_pt">controles de motores</column>
+      <column name="definition_fi">moottorinohjaus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6470,6 +7138,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jon:n:hyp}, {SeH:v} or {SeH:n:hyp,nolink}</column>
       <column name="examples">{jonSeH yaH:n}</column>
@@ -6479,6 +7148,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6486,6 +7156,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -6499,6 +7170,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">проектирование, место управления двигателем [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">工程、發動機控制位置 [AUTOTRANSLATED]</column>
       <column name="definition_pt">engenharia, localização de controle do motor</column>
+      <column name="definition_fi">moottorin ohjauspaikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yo'SeH yaHnIv:n}, {jonwI':n}, {jonpIn:n}</column>
@@ -6509,6 +7181,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Это относится к месту, где контролируются двигатели, где бы они ни находились или где-то еще. Если двигатели и место управления двигателем одинаковы, {jonta' pa':n} будет работать, чтобы описать это. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指控制引擎的地方，無論是引擎所在的地方還是其他地方。如果引擎和引擎控制位置相同，則{jonta' pa':n}將對其進行描述。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao local onde os motores são controlados, seja lá onde estão os motores ou em algum outro lugar. Se os motores e o local de controle do motor forem os mesmos, o {jonta' pa':n} trabalhará para descrevê-lo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa paikkaan, jossa moottoreita ohjataan, olipa moottorit siellä tai muualla. Jos moottorit ja moottorin ohjauspaikka ovat samat, {jonta' pa':n} toimisi kuvaamaan sitä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jonSeH:n}, {yaH:n}</column>
       <column name="examples"></column>
@@ -6518,6 +7191,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6525,6 +7199,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - The Butcher's Knife Cares Not for the Lamb's Cry:src}</column>
     </table>
     <table name="mem">
@@ -6539,6 +7214,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">Двигатель</column>
       <column name="definition_zh_HK">引擎、發動機</column>
       <column name="definition_pt">motor</column>
+      <column name="definition_fi">moottori</column>
       <column name="synonyms">{QuQ:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{nguSDI':n}, {QoD:v}</column>
@@ -6549,6 +7225,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is a side-effect of the backfit that also gave us {qama':n}.</column>
       <column name="components">{jon:n:hyp}, {ta':n:hyp,nolink}</column>
       <column name="examples">{matHa', DoS jonta' neH.:sen}</column>
@@ -6558,6 +7235,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Maschine</column>
       <column name="search_tags_fa"></column>
@@ -6565,6 +7243,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6578,6 +7257,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">инженерия, проектирование, комната двигателя</column>
       <column name="definition_zh_HK">機房、機艙</column>
       <column name="definition_pt">engenharia, sala de máquinas</column>
+      <column name="definition_fi">konehuone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jonSeH yaH:n}, {jonwI':n}, {jonpIn:n}</column>
@@ -6588,6 +7268,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jonta':n}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -6597,6 +7278,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6604,6 +7286,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -6617,6 +7300,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">Инженер</column>
       <column name="definition_zh_HK">工程師</column>
       <column name="definition_pt">engenheiro</column>
+      <column name="definition_fi">teknikko, mekaanikko, insinööri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jonpIn:n}, {jonta' pa':n}, {jonSeH yaH:n}</column>
@@ -6627,6 +7311,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jon:n:hyp}, {-wI':v}</column>
       <column name="examples"></column>
@@ -6636,6 +7321,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6643,6 +7329,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6656,6 +7343,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">ринуться, устремиться, толкать</column>
       <column name="definition_zh_HK">刺、推力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estocada, impulso</column>
+      <column name="definition_fi">pistää, iskeä, työntää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baQ:v:1}, {way':v}, {chaQ:v}, {ngol:v}, {lev:v}, {DIj:v:1}, {jIrmoH:v:1}</column>
@@ -6666,6 +7354,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Это используется метафорически для аргументов (см. {jop 'ej way':sen}). Он также используется для выражения концепции смены хода (см. {jop:v:2}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這被隱喻地用作參數（請參閱{jop 'ej way':sen}）。它還用於表達轉彎的概念（請參閱{jop:v:2}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado metaforicamente para argumentos (consulte {jop 'ej way':sen}). Também é usado para expressar o conceito de revezamento (consulte {jop:v:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään metaforisesti argumenteissa (katso {jop 'ej way':sen}). Sitä käytetään myös ilmaisemaan vuorottelun käsite (katso {jop:v:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6675,6 +7364,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6682,6 +7372,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6695,6 +7386,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">принять поворот [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">輪流 [AUTOTRANSLATED]</column>
       <column name="definition_pt">revezar</column>
+      <column name="definition_fi">olla vuorossa, aloittaa vuoro</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6705,6 +7397,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Это расширение {jop:v:1} для игр или других ситуаций, когда игроки и т. Д. Действуют в заранее определенном порядке. Чтобы выразить концепцию чередования, используйте {baQ:v:3}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{jop:v:1}的擴展，適用於遊戲或其他情況（玩家等以預定義的順序進行操作）。要表達輪流的概念，請使用{baQ:v:3}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma extensão do {jop:v:1} para jogos ou outras situações onde os jogadores, etc., agem em uma ordem predefinida. Para expressar o conceito de revezamento, use {baQ:v:3}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {jop:v:1}: n laajennus pelaamiseen tai muihin tilanteisiin, joissa pelaajat jne. Toimivat ennalta määrätyssä järjestyksessä. Voit ilmaista vuorottelun käsitteen käyttämällä {baQ:v:3}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6719,6 +7412,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6726,6 +7420,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
         <table name="mem">
@@ -6739,6 +7434,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="definition_ru">противооткатная техника [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">反沖機械 [AUTOTRANSLATED]</column>
           <column name="definition_pt">máquinas de recuo</column>
+      <column name="definition_fi">työntölaite?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -6749,6 +7445,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{jop:v:1}, {-wI':v}, {jo':n}</column>
           <column name="examples"></column>
@@ -6758,6 +7455,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6765,6 +7463,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -6778,6 +7477,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="definition_ru">спорить, иметь аргумент [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">爭執、爭論</column>
           <column name="definition_pt">argumentar, ter uma discussão</column>
+      <column name="definition_fi">väitellä, kiistellä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{ghoH:v}, {ngach:v}</column>
@@ -6788,6 +7488,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="notes_ru">Это идиоматическое выражение буквально означает «выпадать и отклоняться». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這種慣用語的字面意思是“衝刺和偏轉”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Essa expressão idiomática literalmente significa "atacar e desviar". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "tunkeutumista ja taipumista". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{jop:v:1}, {'ej:conj}, {way':v}</column>
           <column name="examples">
@@ -6798,6 +7499,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">dispute</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6805,6 +7507,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.115:src}</column>
         </table>
     <table name="mem">
@@ -6819,6 +7522,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">махать, колыхаться, развеваться, трепетать</column>
       <column name="definition_zh_HK">皮瓣、撲動、波浪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">movimentar abas, vibrar</column>
+      <column name="definition_fi">lepattaa, hulmuta, aaltoilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{laq:v:1}, {joqwI':n}</column>
@@ -6829,6 +7533,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Этот глагол также используется, чтобы обозначить сердцебиение ({tIq:n}).[2]</column>
       <column name="notes_zh_HK">此動詞也用於表示心臟跳動（{tIq:n}）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado para indicar a batida de um coração ({tIq:n}) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös osoittamaan sydämen lyöntiä ({tIq:n}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6874,6 +7579,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
    He sets them free in the crimson water."[2, p.170-171]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">beat, heartbeat</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6881,6 +7587,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru">сердцебиение</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -6894,6 +7601,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">или, и/или(объединяет существительные)</column>
       <column name="definition_zh_HK">或者、和/或（加入名詞） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ou, e/ou (juntando nomes)</column>
+      <column name="definition_fi">tai, ja/tai (inklusiivinen tai) (yhdistää substantiivilausekkeita)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{je:conj}, {ghap:conj}, {qoj:conj}</column>
@@ -6904,6 +7612,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Следует за последним существительным</column>
       <column name="notes_zh_HK">這是最後一個名詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto segue o substantivo final. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä seuraa lopullista substantiivia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6913,6 +7622,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6920,6 +7630,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6933,6 +7644,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">флаг</column>
       <column name="definition_zh_HK">旗</column>
       <column name="definition_pt">bandeira</column>
+      <column name="definition_fi">lippu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joq:v}, {Degh:n:1}, {pIlghIm:n}</column>
@@ -6943,6 +7655,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{joq:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -6952,6 +7665,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6959,6 +7673,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6972,6 +7687,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">ребро</column>
       <column name="definition_zh_HK">肋骨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">costela</column>
+      <column name="definition_fi">kylkiluu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ro:n}, {joQ:n:2}, {Hom:n:1}</column>
@@ -6982,6 +7698,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">You "rib" someone when you make a joke about them.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6991,6 +7708,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6998,6 +7716,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7011,6 +7730,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">полоса материала в инструменте сусдек [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">susdek儀器中的材料條 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tira de material em um instrumento susdek</column>
+      <column name="definition_fi">kaistale materiaalia susdek-soittimessa?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuSDeq:n}, {joQ:n:1}</column>
@@ -7021,6 +7741,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7030,6 +7751,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7037,6 +7759,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7050,6 +7773,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">взрывать</column>
       <column name="definition_zh_HK">爆炸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">explodir</column>
+      <column name="definition_fi">räjähtää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dej:v}, {jorwI':n}</column>
@@ -7060,6 +7784,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7069,6 +7794,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7076,6 +7802,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7089,6 +7816,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">боеголовка (торпеды)</column>
       <column name="definition_zh_HK">彈頭（魚雷） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ogiva (de um torpedo)</column>
+      <column name="definition_fi">taistelukärki (torpedossa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peng:n}</column>
@@ -7099,6 +7827,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Также написано {jornub:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">還寫了{jornub:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Também escrito {jornub:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kirjoitettu myös {jornub:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It is written {jorneb:n:nolink} in the {KGT:src} body text and in the E-K word list. The K-E side has {jornub:n:nolink}.</column>
       <column name="components">{jor:v} or {jor:n:hyp,nolink}, {neb:n:1}</column>
       <column name="examples"></column>
@@ -7108,6 +7837,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7115,6 +7845,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7128,6 +7859,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">{jorneb:n}</column>
       <column name="definition_zh_HK">{jorneb:n}</column>
       <column name="definition_pt">{jorneb:n}</column>
+      <column name="definition_fi">{jorneb:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7138,6 +7870,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7147,6 +7880,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7154,6 +7888,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7167,6 +7902,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">взрывчатка</column>
       <column name="definition_zh_HK">爆炸物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">explosivo</column>
+      <column name="definition_fi">räjähde, pommi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghay:v}, {jorneb:n}</column>
@@ -7177,6 +7913,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jor:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7186,6 +7923,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bomb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7193,6 +7931,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7206,6 +7945,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">вид, сцена, декорации, прицел, пейзаж [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">視圖、場景、風景、景觀、景觀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vista, cena, paisagem</column>
+      <column name="definition_fi">näkymä, maisema</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7216,6 +7956,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">George Chann was a landscape painter.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7225,6 +7966,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7232,6 +7974,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
         <table name="mem">
@@ -7245,6 +7988,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="definition_ru">оформление сцены [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">舞台裝飾 [AUTOTRANSLATED]</column>
           <column name="definition_pt">decoração de palco</column>
+      <column name="definition_fi">(näyttämön) lavastus</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{much yaH:n}</column>
@@ -7255,6 +7999,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{jorchan:n}, {velqa':n}</column>
           <column name="examples"></column>
@@ -7264,6 +8009,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7271,6 +8017,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
         </table>
     <table name="mem">
@@ -7284,6 +8031,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">сплетни, слухи, болтовня</column>
       <column name="definition_zh_HK">八卦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fofoca</column>
+      <column name="definition_fi">juoruta, juoruilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joS:n}</column>
@@ -7294,6 +8042,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7303,6 +8052,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7310,6 +8060,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7323,6 +8074,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">слух, сплетня</column>
       <column name="definition_zh_HK">謠言、八卦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rumor, fofoca</column>
+      <column name="definition_fi">huhu, juoru</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joS:v}</column>
@@ -7333,6 +8085,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7342,6 +8095,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rumour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7349,6 +8103,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7362,6 +8117,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">кратер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">火山口 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cratera</column>
+      <column name="definition_fi">kraatteri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chunDab:n}</column>
@@ -7372,6 +8128,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7381,6 +8138,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Laach</column>
       <column name="search_tags_fa"></column>
@@ -7388,6 +8146,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7401,6 +8160,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">быть тихим, быть спокойным</column>
       <column name="definition_zh_HK">淡定 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser calmo</column>
+      <column name="definition_fi">olla rauhallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jotHa':v}</column>
       <column name="see_also">{bergh:v}, {bIt:v}, {lIm:v}, {jot:v:2}</column>
@@ -7411,6 +8171,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7420,6 +8181,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7427,6 +8189,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7440,6 +8203,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">be bland (referring to food) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">平淡無奇（指食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser branda (referindo-se a comida)</column>
+      <column name="definition_fi">olla mauton, laimea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jot:v:1}</column>
@@ -7450,6 +8214,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Это архаичное и высшее слово, имеющее то же значение, что и {tlhorghHa':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個古老而上流的單詞，與{tlhorghHa':v}的含義相同。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é uma palavra arcaica e de classe alta com o mesmo significado que {tlhorghHa':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on arkaainen ja ylemmän luokan sana, jolla on sama merkitys kuin {tlhorghHa':v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7459,6 +8224,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7466,6 +8232,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.42:src}</column>
     </table>
     <table name="mem">
@@ -7479,6 +8246,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">быть нелегким</column>
       <column name="definition_zh_HK">不安 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser inquieto</column>
+      <column name="definition_fi">ole levoton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jot:v:1}</column>
       <column name="see_also">{bIt:v}, {ngoj:v}</column>
@@ -7489,6 +8257,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jot:v:1}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -7498,6 +8267,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7505,6 +8275,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7518,6 +8289,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">спустить вниз, опустить</column>
       <column name="definition_zh_HK">記錄下來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">derrubar</column>
+      <column name="definition_fi">ottaa tai nostaa alas</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jotlhHa':v}</column>
       <column name="see_also">{teq:v}, {lel:v}</column>
@@ -7528,6 +8300,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru">Это означает снять предмет с полки или другой конструкции. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著將物體從架子或其他高架結構上取下。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa retirar um objeto de uma prateleira ou outra estrutura aérea. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kohteen poistamista hyllystä tai muusta ylärakenteesta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The explanation comes from {peHruS:n:name,nolink} via {voragh:n:name,nolink}[2].</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7537,6 +8310,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7544,6 +8318,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2014.07.30:src}</column>
     </table>
     <table name="mem">
@@ -7557,6 +8332,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">положить обратно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">放好了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colocar de volta</column>
+      <column name="definition_fi">laittaa takaisin ylös</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jotlh:v}</column>
       <column name="see_also">{-Ha':v}</column>
@@ -7567,6 +8343,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. However, when it was suggested to MO that {jotlhHa':v:nolink} would mean "put up" since {jotlh:v:nolink} means "take down", he corrected it by saying that "put back up" would be a better translation.[1]</column>
       <column name="components">{jotlh:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -7576,6 +8353,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">put up</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7583,6 +8361,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 1997.04.07:src}</column>
     </table>
     <table name="mem">
@@ -7596,6 +8375,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="definition_ru">пытать</column>
       <column name="definition_zh_HK">折磨、拷打</column>
       <column name="definition_pt">torturar</column>
+      <column name="definition_fi">kiduttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7606,6 +8386,7 @@ In the "Radio Times Star Trek 30th Anniversary Special Issue", Lady Di (Diana, P
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Joy".
 
 In the novel {Sarek:src}, the word {be'joy':n} is used for a form of ritualized torture performed by women.</column>
@@ -7617,6 +8398,7 @@ In the novel {Sarek:src}, the word {be'joy':n} is used for a form of ritualized 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7624,6 +8406,7 @@ In the novel {Sarek:src}, the word {be'joy':n} is used for a form of ritualized 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7637,6 +8420,7 @@ In the novel {Sarek:src}, the word {be'joy':n} is used for a form of ritualized 
       <column name="definition_ru">машинное оборудование, механизм</column>
       <column name="definition_zh_HK">機械</column>
       <column name="definition_pt">maquinaria</column>
+      <column name="definition_fi">koneisto, mekanismi</column>
       <column name="synonyms">{mIqta':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{jan:n:1}</column>
@@ -7647,6 +8431,7 @@ In the novel {Sarek:src}, the word {be'joy':n} is used for a form of ritualized 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7656,6 +8441,7 @@ In the novel {Sarek:src}, the word {be'joy':n} is used for a form of ritualized 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7663,6 +8449,7 @@ In the novel {Sarek:src}, the word {be'joy':n} is used for a form of ritualized 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7676,6 +8463,7 @@ In the novel {Sarek:src}, the word {be'joy':n} is used for a form of ritualized 
       <column name="definition_ru">взорвать в контейнер какой-то [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吹進某種容器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">soprar em um recipiente de algum tipo</column>
+      <column name="definition_fi">täyttää (ilmapallo, pussi, kupla tms.) puhaltamalla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ba'Suq:n}</column>
@@ -7700,6 +8488,9 @@ Om {-Daq:n} används, innebär det en miss: luft blåstes mot föremålet, men f
       <column name="notes_pt">Isso significa "inflar, encher com ar, explodir". Isso é usado para estourar um balão, um saco de papel, uma bolha e assim por diante. Ao contrário do {SuS:v}, o ar fica preso na coisa que é soprada e não pode sair até que seja liberada (ou a coisa quebre).
 
 Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao objeto, mas o contornou. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "täytä, täytä ilmalla, räjäytä". Tätä käytetään ilmapallon, paperipussin, kuplan ja niin edelleen puhaltamiseen. Toisin kuin {SuS:v}, ilma jää loukkuun esineeseen, johon on puhallettu, eikä se voi tulla ulos, ennen kuin se päästetään ulos (tai asia rikkoutuu).
+
+Jos käytetään {-Daq:n}, se tarkoittaa epäonnistumista: ilmaa puhallettiin kohti kohdetta, mutta ohitettiin se. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Bazooka Joe" is the mascot of the Bazooka brand of bubble gum. {ba'Suq'a' jo':sen@@ba'Suq:n, -'a':n, jo':v} means "he blows a great bubble".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7709,6 +8500,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">inflate, fill with air, blow up</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7716,6 +8508,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -7729,6 +8522,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">палатка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">帳篷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tenda</column>
+      <column name="definition_fi">teltta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{weSjech:n}, {ghIchDep:n}</column>
@@ -7739,6 +8533,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7748,6 +8543,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7755,6 +8551,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7768,6 +8565,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">ты(действие)-нам, вы(единиственное число)(действие)-нам</column>
       <column name="definition_zh_HK">你：我們</column>
       <column name="definition_pt">você-nós</column>
+      <column name="definition_fi">sinä-meitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pI-:v:pref}</column>
       <column name="see_also">{che-:v:pref}, {cho-:v:pref}, {gho-:v:pref}</column>
@@ -7778,6 +8576,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SoH:n}: {maH:n:1h} = {ju-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7787,6 +8586,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7794,6 +8594,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7807,6 +8608,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">быть бессмертным</column>
       <column name="definition_zh_HK">是不朽的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser imortal</column>
+      <column name="definition_fi">olla kuolematon</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jubbe':v}</column>
       <column name="see_also">{Hegh:v}</column>
@@ -7817,6 +8619,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7826,6 +8629,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7833,6 +8637,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7846,6 +8651,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">быть смертным</column>
       <column name="definition_zh_HK">凡人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser mortal</column>
+      <column name="definition_fi">olla kuolevainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jub:v}</column>
       <column name="see_also">{Hegh:v}, {jubbe'wI':n}</column>
@@ -7856,6 +8662,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7865,6 +8672,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7872,6 +8680,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7885,6 +8694,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">смертный</column>
       <column name="definition_zh_HK">凡人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mortal</column>
+      <column name="definition_fi">kuolevainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jubbe':v}</column>
@@ -7895,6 +8705,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jubbe':v}, {-wI':v}</column>
       <column name="examples">
@@ -7916,6 +8727,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
    Кейлес должен быть выслежен и убит."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7923,6 +8735,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.122-123:src}</column>
     </table>
     <table name="mem">
@@ -7936,6 +8749,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">иметь ширину [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">寬度為 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter uma largura de</column>
+      <column name="definition_fi">olla leveä, olla leveydeltään jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uj:n}, {lang:v}, {pI':v}, {ror:v}, {vaS:v}, {'ab:v}, {'aD:v}, {Saw':v}, {juv:v}, {men:v}</column>
@@ -7946,6 +8760,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru">Для измерения плоского объекта, такого как столешница, {juch:v:nolink} и {'aD:v} используются для двух измерений.[1] Для круга это измеряет диаметр.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{juch:v:nolink}和{'aD:v}用於測量平面等平面物體的二維尺寸.[1]對於圓形，則用於測量直徑。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para medir um objeto plano como um tampo de mesa, {juch:v:nolink} e {'aD:v} são usados ​​para as duas dimensões.[1] Para um círculo, mede o diâmetro.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tasaisen esineen, kuten pöydän, mittaamiseen käytetään {juch:v:nolink} ja {'aD:v} kahta ulottuvuutta.[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7955,6 +8770,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">wide, diameter</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7962,6 +8778,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {msn 1997.10.22:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7975,6 +8792,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">дом(не постройка)</column>
       <column name="definition_zh_HK">家裡、屋企、故鄉</column>
       <column name="definition_pt">casa</column>
+      <column name="definition_fi">koti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qach:n}, {juH qach:n}</column>
@@ -7985,6 +8803,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{juHqo':n}</column>
@@ -7994,6 +8813,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8001,6 +8821,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8014,6 +8835,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">родной мир</column>
       <column name="definition_zh_HK">家園星球</column>
       <column name="definition_pt">mundo natal</column>
+      <column name="definition_fi">kotimaailma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qo'noS:n}, {tera':n}</column>
@@ -8024,6 +8846,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{juH:n}, {qo':n}</column>
       <column name="examples">
@@ -8034,6 +8857,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">homeworld</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8041,6 +8865,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru">родной мир</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -8054,6 +8879,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">Я заберу это в свой родной мир</column>
       <column name="definition_zh_HK">我會帶那件東西回我家。</column>
       <column name="definition_pt">Vou levar isso para minha casa.</column>
+      <column name="definition_fi">Otan tuon mukaan kotiini.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8064,6 +8890,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8073,6 +8900,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">QI'lop</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8080,6 +8908,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -8093,6 +8922,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">дом(физическое строение)</column>
       <column name="definition_zh_HK">房屋</column>
       <column name="definition_pt">casa</column>
+      <column name="definition_fi">talo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8103,6 +8933,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{juH:n}, {qach:n}</column>
       <column name="examples">
@@ -8114,6 +8945,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
 ▶ {Quj wa'DIch juH qachmey mebpa'mey je qa' raQmey chu' monmey chu' je:sen:nolink} "Пользовательские заставы и столицы заменены оригинальными домами и отелями"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8121,6 +8953,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -8134,6 +8967,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">солнце [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">太陽、日</column>
       <column name="definition_pt">sol</column>
+      <column name="definition_fi">aurinko</column>
       <column name="synonyms">{Hov:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{muD Dotlh:n}, {DIS:n:2}, {bav:v}, {yuQ:n}, {maS:n}, {namchIl:n}</column>
@@ -8144,6 +8978,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru">Смотрите {wov:v}, чтобы описать солнечный день. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關如何描述晴天的信息，請參見{wov:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {wov:v} para saber como descrever um dia ensolarado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso kohdasta {wov:v} kuinka kuvata aurinkoinen päivä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A reference to Juliet from Shakespeare's play, where Romeo says that "Juliet is the sun". A "Joule" is also a unit of energy.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8153,6 +8988,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8160,6 +8996,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}</column>
     </table>
     <table name="mem">
@@ -8173,6 +9010,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">Гелий</column>
       <column name="definition_zh_HK">氦氣</column>
       <column name="definition_pt">hélio</column>
+      <column name="definition_fi">helium</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIp:n}, {tamler:n}</column>
@@ -8183,6 +9021,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru">Это дословно значит "Солнечный газ"</column>
       <column name="notes_zh_HK">這字面意思是“太陽氣”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso literalmente significa "gás solar". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "aurinkokaasua". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Aside from the fact that Helium comes from the Greek word for "Sun" (helios) (see {jul:n}), helium was also first detected by Jules Janssen.</column>
       <column name="components">{jul:n}, {SIp:n}</column>
       <column name="examples"></column>
@@ -8192,6 +9031,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8199,6 +9039,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -8212,6 +9053,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">странный, необычный, чудной</column>
       <column name="definition_zh_HK">奇怪</column>
       <column name="definition_pt">ser estranho</column>
+      <column name="definition_fi">olla outo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Huj:v:1}, {taQ:v}</column>
@@ -8222,6 +9064,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru">Это означает «странный», как в своеобразном, неожиданном, подозрительном.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著“奇怪”，如特有的，意外的，可疑的。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "estranho", como em peculiar, inesperado, suspeito.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "outoa" kuten omituisessa, odottamattomassa, hämärässä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8231,6 +9074,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">peculiar, unexpected, fishy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8238,6 +9082,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru">своеобразный, неожиданный</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -8251,6 +9096,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">уклоняться, предпринять уклонительные действия</column>
       <column name="definition_zh_HK">逃避、採取規避行動</column>
       <column name="definition_pt">evadir, tomar medidas evasivas</column>
+      <column name="definition_fi">väistää, tehdä väistöliike, välttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlha':v}, {nargh:v:2}</column>
@@ -8261,6 +9107,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8277,6 +9124,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">avoid</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8284,6 +9132,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru">избегать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.158-159:src}</column>
     </table>
     <table name="mem">
@@ -8297,6 +9146,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">друг</column>
       <column name="definition_zh_HK">朋友</column>
       <column name="definition_pt">amigo</column>
+      <column name="definition_fi">ystävä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jagh:n}</column>
       <column name="see_also">{chaj:n}, {maqoch:n}, {wIj jup:sen}, {ruS:n}</column>
@@ -8307,6 +9157,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8316,6 +9167,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8323,6 +9175,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8336,6 +9189,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">догонять, настигать, проходить</column>
       <column name="definition_zh_HK">趕超、路過</column>
       <column name="definition_pt">ultrapassar, passar</column>
+      <column name="definition_fi">ohittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8346,6 +9200,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8381,6 +9236,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
    К месту власти Молора."[3, стр.138-139]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8388,6 +9244,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}, [3] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -8401,6 +9258,7 @@ Se {-Daq:n} for usado, isso implica um erro: o ar foi soprado em direção ao ob
       <column name="definition_ru">оценивать, измерять, отсчитывать, мерить</column>
       <column name="definition_zh_HK">測量</column>
       <column name="definition_pt">medir</column>
+      <column name="definition_fi">mitata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8433,6 +9291,19 @@ To express an area, use {men:v}. See also {morgh:n} for a unit of area.
 Чтобы выразить вес(массу), используйте {ngI':v} (смотрите также {tIS:v}, {'ugh:v}). Смотрите {cheb:n} для единицы веса или массы.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on yleinen verbi mittaamiseen. Tämän verbin aihe suorittaa objektin mittauksen.[2]
+
+Kohteen {'aD:v}, {juch:v} ja {Saw':v} osoittavat kohteen pituus, leveys ja syvyys. Käytä esineitä, jotka ovat paljon pitempiä tai pitempiä kuin leveät, käytä {'ab:v} {'aD:v}: n sijaan. Klingonin lineaarinen mittayksikkö on {'uj:n}.
+
+Etäisyydet voidaan kuvata käyttämällä {chuq:n}, {Sum:v} ja {Hop:v}. Käytä pitkiä matkoja {qelI'qam:n}; Käytä vielä suurempia (esim. tähtienvälisiä) etäisyyksiä {loghqam:n}.
+
+Käytä aluetta ilmaisemaan {men:v}. Katso myös pinta-alayksikkö {morgh:n}.
+
+Voit ilmaista äänenvoimakkuutta käyttämällä {muq:v} (katso myös {tIn:v}, {mach:v}). Katso kohdasta {tlho'ren:n} tilavuusyksikkö.
+
+Paino (massa) ilmaistaan ​​käyttämällä {ngI':v} (katso myös {tIS:v}, {'ugh:v}). Katso painoyksikkö {cheb:n}.
+
+Lämpötilan ilmaisemiseksi käytä {gheH:v}. Katso lämpötilan yksikkö kohdasta {SImyon:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8444,6 +9315,7 @@ To express an area, use {men:v}. See also {morgh:n} for a unit of area.
 ▶ {naQjej vIjuv.:sen:nolink} "Я измеряю копьё."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">size</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8451,5 +9323,6 @@ To express an area, use {men:v}. See also {morgh:n} for a unit of area.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.10.22:src}</column>
     </table>

--- a/mem-07-l.xml
+++ b/mem-07-l.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {l:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{l:sen:nolink}</column>
       <column name="definition_pt">a consoante {l:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {l:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">Передавать данные(находясь удалённо)</column>
       <column name="definition_zh_HK">傳輸數據（遠離某個地方） [AUTOTRANSLATED]</column>
       <column name="definition_pt">transmitir dados (longe de um lugar)</column>
+      <column name="definition_fi">lähettää dataa (ulospäin)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lI':v:2}</column>
       <column name="see_also">{ngeH:v}, {Qol:v}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Другое значение-загрузка или возможно скачивание. Заивист от контекста</column>
       <column name="notes_zh_HK">換句話說，“上傳”（或可能是“下載”，取決於上下文）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em outras palavras, "upload" (ou possivelmente "download", dependendo do contexto). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toisin sanoen "lataa" (tai mahdollisesti "lataa", kontekstista riippuen). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">upload</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru">загрузка, скачивание</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">преувеличивать, утрировать, чрезмерно подчеркивать</column>
       <column name="definition_zh_HK">誇張、作大</column>
       <column name="definition_pt">exagerar</column>
+      <column name="definition_fi">liioitella, mennä liiallisuuksiin tai liian pitkälle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yap:v}, {bo'Dagh'a' lo':sen}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">читать, прочесть, снимать показания с приборов, толковать</column>
       <column name="definition_zh_HK">讀</column>
       <column name="definition_pt">ler</column>
+      <column name="definition_fi">lukea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaD:v}, {ghItlh:v}, {qon:v}</column>
@@ -136,6 +149,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -145,6 +159,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -152,6 +167,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -165,6 +181,7 @@
       <column name="definition_ru">Энсин, прапорщик</column>
       <column name="definition_zh_HK">軍旗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alferes</column>
+      <column name="definition_fi">vänrikki, aliluutnantti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -175,6 +192,7 @@
       <column name="notes_ru">Это 8-й ранг {yaS:n}.</column>
       <column name="notes_zh_HK">這是{yaS:n}的第8位。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o 8º ranking do {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {yaS:n}: n 8. sija. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -184,6 +202,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -191,6 +210,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -204,6 +224,7 @@
       <column name="definition_ru">разбивать в пух и прах, разбирать на части, демонтировать</column>
       <column name="definition_zh_HK">拆開、拆卸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desmontar</column>
+      <column name="definition_fi">purkaa, hajottaa osiin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chenmoH:v}, {mutlh:v}</column>
       <column name="see_also"></column>
@@ -214,6 +235,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -223,6 +245,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -230,6 +253,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -243,6 +267,7 @@
       <column name="definition_ru">Возможность, способность, умение</column>
       <column name="definition_zh_HK">能力</column>
       <column name="definition_pt">habilidade</column>
+      <column name="definition_fi">kyky</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-laH:v}</column>
@@ -253,6 +278,7 @@
       <column name="notes_ru">Это также может использоваться, чтобы обозначить "фичу" в контексте разработки ПО.[2]</column>
       <column name="notes_zh_HK">從軟件使用的意義上講，這也可以用來表達“功能”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser usado para expressar "recurso" no sentido usado no software.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää myös ilmaisemaan "ominaisuus" siinä mielessä kuin sitä käytetään ohjelmistossa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -262,6 +288,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">feature</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -269,6 +296,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.25:src}</column>
     </table>
     <table name="mem">
@@ -282,6 +310,7 @@
       <column name="definition_ru">принимать, брать, допускать</column>
       <column name="definition_zh_HK">接受</column>
       <column name="definition_pt">aceitar</column>
+      <column name="definition_fi">hyväksyä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lajQo':v}</column>
       <column name="see_also">{chergh:v}, {laj:n}</column>
@@ -292,6 +321,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -304,6 +334,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -311,6 +342,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -324,6 +356,7 @@
       <column name="definition_ru">принятие, признание, прием, одобрение</column>
       <column name="definition_zh_HK">接受</column>
       <column name="definition_pt">aceitação</column>
+      <column name="definition_fi">hyväksyntä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{laj:v}</column>
@@ -334,6 +367,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -343,6 +377,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -350,6 +385,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -363,6 +399,7 @@
       <column name="definition_ru">отклонять, отвергать, отказываться</column>
       <column name="definition_zh_HK">拒絕</column>
       <column name="definition_pt">rejeitar</column>
+      <column name="definition_fi">hylätä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{laj:v}</column>
       <column name="see_also"></column>
@@ -373,6 +410,7 @@
       <column name="notes_ru">Посетитель {Qe':n} может {lajQo':v:nolink} блюдо, если {jabwI':n} имеет {qawHa':v}.[1, p.102] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果{jabwI':n}有{qawHa':v}，則{Qe':n}的顧客可以{lajQo':v:nolink}用餐。[1, p.102] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um usuário em um {Qe':n} pode {lajQo':v:nolink} um prato se o {jabwI':n} tiver {qawHa':v}.[1, p.102] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Qe':n}: n suojelija voi {lajQo':v:nolink} lautasen, jos {jabwI':n}: lla on {qawHa':v}.[1, p.102] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{laj:v}, {-Qo':v}</column>
       <column name="examples"></column>
@@ -382,6 +420,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">refuse</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -389,6 +428,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -402,6 +442,7 @@
       <column name="definition_ru">религия</column>
       <column name="definition_zh_HK">宗教</column>
       <column name="definition_pt">religião</column>
+      <column name="definition_fi">uskonto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paQDI'norgh:n}, {ghIn:n}, {maqlegh:n}, {bulvar:n}</column>
@@ -412,6 +453,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -421,6 +463,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -428,6 +471,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -441,6 +485,7 @@
       <column name="definition_ru">быть грязным, быть нечистоплотным</column>
       <column name="definition_zh_HK">很髒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser sujo</column>
+      <column name="definition_fi">olla likainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Say':v}</column>
       <column name="see_also">{SuQ:v}, {lam:n}</column>
@@ -451,6 +496,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Mary had a little "lamb", and its fleece was not white as snow.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -460,6 +506,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -467,6 +514,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -481,6 +529,7 @@
       <column name="definition_ru">грязь, нечистоты, сор, грунт, почва</column>
       <column name="definition_zh_HK">污垢、膩</column>
       <column name="definition_pt">sujeira</column>
+      <column name="definition_fi">lika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lam:v}, {tlhan:v}</column>
@@ -491,6 +540,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -500,6 +550,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -507,6 +558,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -520,6 +572,7 @@
       <column name="definition_ru">размещать, помещать, определять место</column>
       <column name="definition_zh_HK">地點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colocar, colocar no lugar</column>
+      <column name="definition_fi">panna, asettaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIl:v}</column>
@@ -530,6 +583,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">此動詞可以與後綴{-chu':v}一起使用，以表示將某些東西疊加到其他東西上的想法。[2]請參閱{tIr:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo pode ser usado com o sufixo {-chu':v} para expressar a ideia de sobrepor algo em (para) outra coisa.[2] Consulte {tIr:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä voidaan käyttää liitetiedolla {-chu':v} ilmaisemaan ajatusta, että jotain asetetaan päällekkäin jollekin muulle ([2]).{tIr:v} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu':sen:nolink} was incorrectly written as {lalchu':sen:nolink}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -541,6 +595,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">put, lal</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -548,6 +603,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -561,6 +617,7 @@
       <column name="definition_ru">row or line (of people or things expected to be in motion) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一行或一行（預計正在運動的人或事物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">linha (de pessoas ou coisas que se espera que estejam em movimento)</column>
+      <column name="definition_fi">jono</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -585,6 +642,9 @@ Ordet {mIr:n:1} kan användas som slangbegrepp för detta, om saker är tydliga.
       <column name="notes_pt">Isso seria usado para uma fila, ou seja, uma fila de pessoas esperando para entrar no filme. Espera-se que a fila ou fila de pessoas ou coisas esteja (ou esteja ou possa estar) em movimento, de modo que eventualmente diminua até que desapareça (em contraste com um {wIyqap:n} que é estacionário). Esta palavra é usada mesmo se as pessoas ou coisas estiverem agrupadas. Se houver duas filas de pessoas esperando para entrar em duas entradas lado a lado, {lanSoy:n:nolink} ainda será usado para cada uma delas (e não {wev:n}).
 
 A palavra {mIr:n:1} pode ser usada como uma gíria para isso, se as coisas estiverem claras. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytettäisiin jonoon, ts. Jonoon ihmisiin, jotka odottavat pääsyä elokuvaan. On odotettavissa, että ihmisten tai asioiden rivi tai rivi on (tai tulee tai saattaa olla) liikkeessä, joten lopulta se pienenee, kunnes se on kadonnut (toisin kuin {wIyqap:n}, joka on paikallaan). Tätä sanaa käytetään, vaikka ihmiset tai asiat olisivatkin joukossa. Jos on kaksi riviä ihmisiä, jotka odottavat pääsyä kahteen vierekkäiseen sisäänkäyntiin, {lanSoy:n:nolink}: ta käytettäisiin edelleen kullekin niistä (eikä {wev:n}).
+
+Sanaa {mIr:n:1} voidaan käyttää slangiterminä tähän, jos asiat ovat selvät. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -594,6 +654,7 @@ A palavra {mIr:n:1} pode ser usada como uma gíria para isso, se as coisas estiv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">queue</column>
       <column name="search_tags_de">Warteschlange, Schlange</column>
       <column name="search_tags_fa"></column>
@@ -601,6 +662,7 @@ A palavra {mIr:n:1} pode ser usada como uma gíria para isso, se as coisas estiv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -614,6 +676,7 @@ A palavra {mIr:n:1} pode ser usada como uma gíria para isso, se as coisas estiv
       <column name="definition_ru">быть тонким, быть худым</column>
       <column name="definition_zh_HK">要瘦、要窄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser magro, ser estreito</column>
+      <column name="definition_fi">olla ohut, olla kapea</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ror:v}, {pI':v}, {vaS:v}</column>
       <column name="see_also">{juch:v}</column>
@@ -624,6 +687,7 @@ A palavra {mIr:n:1} pode ser usada como uma gíria para isso, se as coisas estiv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Something that is "long" is usually thin.
 
 This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" at {qep'a' 25 (2018):src}.</column>
@@ -635,6 +699,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -642,6 +707,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -655,6 +721,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="definition_ru">голосовать, проголосовать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">投票，進行投票 [AUTOTRANSLATED]</column>
       <column name="definition_pt">votar, escolher</column>
+      <column name="definition_fi">äänestää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wIv:v}, {wuq:v}</column>
@@ -665,6 +732,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="notes_ru">Это голосовать на выборах или голосовать за движение. Он не имеет идиоматического смысла «выражать мнение» и используется только в том случае, если фактически проводится формальное голосование.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是在選舉中投票或對議案進行投票。它沒有“表達意見”的慣用語，僅在實際進行正式投票時使用。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é votar em uma eleição ou votar em uma moção. Ele não tem o senso idiomático de "expressar uma opinião" e é usado apenas se uma votação formal for realmente realizada.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on äänestäminen vaaleissa tai äänestys esityksen puolesta. Sillä ei ole idiomaattista "mielipiteen ilmaisun" merkitystä, ja sitä käytetään vain, jos muodollinen äänestys todella suoritetaan.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -674,6 +742,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -681,6 +750,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -694,6 +764,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="definition_ru">махать, хлопать, колыхаться, махать крыльями</column>
       <column name="definition_zh_HK">拍打 [AUTOTRANSLATED]</column>
       <column name="definition_pt">flutuar (como as asas de um pássaro, não como uma bandeira)</column>
+      <column name="definition_fi">räpytellä, tehdä siiveniskuja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}, {tel:n}</column>
@@ -704,6 +775,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="notes_ru">Этот глагол описывает движение, подобное крыльям птицы, а не развевание флага (для которого смотрите {joq:v}). В полете крылья птицы {laq:v:1:nolink}, а птица, как говорят, {laqmoH@@laq:v:1, -moH:v} свои крылья. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este verbo descreve o movimento como o das asas de um pássaro, e não como o de uma bandeira (para ver {joq:v}). Em vôo, as asas de um pássaro {laq:v:1:nolink}, e diz-se que o pássaro {laqmoH@@laq:v:1, -moH:v} suas asas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi kuvaa liikettä kuin linnun siipiä, eikä kuin lippua (josta ks.{joq:v}). Lennon aikana linnun siivet {laq:v:1:nolink}, ja linnun sanotaan {laqmoH@@laq:v:1, -moH:v} siipensä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example comes from the KLI website and not from the {HolQeD:src} article itself.</column>
       <column name="components"></column>
       <column name="examples">
@@ -714,6 +786,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -721,6 +794,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -734,6 +808,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="definition_ru">говорить тарабарщину [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">說胡言亂語 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falar sem sentido</column>
+      <column name="definition_fi">puhua siansaksaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{laqlaq:n}</column>
@@ -744,6 +819,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="notes_ru">Не сленговый способ сказать, что это будет {jat Hol jatlh:sen@@jat Hol:n, jatlh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">非語的說法是{jat Hol jatlh:sen@@jat Hol:n, jatlh:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A maneira não-gíria de dizer isso seria {jat Hol jatlh:sen@@jat Hol:n, jatlh:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei-slangi tapa sanoa tämä olisi {jat Hol jatlh:sen@@jat Hol:n, jatlh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The English idiom "flap one's gums" means to talk meaninglessly.</column>
       <column name="components"></column>
       <column name="examples">
@@ -754,6 +830,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -761,6 +838,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -774,6 +852,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="definition_ru">тарабарщина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">胡言亂語 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sem sentido</column>
+      <column name="definition_fi">siansaksa</column>
       <column name="synonyms">{jat Hol:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{laq:v:2}, {Dap:n}, {chatlh:n:2}</column>
@@ -784,6 +863,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -793,6 +873,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -800,6 +881,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -813,6 +895,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="definition_ru">огонь, питание (например, двигатели) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">啟動（例如：火箭推進器）</column>
       <column name="definition_pt">fogo (motores), energização (por exemplo, propulsores)</column>
+      <column name="definition_fi">sytyttää, aktivoida, käynnistää (rakettimoottorit tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuyDaH:n}, {vIj:n}, {rIH:v}</column>
@@ -823,6 +906,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -832,6 +916,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -839,6 +924,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -852,6 +938,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="definition_ru">пахнуть, нюхать, чуять, чувствовать запах/аромат/и т.д</column>
       <column name="definition_zh_HK">聞（氣味）</column>
       <column name="definition_pt">cheirar, sentir odores</column>
+      <column name="definition_fi">haistaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{He':v}, {He'So':v}, {pIw:n}, {mum:v}</column>
@@ -862,6 +949,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -871,6 +959,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sense odours, scent</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -878,6 +967,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -891,6 +981,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="definition_ru">фабрика</column>
       <column name="definition_zh_HK">工廠</column>
       <column name="definition_pt">fábrica</column>
+      <column name="definition_fi">tehdas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoS waw':n}</column>
@@ -901,6 +992,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -911,6 +1003,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -918,6 +1011,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -931,6 +1025,7 @@ This was defined as "be thin" in {TKD:src} and expanded to include "be narrow" a
       <column name="definition_ru">чернила, нанесите краску на кисть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">墨水、把油漆刷在刷子上 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tinta, coloque tinta em um pincel</column>
+      <column name="definition_fi">kostuttaa (sivellintä musteessa tai maalissa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -955,6 +1050,9 @@ En slangterm för denna åtgärd är {pID:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado tanto para o ato de transferir tinta de um {rItlh 'echlet:n} para um {toqwIn:n}, quanto para o ato de colocar tinta em um {rItlh naQ:n}.
 
 Uma gíria para essa ação é {pID:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään sekä musteen siirtämiseen {rItlh 'echlet:n}: stä {toqwIn:n}: een että maalin asettamiseen {rItlh naQ:n}: een.
+
+Slangitermi tälle toiminnolle on {pID:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -964,6 +1062,7 @@ Uma gíria para essa ação é {pID:v:2}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -971,6 +1070,7 @@ Uma gíria para essa ação é {pID:v:2}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -984,6 +1084,7 @@ Uma gíria para essa ação é {pID:v:2}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">храм, памятник, мемориал (здание) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">廟、祠、龕、神殿、紀念館</column>
       <column name="definition_pt">santuário, monumento, memorial (edifício)</column>
+      <column name="definition_fi">pyhäkkö, muistomerkki (rakennus)</column>
       <column name="synonyms">{van qach:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{chIrgh:n}, {ghIn:n}</column>
@@ -994,6 +1095,7 @@ Uma gíria para essa ação é {pID:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined only as "shrine" in {KGT:src}. The definition "monument, memorial (building)" was added at the {Saarbrücken qepHom'a' 2016:src}.
 
 In English slang, a "lat"rine is sometimes called a "shrine".</column>
@@ -1005,6 +1107,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1012,6 +1115,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1026,6 +1130,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="definition_ru">другой, дополнительный</column>
       <column name="definition_zh_HK">多一個、另一個</column>
       <column name="definition_pt">outro, mais um</column>
+      <column name="definition_fi">toinen, muu, ylimääräinen (asia)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1036,6 +1141,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="notes_ru">Суффикс для множественного числа этого слова зависит от того, где он использован, чтобы соотнести возможность использования его в языке(смотрите {-pu':n:suff}), для частей тела (смотрите {-Du':n:suff}), или вещей, а также чего-то другого (смотрите {-mey:n:suff}).</column>
       <column name="notes_zh_HK">這個單詞的複數形式的後綴取決於它是否用於指代具有語言能力的生物（請參閱{-pu':n:suff}），身體部位（請參見{-Du':n:suff}）或兩者都不是（請參見{-mey:n:suff}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän sanan monikon loppuliite riippuu siitä, käytetäänkö sitä viittaamaan olentoja, jotka osaavat kieltä (ks.{-pu':n:suff}{-Du':n:suff}{-mey:n:suff} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The English translation of the sentence from {Star Trek Constellations:src} does not appear in the book, but in the author's annotations which was a separate document. The {'e':n:pro} was probably a mistake, but can be rationalized as a typo for {-'e':n:suff}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1049,6 +1155,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
 ▶ {yIntaH qIrq 'e' vIneH. DaSwIj bIngDaq latlhpu' vItap.:sen@@yIn:v, -taH:v, qIrq:n:name, -'e':n, vI-:v, neH:v, DaS:n, -wIj:n, bIng:n, -Daq:n, latlh:n, -pu':n, vI-:v, tap:v} "Кирка я хочу взять живым. Остальных я разотру под своим ботинком."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">another</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1056,6 +1163,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {PK:src}, [3] {Star Trek Constellations p.232:src}</column>
     </table>
     <table name="mem">
@@ -1069,6 +1177,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="definition_ru">Pour the cold bloodwine into another glass! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">把冷的紅酒倒進另一個杯子裡！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Despeje o vinho de sangue frio em outro copo!</column>
+      <column name="definition_fi">Kaada kylmää veriviiniä toiseen lasiin!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1079,6 +1188,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="notes_ru">Это идиоматическое выражение означает: «Я не верю тебе, может быть, кто-то еще», или «Это не имеет значения для меня, может, кому-то еще будет все равно». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語表示“我不相信您，也許其他人會”，或“這與我無關，也許其他人會在意。” [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa "Eu não acredito em você, talvez alguém o faça" ou "Isso é irrelevante para mim, talvez alguém se importe". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa "En usko sinua, ehkä joku muu uskoo" tai "Se ei ole minulle merkitystä, ehkä joku muu välittää". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{latlh:n}, {HIvje':n}, {-Daq:n}, {'Iw HIq:n}, {bIr:v}, {yI-:v}, {qang:v:1}</column>
       <column name="examples"></column>
@@ -1088,6 +1198,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1095,6 +1206,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.118:src}</column>
     </table>
     <table name="mem">
@@ -1108,6 +1220,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="definition_ru">и так далее [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">等等 [AUTOTRANSLATED]</column>
       <column name="definition_pt">et cetera</column>
+      <column name="definition_fi">ja niin edelleen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1118,6 +1231,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="notes_ru">Менее формально, можно закончить список вещей, сказав {latlh latlh latlh:sen@@latlh:n, latlh:n, latlh:n} или {taH taH taH:sen@@taH:v:1, taH:v:1, taH:v:1}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Vähemmän muodollisesti, asiainluettelon voisi lopettaa sanomalla {latlh latlh latlh:sen@@latlh:n, latlh:n, latlh:n} tai {taH taH taH:sen@@taH:v:1, taH:v:1, taH:v:1}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1127,6 +1241,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">etc.</column>
       <column name="search_tags_de">usw.</column>
       <column name="search_tags_fa"></column>
@@ -1134,6 +1249,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1147,6 +1263,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="definition_ru">кустарник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">灌木、矮樹</column>
       <column name="definition_pt">arbusto</column>
+      <column name="definition_fi">pensas, puska</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tI:n}, {Sor:n}</column>
@@ -1157,6 +1274,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">People often just use a shrub when they can't find a "lav"atory.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1166,6 +1284,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1173,6 +1292,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1186,6 +1306,7 @@ In English slang, a "lat"rine is sometimes called a "shrine".</column>
       <column name="definition_ru">наклонный, наклонный, наклонный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傾斜，傾斜，傾斜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inclinar</column>
+      <column name="definition_fi">kallistua, olla kallistunut, kalteva, vinossa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'ghey:n}, {janbI':n}</column>
@@ -1224,6 +1345,11 @@ Om svängningen är kontinuerligt fram och tillbaka, använd {ler:v} istället. 
 Retornar à posição vertical (ou anterior) é {lavHa':v@@lav:v, -Ha':v}.
 
 Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa siirtymistä vinoon tai kulmaan. Lähtöasento on usein, mutta ei tarvitse olla, pystyssä tai kohtisuorassa. Jos sitä käytetään henkilöön, se tarkoittaa, että henkilön jalat pysyvät paikallaan. Kääntö voi olla ylä-, ala- tai muualla.
+
+Paluu pystyasentoon (tai aikaisempaan) on {lavHa':v@@lav:v, -Ha':v}.
+
+Jos heiluu jatkuvasti edestakaisin, käytä sen sijaan {ler:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1233,6 +1359,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1240,6 +1367,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.02:src}</column>
     </table>
     <table name="mem">
@@ -1253,6 +1381,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="definition_ru">degree (traditional unit of angle) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">度（傳統的角度單位） [AUTOTRANSLATED]</column>
       <column name="definition_pt">graus (unidade tradicional de medida de ângulo)</column>
+      <column name="definition_fi">aste (perinteinen klingonien kulman yksikkö)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lawrI':n}, {tajvaj:n:1}</column>
@@ -1263,6 +1392,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="notes_ru">Это традиционная (в том смысле, что использовалась давно, но больше не используется сегодня) единица измерения угла. В {gho:n} есть 243 {lawmey:n:nolink}. (Обратите внимание, что 243 - это 3 в 5-й степени.) [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個傳統的角度單位（從很早以前就使用過，到今天不再使用）。 {gho:n}中有243 {lawmey:n:nolink}。 （請注意，243是3到5的冪。） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma unidade de ângulo tradicional (no sentido de ter sido usada há muito tempo, mas não é mais usada hoje). Existem 243 {lawmey:n:nolink} em um {gho:n}. (Observe que 243 é 3 elevado à 5ª potência.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on perinteinen (siinä mielessä, että sitä on käytetty kauan sitten, mutta ei enää käytössä tänään) kulmayksikkö. {gho:n}: ssa on 243 {lawmey:n:nolink}. (Huomaa, että 243 on 3–5. Teho.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1272,6 +1402,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1279,6 +1410,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1293,6 +1425,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="definition_ru">degree (unit of angle) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">度（角度單位） [AUTOTRANSLATED]</column>
       <column name="definition_pt">graus (unidade de ângulo)</column>
+      <column name="definition_fi">aste (kulman yksikkö)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{law:n}, {tajvaj:n:1}, {lID:v}</column>
@@ -1303,6 +1436,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="notes_ru">Это современная единица угла, заимствованная у других цивилизаций галактики. Его также называют {law chu':n:nolink} (хотя этот термин используется все реже и реже). В {gho:n} есть 360 {lawrI'mey:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是銀河係其他文明採用的現代角度單位。它也被稱為{law chu':n:nolink}（儘管使用的術語越來越少）。 {gho:n}中有360個{lawrI'mey:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma unidade de ângulo moderna adotada de outras civilizações da galáxia. Também é conhecido como {law chu':n:nolink} (embora esse termo seja usado cada vez menos). Existem 360 {lawrI'mey:n:nolink} em um {gho:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on moderni kulman yksikkö, joka on otettu käyttöön muilta galaksin sivilisaatioilta. Sitä kutsutaan myös nimellä {law chu':n:nolink} (vaikka tätä termiä käytetään yhä vähemmän). {gho:n}: ssa on 360 {lawrI'mey:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1312,6 +1446,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1319,6 +1454,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1332,6 +1468,7 @@ Se o balanço for continuamente para frente e para trás, use {ler:v}. [AUTOTRAN
       <column name="definition_ru">быть многочисленным, быть множественным</column>
       <column name="definition_zh_HK">很多</column>
       <column name="definition_pt">ser muitos, ser numerosos</column>
+      <column name="definition_fi">olla monta, olla paljon</column>
       <column name="synonyms"></column>
       <column name="antonyms">{puS:v:1}</column>
       <column name="see_also">{'Iq:v}, {yap:v}, {Sar:v}</column>
@@ -1356,6 +1493,9 @@ För saker som är mätbara eller kvantifierbara, men inte nödvändigtvis räkn
       <column name="notes_pt">A palavra {law':v:nolink} é usada em construções comparativas. Consulte {... X law' ... X puS:sen}.
 
 Para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariamente contáveis, use {vItlh:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sanaa {law':v:nolink} käytetään vertailurakenteissa. Katso {... X law' ... X puS:sen}.
+
+Käytä asioita, jotka ovat mitattavissa tai mitattavissa, mutta eivät välttämättä laskettavissa, käytä {vItlh:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1365,6 +1505,7 @@ Para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariam
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1372,6 +1513,7 @@ Para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariam
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -1385,6 +1527,7 @@ Para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariam
       <column name="definition_ru">{... X law' ... X puS:sen}</column>
       <column name="definition_zh_HK">{... X law' ... X puS:sen}</column>
       <column name="definition_pt">{... X law' ... X puS:sen}</column>
+      <column name="definition_fi">{... X law' ... X puS:sen}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1395,6 +1538,7 @@ Para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariam
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{law':v}</column>
       <column name="examples"></column>
@@ -1404,6 +1548,7 @@ Para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariam
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1411,6 +1556,7 @@ Para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariam
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1424,6 +1570,7 @@ Para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariam
       <column name="definition_ru">... больше X чем...</column>
       <column name="definition_zh_HK">......比X更...... [AUTOTRANSLATED]</column>
       <column name="definition_pt">... é mais X que ...</column>
+      <column name="definition_fi">... on enemmän X kuin ...</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{law':v}, {puS:v:1}, {rap:v}, {nIb:v}</column>
@@ -1482,6 +1629,15 @@ Para dizer que algo não é mais {X:sen:nolink} do que outra coisa, {law'be':v:n
 Para dizer que duas coisas têm a mesma quantidade de alguma qualidade, também é possível usar {rap:v} ou {nIb:v} sem uma construção {law':v:nolink} / {puS:v:nolink}. (Veja esses verbos para obter detalhes.)
 
 As construções acima são normalmente usadas apenas para comparar coisas semelhantes. Para formar símiles, que comparam coisas que são diferentes, use {rur:v} em vez disso. Quando as construções acima são usadas para comparar coisas diferentes, geralmente fazem referência a símiles bem conhecidos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä rakennetta käytetään muodostamaan vertailuja ja superlatiiveja. Kaksi vertailtavaa asiaa menee kahteen paikkaan. Superlatiivin muodostamiseksi {Hoch:n} käytetään toisessa paikassa.
+
+Muut antonyymiparit voidaan korvata {law':v}: n ja {puS:v:1}: n sijaan sananmuodon muodossa.
+
+Jos haluat sanoa, että jokin ei ole enemmän {X:sen:nolink} kuin jokin muu, käytetään {law'be':v:nolink} ja {puSbe':v:nolink} {law':v:nolink}: n ja {puS:v:nolink}: n sijaan. Sanoa, että jokin on yhtä {X:sen:nolink} kuin jokin muu, {law':v:nolink}: ta käytetään yhdessä {law':v:nolink}: n kanssa (jos laatua tai sen hallussapitoa pidetään positiivisena) tai {puS:v:nolink}: ää käytetään {puS:v:nolink}: n kanssa (jos laatua tai sen hallintaa pidetään negatiivisena) tai {rap:v}: n tai {nIb:v}: n kanssa (joista jälkimmäinen merkitsee, että verratut kaksi asiaa ovat jollain tavalla täsmälleen samat). On myös mahdollista käyttää {puS:v:nolink}: tä [1]0: n tai {nIb:v}: n kanssa, mutta sillä on merkitys halveksinnalle. Sanoa, että jokin ei ole niin {X:sen:nolink} kuin jokin muu, {pIm:v}-paria käytetään toisen verbin sijaan.
+
+Voit sanoa, että kahdella asialla on sama määrä laatua, on myös mahdollista käyttää {rap:v} tai {nIb:v} ilman {law':v:nolink} / {puS:v:nolink} -rakennetta. (Katso lisätietoja näistä verbeistä.)
+
+Edellä mainittuja rakenteita käytetään tyypillisesti vain vertaamaan samanlaisia ​​asioita. Muodosta vertailuja, jotka vertaavat toisiaan poikkeavia asioita, käyttämällä sen sijaan {rur:v}. Kun yllä olevia rakenteita verrataan toisiinsa, ne viittaavat yleensä hyvin tunnettuihin vertailuihin.[2]{law':v:nolink}{rap:v}[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{law':v}, {puS:v:1}</column>
       <column name="examples">
@@ -1553,6 +1709,7 @@ The following example shows that the verb of quality can take a suffix:
 ▶ {SoH rallaw' law' Hoch rallaw' puS.:sen:nolink}[4]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1560,6 +1717,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.6:src}, [2] {KGT p.178-9:src}, [3] {HQ 13.1, p.8-10, Mar. 2004:src}, [4] {paq'batlh p.126-127:src}, [5] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -1573,6 +1731,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">воздух(технический термин)</column>
       <column name="definition_zh_HK">空氣（技術術語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ar (termo técnico)</column>
+      <column name="definition_fi">ilma (tekninen termi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rewve':n}, {muD:n:1}, {HIS:v}</column>
@@ -1583,6 +1742,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru">Это своего рода технический термин. Было бы странно сказать {lay vItlhuH:sen@@lay:n:2, vI-:v, tlhuH:v:1} для «Я дышу воздухом», но это будет понятно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是某種技術術語。 {lay vItlhuH:sen@@lay:n:2, vI-:v, tlhuH:v:1}的意思是“我呼吸空氣”，這很奇怪，但可以理解。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é algum tipo de termo técnico. Seria estranho dizer {lay vItlhuH:sen@@lay:n:2, vI-:v, tlhuH:v:1} para "Eu respiro ar", mas seria entendido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on jonkinlainen tekninen termi. Olisi outoa sanoa {lay vItlhuH:sen@@lay:n:2, vI-:v, tlhuH:v:1} ilmaisulle "hengitän ilmaa", mutta se ymmärretään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1592,6 +1752,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1599,6 +1760,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -1612,6 +1774,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">воздухоплавание [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">航空術</column>
       <column name="definition_pt">aeronáutica</column>
+      <column name="definition_fi">ilmailu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1622,6 +1785,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lay:n:2}, {leng:n}</column>
       <column name="examples"></column>
@@ -1631,6 +1795,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1638,6 +1803,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -1651,6 +1817,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">Лаэрт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">萊爾提斯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Laertes</column>
+      <column name="definition_fi">Laertes</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -1661,6 +1828,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1670,6 +1838,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1677,6 +1846,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -1690,6 +1860,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">обещать, давать обещание</column>
       <column name="definition_zh_HK">諾言 [AUTOTRANSLATED]</column>
       <column name="definition_pt">promessa</column>
+      <column name="definition_fi">luvata</column>
       <column name="synonyms">{'Ip:v}</column>
       <column name="antonyms">{lay'Ha':v}</column>
       <column name="see_also">{nep:v}, {Hovmey Davan.:sen}</column>
@@ -1700,6 +1871,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Lie".</column>
       <column name="components"></column>
       <column name="examples">
@@ -1721,6 +1893,7 @@ The following example shows that the verb of quality can take a suffix:
    И также следует поступить и тебе"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1728,6 +1901,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.150-151,186-187:src}</column>
     </table>
     <table name="mem">
@@ -1741,6 +1915,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">нарушать данное обещание</column>
       <column name="definition_zh_HK">打破一個字 [AUTOTRANSLATED]</column>
       <column name="definition_pt">quebrar a palavra</column>
+      <column name="definition_fi">rikkoa (lupaus)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lay':v}</column>
       <column name="see_also">{nep:v}</column>
@@ -1751,6 +1926,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lay':v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -1760,6 +1936,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1767,6 +1944,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1780,6 +1958,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">Командер</column>
       <column name="definition_zh_HK">指揮官 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comandante</column>
+      <column name="definition_fi">komentaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1790,6 +1969,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru">Это 6-й ранг {yaS:n}.</column>
       <column name="notes_zh_HK">這是{yaS:n}的第六名。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o 6º ranking do {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {yaS:n}: n 6. sijoitus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1799,6 +1979,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1806,6 +1987,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1819,6 +2001,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">Лаппа 4(планета)</column>
       <column name="definition_zh_HK">「拉帕」四星</column>
       <column name="definition_pt">Lappa IV</column>
+      <column name="definition_fi">Lappa IV</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1829,6 +2012,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru">Планета в составе Альянса Ференги</column>
       <column name="notes_zh_HK">Ferengi聯盟中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta na Aliança Ferengi. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeeta Ferengi-allianssissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1838,6 +2022,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1845,6 +2030,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1858,6 +2044,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">Верховный главнокомандующий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">總司令、最高指揮官</column>
       <column name="definition_pt">Comandante supremo</column>
+      <column name="definition_fi">ylipäällikkö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qang:n}</column>
@@ -1868,6 +2055,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru">{la'quv:n:nolink} является главой Высшего совета клингонов и занимает первое место в рейтинге {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{la'quv:n:nolink}是克林崗高級議會的主席，也是排名最高的{yaS:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {la'quv:n:nolink} é o chefe do Alto Conselho Klingon e o {yaS:n} com melhor classificação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{la'quv:n:nolink} on Klingonin korkean neuvoston päällikkö ja korkeimmalla sijalla {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{la':n}, {quv:v}</column>
       <column name="examples"></column>
@@ -1877,6 +2065,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1884,6 +2073,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1898,6 +2088,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">черепаха, черепаха [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">烏龜</column>
       <column name="definition_pt">tartaruga</column>
+      <column name="definition_fi">eräs kilpikonnaa muistuttava eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lung:n}</column>
@@ -1908,6 +2099,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru">Это относится к существу клингон, которое напоминает черепаху терранов, которую можно назвать {tera' la'SIv:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指類似於人龜的克林崗人生物，可能被稱為{tera' la'SIv:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a uma criatura Klingon que se assemelha a uma tartaruga terráquea, que pode ser chamada de {tera' la'SIv:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa Klingon-olentoon, joka muistuttaa Terran-kilpikonnaa, jota voidaan kutsua {tera' la'SIv:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Source is an e-mail from MO to loghaD.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1917,6 +2109,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1924,6 +2117,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.08.03:src}</column>
     </table>
     <table name="mem">
@@ -1937,6 +2131,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">Комендант</column>
       <column name="definition_zh_HK">司令官 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comandante</column>
+      <column name="definition_fi">komendantti, komentaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1947,6 +2142,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru">Это офицер на дежурстве в специальном подразделении внутри военных сил.</column>
       <column name="notes_zh_HK">這是負責軍隊中某些專門部門的軍官。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um oficial encarregado de certas unidades especializadas nas forças armadas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on upseeri, joka vastaa tietyistä armeijan erikoistuneista yksiköistä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{la':n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -1956,6 +2152,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1963,6 +2160,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1976,6 +2174,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="definition_ru">шантажировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勒索 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chantagear</column>
+      <column name="definition_fi">kiristää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{buQ:v}</column>
@@ -1986,6 +2185,7 @@ The following example shows that the verb of quality can take a suffix:
       <column name="notes_ru">Объект этого глагола является жертвой шантажа. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞的賓語是勒索的受害者。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto desse verbo é vítima de chantagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde on kiristyksen uhri. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">When someone's a "lech", they may be subject to blackmail.
 
 The object was confirmed during the Q &amp; A session.</column>
@@ -1997,6 +2197,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2004,6 +2205,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2017,6 +2219,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">быть перпендикулярно, быть под прямым углом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">是垂直的、是一個直角 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser perpendicular, estar em um ângulo reto</column>
+      <column name="definition_fi">olla kohtisuorassa, olla suorassa kulmassa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Don:v}</column>
       <column name="see_also">{tajvaj leD:n}, {Dop:v:1}, {neq:v}</column>
@@ -2027,6 +2230,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru">Это обычно используется с множественным предметом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常用於多個主題。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é normalmente usado com um assunto plural. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään yleensä monikkomuodon kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A plumb bob is often made of lead.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2038,6 +2242,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2045,6 +2250,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2058,6 +2264,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">видеть, смотреть, наблюдать, рассматривать, видеться</column>
       <column name="definition_zh_HK">看到 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ver</column>
+      <column name="definition_fi">nähdä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghan:v:2}</column>
@@ -2068,6 +2275,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2080,6 +2288,7 @@ The object was confirmed during the Q &amp; A session.</column>
 ▶ {pa'vo' pagh leghlu'.:sen:nolink} "Комната не имеет вида."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">look, view</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2087,6 +2296,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2100,6 +2310,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">Острый нож без острого глаза ничто</column>
       <column name="definition_zh_HK">沒有敏銳的眼睛，鋒利的刀是沒有的。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Uma faca afiada não é nada sem um olho afiado.</column>
+      <column name="definition_fi">Terävä veitsi ei ole mitään ilman terävää silmää.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2110,6 +2321,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{legh:v}, {-laH:v}, {-chu':v}, {-be':v}, {-chugh:v}, {mIn:n}, {lo'laHbe':v}, {taj:n}, {jej:v}</column>
       <column name="examples"></column>
@@ -2119,6 +2331,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2126,6 +2339,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.169:src}</column>
     </table>
     <table name="mem">
@@ -2139,6 +2353,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">держать, поддерживать, сохранять, удерживать, содержать в исправности</column>
       <column name="definition_zh_HK">保持、維修</column>
       <column name="definition_pt">manter</column>
+      <column name="definition_fi">ylläpitää, huoltaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leH:n}</column>
@@ -2149,6 +2364,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2158,6 +2374,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2165,6 +2382,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2178,6 +2396,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">поддержание в исправности, удержание, сохранение</column>
       <column name="definition_zh_HK">維修</column>
       <column name="definition_pt">manutenção</column>
+      <column name="definition_fi">huolto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leH:v}</column>
@@ -2188,6 +2407,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2197,6 +2417,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2204,6 +2425,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2217,6 +2439,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">выбираться откуда то, уходить откуда-то, уходить откуда-то, убирать что-то или кого-то</column>
       <column name="definition_zh_HK">拿出來</column>
       <column name="definition_pt">tirar, puxar para fora</column>
+      <column name="definition_fi">ottaa pois tai ulos (jonkin sisältä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jotlh:v}, {nge':v}, {yaH:v}, {Haw':v}, {yong:v}</column>
@@ -2227,6 +2450,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru">Для удаления чего-то с внешней стороны рассмотрите {teq:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了從外部去除某些東西，請考慮​​使用{teq:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para remover algo do exterior, considere {teq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat poistaa jotain ulkopuolelta, harkitse {teq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2248,6 +2472,7 @@ The object was confirmed during the Q &amp; A session.</column>
    Одним движением, битва была закончена."[2, p.169]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2255,6 +2480,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -2268,6 +2494,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">копыто</column>
       <column name="definition_zh_HK">蹄</column>
       <column name="definition_pt">casco</column>
+      <column name="definition_fi">kavio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qam:n}, {gham:n}, {namwech:n}, {Ha'DIbaH:n:1}</column>
@@ -2278,6 +2505,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2287,6 +2515,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2294,6 +2523,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2307,6 +2537,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">углубление, выемка, паз, ниша, впадина, разрыв, пролом</column>
       <column name="definition_zh_HK">休息</column>
       <column name="definition_pt">recesso, pausa</column>
+      <column name="definition_fi">tauko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leS:v}</column>
@@ -2317,6 +2548,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2326,6 +2558,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2333,6 +2566,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2346,6 +2580,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">Ленмак</column>
       <column name="definition_zh_HK">《Lenmak》</column>
       <column name="definition_pt">Lenmak</column>
+      <column name="definition_fi">Lenmak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2356,6 +2591,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="notes_ru">Обитатели Ленмака используют восьмидневную неделю ({Hogh:n}).</column>
       <column name="notes_zh_HK">Lenmak的居民每星期工作八天（{Hogh:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os habitantes de Lenmak usam uma semana de oito dias ({Hogh:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Lenmakin asukkaat käyttävät kahdeksan päivän viikkoa ({Hogh:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to John Lennon and Paul McCartney. The names of the days of the week are all references to the Beatles.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2365,6 +2601,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2372,6 +2609,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -2385,6 +2623,7 @@ The object was confirmed during the Q &amp; A session.</column>
       <column name="definition_ru">странствовать, путешествовать, скитаться, блуждать</column>
       <column name="definition_zh_HK">漫遊、旅行、漫遊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vaguear, viajar, perambular</column>
+      <column name="definition_fi">valtaa, matkustaa, kuljeksia, kierrellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jaH:v}, {ghIQ:v}, {Such:v}, {qugh:v}, {ngIv:v}, {chIq:v}, {raQpo':n}, {ghoch:n}, {leng:n}</column>
@@ -2409,6 +2648,9 @@ Detta ord kan användas för att hänvisa till resor med eller utan ett särskil
       <column name="notes_pt">{leng:v:nolink} funciona como {jaH:v}.[2]
 
 Essa palavra pode ser usada para se referir a viagens com ou sem um propósito especial. Se desejar indicar uma viagem em missão, use {ve':v} em vez disso.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{leng:v:nolink} toimii kuten {jaH:v}.[2]
+
+Tätä sanaa voidaan käyttää viittaamaan matkustamiseen erityistarkoituksessa tai ilman sitä. Jos haluat ilmoittaa matkalla matkalla, käytä sen sijaan {ve':v}.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2427,6 +2669,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
 ▶ {yuQDaq jIleng.:sen:nolink} "Я путешествую вокруг/по планете."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2434,6 +2677,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}, [3] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -2447,6 +2691,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">путешествие, рейс, поездка</column>
       <column name="definition_zh_HK">旅行、航行 [AUTOTRANSLATED]</column>
       <column name="definition_pt">viagem</column>
+      <column name="definition_fi">matka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIQ:v}, {Such:v}, {Hoq:n}, {jey:n}, {leng:v}, {tlheD:v}</column>
@@ -2457,6 +2702,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2466,6 +2712,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2473,6 +2720,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2486,6 +2734,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">Ровер (грамматический термин)</column>
       <column name="definition_zh_HK">流浪者（語法術語）</column>
       <column name="definition_pt">rover (termo gramatical)</column>
+      <column name="definition_fi">seikkailija (kielioppi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-be':v:suff}, {-Qo':v:suff}, {-Ha':v:suff}, {-qu':v:suff}</column>
@@ -2496,6 +2745,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{leng:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2505,6 +2755,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2512,6 +2763,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.3:src}</column>
     </table>
     <table name="mem">
@@ -2525,6 +2777,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">чемодан [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">行李箱</column>
       <column name="definition_pt">mala de viagem</column>
+      <column name="definition_fi">matkalaukku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tep:n}, {luch:n}</column>
@@ -2535,6 +2788,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{leng:n}, {buq:n}</column>
       <column name="examples"></column>
@@ -2544,6 +2798,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">luggage, briefcase</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2551,6 +2806,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -2564,6 +2820,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">паспорт</column>
       <column name="definition_zh_HK">護照</column>
       <column name="definition_pt">Passaporte</column>
+      <column name="definition_fi">passi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2574,6 +2831,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{leng:n}, {chaw':n}</column>
       <column name="examples"></column>
@@ -2583,6 +2841,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2590,6 +2849,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -2604,6 +2864,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">система управления реакцией полета [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">飛行反應控制系統</column>
       <column name="definition_pt">sistema de controle de reação de voo</column>
+      <column name="definition_fi">lennonohjausjärjestelmä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2614,6 +2875,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{leng:n}, {Dotlh:n}, {SeHwI' pat:n}</column>
       <column name="examples"></column>
@@ -2623,6 +2885,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2630,6 +2893,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2643,6 +2907,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">фастфуд, дорожная еда</column>
       <column name="definition_zh_HK">旅遊食品、快餐</column>
       <column name="definition_pt">comida de viagem, fast food</column>
+      <column name="definition_fi">pikaruoka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2653,6 +2918,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="notes_ru">Это может быть применено к любой пище, к примеру {leng megh:n:nolink} "дорожный обед" (смотрите {megh:n}). Смотрите {KGT p.103:src} для более полного объяснения.</column>
       <column name="notes_zh_HK">這可以應用於任何膳食，例如{leng megh:n:nolink}“航海午餐”（請參閱{megh:n}）。請參閱{KGT p.103:src}以獲取更完整的說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser aplicado a qualquer refeição, por exemplo, "almoço de viagem" {leng megh:n:nolink} (consulte {megh:n}). Consulte {KGT p.103:src} para obter uma explicação mais completa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan soveltaa mihin tahansa ateriaan, esim. {leng megh:n:nolink} "matkalounaaseen" (katso {megh:n}). Katso tarkempi selitys kohdasta {KGT p.103:src}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{leng:n}, {Soj:n:1}</column>
       <column name="examples"></column>
@@ -2662,6 +2928,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2669,6 +2936,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2682,6 +2950,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">твердый [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">固體</column>
       <column name="definition_pt">substância sólida (estado físico)</column>
+      <column name="definition_fi">kiinteä aine (olomuoto)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sub:v:1}, {betgham:n}, {SIp:n}, {lI'choD:n}</column>
@@ -2692,6 +2961,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2701,6 +2971,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2708,6 +2979,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2721,6 +2993,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">переключатель, коммутатор, выключатель</column>
       <column name="definition_zh_HK">開關</column>
       <column name="definition_pt">interruptor</column>
+      <column name="definition_fi">kytkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuv:v}, {'uy:v}, {luH:v:1}</column>
@@ -2731,6 +3004,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="notes_ru">Это также может относиться к кнопке, такой как {'eQway':n}.</column>
       <column name="notes_zh_HK">這也可以指代按鈕，例如在{'eQway':n}上。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode se referir a um botão, como em um {'eQway':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata myös painikkeeseen, kuten {'eQway':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2740,6 +3014,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">button</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2747,6 +3022,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2760,6 +3036,7 @@ Essa palavra pode ser usada para se referir a viagens com ou sem um propósito e
       <column name="definition_ru">качаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">搖晃 [AUTOTRANSLATED]</column>
       <column name="definition_pt">balançar, pesar</column>
+      <column name="definition_fi">keinua, huojua, horjua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2782,6 +3059,11 @@ Informationen zur seitlichen Bewegung ohne Drehung oder Fixierung an einem Punkt
 Para movimento em torno de um pivô em apenas uma direção, que para, consulte {lav:v}.[2]
 
 Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {Dav:v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kuvaa edestakaisen liikkeen, joka on kiinnitetty toiseen päähän kääntöön. Kun sitä käytetään henkilöön, se tarkoittaa, että jalat pysyvät maassa, kun taas keho nojaa vasemmalle ja oikealle. Heilurin kaltainen rytminen värähtely olisi {lerchu':v}.[2]
+
+Katso liike kääntymän ympäri vain yhteen suuntaan, joka pysähtyy, katso {lav:v}.[2]
+
+Katso sivulta {Dav:v:1} liikkuminen sivulle pyörimättä tai kiinnittämättä pisteeseen.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2791,6 +3073,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2798,6 +3081,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.01:src}, [2] {KLI mailing list 2019.03.02:src}</column>
     </table>
     <table name="mem">
@@ -2811,6 +3095,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">осциллирует [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擺動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">oscilar</column>
+      <column name="definition_fi">värähdellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2821,6 +3106,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="notes_ru">Это относится к ритмичному движению вперед-назад чего-либо, зафиксированного на одном конце, например маятника, независимо от того, находится ли ось сверху, снизу (как перевернутый маятник метронома) или где-то еще. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是固定在一端的物體（如擺錘）的有節奏的來回運動，無論樞軸位於頂部，底部（如節拍器的倒立擺錘）還是其他位置。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao movimento rítmico de vaivém de algo fixo em uma extremidade, como um pêndulo, se o pivô está no topo, na parte inferior (como o pêndulo invertido de um metrônomo) ou em outro lugar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa rytmiseen edestakaisen liikkeen kanssa, joka on kiinnitetty toiseen päähän, kuten heiluri, riippumatta siitä, onko kääntö yläosassa, alhaalla (kuten metronomin käänteinen heiluri) vai jossain muualla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">For another example where {-chu':v} on a verb of motion indicates a rhythmic pattern, see {jaDchu':v}.</column>
       <column name="components">{ler:v}, {-chu':v}</column>
       <column name="examples"></column>
@@ -2830,6 +3116,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2837,6 +3124,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.02:src}</column>
     </table>
     <table name="mem">
@@ -2850,6 +3138,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">бактерия, бактерии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">細菌</column>
       <column name="definition_pt">bactéria</column>
+      <column name="definition_fi">bakteeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rop:n}, {ngej:v}, {HanDI':n}, {javtIm:n}</column>
@@ -2860,6 +3149,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Purell" is a brand of hand sanitiser.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2869,6 +3159,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2876,6 +3167,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2889,6 +3181,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">аукцион [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">拍賣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">leilão</column>
+      <column name="definition_fi">huutokauppa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2899,6 +3192,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2908,6 +3202,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2915,6 +3210,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2928,6 +3224,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">дней спустя</column>
       <column name="definition_zh_HK">（幾）日後</column>
       <column name="definition_pt">... dias a partir de agora</column>
+      <column name="definition_fi">päivän päästä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hu':n}</column>
       <column name="see_also">{jaj:n}, {pIq:n}, {'opleS:n}</column>
@@ -2938,6 +3235,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The fact that this is homophonous with {leS:v} may have to do with how many "rests" (sleeps) one gets before the day in question. Note that {Hu':n:nolink} is also homohonous with {Hu':v}.</column>
       <column name="components"></column>
       <column name="examples">{wa'leS:n}, {cha'leS:n}</column>
@@ -2947,6 +3245,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2954,6 +3253,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2967,6 +3267,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">отдыхать, расслабляться</column>
       <column name="definition_zh_HK">休息、放鬆</column>
       <column name="definition_pt">descansar, relaxar</column>
+      <column name="definition_fi">levätä, rentoutua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dum:v}, {Qong:v}, {ghIQ:v}, {len:n}</column>
@@ -2977,6 +3278,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2986,6 +3288,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2993,6 +3296,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3006,6 +3310,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">тип струнного инструмента</column>
       <column name="definition_zh_HK">弦樂器的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de instrumento de cordas</column>
+      <column name="definition_fi">eräs kielisoitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pang:v}, {yach:v:2}, {Heng:v}</column>
@@ -3016,6 +3321,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="notes_ru">Это тип {HurDagh:n}.</column>
       <column name="notes_zh_HK">這是一種{HurDagh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de {HurDagh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen {HurDagh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Les Paul was an American guitarist, after whom the Gibson Les Paul electric guitar was named.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3025,6 +3331,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">guitar</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3032,6 +3339,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3045,6 +3353,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">увольнение на берег</column>
       <column name="definition_zh_HK">休假、岸上休假</column>
       <column name="definition_pt">licença de Costa</column>
+      <column name="definition_fi">loma maissa (poissa alukselta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3055,6 +3364,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{leS:n}, {poH:n}</column>
       <column name="examples"></column>
@@ -3064,6 +3374,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3071,6 +3382,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3084,6 +3396,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">предвидение, предусмотрительность</column>
       <column name="definition_zh_HK">超前意識</column>
       <column name="definition_pt">previsão</column>
+      <column name="definition_fi">ennakkoaavistus tai -näkemys, kaukokatseisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIbpoH:n}</column>
@@ -3094,6 +3407,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{leS:n}, {Sov:n}</column>
       <column name="examples"></column>
@@ -3103,6 +3417,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3110,6 +3425,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3124,6 +3440,7 @@ Para movimento para o lado sem rotação ou sendo fixado em um ponto, consulte {
       <column name="definition_ru">быть твердым, быть тяжелым(как камень)</column>
       <column name="definition_zh_HK">硬</column>
       <column name="definition_pt">ser duro (como uma pedra)</column>
+      <column name="definition_fi">olla kova (kuin kivi)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tun:v}</column>
       <column name="see_also">{Separ:n}, {Sub:v:1}</column>
@@ -3146,6 +3463,9 @@ Detta ord kan användas bildligt. Det finns ett formspråk, {let mInDu'Daj; Sepa
       <column name="notes_pt">Para "ser difícil (ser difícil)", consulte {Qatlh:v}.
 
 Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; Separmey rur@@let:v, mIn:n, -Du':n, -Daj:n, Separ:n, -mey:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso "Ole kova (ole vaikeaa)", katso {Qatlh:v}.
+
+Tätä sanaa voidaan käyttää kuvaannollisesti. On idioomi {let mInDu'Daj; Separmey rur@@let:v, mIn:n, -Du':n, -Daj:n, Separ:n, -mey:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3155,6 +3475,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3162,6 +3483,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3175,6 +3497,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">прямоугольник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">長方形</column>
       <column name="definition_pt">retângulo</column>
+      <column name="definition_fi">suorakulmio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meyrI':n}, {mey':n}, {loS reD mey':n}</column>
@@ -3185,6 +3508,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Letterbox".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3194,6 +3518,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3201,6 +3526,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -3214,6 +3540,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">Меркурий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">汞、水銀</column>
       <column name="definition_pt">mercúrio</column>
+      <column name="definition_fi">elohopea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}</column>
@@ -3224,6 +3551,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Это металлический химический элемент с символом Hg и атомным номером 80. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是金屬化學元素，符號為Hg，原子序數為80。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o elemento químico metálico com o símbolo Hg e o número atômico 80. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on metallinen kemiallinen alkuaine, jolla on symboli Hg ja atominumero 80. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3233,6 +3561,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">quicksilver, hydragyrum</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3240,6 +3569,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3253,6 +3583,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">лестница, лестница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">樓梯</column>
       <column name="definition_pt">escada, escadaria</column>
+      <column name="definition_fi">portaat, portaikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3263,6 +3594,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Лестница, ведущая к двери корабля, называется более конкретным словом, {choghvat:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">通向船門的樓梯用一個更具體的詞{choghvat:n:1}來指代。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A escada que leva à porta de um navio é referida por uma palavra mais específica, {choghvat:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Aluksen ovelle johtavaan portaikkoon viitataan tarkemmalla sanalla {choghvat:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3272,6 +3604,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">steps, escalator</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3279,6 +3612,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3292,6 +3626,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">лестница, ведущая к двери корабля [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通往船門的樓梯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">escada que leva à porta de um navio</column>
+      <column name="definition_fi">aluksen ovelle johtavat portaat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngep'oS:n}</column>
@@ -3302,6 +3637,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">В некоторых диалектах {meqro'vaq Sep:n} это относится к тому, что в другом месте называется {choghvat:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在某些{meqro'vaq Sep:n}方言中，這是指在其他地方稱為{choghvat:n:1}的方言。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em alguns dialetos {meqro'vaq Sep:n}, isso se refere ao que em outro lugar é chamado de {choghvat:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Joissakin {meqro'vaq Sep:n}-murteissa tämä viittaa siihen, mitä muualla kutsutaan {choghvat:n:1}-murteiksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3311,6 +3647,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3318,6 +3655,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3331,6 +3669,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">твердое небо, ротик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">硬齶</column>
       <column name="definition_pt">céu da boca, palato duro</column>
+      <column name="definition_fi">kova kitalaki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuj:n}</column>
@@ -3341,6 +3680,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The soft palate is known as the "vel"um.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3350,6 +3690,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3357,6 +3698,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 12 (2005):src}</column>
     </table>
     <table name="mem">
@@ -3370,6 +3712,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">переместить летучую мышь из вертикальной в горизонтальную ориентацию [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">將bat'leth從垂直方向移動到水平方向 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mover bat'leth da orientação vertical para a horizontal</column>
+      <column name="definition_fi">siirtää bat'leth pystyasennosta vaaka-asentoon</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngol:v}</column>
       <column name="see_also">{betleH:n}, {jop:v:1}, {baQ:v:1}, {way':v}, {chaQ:v}, {jIrmoH:v:1}, {DIj:v:1}</column>
@@ -3380,6 +3723,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3389,6 +3733,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3396,6 +3741,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3409,6 +3755,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">нос [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鼻</column>
       <column name="definition_pt">nariz</column>
+      <column name="definition_fi">nenä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3419,6 +3766,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Слово для носа везде {ghIch:n}, но в некоторых регионах это слово используется в качестве альтернативы. [1, p.28] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">鼻子這個詞到處都是{ghIch:n}，但在某些地區，這個詞被用作替代。[1, p.28] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra para nariz é {ghIch:n} em todos os lugares, mas em algumas regiões esta palavra é usada como alternativa.[1, p.28] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nenän sana on {ghIch:n} kaikkialla, mutta joillakin alueilla tätä sanaa käytetään vaihtoehtona.[1, p.28] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The regions where this word is used are not specified in {KGT:src}.[1, p.28]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3428,6 +3776,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3435,6 +3784,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3448,6 +3798,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">быть специальным, быть особым, быть особенным, быть исключительным, быть специфичным</column>
       <column name="definition_zh_HK">特別</column>
       <column name="definition_pt">ser especial, ser excepcional</column>
+      <column name="definition_fi">olla erityinen, poikkeuksellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{le'be':v}</column>
       <column name="see_also">{Dal:v}, {qetlh:v}, {Daj:v:1}, {motlh:v}</column>
@@ -3458,6 +3809,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3467,6 +3819,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3474,6 +3827,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3487,6 +3841,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">Быть неисключительнмы, быть неособенным, бытьнеособым</column>
       <column name="definition_zh_HK">是無與倫比的、是非特異性的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser excepcional, ser inespecífico</column>
+      <column name="definition_fi">olla tavallinen, ei-erityinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{le':v}</column>
       <column name="see_also">{motlh:v}</column>
@@ -3497,6 +3852,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Это может быть использовано в общем смысле (как противоположность к слову специфичный, особенный и пр). Например, {nav HablI' le'be'} может относиться к общему или коллективному факсу у кого-то на столе, как противоположность факс-машине на чьем-то столе.[2]</column>
       <column name="notes_zh_HK">可以按“一般”（相對於特定）的意義使用它。例如，{nav HablI' le'be'}可能是指辦公室前台的通用或共享傳真機，與某人的辦公桌上的傳真機相反。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado no sentido de "geral" (em oposição a específico). Por exemplo, {nav HablI' le'be'} pode se referir à máquina de fax geral ou compartilhada na recepção de um escritório, em oposição a uma máquina de fax na mesa de alguém.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää "yleisen" merkityksessä (toisin kuin erityinen). Esimerkiksi {nav HablI' le'be'} voi viitata toimiston vastaanotossa olevaan yleiseen tai jaettuun faksilaitteeseen, toisin kuin jonkun työpöydän faksilaitteeseen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3506,6 +3862,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be general</column>
       <column name="search_tags_de">allgemein</column>
       <column name="search_tags_fa"></column>
@@ -3513,6 +3870,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru">быть общим</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 5.2, p.20, Jun. 1996:src}</column>
     </table>
     <table name="mem">
@@ -3526,6 +3884,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">блокада</column>
       <column name="definition_zh_HK">封鎖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bloqueio</column>
+      <column name="definition_fi">saarto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bot:v}</column>
@@ -3536,6 +3895,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to a famous scene from Les Miserables.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3548,6 +3908,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
 ▶ {DIvI' le'mISvo' bInargh.:sen:nolink} "Побег из блокады Федерации."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">barricade</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3555,6 +3916,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3568,6 +3930,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">гордость(эмоция)</column>
       <column name="definition_zh_HK">驕傲（情緒） [AUTOTRANSLATED]</column>
       <column name="definition_pt">orgulho (emoção)</column>
+      <column name="definition_fi">ylpeys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'quj nge':sen:idiom}, {Hem:v}, {nguq:v}, {nur:n}</column>
@@ -3578,6 +3941,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Leo" (pride of lions)</column>
       <column name="components"></column>
       <column name="examples">
@@ -3611,6 +3975,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
    для них это представление чистоты их крови."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3618,6 +3983,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, [2] {paq'batlh p.118-121:src}</column>
     </table>
     <table name="mem">
@@ -3631,6 +3997,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">Он/она/это(действие)-вам(множественное число), они-вам(множественное число)</column>
       <column name="definition_zh_HK">他、它、他們、它們：你們</column>
       <column name="definition_pt">ele/ela-vocês, eles-vocês</column>
+      <column name="definition_fi">hän/se-teitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bo-:v:pref}</column>
       <column name="see_also">{Du-:v:pref}, {nI-:v:pref}</column>
@@ -3641,6 +4008,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n}: {tlhIH:n} = {lI-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3650,6 +4018,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">he-you (plural), she-you (plural), it-you (plural)</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3657,6 +4026,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru">он-вам (множественное число), она-вам (множественное число), это-вам (множественное число)</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3670,6 +4040,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">быть неизбежным, неизбежным, вырисовываться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">在即、即將來臨、迫在眉睫、近在眼前</column>
       <column name="definition_pt">ser iminente, iminente, tear</column>
+      <column name="definition_fi">olla lähestyvä, häämöttävä, välitön</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tugh:adv}</column>
@@ -3680,6 +4051,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3690,6 +4062,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3697,6 +4070,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -3710,6 +4084,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">налить (во что угодно) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斟入、倒在上面</column>
       <column name="definition_pt">despejar (em/em qualquer coisa)</column>
+      <column name="definition_fi">kaataa (nestettä johonkin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qang:v:1}, {teb:v}, {Qoy':v}</column>
@@ -3720,6 +4095,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Это один из возможных глаголов для использования с {watrIn:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是與{watrIn:n}.[2]一起使用的可能動詞 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um verbo possível para usar com {watrIn:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksi mahdollinen verbi, jota voidaan käyttää {watrIn:n}.[2]: n kanssa [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3729,6 +4105,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3736,6 +4113,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -3749,6 +4127,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">путешествовать или перемещаться на указанное или измеримое расстояние или траекторию [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">行駛或移動指定的或可測量的距離或軌跡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">viajar ou mover uma distância ou trajetória especificada ou mensurável</column>
+      <column name="definition_fi">matkustaa tai siirtyä mitattavalla tai määrätyllä etäisyydellä tai reitillä/lentoradalla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uj:n}, {lawrI':n}</column>
@@ -3759,6 +4138,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Объектом этого глагола является расстояние или диапазон движения. Он используется с глаголами движения, такими как {ron:v:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞的對像是運動的距離或範圍。它與動詞動詞（例如{ron:v:1}）一起使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto desse verbo é a distância ou amplitude de movimento. É usado com verbos de movimento como {ron:v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde on liikkeen etäisyys tai alue. Sitä käytetään liikeverbeillä, kuten {ron:v:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3770,6 +4150,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3777,6 +4158,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -3790,6 +4172,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">ездить, кататься, ехать</column>
       <column name="definition_zh_HK">騎 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dirigir</column>
+      <column name="definition_fi">ratsastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lupwI':n}, {lIt:v}, {yong:v}, {SeD:v}, {ba'qIn:n}</column>
@@ -3800,6 +4183,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3809,6 +4193,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3816,6 +4201,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3829,6 +4215,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">Лигон</column>
       <column name="definition_zh_HK">利根 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ligon</column>
+      <column name="definition_fi">Ligon</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIghonngan:n}</column>
@@ -3839,6 +4226,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Это также называется {lIghonya':n:nolink}, как правило, старшими ораторами. [1, p.141-142] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso também é chamado {lIghonya':n:nolink}, geralmente por falantes mais antigos.[1, p.141-142] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä kutsutaan tyypillisesti vanhemmiksi puhujiksi {lIghonya':n:nolink}[1, p.141-142] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3848,6 +4236,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3855,6 +4244,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3868,6 +4258,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">главин, Лигонская перчатка с шипами [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">glavin、Ligonian釘鞋手套 [AUTOTRANSLATED]</column>
       <column name="definition_pt">glavin, luva de espiga ligoniana</column>
+      <column name="definition_fi">ligonilainen piikkikäsine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3878,6 +4269,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lIghon:n}, {DuQ:v:1}, {-wI':v}, {pogh:n}</column>
       <column name="examples"></column>
@@ -3887,6 +4279,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3894,6 +4287,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3907,6 +4301,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">Лигонианин</column>
       <column name="definition_zh_HK">Ligonian [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ligoniano</column>
+      <column name="definition_fi">ligonilainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIghon:n}</column>
@@ -3917,6 +4312,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Это часто произносится, как если бы это было {lIghongan:n:nolink}[1, p.141] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常發音為{lIghongan:n:nolink}[1, p.141] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso geralmente é pronunciado como se fosse {lIghongan:n:nolink}[1, p.141] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lausutaan usein ikään kuin se olisi {lIghongan:n:nolink}[1, p.141] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{lIghon:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -3926,6 +4322,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3933,6 +4330,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3946,6 +4344,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">представлять кого-то</column>
       <column name="definition_zh_HK">介紹 [AUTOTRANSLATED]</column>
       <column name="definition_pt">introduzir</column>
+      <column name="definition_fi">esitellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qIH:v}, {lIH:v:2}</column>
@@ -3956,6 +4355,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3965,6 +4365,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3972,6 +4373,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3985,6 +4387,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">начать песню [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">開一首歌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">começar uma canção</column>
+      <column name="definition_fi">aloittaa laulu tai kappale</column>
       <column name="synonyms"></column>
       <column name="antonyms">{van:v:2}, {ghang:v}</column>
       <column name="see_also">{namtun:n}, {lIH:v:1}</column>
@@ -3996,6 +4399,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Это значит начать петь песню (певец - это субъект, а песня - это объект).[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著要開始唱歌（歌手是主體，而歌曲是目標）。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa começar a cantar uma música (o cantor é o assunto e a música é o objeto).[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa laulun aloittamista (laulaja on aihe ja kappale on esine).[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4005,6 +4409,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">start</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4012,6 +4417,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -4025,6 +4431,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">Забывать</column>
       <column name="definition_zh_HK">忘記</column>
       <column name="definition_pt">esquecer</column>
+      <column name="definition_fi">unohtaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qaw:v}</column>
       <column name="see_also"></column>
@@ -4035,6 +4442,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{qeylIS'e' lIjlaHbe'bogh vay':n:name}</column>
@@ -4044,6 +4452,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4051,6 +4460,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4064,6 +4474,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">паниковать</column>
       <column name="definition_zh_HK">恐慌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">entrar em pânico</column>
+      <column name="definition_fi">panikoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIt:v}, {jot:v:1}, {ghIj:v}, {Haj:v}</column>
@@ -4074,6 +4485,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Panic when on a "limb".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4083,6 +4495,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4090,6 +4503,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4103,6 +4517,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">симулировать, подражать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">模擬、冒充</column>
       <column name="definition_pt">simular, personificar</column>
+      <column name="definition_fi">simuloida, imitoida, esittää (jotakin tai jotakuta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIlwI':n}</column>
@@ -4113,6 +4528,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Идея состоит в том, что субъект глагола выглядит или ведет себя как-то (или кто-то) еще или представляет что-то (или кого-то) еще. Как и {ghet:v}, он не имеет никакого смысла в мошенничестве или чем-то закулисном. Объект - это моделируемая вещь или человек, изображающий себя подражающим. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個想法是動詞的主語看起來或表現得像其他東西（或某人）或代表其他東西（或某人）。像{ghet:v}一樣，它沒有欺詐或任何卑鄙的含義。對像是被模擬的事物或被模仿的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A idéia é que o sujeito do verbo se pareça ou se comporte com algo (ou alguém) ou represente algo (ou alguém). Como o {ghet:v}, ele não tem conotação de fraude ou qualquer coisa oculta. O objeto é a coisa que está sendo simulada ou a pessoa que está sendo representada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ajatuksena on, että verbin aihe näyttää tai käyttäytyy kuin jotain (tai joku) tai edustaa jotain (tai jotakuta) muuta. Kuten {ghet:v}, sillä ei ole merkitystä petoksille eikä mitään aliarvioitua. Kohde on simuloitu asia tai toisena henkilönä esiintyminen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4124,6 +4540,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4131,6 +4548,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -4144,6 +4562,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">имитатор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">模擬器、冒充者</column>
       <column name="definition_pt">simulador</column>
+      <column name="definition_fi">simulaattori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4154,6 +4573,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="notes_ru">Это что-то (или кто-то), которое выглядит или ведет себя как что-то (или кто-то) другое. {lIlwI':n:nolink} отличается от {lIw:n}, поскольку {lIw:n:nolink} подразумевает замену, тогда как {lIlwI':n:nolink} никого и ничего не заменяет. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是看起來（或行為類似）的東西（或某人）。 {lIlwI':n:nolink}與{lIw:n}不同，因為{lIw:n:nolink}表示替換，而{lIlwI':n:nolink}不替換任何人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é algo (ou alguém) que se parece ou se comporta como outra coisa (ou alguém). Um {lIlwI':n:nolink} é diferente de um {lIw:n}, pois {lIw:n:nolink} implica substituição, enquanto um {lIlwI':n:nolink} não substitui ninguém nem nada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on jotain (tai joku), joka näyttää tai käyttäytyy kuin jokin (tai joku) muu. {lIlwI':n:nolink} eroaa {lIw:n}: sta, koska {lIw:n:nolink} merkitsee korvaamista, kun taas {lIlwI':n:nolink} ei korvaa ketään tai mitään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{lIl:v}, {-wI':v}</column>
       <column name="examples">
@@ -4164,6 +4584,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">impersonator</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4171,6 +4592,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -4184,6 +4606,7 @@ Esta palavra pode ser usada figurativamente. Existe um idioma, {let mInDu'Daj; S
       <column name="definition_ru">Поделиться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">分享 [AUTOTRANSLATED]</column>
       <column name="definition_pt">compartilhar</column>
+      <column name="definition_fi">jakaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bon:v}, {lInchuq:sen}</column>
@@ -4208,6 +4631,9 @@ När en dator (eller datorsystem) är online sägs det vara "delning". Se {lIn:v
       <column name="notes_pt">Quando {A:sen:nolink} e {B:sen:nolink} compartilham {C:sen:nolink} um com o outro, a construção é {C lulIn A B je:sen:nolink} (ou {C lIn A B je:sen:nolink} se {C:sen:nolink} for plural). Neste caso, o falante não se compromete sobre se {A:sen:nolink} ou {B:sen:nolink} é quem decidiu compartilhar com o outro.[1]
 
 Quando um computador (ou sistema de computador) está online, ele está "compartilhando". Consulte {lIn:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun {A:sen:nolink} ja {B:sen:nolink} jakavat {C:sen:nolink} keskenään, rakenne on {C lulIn A B je:sen:nolink} (tai {C lIn A B je:sen:nolink}, jos {C:sen:nolink} on monikko). Tässä tapauksessa puhuja ei ole sitoutunut siihen, onko {A:sen:nolink} vai {B:sen:nolink} se, joka päätti jakaa jakamisen toisen kanssa.
+
+Kun tietokone (tai tietokonejärjestelmä) on verkossa, sen sanotaan olevan "jakamista". Katso {lIn:v:2}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4217,6 +4643,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4224,6 +4651,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4237,6 +4665,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">выходить в интернет (подключиться к компьютерной сети) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">上網（連接到計算機網絡） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fique on-line (conecte-se à rede de computadores)</column>
+      <column name="definition_fi">muodostaa yhteys tietoverkkoon, siirtyä online-tilaan</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lInHa':v}</column>
       <column name="see_also"></column>
@@ -4247,6 +4676,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru">Это всего лишь приложение {lIn:v:1} к контексту компьютерной сети. Клингоны думают о компьютере (или компьютерной системе), который находится в сети как «обмен». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是{lIn:v:1}在計算機網絡環境中的應用。 Klingons認為在線的計算機（或計算機系統）是“共享”的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é apenas a aplicação do {lIn:v:1} a um contexto de rede de computadores. Os klingons pensam em um computador (ou sistema de computador) que está online como "compartilhamento". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain {lIn:v:1} -sovelluksen käyttö tietokoneverkkokontekstissa. Klingonit ajattelevat tietokonetta (tai tietokonejärjestelmää), joka on verkossa "jakamisena". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The definition was not given. It's just explained that going online would use the verb {lIn:v:2,nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4256,6 +4686,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4263,6 +4694,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.25:src}</column>
     </table>
     <table name="mem">
@@ -4276,6 +4708,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">делиться друг с другом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">互相分享 [AUTOTRANSLATED]</column>
       <column name="definition_pt">compartilham um ao outro</column>
+      <column name="definition_fi">jakaa toisensa, olla fyysisessä/seksuaalisessa kanssakäymisessä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4287,6 +4720,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_zh_HK">這種慣用語不是委婉的說法，而是有點過時的話。這意味著受試者俱有某種物理關係。 [AUTOTRANSLATED]</column>
       <!-- This may refer to two specific people who are always working together. -->
       <column name="notes_pt">Essa expressão idiomática não é um eufemismo, mas é um pouco arriscada. Isso significa que os sujeitos têm algum tipo de relação física. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu ei ole eufemismi, mutta on hieman räikeä. Se tarkoittaa, että tutkittavilla on jonkinlainen fyysinen suhde. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4298,6 +4732,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4305,6 +4740,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4318,6 +4754,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">шпионаж</column>
       <column name="definition_zh_HK">間諜活動</column>
       <column name="definition_pt">espionagem</column>
+      <column name="definition_fi">vakoilu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoq:v}, {ghoqwI':n}</column>
@@ -4328,6 +4765,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4337,6 +4775,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4344,6 +4783,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4357,6 +4797,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">отключиться (отключиться от компьютерной сети) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">脫機（斷開與計算機網絡的連接） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficar offline (desconectar da rede de computadores)</column>
+      <column name="definition_fi">katkaista yhteys tietoverkkoon, mennä offline-tilaan</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lIn:v:2}</column>
       <column name="see_also"></column>
@@ -4367,6 +4808,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The definition was not given. It's just explained that going offline would use the verb {lInHa':v:nolink}.</column>
       <column name="components">{lIn:v:2}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -4376,6 +4818,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4383,6 +4826,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.25:src}</column>
     </table>
     <table name="mem">
@@ -4396,6 +4840,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">производить, вырабатывать, плодить</column>
       <column name="definition_zh_HK">生產</column>
       <column name="definition_pt">produzir</column>
+      <column name="definition_fi">tuottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIngwI':n}</column>
@@ -4406,6 +4851,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4415,6 +4861,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">generate, create</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4422,6 +4869,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru">генерировать, создавать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4435,6 +4883,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">тип животного, лингта [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物的類型、lingta [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, lingta</column>
+      <column name="definition_fi">eräs eläin, lingta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4445,6 +4894,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru">Крупный дичь, обитающая в {Qo'noS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{Qo'noS:n}的大型野生動物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Animal de caça de grande porte nativo do {Qo'noS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Qo'noS:n}: n alkuperäiskansojen suuri riistaeläin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4454,6 +4904,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4461,6 +4912,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -4474,6 +4926,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">генератор</column>
       <column name="definition_zh_HK">發電機、生產者</column>
       <column name="definition_pt">gerador</column>
+      <column name="definition_fi">generaattori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoS lIngwI':n}, {woj choHwI':n}, {pIvghor lIngwI':n}</column>
@@ -4484,6 +4937,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lIng:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4493,6 +4947,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4500,6 +4955,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -4513,6 +4969,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">окружать, сгонять</column>
       <column name="definition_zh_HK">圍捕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">arredondar para cima</column>
+      <column name="definition_fi">kerätä, koota yhteen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boS:v}, {yIr:v}</column>
@@ -4523,6 +4980,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was confirmed to mean to cause to gather in one place, as with prisoners or livestock.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4532,6 +4990,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4539,6 +4998,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 18 (2011):src}</column>
     </table>
     <table name="mem">
@@ -4552,6 +5012,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">застрять, зайти в тупик при решении какой-то проблемы</column>
       <column name="definition_zh_HK">陷入困境（精神上、問題） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficar preso (mentalmente, em um problema)</column>
+      <column name="definition_fi">olla jumissa (henkisesti, ongelman kanssa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4562,6 +5023,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru">Это означает застрять, подобно тому, как вы не можете решить алгебраическое уравнение или разгадать кроссворд.</column>
       <column name="notes_zh_HK">這意味著當您無法解決代數問題或填字遊戲時就陷入困境。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa ficar preso como quando você não pode resolver um problema de álgebra ou palavras cruzadas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa jumittumista kuten silloin, kun et pysty ratkaisemaan algebra-ongelmaa tai ristisanatehtävää. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">To "be licked" is to be soundly defeated by something.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4571,6 +5033,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4578,6 +5041,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4591,6 +5055,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">ночная птица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一隻夜行鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro noturno</column>
+      <column name="definition_fi">eräs yölintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -4601,6 +5066,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Edward Lear was the author of the poem "The Owl and the Pussycat".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4610,6 +5076,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">owl</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4617,6 +5084,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4630,6 +5098,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">Л'Релл</column>
       <column name="definition_zh_HK">L'RELL [AUTOTRANSLATED]</column>
       <column name="definition_pt">L'Rell</column>
+      <column name="definition_fi">L'Rell</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gha'vIq:n:name}, {SIlreq:n:name}, {to'ratlh:n:name}</column>
@@ -4640,6 +5109,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru">Она последовательница {tIquvma:n:name}.</column>
       <column name="notes_zh_HK">她是{tIquvma:n:name}的追隨者。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ela é seguidora de {tIquvma:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on {tIquvma:n:name}-seuraaja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4649,6 +5119,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4656,6 +5127,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Battle at the Binary Stars:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -4669,6 +5141,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">регулировать, приспосабливать, выверять, приспособлять, прилаживать</column>
       <column name="definition_zh_HK">調整 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ajustar, definir, afinar</column>
+      <column name="definition_fi">säätää, virittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SeH:v}, {choH lISbogh Hap'e':n}</column>
@@ -4679,6 +5152,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4688,6 +5162,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">moderate</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4695,6 +5170,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4708,6 +5184,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">get on (to) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沾到） [AUTOTRANSLATED]</column>
       <column name="definition_pt">continuar (para)</column>
+      <column name="definition_fi">nousta, astua (alukseen tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lItHa':v}</column>
       <column name="see_also">{lIgh:v}, {lupwI':n}, {ten:v}, {tIj:v}, {yong:v}, {'el:v}</column>
@@ -4718,6 +5195,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4727,6 +5205,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4734,6 +5213,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4747,6 +5227,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">сойти [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">下車了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">descer (de)</column>
+      <column name="definition_fi">poistua (aluksesta tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lIt:v}</column>
       <column name="see_also">{lIgh:v}, {lupwI':n}</column>
@@ -4757,6 +5238,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lIt:v}, {-Ha':v}</column>
       <column name="examples">
@@ -4768,6 +5250,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4775,6 +5258,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {PK:src}, [3] {HQ 3.3, p.10-13, Sept. 1994:src}</column>
     </table>
     <table name="mem">
@@ -4788,6 +5272,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">дверная рама [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">門框 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estrutura da porta</column>
+      <column name="definition_fi">ovenkarmi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lojmIt:n}, {qal'aq:n}</column>
@@ -4798,6 +5283,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru">Это нечто, предназначенное для удержания двери или ворот, независимо от того, есть дверь или ворота или нет. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">無論門或門是否在那裡，都是用來固定門或門的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é algo construído para segurar uma porta ou portão, esteja uma porta ou portão lá ou não. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on rakennettu oven tai portin pitämiseen riippumatta siitä, onko ovi tai portti siellä vai ei. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4807,6 +5293,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4814,6 +5301,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.11:src}</column>
     </table>
     <table name="mem">
@@ -4827,6 +5315,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">гранит [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">花崗岩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">granito</column>
+      <column name="definition_fi">graniitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nagh:n}, {Hotnagh:n}</column>
@@ -4837,6 +5326,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru">Это относится к группе магматических пород, состоящих в основном из полевого шпата и кварца. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指一組主要由長石和石英組成的火成岩。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um grupo de rochas ígneas compostas principalmente de feldspato e quartzo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa magmakivikokonaisuuteen, joka koostuu pääasiassa maasälpästä ja kvartsista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4846,6 +5336,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4853,6 +5344,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4866,6 +5358,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="definition_ru">замена, замена, временный суррогат [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">替代、替身、臨時代理 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Substituto, representante, substituição temporária</column>
+      <column name="definition_fi">(väliaikainen) korvike, sijainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ru':v:1}, {QujwI' lIw:n}, {qa'meH:n}, {velqa':n}, {lIl:v}</column>
@@ -4876,6 +5369,7 @@ Quando um computador (ou sistema de computador) está online, ele está "compart
       <column name="notes_ru">Это относится к временной замене или замене. Чтобы обозначить постоянную замену, используйте {qa'meH:n}.[2]. Для обозначения чего-либо или кого-то, кто имитирует или исполняет что-то или кого-то другого, без замены, см. {lIlwI':n}.[4] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指臨時替代品或替代品。要表示永久替換，請使用{qa'meH:n}.[2]要引用未經模仿的模仿或模仿某物或某物的某物或某物，請參見{lIlwI':n}.[4] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um substituto temporário ou substituto. Para indicar uma substituição permanente, use {qa'meH:n}.[2] Para se referir a algo ou alguém que simula ou representa algo ou alguém, sem substituição, consulte {lIlwI':n}.[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa väliaikaiseen korvaamiseen tai stand-iniin. Jos haluat tarkoittaa pysyvää korvausta, käytä sanaa {qa'meH:n}.[2] Jos haluat viitata johonkin tai johonkin, joka simuloi tai esiintyy toisena tai jonkun toisena ilman korvaamista, katso {lIlwI':n}.[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a substitute in "lieu" of something.
 
 This was used to refer to "variables" (a memory location used for storing data in a computer program) in Klingon Blockly.[3]</column>
@@ -4887,6 +5381,7 @@ This was used to refer to "variables" (a memory location used for storing data i
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">variable</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4894,6 +5389,7 @@ This was used to refer to "variables" (a memory location used for storing data i
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 5.1, Mar. 1996 p.10:src}, [3] {KLI mailing list 2014.11.26:src}, [4] {KLI mailing list 2016.11.25:src}</column>
     </table>
         <table name="mem">
@@ -4907,6 +5403,7 @@ This was used to refer to "variables" (a memory location used for storing data i
           <column name="definition_ru">местоимение [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">代詞 [AUTOTRANSLATED]</column>
           <column name="definition_pt">pronome</column>
+      <column name="definition_fi">pronomini</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4917,6 +5414,7 @@ This was used to refer to "variables" (a memory location used for storing data i
           <column name="notes_ru">Это относится только к полным словам, а не к префиксам ({moHaq:n}). [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這僅適用於完整單詞，而不適用於前綴（{moHaq:n}）。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso se aplica apenas a palavras completas, não a prefixos (que são {moHaq:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä koskee vain kokonaisia ​​sanoja, ei etuliitteitä (jotka ovat {moHaq:n}). [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{lIw:n}, {mu':n}</column>
           <column name="examples"></column>
@@ -4926,6 +5424,7 @@ This was used to refer to "variables" (a memory location used for storing data i
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4933,6 +5432,7 @@ This was used to refer to "variables" (a memory location used for storing data i
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -4946,6 +5446,7 @@ This was used to refer to "variables" (a memory location used for storing data i
           <column name="definition_ru">наложница [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">妾 [AUTOTRANSLATED]</column>
           <column name="definition_pt">concubina</column>
+      <column name="definition_fi">jalkavaimo, sivuvaimo</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4970,6 +5471,9 @@ Endast gifta personer kunde ha en partner som kan betraktas som {lIwnal:n:nolink
           <column name="notes_pt">As conotações culturais são um pouco diferentes da palavra inglesa "concubine". Na cultura klingon, tudo o que está associado a um {lIwnal:n:nolink} carece de honra, o que não é necessariamente o caso das concubinas ou cortesãs de um rei (terráqueo).
 
 Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwnal:n:nolink}. Um {lIwnal:n:nolink} pode ser masculino ou feminino, então se for necessário distinguir, use {loD lIwnal:n@@loD:n, lIwnal:n} ou {be' lIwnal:n@@be':n, lIwnal:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kulttuurinen merkitys on hieman erilainen kuin englanninkielinen sana "sivuvaimo". Klingonin kulttuurissa kaikesta, mikä liittyy {lIwnal:n:nolink}: een, puuttuu kunnia, mikä ei välttämättä päde (Terran) kuninkaan sivuvaimoihin tai kurtisaaneihin.
+
+Ainoastaan ​​naimisissa olevilla ihmisillä voisi olla kumppani, jota voidaan pitää {lIwnal:n:nolink}: na. {lIwnal:n:nolink} voi olla mies tai nainen, joten jos se on tarpeen erottaa, käytä {loD lIwnal:n@@loD:n, lIwnal:n} tai {be' lIwnal:n@@be':n, lIwnal:n}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{lIw:n}, {nal:n:hyp}</column>
           <column name="examples"></column>
@@ -4979,6 +5483,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4986,6 +5491,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
         </table>
     <table name="mem">
@@ -4999,6 +5505,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="definition_ru">комета</column>
       <column name="definition_zh_HK">彗星</column>
       <column name="definition_pt">cometa</column>
+      <column name="definition_fi">komeetta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chunDab:n}, {ghopDap:n}</column>
@@ -5009,6 +5516,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Possibly a reference Halley's Comet.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5018,6 +5526,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5025,6 +5534,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5038,6 +5548,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="definition_ru">быть полезным, быть пригодным</column>
       <column name="definition_zh_HK">有用</column>
       <column name="definition_pt">ser útil</column>
+      <column name="definition_fi">olla hyödyllinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lo':v}, {lo'laH:v}</column>
@@ -5048,6 +5559,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{Qu'vaD lI' net tu'bej.:sen}</column>
@@ -5057,6 +5569,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5064,6 +5577,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5077,6 +5591,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="definition_ru">передавать данные(в какое-то место)</column>
       <column name="definition_zh_HK">傳輸數據（到一個地方） [AUTOTRANSLATED]</column>
       <column name="definition_pt">transmitir dados (para um local)</column>
+      <column name="definition_fi">lähettää dataa (sisäänpäin)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lab:v}</column>
       <column name="see_also">{Hev:v}</column>
@@ -5087,6 +5602,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="notes_ru">Это может означать "скачивание" или "загрузка", в зависимости от контекста</column>
       <column name="notes_zh_HK">根據上下文，這可能意味著“下載”或“上傳”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode significar "download" ou "upload", dependendo do contexto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi tarkoittaa "ladata" tai "ladata" kontekstista riippuen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5096,6 +5612,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">download, upload</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5103,6 +5620,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="search_tags_ru">скачивание, загрузка</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5116,6 +5634,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="definition_ru">плазма [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">等離子體</column>
       <column name="definition_pt">plasma</column>
+      <column name="definition_fi">plasma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lep:n}, {betgham:n}, {SIp:n}</column>
@@ -5126,6 +5645,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="notes_ru">Это относится к состоянию материи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指物質狀態。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um estado da matéria. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa aineen tilaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">LCD and plasma are both types of flatscreen television technologies.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5135,6 +5655,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5142,6 +5663,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -5155,6 +5677,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="definition_ru">подчиняться, повиноваться</column>
       <column name="definition_zh_HK">遵守、服從</column>
       <column name="definition_pt">obedecer</column>
+      <column name="definition_fi">totella</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lobHa':v}</column>
       <column name="see_also">{ra':v:1}, {HeQ:v}, {wem:v}, {pab:v}</column>
@@ -5165,6 +5688,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5174,6 +5698,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5181,6 +5706,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5194,6 +5720,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="definition_ru">Неподчиняться, неповиноваться</column>
       <column name="definition_zh_HK">違 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desobedecer</column>
+      <column name="definition_fi">olla tottelematta, rikkoa (lakia tai sääntöä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lob:v}</column>
       <column name="see_also">{tlhIv:v}</column>
@@ -5204,6 +5731,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lob:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -5213,6 +5741,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5220,6 +5749,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5233,6 +5763,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="definition_ru">усы</column>
       <column name="definition_zh_HK">鬍、髭</column>
       <column name="definition_pt">bigode</column>
+      <column name="definition_fi">viikset</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rol:n}</column>
@@ -5243,6 +5774,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="notes_ru">Это относится к волосам на верхней губе.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指上唇的頭髮。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a cabelos no lábio superior.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa hiuksiin ylähuulella[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5252,6 +5784,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">moustache</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5259,6 +5792,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="search_tags_ru">усы</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5272,6 +5806,7 @@ Somente pessoas casadas podem ter um parceiro que possa ser considerado um {lIwn
       <column name="definition_ru">быть частью, составлять часть, составлять часть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">構成一部分，構成一部分 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser uma fração de, constituir uma parte de</column>
+      <column name="definition_fi">olla osa jotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yugh:v}, {boqHa''egh:v}</column>
@@ -5296,6 +5831,9 @@ Om det är lämpligt i en matematisk diskussion används inget prefix även om n
       <column name="notes_pt">Isso é usado para expressar frações em matemática.
 
 Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que o denominador seja um, mesmo que seja um pouco aberrante gramaticalmente. (Não se diria {wa' luloch wej:sen@@wa':n:num, lu-:v, loch:v, wej:n:num}.) [1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään murtolukujen ilmaisemiseen matematiikassa.
+
+Tarvittaessa matemaattisessa keskustelussa etuliitettä ei käytetä, vaikka nimittäjä on yksi, vaikka tämä onkin kieliopillisesti hieman poikkeava. (Ei voida sanoa {wa' luloch wej:sen@@wa':n:num, lu-:v, loch:v, wej:n:num}.) [1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5309,6 +5847,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5316,6 +5855,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5329,6 +5869,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">мужчина, самец</column>
       <column name="definition_zh_HK">男性、男人</column>
       <column name="definition_pt">homem, macho</column>
+      <column name="definition_fi">mies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{be':n}, {loDnal:n}</column>
@@ -5339,6 +5880,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru">Суффикс множественного числа этого слова зависит от того, используется ли оно для обозначения существ, способных к языку (см. {-pu':n:suff}) или нет (см. {-mey:n:suff}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此單詞的複數形式的後綴取決於它是否用於表示具有語言能力的人（請參閱{-pu':n:suff}）（請參見{-mey:n:suff}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O sufixo para o plural desta palavra depende se é usado para se referir a seres capazes de linguagem (veja {-pu':n:suff}) ou não (veja {-mey:n:suff}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan monikon loppuliite riippuu siitä, käytetäänkö sitä viittaamaan olentoja, jotka osaavat kieltä (katso {-pu':n:suff}) vai ei (katso {-mey:n:suff}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Lord".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5348,6 +5890,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5355,6 +5898,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5368,6 +5912,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">Я не веселый мужчина</column>
       <column name="definition_zh_HK">我不是快樂人。</column>
       <column name="definition_pt">Eu não sou um homem alegre.</column>
+      <column name="definition_fi">En ole iloinen mies.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5378,6 +5923,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{loD:n}, {Quch:v}, {jIH:n:1}, {-be':v}</column>
       <column name="examples"></column>
@@ -5387,6 +5933,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5394,6 +5941,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.206:src}</column>
     </table>
     <table name="mem">
@@ -5407,6 +5955,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">мальчик</column>
       <column name="definition_zh_HK">男孩</column>
       <column name="definition_pt">garoto</column>
+      <column name="definition_fi">poika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{be'Hom:n}, {puqloD:n}</column>
@@ -5417,6 +5966,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{loD:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -5426,6 +5976,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5433,6 +5984,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5446,6 +5998,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">муж</column>
       <column name="definition_zh_HK">丈夫</column>
       <column name="definition_pt">marido</column>
+      <column name="definition_fi">aviomies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Saw:v}, {be'nal:n}, {'e'nal:n}, {'Ipnal:n}</column>
@@ -5456,6 +6009,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{loD:n}, {nal:n:hyp}</column>
       <column name="examples"></column>
@@ -5465,6 +6019,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5472,6 +6027,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5485,6 +6041,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">брат</column>
       <column name="definition_zh_HK">兄弟</column>
       <column name="definition_pt">irmão</column>
+      <column name="definition_fi">veli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{be'nI':n}</column>
@@ -5495,6 +6052,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru">Шурин будет {loDnI' loDnal:n@@loDnI':n, loDnal:n} или {be'nI' loDnal:n@@be'nI':n, loDnal:n}.</column>
       <column name="notes_zh_HK">“ br子”是{loDnI' loDnal:n@@loDnI':n, loDnal:n}或{be'nI' loDnal:n@@be'nI':n, loDnal:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um "cunhado" é {loDnI' loDnal:n@@loDnI':n, loDnal:n} ou {be'nI' loDnal:n@@be'nI':n, loDnal:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"Veli" on {loDnI' loDnal:n@@loDnI':n, loDnal:n} tai {be'nI' loDnal:n@@be'nI':n, loDnal:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5504,6 +6062,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5511,6 +6070,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5524,6 +6084,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">космос, космическое пространство</column>
       <column name="definition_zh_HK">外太空</column>
       <column name="definition_pt">espaço, espaço sideral</column>
+      <column name="definition_fi">avaruus, ulkoavaruus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngeHbej:n}, {qIb:n}, {'evnagh:n}, {tengchaH:n}, {jogh:n}, {tlhey'at:n}, {'achghej:n}</column>
@@ -5534,6 +6095,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Em Klingon, "espaço profundo" é chamado {logh Hop:n}, literalmente, "espaço distante" .[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonissa "syvä avaruus" on nimeltään {logh Hop:n}, kirjaimellisesti "kaukaa tilaa".[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5544,6 +6106,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5551,6 +6114,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}, [3] {SkyBox 99:src}</column>
     </table>
     <table name="mem">
@@ -5564,6 +6128,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">количество раз (суффикс повторения)</column>
       <column name="definition_zh_HK">次數、重複（後綴）</column>
       <column name="definition_pt">vezes, número de vezes (sufixo de repetição)</column>
+      <column name="definition_fi">... kertaa (toistojohdin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-DIch:n:num,suff}, {'arlogh:ques}, {boq'egh:v}</column>
@@ -5574,6 +6139,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru">Присоединяется к числу, чтобы сформировать обстоятельственное значение. К примеру, {wa'logh:adv} "единожды, один раз" из {wa':n:num} "один", {cha'logh:adv} "дважды, два раза" from {cha':n:num} "два", и так далее.</column>
       <column name="notes_zh_HK">這被附加到一個數字上，形成許多次狀語。例如，來自{wa':n:num}“一個”的{wa'logh:adv}“一次，一次”，來自{cha':n:num}“兩個”的{cha'logh:adv}“兩次，兩次”，依此類推。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é anexado a um número para formar um significado adverbial tantas vezes. Por exemplo, {wa'logh:adv} "uma vez, uma vez" de {wa':n:num} "um", {cha'logh:adv} "duas vezes, duas vezes" de {cha':n:num} "dois" e assim por diante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä liitetään numeroon muodostaen adverbiaalisen merkityksen niin monta kertaa. Esimerkiksi {wa'logh:adv} "kerran, yksi kerta" {wa':n:num}: sta "yksi", {cha'logh:adv} "kahdesti, kaksi kertaa" {cha':n:num}: sta "kaksi" ja niin edelleen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5583,6 +6149,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">repetition suffix</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5590,6 +6157,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru">суффикс повторения</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5603,6 +6171,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">В космосе все воины холодны</column>
       <column name="definition_zh_HK">在太空中，所有戰士都是冷戰士。</column>
       <column name="definition_pt">No espaço, todos os guerreiros são guerreiros frios.</column>
+      <column name="definition_fi">Avaruudessa kaikki soturit ovat valmiita taistelemaan?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5613,6 +6182,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{logh:n}, {-Daq:n}, {Suv:v}, {-rup:v}, {-bogh:v}, {SuvwI':n}, {-pu':n}, {chaH:n}, {Hoch:n}, {SuvwI':n}, {-pu':n}, {-'e':n}</column>
       <column name="examples"></column>
@@ -5622,6 +6192,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5629,6 +6200,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.33:src}</column>
     </table>
     <table name="mem">
@@ -5642,6 +6214,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">планетарий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">天象儀</column>
       <column name="definition_pt">planetário</column>
+      <column name="definition_fi">planetaario</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh chal je 'angweD qach:n}</column>
@@ -5652,6 +6225,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{logh:n}, {chal:n}, {je:conj}, {'angweD:n}</column>
       <column name="examples"></column>
@@ -5661,6 +6235,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5668,6 +6243,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5681,6 +6257,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">planetarium (building) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">天象儀（建筑物）</column>
       <column name="definition_pt">planetário (construção)</column>
+      <column name="definition_fi">planetaario (rakennus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh chal je 'angweD:n}</column>
@@ -5691,6 +6268,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{logh:n}, {chal:n}, {je:conj}, {'angweD:n}, {qach:n}</column>
       <column name="examples"></column>
@@ -5700,6 +6278,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5707,6 +6286,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5720,6 +6300,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">Глубокий космос [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">深空</column>
       <column name="definition_pt">espaço profundo</column>
+      <column name="definition_fi">syvä avaruus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh Hop Hut tengchaH:n}</column>
@@ -5730,6 +6311,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{logh:n}, {Hop:v}</column>
       <column name="examples"></column>
@@ -5739,6 +6321,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5746,6 +6329,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 99:src}</column>
     </table>
     <table name="mem">
@@ -5759,6 +6343,7 @@ Se apropriado em uma discussão matemática, nenhum prefixo é usado, mesmo que 
       <column name="definition_ru">Глубокий космос 9</column>
       <column name="definition_zh_HK">深空九號（太空站）</column>
       <column name="definition_pt">Deep Space Nine</column>
+      <column name="definition_fi">Deep Space Nine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hov leng:n}, {logh mIn:n}</column>
@@ -5790,6 +6375,10 @@ Texten till {SkyBox 99:src} lyder:
 
 O texto de {SkyBox 99:src} diz:
 ▶ {loS... qIb HeHDaq, 'u' SepmeyDaq Sovbe'lu'bogh lenglu'meH He ghoSlu'bogh retlhDaq 'oHtaH. HaDlu'meH, QuSlu'meH, SuDlu'meH lojmIt Da logh Hop Hut tengchaH. vaj loghDaq lenglaHtaH Humanpu'. veH Qav 'oH logh'e'.:sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on federaation avaruusaseman nimi.
+
+{SkyBox 99:src}:n teksti kuuluu:
+▶ {loS... qIb HeHDaq, 'u' SepmeyDaq Sovbe'lu'bogh lenglu'meH He ghoSlu'bogh retlhDaq 'oHtaH. HaDlu'meH, QuSlu'meH, SuDlu'meH lojmIt Da logh Hop Hut tengchaH. vaj loghDaq lenglaHtaH Humanpu'. veH Qav 'oH logh'e'.:sen:nolink}</column>
       <column name="hidden_notes"></column>
       <column name="components">{logh Hop:n}, {Hut:n:num}, {tengchaH:n}</column>
       <column name="examples"></column>
@@ -5799,6 +6388,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5806,6 +6396,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 99:src}</column>
     </table>
     <table name="mem">
@@ -5819,6 +6410,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">червоточина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蟲洞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">buraco de minhoca</column>
+      <column name="definition_fi">madonreikä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh Hop Hut tengchaH:n}</column>
@@ -5829,6 +6421,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{logh:n}, {mIn:n}</column>
       <column name="examples"></column>
@@ -5838,6 +6431,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5845,6 +6439,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5858,6 +6453,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">Четверг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星期四</column>
       <column name="definition_pt">Quinta-feira</column>
+      <column name="definition_fi">torstai</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hogh:n}</column>
@@ -5868,6 +6464,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This refers to a line in "Lady Madonna" by The Beatles: "Thursday night your stockings needed mending." (See {paSlogh:n}.)</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5877,6 +6474,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5884,6 +6482,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -5897,6 +6496,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">единица измерения, 1,25 светового года [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">計量單位、1.25光年 [AUTOTRANSLATED]</column>
       <column name="definition_pt">unidade de medida, 1,25 anos-luz</column>
+      <column name="definition_fi">eräs pituuden yksikkö, n. 1,25 valovuotta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuq:n}, {qelI'qam:n}</column>
@@ -5907,6 +6507,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a "space foot".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5916,6 +6517,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5923,6 +6525,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5936,6 +6539,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">грудь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">胸部</column>
       <column name="definition_pt">peito</column>
+      <column name="definition_fi">rinta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{porgh:n}, {ro:n}, {chor:n:1}</column>
@@ -5946,6 +6550,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru">Это относится к верхней передней части туловища. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指軀幹的上前部。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à parte superior frontal do tronco. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa vartalon yläosaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5955,6 +6560,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5962,6 +6568,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5975,6 +6582,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">управлять, вести дела, назначать</column>
       <column name="definition_zh_HK">管轄、執政</column>
       <column name="definition_pt">administrar</column>
+      <column name="definition_fi">hallita (korkealla tasolla)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{che':v}, {qum:v}, {teblaw':n}, {loH:n}, {loHwI':n}</column>
@@ -5985,6 +6593,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5994,6 +6603,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6001,6 +6611,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6014,6 +6625,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">администрация, администрирование, управление</column>
       <column name="definition_zh_HK">行政</column>
       <column name="definition_pt">administração</column>
+      <column name="definition_fi">hallinto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qum:n}, {teblaw':n}, {loH:v}</column>
@@ -6024,6 +6636,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6033,6 +6646,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6040,6 +6654,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6053,6 +6668,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">ЦПУ [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">中央處理器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">CPU</column>
+      <column name="definition_fi">prosessori, CPU</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{De'wI' SoSbor'a':n}</column>
@@ -6063,6 +6679,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru">Это относится к центральному процессору компьютера. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指計算機的中央處理單元。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à unidade central de processamento de um computador. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tietokoneen keskusyksikköön. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{loH:n}, {jan:n:1}</column>
       <column name="examples"></column>
@@ -6072,6 +6689,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6079,6 +6697,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -6092,6 +6711,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">магистрат</column>
       <column name="definition_zh_HK">執政官、法官、判官</column>
       <column name="definition_pt">magistrado</column>
+      <column name="definition_fi">tuomari, raatimies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loH:v}</column>
@@ -6102,6 +6722,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{loH:v}, {-wI':v}</column>
       <column name="examples">
@@ -6112,6 +6733,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6119,6 +6741,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -6132,6 +6755,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">не быть там больше</column>
       <column name="definition_zh_HK">一切都消失了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">não estar mais</column>
+      <column name="definition_fi">olla kokonaan käytetty, olla loppu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{buy':v}, {Huj:v:2}, {natlh:v:1}</column>
@@ -6142,6 +6766,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6151,6 +6776,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be depleted</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6158,6 +6784,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru">быть истощенным</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6171,6 +6798,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">дверь, ворота, шлюз, калитка</column>
       <column name="definition_zh_HK">門</column>
       <column name="definition_pt">porta, portão</column>
+      <column name="definition_fi">ovi, portti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jI'ev:n}, {lIvqa'nan:n}, {DIn:n}, {Qorwagh:n}, {poS:v}, {SoQ:v}, {ngaQ:v}, {HIchDal:n}, {Durghang:n}, {notron:n}</column>
@@ -6181,6 +6809,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Locksmith".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6190,6 +6819,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hatch</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6197,6 +6827,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru">люк</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6210,6 +6841,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">Никто не подслушивает у открытой двери. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沒有人會在敞開的門邊偷聽。</column>
       <column name="definition_pt">Ninguém escuta uma porta aberta.</column>
+      <column name="definition_fi">Kukaan ei salakuuntele avoimen oven luona.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6220,6 +6852,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lojmIt:n}, {poS:v}, {-Daq:n}, {Daq:v}, {pagh:n:1}</column>
       <column name="examples"></column>
@@ -6229,6 +6862,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">secrecy proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6236,6 +6870,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -6249,6 +6884,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">суббота [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星期六</column>
       <column name="definition_pt">sábado</column>
+      <column name="definition_fi">lauantai</column>
       <column name="synonyms">{ghInjaj:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{Hogh:n}</column>
@@ -6259,6 +6895,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru">{lojmItjaj:n:nolink} обычно используется в формальных случаях, в то время как и он, и {ghInjaj:n:nolink} используются, по-видимому, без разбора, в противном случае. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{lojmItjaj:n:nolink}傾向於在正式場合使用，而{ghInjaj:n:nolink}和DONOTTRANSLATE2都被使用，否則似乎是不加區別的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {lojmItjaj:n:nolink} tende a ser usado em ocasiões formais, enquanto o {ghInjaj:n:nolink} é usado, aparentemente indiscriminadamente, caso contrário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{lojmItjaj:n:nolink}: ää käytetään yleensä muodollisissa tilaisuuksissa, kun taas sekä sitä että {ghInjaj:n:nolink}: ta käytetään näennäisesti valikoimattomasti, muuten. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This refers to a line in "Being for the Benefit of Mr. Kite!" by The Beatles, which partly goes "on Saturday at Bishopsgate".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6268,6 +6905,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6275,6 +6913,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -6288,6 +6927,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">be in a stance, be in a pose (people, animals, or martial arts) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">站立、姿勢（人、動物或武術） [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar em uma posição, em uma pose (pessoas, animais ou artes marciais)</column>
+      <column name="definition_fi">olla asennossa (ihmisistä, eläimistä, esim. taistelulajeissa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lol:n}, {moQbara':n}, {lol:v:2}</column>
@@ -6298,6 +6938,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="notes_ru">Глагол для обозначения позы или стойки - {much:v:3}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">用於打擊姿勢或姿態的動詞是{much:v:3}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O verbo a ser usado para fazer pose ou postura é {much:v:3}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Pose tai asenne lyömiseksi käytettävä verbi on {much:v:3}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Lol about".</column>
       <column name="components"></column>
       <column name="examples">
@@ -6308,6 +6949,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6315,6 +6957,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}, [2] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -6328,6 +6971,7 @@ O texto de {SkyBox 99:src} diz:
       <column name="definition_ru">быть в позиции [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">態度（飛機） [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar em uma altitude (aeronave)</column>
+      <column name="definition_fi">olla lentoasennossa (lentokoneesta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dav:v:2}, {Der:v:2}, {jer:v}, {jIm:v:2}, {ron:v:2}, {tor:v:2}, {taH:v:2}, {'or:v}, {lol:v:1}</column>
@@ -6344,6 +6988,13 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Huomaa, että on olemassa homofoninen verbi {lol:v:1}, jota voidaan soveltaa ihmisiin tai eläimiin.
+
+Joillakin verbiliitteillä on tarkka merkitys käytettäessä tätä verbiä, kun niitä käytetään lentokoneisiin tai avaruusaluksiin:
+▶ {lolchu':v} "ole oikeassa asennossa"
+▶ {lolchu'taH:v} "säilytä oikea asenne"
+▶ {lolmoH:v} "liikkumavaraa (lentokone) asennossa"
+▶ {loltaH:v} "säilytä asenne" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6353,6 +7004,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6360,6 +7012,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -6373,6 +7026,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">определенная позиция в боевых искусствах формы Мокбара [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Mok'bara武術中的一個特定位置 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma posição específica nas artes marciais forma Mok'bara</column>
+      <column name="definition_fi">eräs asento Mok'bara-taistelulajissa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moQbara':n}, {lol:v:1}</column>
@@ -6383,6 +7037,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">Это относится к конкретной позиции боевых искусств, и не является общим термином для «позиции», для которой см. {tonSaw':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指一種特定的武術立場，而不是“立場”的統稱，有關其詳細信息，請參見{tonSaw':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa tiettyyn taistelulajien viritykseen, eikä se ole yleinen termi "viritys", jota varten katso {tonSaw':n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6392,6 +7047,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6399,6 +7055,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}, [2] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -6412,6 +7069,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">be in a correct attitude (aircraft) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">保持正確的態度（飛機） [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar em uma altitude correta (aeronave)</column>
+      <column name="definition_fi">olla oikeassa lentoasennossa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6422,6 +7080,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lol:v:2}, {-chu':v}</column>
       <column name="examples"></column>
@@ -6431,6 +7090,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6438,6 +7098,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -6451,6 +7112,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">поддерживать правильное отношение (самолет) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">保持正確的態度（飛機） [AUTOTRANSLATED]</column>
       <column name="definition_pt">manter uma altitude correta (aeronave)</column>
+      <column name="definition_fi">ylläpitää oikeaa lentoasentoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6461,6 +7123,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lolchu':v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -6470,6 +7133,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6477,6 +7141,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -6490,6 +7155,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">маневрировать (самолет) быть в положении [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">機動（飛機）態度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">manobra (uma aeronave) para estar em uma altitude</column>
+      <column name="definition_fi">ohjata (lentokonetta) lentoasentoon</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6500,6 +7166,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lol:v:2}, {-moH:v}</column>
       <column name="examples">
@@ -6510,6 +7177,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6517,6 +7185,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -6530,6 +7199,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">двигатели контроля положения</column>
       <column name="definition_zh_HK">態度控制推進器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">propulsores de controle de altitude</column>
+      <column name="definition_fi">ohjausmoottorit, ohjausraketit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuyDaH:n}, {'eDSeHcha:n}</column>
@@ -6540,6 +7210,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">Это слово во множественном числе. Его форма в единственном числе неизвеста.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta palavra é plural. Sua forma singular é desconhecida. Parece consistir nos elementos {lol:v:2}, {SeH:v} e {cha:n} ou em seus homofones. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on monikko. Sen yksikkömuotoa ei tunneta. Se näyttää koostuvan elementeistä {lol:v:2}, {SeH:v} ja {cha:n} tai niiden homofoneista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6549,6 +7220,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6556,6 +7228,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6569,6 +7242,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">поддерживать отношение (самолет) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">保持態度（飛機） [AUTOTRANSLATED]</column>
       <column name="definition_pt">manter uma altitude (uma aeronave)</column>
+      <column name="definition_fi">ylläpitää lentoasentoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6579,6 +7253,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lol:v:2}, {-taH:v}</column>
       <column name="examples"></column>
@@ -6588,6 +7263,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6595,6 +7271,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -6608,6 +7285,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">труп</column>
       <column name="definition_zh_HK">屍體</column>
       <column name="definition_pt">cadáver</column>
+      <column name="definition_fi">(kuollut) ruumis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mol:v}, {mol:n}, {nol:n}</column>
@@ -6618,6 +7296,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {mol:v} and {mol:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6627,6 +7306,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6634,6 +7314,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6647,6 +7328,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">покидать, оставлять, бросать</column>
       <column name="definition_zh_HK">拋棄、廢棄、遺棄</column>
       <column name="definition_pt">abandonar</column>
+      <column name="definition_fi">luopua, hylätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choS:v}, {woD:v:1}</column>
@@ -6657,6 +7339,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Left a"lone".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6666,6 +7349,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6673,6 +7357,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6686,6 +7371,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">наблюдать, соблюдать, вести наблюдения, праздновать(ритуал)</column>
       <column name="definition_zh_HK">觀察、慶祝（一種儀式） [AUTOTRANSLATED]</column>
       <column name="definition_pt">observar, celebrar (um ritual)</column>
+      <column name="definition_fi">seurata, toimittaa (rituaali)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lop:n}</column>
@@ -6696,6 +7382,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6707,6 +7394,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
 ▶ {ja'chuq Dalopchu'. Qang Damoj.:sen:nolink} "Завершите обряд посвящения, чтобы стать канцлером."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6714,6 +7402,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6727,6 +7416,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">празднование</column>
       <column name="definition_zh_HK">慶典 [AUTOTRANSLATED]</column>
       <column name="definition_pt">celebração</column>
+      <column name="definition_fi">juhla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lop:v}, {yupma':n}, {lopno':n}, {qelHay'ya:n}</column>
@@ -6737,6 +7427,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6746,6 +7437,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">holiday</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6753,6 +7445,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru">праздник</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6766,6 +7459,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">празднование, званый вечер</column>
       <column name="definition_zh_HK">派對、慶祝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">festa, celebração</column>
+      <column name="definition_fi">juhlat, festivaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lop:v}, {lop:n}, {nentay:n}, {yupma':n}</column>
@@ -6776,6 +7470,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">Это событие, на которое приглашаются духи предков. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這項活動邀請了祖先的精神。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um evento para o qual os espíritos dos antepassados ​​são convidados. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tapahtuma, johon kutsutaan esi-isien henkiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{lop:n}, {no':n}</column>
       <column name="examples"></column>
@@ -6785,6 +7480,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6792,6 +7488,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -6805,6 +7502,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">немного, слегка, чуть-чуть, едва</column>
       <column name="definition_zh_HK">稍微、略為</column>
       <column name="definition_pt">ligeiramente, um pouco</column>
+      <column name="definition_fi">hieman, vähän, jossain määrin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{loQHa':adv:hyp}, {-qu':v:suff}</column>
       <column name="see_also">{tlhoy:adv}, {tlhoS:adv}, {-law':v:suff}</column>
@@ -6815,6 +7513,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6824,6 +7523,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6831,6 +7531,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6844,6 +7545,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">Воин не жалуется на физический дискомфорт</column>
       <column name="definition_zh_HK">戰士不會抱怨身體不適。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Um guerreiro não reclama de desconforto físico.</column>
+      <column name="definition_fi">Soturi ei valita fyysisestä epämukavuudesta.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6854,6 +7556,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{loQ:adv}, {'oy':v}, {-DI':v}, {SuvwI':n}, {bep:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -6863,6 +7566,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6870,6 +7574,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.46:src}</column>
     </table>
     <table name="mem">
@@ -6883,6 +7588,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">вымереть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滅絕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser extinto</column>
+      <column name="definition_fi">olla sukupuutossa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIntlher:n}</column>
@@ -6893,6 +7599,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">Это относится к ранее живым существам, а не, например, к вулканам.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是以前的生物，而不是指火山。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a coisas vivas anteriormente, e não, por exemplo, a vulcões.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa aiemmin eläviin olentoihin, ei esimerkiksi tulivuoriin.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6902,6 +7609,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6909,6 +7617,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6922,6 +7631,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">cousin (child of {'IrneH:n} or {'e'mam:n}) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">堂兄（{'IrneH:n}的孩子或{'e'mam:n}） [AUTOTRANSLATED]</column>
       <column name="definition_pt">primo (filho de {'IrneH:n} ou {'e'mam:n})</column>
+      <column name="definition_fi">serkku (äidin veljen ({'IrneH:n}) tai isän sisaren ({'e'mam:n}) lapsi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tey':n:0}, {vIn:n}, {yur:n}, {lor:n:2}</column>
@@ -6932,6 +7642,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">Это слово относится к ребенку от брата матери или от сестры отца (т. Е. "Кузены"). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞是指一個人的母親的兄弟孩子或一個人的父親的姐妹孩子（即“跨表兄弟”）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se ao filho do irmão da mãe ou ao filho da irmã do pai (ou seja, "primos cruzados"). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa äitinsä veljen lapseen tai isänsä sisaren lapseen (eli "ristiserkkuihin"). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6941,6 +7652,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6948,6 +7660,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -6961,6 +7674,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">племянник племянница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">侄子侄女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sobrinho, sobrinha</column>
+      <column name="definition_fi">sisarenpoika tai sisarentytär (miehen sisaren lapsi); veljenpoika tai veljentytär (naisen veljen lapsi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lor:n:1}, {tey':n:2}</column>
@@ -6971,6 +7685,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">Для мужчины это слово относится к ребенку его сестры. Для женщины это слово относится к ребенку ее брата. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於一個男人來說，這個詞指的是他姐姐的孩子。對於一個女人來說，這個詞指的是她哥哥的孩子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para um homem, essa palavra se refere a um filho de sua irmã. Para uma mulher, essa palavra se refere a um filho de seu irmão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Miehelle tämä sana viittaa sisarensa lapseen. Naiselle tämä sana viittaa veljensä lapseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6980,6 +7695,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6987,6 +7703,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -7000,6 +7717,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">двоюродная сестра, племянница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">女錶弟、侄女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prima do sexo feminino, sobrinha</column>
+      <column name="definition_fi">naispuolinen serkku (äidin veljen tytär tai isän sisaren tytär), sisarentytär (miehen sisaren tytär), veljentytär (naisen veljen tytär)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7010,6 +7728,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">{lor:n:0} женского пола, то есть двоюродный брат, который является дочерью брата своей матери или дочери сестры отца, или племянницей в смысле дочери сестры мужчины или дочери брата женщины. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{lor:n:0}的女性，即是表親，表姐是母親的兄弟女兒或父親的姐姐的女兒，或者是侄子，在男人的姐姐的女兒或女人的兄弟的女兒的意義上。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma {lor:n:0} feminina, isto é, uma prima que é filha do irmão de uma mãe ou filha da irmã de um pai, ou uma sobrinha no sentido de filha da irmã de um homem ou filha do irmão de uma mulher. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nainen {lor:n:0}, eli serkku, joka on äitinsä veljen tytär tai isänsä sisaren tytär tai veljentytär miehen sisaren tyttären tai naisen veljen tyttären merkityksessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{lor:n:0}, {be':n}</column>
       <column name="examples"></column>
@@ -7019,6 +7738,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7026,6 +7746,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -7039,6 +7760,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">кузен, племянник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">男錶弟、侄子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">primo masculino, sobrinho</column>
+      <column name="definition_fi">miespuolinen serkku (äidin veljen poika tai isän sisaren poika), sisarenpoika (miehen sisaren poika), veljenpoika (naisen veljen poika)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7049,6 +7771,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">Мужчина {lor:n:0}, то есть двоюродный брат, который является сыном брата своей матери или сына сестры своего отца, или племянник в смысле сына сестры мужчины или сына брата женщины. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">堂兄，即堂兄，是一個母親的兄弟兒子或一個父親的妹妹的兒子，或者是一個男人的姐姐的兒子或一個女人的兒子的侄子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um {lor:n:0} masculino, isto é, um primo que é filho do irmão de uma mãe ou filho da irmã de um pai, ou um sobrinho no sentido de filho da irmã de um homem ou filho do irmão de uma mulher. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Mies {lor:n:0}, eli serkku, joka on äitinsä veljen poika tai isänsä sisaren poika tai veljenpoika miehen sisaren pojan tai naisen veljen pojan merkityksessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{lor:n:0}, {loD:n}</column>
       <column name="examples"></column>
@@ -7058,6 +7781,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7065,6 +7789,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -7078,6 +7803,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">ждать чего-то</column>
       <column name="definition_zh_HK">等待、等候</column>
       <column name="definition_pt">aguardar (por)</column>
+      <column name="definition_fi">odottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuv:v}, {boH:v}</column>
@@ -7088,6 +7814,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7097,6 +7824,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7104,6 +7832,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7117,6 +7846,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">четыре</column>
       <column name="definition_zh_HK">四</column>
       <column name="definition_pt">quatro</column>
+      <column name="definition_fi">neljä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loS:n:2} (musical tone)</column>
@@ -7127,6 +7857,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7136,6 +7867,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7143,6 +7875,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -7156,6 +7889,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
           <column name="definition_ru">четвертый</column>
           <column name="definition_zh_HK">第四</column>
           <column name="definition_pt">quarto (numeral)</column>
+      <column name="definition_fi">neljäs</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7166,6 +7900,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{loS:n:1,num}, {-DIch:n:num,suff}</column>
           <column name="examples"></column>
@@ -7175,6 +7910,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">4th</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7182,6 +7918,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -7195,6 +7932,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
           <column name="definition_ru">сорок [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">四十 [AUTOTRANSLATED]</column>
           <column name="definition_pt">quarenta</column>
+      <column name="definition_fi">neljäkymmentä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7205,6 +7943,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{loS:n:1,num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -7214,6 +7953,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7221,6 +7961,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -7234,6 +7975,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">четвертый тон неатонической музыкальной гаммы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">第四音非音階音階 [AUTOTRANSLATED]</column>
       <column name="definition_pt">quarto tom da escala musical não-atônica</column>
+      <column name="definition_fi">nonatoonisen musiikkiasteikon neljäs sävel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loS:n:1} (number)</column>
@@ -7244,6 +7986,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin musiikkiasteikon sävyt (katso {yutlhegh:n}) ovat: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2,nolink}, {vagh:n:2}, {jav:n:2}, {Soch:n:2}, {chorgh:n:2}, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DOT{yu:n:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7253,6 +7996,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7260,6 +8004,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7273,6 +8018,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="definition_ru">стечение обстоятельств [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">巧合 [AUTOTRANSLATED]</column>
       <column name="definition_pt">coincidência</column>
+      <column name="definition_fi">yhteensattuma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7283,6 +8029,7 @@ Some of the verb suffixes have a precise meaning when used with this verb, when 
       <column name="notes_ru">Глагол, обычно ассоциируемый с этим: {qaS:v}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tähän yleensä liitetty verbi on {qaS:v}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"42". Four-two-itous (fortuitous).
 
 Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Klingon vocabulary "coincidences".</column>
@@ -7294,6 +8041,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7301,6 +8049,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7314,6 +8063,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">Квадротритикаль</column>
       <column name="definition_zh_HK">四小黑麥</column>
       <column name="definition_pt">quadrotriticale</column>
+      <column name="definition_fi">neliruisvehnä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIr:n}</column>
@@ -7324,6 +8074,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru">Квадротритикаль это четырехдольная гибридизация пшеницы (рода Triticum) и ржи (род Secale).</column>
       <column name="notes_zh_HK">Quadrotriticale是小麥（Triticum屬）和黑麥（Secale屬）的四葉雜交。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quadrotriticale é uma hibridização em quatro lóbulos de trigo (gênero Triticum) e centeio (gênero Secale). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Quadrotriticale on vehnän (Triticum-suku) ja rukiin (Secale-suku) nelilohkoinen hybridisaatio. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{loS:n:1,num}, {pev:n:hyp}</column>
       <column name="examples"></column>
@@ -7333,6 +8084,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hybridisation, wheat, rye, grain</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7340,6 +8092,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru">гибридизация, рожь</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7353,6 +8106,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">четырехугольник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">四角形</column>
       <column name="definition_pt">quadrilátero</column>
+      <column name="definition_fi">nelikulmio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mey':n}, {moHbey:n}, {qarpal:n}, {letbaQ:n}, {meyrI':n}</column>
@@ -7363,6 +8117,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{loS:n:1,num}, {reD:n:2}, {mey':n}</column>
       <column name="examples"></column>
@@ -7372,6 +8127,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7379,6 +8135,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -7392,6 +8149,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">катастрофа</column>
       <column name="definition_zh_HK">災難</column>
       <column name="definition_pt">catástrofe</column>
+      <column name="definition_fi">katastrofi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7402,6 +8160,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru">Это слово и {Qugh:n:1h} в основном взаимозаменяемы. Чтобы сослаться на то, от чего, по всей вероятности, невозможно оправиться (например, потеря {pIraqSIS:n}), {lot:n:nolink} лучше.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞和{Qugh:n:1h}通常可以互換。提到某種不可能恢復的東西（例如{pIraqSIS:n}的損失，{lot:n:nolink}更好）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sana ja {Qugh:n:1h} ovat enimmäkseen vaihdettavissa. {lot:n:nolink} on parempi viitata johonkin, josta todennäköisesti ei voi toipua (kuten {pIraqSIS:n}: n menetys).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Possibly a reference to the Biblical story of Lot.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7411,6 +8170,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7418,6 +8178,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2019.01.09:src}</column>
     </table>
     <table name="mem">
@@ -7431,6 +8192,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">бунтовать, восставать, оказывать сопротивление</column>
       <column name="definition_zh_HK">反叛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rebelar</column>
+      <column name="definition_fi">kapinoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daw':v}, {lotlhwI':n}, {qaD:v}</column>
@@ -7441,6 +8203,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7450,6 +8213,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7457,6 +8221,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7470,6 +8235,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">повстанец, бунтовщик</column>
       <column name="definition_zh_HK">反叛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rebelde</column>
+      <column name="definition_fi">kapinallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lotlh:v}, {Daw':v}, {Daw':n}, {qaD:v}</column>
@@ -7480,6 +8246,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lotlh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7489,6 +8256,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7496,6 +8264,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7509,6 +8278,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">птица, которая бросается в воду, чтобы поймать еду, но не умеет плавать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一隻猛撲入水中的鳥、以捕捉食物、但不能游泳 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro que mergulha na água para pegar comida, mas não sabe nadar</column>
+      <column name="definition_fi">eräs lintu (joka syöksyy veteen etsimään ruokaa, mutta ei osaa uida)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -7519,6 +8289,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7528,6 +8299,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7535,6 +8307,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -7548,6 +8321,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">Ловал</column>
       <column name="definition_zh_HK">Loval [AUTOTRANSLATED]</column>
       <column name="definition_pt">Loval</column>
+      <column name="definition_fi">Loval</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7558,6 +8332,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru">Планета в составе Кардассианского союза</column>
       <column name="notes_zh_HK">Cardassian Union中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta na União Cardassiana. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Cardassian Unionissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7567,6 +8342,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7574,6 +8350,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -7587,6 +8364,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">угадывать, догадываться, отгадывать</column>
       <column name="definition_zh_HK">猜測</column>
       <column name="definition_pt">adivinhar</column>
+      <column name="definition_fi">arvata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghut:v}, {noH:v}, {Sov:v}, {Har:v}, {'Ir:v:1}</column>
@@ -7597,6 +8375,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7606,6 +8385,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7613,6 +8393,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7626,6 +8407,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">иметь индивидуальность, быть харизматичным, быть очаровательным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有個性、有魅力、有魅力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter personalidade, ser carismático, ser charmoso</column>
+      <column name="definition_fi">olla personaallinen, olla karismaattinen, olla viehättävä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7636,6 +8418,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7645,6 +8428,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7652,6 +8436,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Lethe:src}</column>
     </table>
     <table name="mem">
@@ -7665,6 +8450,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">использовать</column>
       <column name="definition_zh_HK">使用</column>
       <column name="definition_pt">usar</column>
+      <column name="definition_fi">käyttää, hyödyntää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lI':v:1}, {lo'laH:v}, {lo':n}</column>
@@ -7675,6 +8461,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7684,6 +8471,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7691,6 +8479,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7704,6 +8493,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">режим(относится к работе какого-то устройства), использование</column>
       <column name="definition_zh_HK">用法、用途</column>
       <column name="definition_pt">uso, modo</column>
+      <column name="definition_fi">käyttö, hyöty, tila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lo':v}</column>
@@ -7714,6 +8504,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined as "use" in {TKDA:src}. The "mode" meaning was explained in a message to the {KLI mailing list:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7723,6 +8514,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7730,6 +8522,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -7743,6 +8536,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">утилита [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">實用</column>
       <column name="definition_pt">Utilitário</column>
+      <column name="definition_fi">käyttö-, hyöty-</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7753,6 +8547,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru">Это предшествует существительному, которое оно изменяет. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它在它所修飾的名詞之前。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso precede o substantivo que ele modifica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä edeltää substantiivia, jota se muuttaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{lo':n}, {law':v}</column>
       <column name="examples">
@@ -7764,6 +8559,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7771,6 +8567,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7784,6 +8581,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">сервисный люк [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">實用門</column>
       <column name="definition_pt">escotilha de serviço</column>
+      <column name="definition_fi">apuluukku [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7794,6 +8592,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lo' law':n}, {lojmIt:n}</column>
       <column name="examples"></column>
@@ -7803,6 +8602,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7810,6 +8610,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7823,6 +8624,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">Быть ценным</column>
       <column name="definition_zh_HK">有價值</column>
       <column name="definition_pt">ser valioso</column>
+      <column name="definition_fi">olla arvokas, olla hyödyllinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lo'laHbe':v}</column>
       <column name="see_also">{Qej:v}, {lI':v:1}</column>
@@ -7833,6 +8635,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru">Это не глагол {lo':v} с суффиксом {-laH:v}.[2]</column>
       <column name="notes_zh_HK">這不是帶後綴{-laH:v}.[2]的動詞{lo':v} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este não é o verbo {lo':v} com o sufixo {-laH:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei ole verbi {lo':v}, jonka pääte on {-laH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7842,6 +8645,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7849,6 +8653,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.11.30:src} (repeated in {s.k 1998.02.23:src})</column>
     </table>
     <table name="mem">
@@ -7862,6 +8667,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">быть бесполезным, быть никчемным</column>
       <column name="definition_zh_HK">毫無價值</column>
       <column name="definition_pt">ser inútil</column>
+      <column name="definition_fi">olla arvoton, olla hyödytön</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lo'laH:v}</column>
       <column name="see_also">{tu'HomI'raH:n}, {qey:v}</column>
@@ -7872,6 +8678,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru">Смотрите {chetvI':n:1} для идиомы, связанной с никчемностью.</column>
       <column name="notes_zh_HK">有關不值錢的習語，請參見{chetvI':n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {chetvI':n:1} para obter um idioma relacionado à inutilidade. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohdasta {chetvI':n:1} on arvottomuuteen liittyvä idioomi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Despite appearing to be composed from {lo':v}, {-laH:v}, and {-be':v}, this word doesn't exactly have the same meaning as the composition of the parts. It means "he/she can't use it", which is what happens to one's hand when one's writer's cramp worsens.</column>
       <column name="components">{lo'laH:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -7881,6 +8688,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">useless</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7888,6 +8696,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru">бесполезность</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7901,6 +8710,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">бесполезность</column>
       <column name="definition_zh_HK">無價值 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inutilidade</column>
+      <column name="definition_fi">arvottomuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7911,6 +8721,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lo'laHbe':v}, {-ghach:v}</column>
       <column name="examples"></column>
@@ -7920,6 +8731,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7927,6 +8739,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7940,6 +8753,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">значение, значимость, ценность</column>
       <column name="definition_zh_HK">價值</column>
       <column name="definition_pt">valor</column>
+      <column name="definition_fi">arvo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7950,6 +8764,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lo'laH:v}, {-ghach:v}</column>
       <column name="examples"></column>
@@ -7959,6 +8774,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7966,6 +8782,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7979,6 +8796,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">упасть (потерять статус) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">墮落、倒灶、下臺</column>
       <column name="definition_pt">cair (sofrer perda de status)</column>
+      <column name="definition_fi">pudota (statuksessa, asemassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIl:v}</column>
@@ -8003,6 +8821,9 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="notes_pt">Veja {pum:v:2} para uma queda literal.
 
 {lu qeng:n:name,nolink} "The Fall of Kang" é um famoso poema de G'trok.[1, p.107] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso kirjaimellinen pudotus kohdasta {pum:v:2}.
+
+{lu qeng:n:name,nolink} "Kangin putoaminen" on G'trokin kuuluisa runo.[1, p.107] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8012,6 +8833,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8019,6 +8841,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8032,6 +8855,7 @@ Marc Okrand has said that he prefers to call the puns or "Easter Eggs" in the Kl
       <column name="definition_ru">Они(действие)-ему/ей/этому</column>
       <column name="definition_zh_HK">他們、它們：他、它</column>
       <column name="definition_pt">eles-ele/ela</column>
+      <column name="definition_fi">he/ne-häntä/sitä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{0:v:pref}</column>
@@ -8050,6 +8874,11 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
 Иногда этот префикс опускается по неизвестным причинам. Хотя это и является ошибкой, это часто упускается из вида, когда ясность не является проблемой, за исключением некоторых ситуаций.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{chaH:n} / {bIH:n}: {ghaH:n} / {'oH:n} = {lu-:v:pref,nolink}
+
+Kun sitä käytetään {-lu':v}: n kanssa, tämä etuliite tarkoittaa "Joku (määrittelemätön aihe) tekee heille jotain".
+
+Tämä etuliite pudotetaan joskus tuntemattomista syistä. Vaikka virhe onkin, tämä jätetään usein huomiotta, kun selkeys ei ole ongelma, paitsi muodollisissa tilanteissa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8059,6 +8888,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">they-him, they-her, they-it</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8066,6 +8896,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.168-172:src}</column>
     </table>
     <table name="mem">
@@ -8079,6 +8910,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">оборудование, экипировка, механизм, шестерня</column>
       <column name="definition_zh_HK">設備、齒輪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">equipamento, engrenagem</column>
+      <column name="definition_fi">laitteet, varusteet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{may'luch:n}, {leng buq:n}, {cham:n}</column>
@@ -8089,6 +8921,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8102,6 +8935,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">technology</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8109,6 +8943,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 3:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -8122,6 +8957,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">быть корректным, быть правым в чем-то</column>
       <column name="definition_zh_HK">是對的、正確的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser certo, correto</column>
+      <column name="definition_fi">olla oikein, olla oikeassa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{muj:v}</column>
       <column name="see_also">{Sor:n}, {qar:v}, {teH:v}, {vIt:v}, {lugh:v}</column>
@@ -8132,6 +8968,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru">Существует идиома {lugh; Sor rur}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{lugh; Sor rur}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {lugh; Sor rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {lugh; Sor rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8141,6 +8978,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8148,6 +8986,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8161,6 +9000,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">дергать</column>
       <column name="definition_zh_HK">猛拉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dar um puxão em</column>
+      <column name="definition_fi">kiskaista, riuhtaista, vetäistä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yuv:v}</column>
       <column name="see_also">{leQ:n}, {luHwI' tIH:n}</column>
@@ -8171,6 +9011,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8180,6 +9021,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pull</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8187,6 +9029,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru">тянуть</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8200,6 +9043,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">заставить (кого-то) признаться или раскрыть секрет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">導致（某人）承認或揭露秘密 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer (alguém) confessar ou revelar um segredo</column>
+      <column name="definition_fi">saada joku tunnustamaan tai paljastamaan salaisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIS:v}, {pegh:v:0}, {pegh:n}</column>
@@ -8210,6 +9054,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Spill one's guts". Note that {luH:n} means "intestine".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8219,6 +9064,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8226,6 +9072,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8239,6 +9086,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">кишка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">腸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">intestino</column>
+      <column name="definition_fi">suolisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{burgh:n}, {chor:n:1}</column>
@@ -8249,6 +9097,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8258,6 +9107,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8265,6 +9115,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8278,6 +9129,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">тяговый луч</column>
       <column name="definition_zh_HK">牽引光束、牽引桿</column>
       <column name="definition_pt">Raio trator</column>
+      <column name="definition_fi">vetosäde</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8288,6 +9140,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{luH:v:1}, {-wI':v}, {tIH:n:1}</column>
       <column name="examples"></column>
@@ -8297,6 +9150,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8304,6 +9158,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2010:src}</column>
     </table>
     <table name="mem">
@@ -8317,6 +9172,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">проигрывать, терпеть поражение</column>
       <column name="definition_zh_HK">失敗、輸（不贏） [AUTOTRANSLATED]</column>
       <column name="definition_pt">falhar, perder (não ganhar)</column>
+      <column name="definition_fi">hävitä, epäonnistua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qap:v:1}</column>
       <column name="see_also">{'ov:v}, {vonlu':v}, {bup:v}, {jegh:v}</column>
@@ -8327,6 +9183,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined as "fail" in {TKD:src}, and as "lose (not win)" in {KGT:src}. In {HQ 2.4:src} it is explained that these are the same word.[3]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8336,6 +9193,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8343,6 +9201,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {HQ 2.4, p.18, Dec. 1993:src}</column>
     </table>
     <table name="mem">
@@ -8356,6 +9215,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">полоса неудач [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">接二連三地失敗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">série de derrotas</column>
+      <column name="definition_fi">tappioputki</column>
       <column name="synonyms">{quvHa'ghach mIr:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8366,6 +9226,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{luj:v}, {-wI':v}, {mIr:n:2}</column>
       <column name="examples"></column>
@@ -8375,6 +9236,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8382,6 +9244,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8395,6 +9258,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">бой, битва (относительно крупный бой) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥、戰鬥（相對重大戰鬥） [AUTOTRANSLATED]</column>
       <column name="definition_pt">lutar, batalhar (luta relativamente grande)</column>
+      <column name="definition_fi">taistella (suhteellisen suuressa taistelussa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suv:v}, {may':n}</column>
@@ -8405,6 +9269,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru">В порядке возрастания жестокости глаголы, используемые для описания военных столкновений: {Qor:v}, {tlhaS:v}, {vay:v}, {lul:v:nolink}, {Hargh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">按照兇猛的升序，用於描述軍事對抗的動詞是：{Qor:v}、{tlhaS:v}、{vay:v}、{lul:v:nolink}、{Hargh:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em ordem crescente de ferocidade, os verbos usados ​​para descrever confrontos militares são: {Qor:v}, {tlhaS:v}, {vay:v}, {lul:v:nolink}, {Hargh:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Armeijan nousevassa järjestyksessä sotilaallisia yhteenottoja kuvaavia verbejä ovat: {Qor:v}, {tlhaS:v}, {vay:v}, {lul:v:nolink}, {Hargh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8414,6 +9279,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8421,6 +9287,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8434,6 +9301,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">убежище, пристанище</column>
       <column name="definition_zh_HK">避難所 [AUTOTRANSLATED]</column>
       <column name="definition_pt">refúgio</column>
+      <column name="definition_fi">turvapaikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qan:v}, {QaD:v:2}</column>
@@ -8444,6 +9312,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This looks like "they ride it", but it's probably a coincidence.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8453,6 +9322,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8460,6 +9330,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8473,6 +9344,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">откладывать, отсрочивать, мешкать</column>
       <column name="definition_zh_HK">推遲、拖延 [AUTOTRANSLATED]</column>
       <column name="definition_pt">adiar, procrastinar</column>
+      <column name="definition_fi">lykätä, viivytellä, vitkastella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIm:v}</column>
@@ -8483,6 +9355,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The deadline is "loom"ing.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8493,6 +9366,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8500,6 +9374,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8513,6 +9388,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">Клингоны не откладывают. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗人不會拖延。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Os klingons não procrastinam.</column>
+      <column name="definition_fi">Klingonit eivät viivyttele.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8523,6 +9399,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8532,6 +9409,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8539,6 +9417,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.9:src}</column>
     </table>
     <table name="mem">
@@ -8552,6 +9431,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">набухай [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">膨脹、膨脹起來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inchar</column>
+      <column name="definition_fi">turvota, paisua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhar:v}, {tlhaw:v}</column>
@@ -8562,6 +9442,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru">Хотя это термин анатомии, он может использоваться для других целей, таких как дерево, которое намокло. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">儘管這是一個解剖學術語，但它可以用於其他事物，例如變濕的木頭。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Embora este seja um termo de anatomia, ele pode ser usado para outras coisas, como madeira que ficou molhada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikka tämä on anatomian termi, sitä voidaan käyttää muihin asioihin, kuten märään kastuneeseen puuhun. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8571,6 +9452,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8578,6 +9460,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -8591,6 +9474,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">тип животного, лонг (ящерица) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、龍（蜥蜴狀） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, longo (semelhante a um lagarto)</column>
+      <column name="definition_fi">eräs liskon kaltainen eläin, loong</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duran lung:n}, {QIncha':n}, {'evta':n}, {la'SIv:n}</column>
@@ -8601,6 +9485,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is the Chinese word for "dragon" (龍). MO confirmed at {Saarbrücken qepHom'a' 2011:src} that this was deliberate.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8610,6 +9495,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8617,6 +9503,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8630,6 +9517,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">секунда</column>
       <column name="definition_zh_HK">秒</column>
       <column name="definition_pt">segundo (de tempo)</column>
+      <column name="definition_fi">sekunti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chaDvay':n}</column>
       <column name="see_also">{tup:n}, {rep:n}</column>
@@ -8640,6 +9528,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8649,6 +9538,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8656,6 +9546,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8669,6 +9560,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">транспортировать, перемещать</column>
       <column name="definition_zh_HK">運輸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transportar</column>
+      <column name="definition_fi">kuljettaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIj:v}, {Qay:v}, {lupDujHom:n}, {lupwI':n}</column>
@@ -8679,6 +9571,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{HIj:v} is used for transporting goods, whereas it seems that {lup:v:nolink} is used for transporting people.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8688,6 +9581,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8695,6 +9589,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8708,6 +9603,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">транспортный корабль</column>
       <column name="definition_zh_HK">運輸船 [AUTOTRANSLATED]</column>
       <column name="definition_pt">navio de transporte</column>
+      <column name="definition_fi">kuljetusalus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8718,6 +9614,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The existence of this word is inferred from {lupDujHom:n}.</column>
       <column name="components">{lup:v} or {lup:n:hyp,nolink}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -8727,6 +9624,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8734,6 +9632,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -8747,6 +9646,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">шаттл</column>
       <column name="definition_zh_HK">穿梭機 [AUTOTRANSLATED]</column>
       <column name="definition_pt">shuttlecraft</column>
+      <column name="definition_fi">sukkula</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DujHomDaq ghaHtaH.:sen}</column>
@@ -8757,6 +9657,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lupDuj:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -8766,6 +9667,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8773,6 +9675,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8786,6 +9689,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">Джитни, автобус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吉特尼、巴士 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ônibus, táxi lotação</column>
+      <column name="definition_fi">linjataksi, linja-auto, bussi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIgh:v}, {lIt:v}, {lupwI' mIr:n}, {ra'wI' lupwI':n}</column>
@@ -8796,6 +9700,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It's a vehicle that "loop"s.</column>
       <column name="components">{lup:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -8805,6 +9710,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">autobus</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8812,6 +9718,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8825,6 +9732,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">поезд (средство передвижения)</column>
       <column name="definition_zh_HK">火車</column>
       <column name="definition_pt">trem (veículo)</column>
+      <column name="definition_fi">juna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIHmey:n}, {tlharwIl Duj:n}, {lIgh:v}, {lIt:v}, {manggha:n}</column>
@@ -8835,6 +9743,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{lupwI':n}, {mIr:n:1}</column>
       <column name="examples">
@@ -8845,6 +9754,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tram</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8852,6 +9762,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8865,6 +9776,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">да, хорошо, я сделаю что-либо</column>
       <column name="definition_zh_HK">是的、好的、我會 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sim, ok, eu vou</column>
+      <column name="definition_fi">selvä, okei (teen niin)</column>
       <column name="synonyms">{lu':excl}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8875,6 +9787,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8884,6 +9797,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8891,6 +9805,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <!-- Gowron says {luq, ratlh}: http://youtu.be/86MOuHE90jg -->
@@ -8905,6 +9820,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">Лукара</column>
       <column name="definition_zh_HK">Lukara [AUTOTRANSLATED]</column>
       <column name="definition_pt">Lukara</column>
+      <column name="definition_fi">Lukara</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8915,6 +9831,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru">Спутница {qeylIS'e' lIjlaHbe'bogh vay':n:name}.</column>
       <column name="notes_zh_HK">{qeylIS'e' lIjlaHbe'bogh vay':n:name}的伴侶。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O companheiro de {qeylIS'e' lIjlaHbe'bogh vay':n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{qeylIS'e' lIjlaHbe'bogh vay':n:name}-kaveri. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The name is written as {luqara:n:nolink} once in the introduction, but is {luqara':n:nolink} (with a final {qaghwI':n}) consistently throughout the text.[1]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8924,6 +9841,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8931,6 +9849,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -8944,6 +9863,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">комендантский час [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">宵禁 [AUTOTRANSLATED]</column>
       <column name="definition_pt">toque de recolher</column>
+      <column name="definition_fi">ulkonaliikkumiskielto, kotiintuloaika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8954,6 +9874,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The word "curfew" comes from the French "cuevrefeu", meaning to cover ({vel:v}) the fire ({qul:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8963,6 +9884,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8970,6 +9892,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -8983,6 +9906,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">зрачок</column>
       <column name="definition_zh_HK">瞳孔（眼睛） [AUTOTRANSLATED]</column>
       <column name="definition_pt">pupila (do olho)</column>
+      <column name="definition_fi">pupilli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn:n}, {valQav:n}</column>
@@ -8993,6 +9917,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9002,6 +9927,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9009,6 +9935,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9022,6 +9949,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">Традиция</column>
       <column name="definition_zh_HK">傳統</column>
       <column name="definition_pt">tradição</column>
+      <column name="definition_fi">perinne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIgh:n}, {quH:n}</column>
@@ -9032,6 +9960,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Klingon sentence on {SkyBox 13:src} seems to have dropped some words, since it is ungrammatical.</column>
       <column name="components"></column>
       <column name="examples">
@@ -9049,6 +9978,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
    Вместе с сильными семейными традициями, преданность и верность семье одна из наиболее важных Клингонских добродетелей. Выше всего, ценится имя Клингонской семьи."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9056,6 +9986,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 13:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -9069,6 +10000,7 @@ This prefix is sometimes dropped for unknown reasons. While an error, this is of
       <column name="definition_ru">направление (пространственное) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">方向</column>
       <column name="definition_pt">direção (espacial)</column>
+      <column name="definition_fi">suunta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dop:n}, {roDSer:n}, {SInan:n}</column>
@@ -9113,6 +10045,15 @@ As áreas ao redor de um objeto são {Dung:n} (área acima), {bIng:n} (área aba
 No Klingon padrão, os substantivos locativos seguem pronomes, por exemplo, {jIH tlhop:n:nolink} "na minha frente". Porém, no dialeto da região de Sakrej ({Sa'Qej Sep:n}), os substantivos locativos recebem sufixos possessivos pronominais, por exemplo, {tlhopwIj:n:nolink} "minha área na frente" .[2] No entanto, os substantivos direcionais são uma exceção a essa regra e usam sufixos possessivos em todos os dialetos conhecidos , por exemplo, {chanwIj:n:nolink} "leste de mim, para o leste". Se o pronome completo for usado com um substantivo direcional, o pronome será enfatizado, por exemplo, {jIH chan:n:nolink} "leste de ME, para MEU leste" .[4]
 
 Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos. Por exemplo, pode-se dizer que {nIHwIj ghop:n@@nIH:n, -wIj:n, ghop:n} se refere à mão direita.[5] Os pontos entre as três direções cardeais são {tIng chan:n:nolink}, {'ev chan:n:nolink} e {tIng 'ev:n:nolink} ou {'ev tIng:n:nolink}. O {chan:n:nolink} sempre fica em segundo lugar nesse tipo de composto.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin kompassissa on kolme pistettä eikä neljä: {chan:n} (itään), {'ev:n} (luoteeseen) ja {tIng:n} (lounaaseen).
+
+Kohteen ympärillä olevat alueet ovat sen {Dung:n} (yläpuolella oleva alue), {bIng:n} (ala alapuolella), {retlh:n} (ala vieressä), {tlhop:n:1} (edessä) ja {'em:n} (takana). Jotain objektin {retlh:n:nolink}-tiedostossa voi olla sen {poS:n} (vasen) tai {nIH:n} (oikea) puolella. Kahden kohteen välinen alue on niiden {joj:n} (välinen alue). Kohteen takana oleva alue on sen {Hay:n:2h}.
+
+Tavallisessa Klingonissa paikannimet käyttävät substantiiveja, esim. {jIH tlhop:n:nolink} "edessäni". Mutta Sakrejin alueen murteessa ({Sa'Qej Sep:n}), paikallisnimet ottavat pronominalin omistavia loppuliitteitä, esim. {tlhopwIj:n:nolink} "minun alueeni edessä". esim. {chanwIj:n:nolink} "itään minusta, itään". Jos täyttä pronominia käytetään suuntasanoman kanssa, pronomini korostetaan, esim. {jIH chan:n:nolink} "MINUN itäpuolella, itään MINUN itään".
+
+Vasemmalle ja oikealle puolelle viitattaessa käytetään omistavia jälkiliitteitä. Esimerkiksi voidaan sanoa {nIHwIj ghop:n@@nIH:n, -wIj:n, ghop:n} viitaten heidän oikeaan käsiinsä.
+
+Kolmen pääsuunnan välissä olevat pisteet ovat {tIng chan:n:nolink}, {'ev chan:n:nolink} ja joko {tIng 'ev:n:nolink} tai {'ev tIng:n:nolink}. {chan:n:nolink} on aina toisessa tällaisessa yhdisteessä[2][4][5][3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9132,6 +10073,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
 ▶ {Daqvam 'ev jIwampu'.:sen:nolink} "Я охотился к северо-западу отсюда(относительно точки, обозначенной говорящим, например на карте)."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9139,6 +10081,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT p.24:src}, [3] {s.k 1999.11.21:src} (reprinted in {HQ 8.4, p.6-8, Dec. 1999:src}), [4] {s.k 1999.12.01:src}, [5] {KLI mailing list 2019.08.05:src}</column>
     </table>
     <table name="mem">
@@ -9152,6 +10095,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="definition_ru">Лурса</column>
       <column name="definition_zh_HK">Lursa [AUTOTRANSLATED]</column>
       <column name="definition_pt">Lursa</column>
+      <column name="definition_fi">Lursa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{be'etor:n:name}, {DuraS:n:name}</column>
@@ -9162,6 +10106,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="notes_ru">Сестра БеТор и Дюраса. Она сыграна актрисой {barbara' ma'rIch:n:name}.</column>
       <column name="notes_zh_HK">B'Etor和Duras的姐妹。她由女演員{barbara' ma'rIch:n:name}飾演。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Irmã de B'Etor e Duras. Ela é interpretada pela atriz {barbara' ma'rIch:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">B'Etorin ja Durasin sisar. Näyttelijä {barbara' ma'rIch:n:name} kuvaa häntä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9175,6 +10120,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
   "Сёстры из дома Дюраса, Лурса и Бетор, постоянно ищут высокого положения для дома Дюраса внутри клингонского высшего совета. В конце, сёстры выступили против Гаурона, зайдя так далеко, что работали с ромуланскими группировками, чтобы усилить власть."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9182,6 +10128,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.3, Sept. 1996:src}, [2] {SkyBox 26:src}</column>
     </table>
     <table name="mem">
@@ -9195,6 +10142,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="definition_ru">быть погруженным в окружение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被淹沒、浸入、被包圍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser submerso, imerso, cercado por</column>
+      <column name="definition_fi">olla upotettu johonkin, olla jonkin ympäröimä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oq:v}, {Dech:v}, {Hurgh Duj:n}</column>
@@ -9205,6 +10153,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9214,6 +10163,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dive</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9221,6 +10171,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -9234,6 +10185,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="definition_ru">черная дыра (астрономическое явление) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">黑洞、坍縮星</column>
       <column name="definition_pt">buraco negro (fenômeno astronômico)</column>
+      <column name="definition_fi">musta aukko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dejpu'bogh Hov rur qablIj!:sen}</column>
@@ -9244,6 +10196,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9254,6 +10207,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9261,6 +10215,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9275,6 +10230,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="definition_ru">история, рассказ</column>
       <column name="definition_zh_HK">故事</column>
       <column name="definition_pt">história</column>
+      <column name="definition_fi">tarina, kertomus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{torSIv:n}, {rorgh:v}</column>
@@ -9285,6 +10241,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="notes_ru">Понятие "сказка" может быть выражено как {puq lut:n@@puq:n, lut:n} или {lut rorgh:n@@lut:n, rorgh:v} или {puq lut rorgh:n@@puq:n, lut:n, rorgh:v}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">“童話”的概念可以表示為{puq lut:n@@puq:n, lut:n}或{lut rorgh:n@@lut:n, rorgh:v}或{puq lut rorgh:n@@puq:n, lut:n, rorgh:v}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Sanan käsite voidaan ilmaista muodossa {puq lut:n@@puq:n, lut:n} tai {lut rorgh:n@@lut:n, rorgh:v} tai {puq lut rorgh:n@@puq:n, lut:n, rorgh:v}.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The translations for "fairy tales" are suggestions only. In particular, it was noted that {SIqnaSwaq:n} would probably not be used to translate this term.[3]</column>
       <column name="components"></column>
       <column name="examples">
@@ -9296,6 +10253,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
 ▶ {meb, lut tlhaQ DaSov'a'?} "Гость, ты знаешь какие-то забавные истории?"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fairy tale, tale</column>
       <column name="search_tags_de">Kindergeschichte, Märchen</column>
       <column name="search_tags_fa"></column>
@@ -9303,6 +10261,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {PK:src}, [3] {KLI mailing list 2020.04.21:src}</column>
     </table>
         <table name="mem">
@@ -9316,6 +10275,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
           <column name="definition_ru">серия (рассказов, фильмов и т. д.) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">系列（故事、電影等） [AUTOTRANSLATED]</column>
           <column name="definition_pt">seriado (de histórias, filmes, etc.)</column>
+      <column name="definition_fi">sarja (tarinoita, elokuvia tms.)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9326,6 +10286,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This was used in the Netflix Klingon-language press release for {DSC:src}, which was written by {Quvar:n:name}.</column>
           <column name="components">{lut:n}, {mIr:n:2}</column>
           <column name="examples"></column>
@@ -9335,6 +10296,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9342,6 +10304,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
         </table>
     <table name="mem">
@@ -9355,6 +10318,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="definition_ru">быть примитивным, быть очень простым, быть отсталым</column>
       <column name="definition_zh_HK">是原始的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser primitivo</column>
+      <column name="definition_fi">olla alkeellinen, primitiivinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'Itlh:v}, {Hach:v}</column>
       <column name="see_also"></column>
@@ -9365,6 +10329,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9374,6 +10339,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9381,6 +10347,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9394,6 +10361,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="definition_ru">помечтать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">白日夢</column>
       <column name="definition_pt">sonhar acordado</column>
+      <column name="definition_fi">päiväuni, toiveuni, haave</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naj:v}, {Suchtuv:n}</column>
@@ -9404,6 +10372,7 @@ Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.
       <column name="notes_ru">Иногда это связано с невнимательностью.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有時這與註意力不集中有關。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Às vezes, isso está associado à desatenção.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tähän liittyy joskus tarkkaamattomuus.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the song "Daydream" by The Lovin' Spoonful.
 
 This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confirmed at {qep'a' 27 (2020):src} during the Q &amp; A session.</column>
@@ -9415,6 +10384,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9422,6 +10392,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -9435,6 +10406,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confi
       <column name="definition_ru">Да, хорошо, я сделаю это</column>
       <column name="definition_zh_HK">是的、好的、我會 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sim, tudo bem, eu vou</column>
+      <column name="definition_fi">okei, selvä (teen niin)</column>
       <column name="synonyms">{luq:excl}</column>
       <column name="antonyms"></column>
       <column name="see_also">{HIja':excl}, {HISlaH:excl}</column>
@@ -9445,6 +10417,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9454,6 +10427,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9461,5 +10435,6 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>

--- a/mem-08-m.xml
+++ b/mem-08-m.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {m:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{m:sen:nolink}</column>
       <column name="definition_pt">a consoante {m:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {m:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">Мы(действие)</column>
       <column name="definition_zh_HK">我們：無</column>
       <column name="definition_pt">nós-nenhum</column>
+      <column name="definition_fi">me-ei mitään</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jI-:v:pref}, {wI-:v:pref}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{maH:n:1h}: {pagh:n:1h} = {ma-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">соглашение, договорённость, контракт</column>
       <column name="definition_zh_HK">條約、合同、承諾、協議</column>
       <column name="definition_pt">tratado, acordo, contrato, compromisso</column>
+      <column name="definition_fi">sopimus, sitoomus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qI':v:1}, {Sutlh:v}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru">Это слово также используется, когда клингоны говорят об учетной записи, на которую подписывают, чтобы использовать службу, такую ​​как учетные записи компьютера. Смотрите {mab:n:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">當Klingons談論一個要註冊使用某項服務的帳戶（例如計算機帳戶）時，也會使用此詞。參見{mab:n:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra também é usada quando os klingons falam sobre uma conta que se registra para usar um serviço, como contas de computador. Consulte {mab:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään myös, kun klingonit puhuvat tilistä, johon käyttäjä kirjautuu käyttämään palvelua, kuten tietokonetilejä. Katso {mab:n:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined only as "treaty" in {TKD:src}. The additional definitions come from {Saarbrücken qepHom'a' 2016:src}.
 
 Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known for making bargains with mortals.</column>
@@ -108,6 +118,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -115,6 +126,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -128,6 +140,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="definition_ru">аккаунта</column>
       <column name="definition_zh_HK">帳戶（用於使用服務） [AUTOTRANSLATED]</column>
       <column name="definition_pt">conta (para usar um serviço)</column>
+      <column name="definition_fi">tili (palvelussa tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -138,6 +151,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="notes_ru">Это расширение {mab:n:1}, означающее учетную запись, на которую кто-то может подписаться для использования службы, такой как учетная запись компьютера. Глагол, чтобы зарегистрировать учетную запись - {qI':v:2}. Для входа в учетную запись - {ngaQHa'moH:v:2}, а для выхода - {ngaQmoH:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{mab:n:1}的擴展，表示有人可以註冊以使用服務的帳戶，例如計算機帳戶。註冊帳戶的動詞是{qI':v:2}。登錄到帳戶是{ngaQHa'moH:v:2}，而註銷是{ngaQmoH:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma extensão do {mab:n:1} para significar uma conta na qual alguém pode se inscrever para usar um serviço, como uma conta de computador. O verbo para se inscrever em uma conta é {qI':v:2}. Para fazer login em uma conta é {ngaQHa'moH:v:2} e para fazer logoff é {ngaQmoH:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {mab:n:1}: n laajennus, joka tarkoittaa tiliä, jolle joku voi rekisteröityä käyttämään palvelua, kuten tietokonetiliä. Verbi tilin rekisteröimiseksi on {qI':v:2}. Tilille kirjautuminen on {ngaQHa'moH:v:2} ja uloskirjautuminen {ngaQmoH:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was used in Netflix's Klingon language promotional material.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -147,6 +161,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -154,6 +169,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -167,6 +183,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="definition_ru">жабоподобное или похожее на лягушку существо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蟾蜍類或青蛙類生物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">criatura do tipo sapo</column>
+      <column name="definition_fi">eräs rupikonnaa tai sammakkoa muistuttava eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -177,6 +194,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Michigan J. Frog is a cartoon character whose first appearance was singing the song "Hello! Ma Baby".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -186,6 +204,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -193,6 +212,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -206,6 +226,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="definition_ru">быть маленьким, быть небольшим, быть малым, быть мелким</column>
       <column name="definition_zh_HK">小、細</column>
       <column name="definition_pt">ser pequeno</column>
+      <column name="definition_fi">olla pieni</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tIn:v}</column>
       <column name="see_also">{nu':v}, {muq:v}</column>
@@ -216,6 +237,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "match" is small, and is kept in a "match tin".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -225,6 +247,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tiny</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -232,6 +255,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -245,6 +269,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="definition_ru">предавать, изменять</column>
       <column name="definition_zh_HK">背叛、出賣</column>
       <column name="definition_pt">trair</column>
+      <column name="definition_fi">pettää</column>
       <column name="synonyms">{bol:v:2}</column>
       <column name="antonyms"></column>
       <column name="see_also">{'ur:v}, {bolwI':n}</column>
@@ -255,6 +280,7 @@ Possibly a reference to the fairy Queen Mab in Romeo and Juliet, who is known fo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">See the note under {mugh:v}.
 
 Some word lists erroneously give another definition of {magh:v:nolink} with the meaning "indicate, reveal". This came from an old website called "Star Trek: Continuum", which had a "Klingon Linguistics Studies" section where someone (not Marc Okrand) took the official definitions and "expanded" them. This person apparently did not understand which meaning of the English word "betray" the Klingon word {magh:v:nolink} corresponded to.
@@ -274,6 +300,7 @@ René Magritte painted "La Trahison des images".</column>
   "Сёстры из дома Дюраса, Лурса и Бетор, постоянно ищут высокого положения для дома Дюраса внутри клингонского высшего совета. В конце, сёстры выступили против Гаурона, зайдя так далеко, что работали с ромуланскими группировками, чтобы усилить власть."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -281,6 +308,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 26:src}</column>
     </table>
     <table name="mem">
@@ -294,6 +322,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="definition_ru">предатель</column>
       <column name="definition_zh_HK">背叛者、出賣者</column>
       <column name="definition_pt">traidor</column>
+      <column name="definition_fi">petturi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bolwI':n}</column>
@@ -304,6 +333,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="notes_ru">Речь идёт о человеке, который предаёт кого-то. Для лица, которое совершает измену смотрите {'urwI':n}.</column>
       <column name="notes_zh_HK">這是一個背叛某人的人。對於犯有叛國罪的人，請參閱{'urwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma pessoa que trai alguém. Para uma pessoa que comete traição, consulte {'urwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on henkilö, joka pettää jonkun. Katso maanpetoksesta syyllistyneen henkilön kohdasta {'urwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">René Magritte painted "La Trahison des images".</column>
       <column name="components">{magh:v}, {-wI':n}</column>
       <column name="examples"></column>
@@ -313,6 +343,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -320,6 +351,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -333,6 +365,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="definition_ru">трава [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">草</column>
       <column name="definition_pt">grama</column>
+      <column name="definition_fi">ruoho</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIp:v}, {nIl:v}, {'eSreH:n}</column>
@@ -343,6 +376,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="notes_ru">Это относится к растению клингон, которое наиболее близко напоминает траву. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指最接近草的克林崗植物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma planta Klingon que mais se assemelha à grama. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa Klingonin tehtaaseen, joka muistuttaa eniten ruohoa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In British English slang, to "grass on" someone means to betray them to a person in authority, such as police. (See {magh:v}.)</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -352,6 +386,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -359,6 +394,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -372,6 +408,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="definition_ru">лужайка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">草坪、草地</column>
       <column name="definition_pt">gramado</column>
+      <column name="definition_fi">nurmikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -382,6 +419,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{magh:n}, {yotlh:n}</column>
       <column name="examples"></column>
@@ -391,6 +429,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -398,6 +437,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -411,6 +451,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="definition_ru">роман [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小說 [AUTOTRANSLATED]</column>
       <column name="definition_pt">romance (novela)</column>
+      <column name="definition_fi">romaani</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -421,6 +462,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A potboiler ({magh:n} + {pub:v}) is a work of dubious literary merit.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -430,6 +472,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -437,6 +480,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -450,6 +494,7 @@ René Magritte painted "La Trahison des images".</column>
       <column name="definition_ru">мы нас [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我們</column>
       <column name="definition_pt">nós</column>
+      <column name="definition_fi">me</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-maj:n}, {-ma':n}</column>
@@ -488,6 +533,21 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
 Префиксом повелительного наклонения когда {maH:n:1h,nolink} является объектом, будет {gho-:v:pref}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on monikko {jIH:n:1h,pro}.
+
+Verbien etuliitteet, kun aihe {maH:n:1h,nolink} on:
+▶ {maH:n:1h,nolink}: {pagh:n:1h} = {ma-:v:pref}
+▶ {maH:n:1h,nolink}: {SoH:n} = {pI-:v:pref}
+▶ {maH:n:1h,nolink}: {tlhIH:n} = {re-:v:pref}
+▶ {maH:n:1h,nolink}: {ghaH:n} / {'oH:n} = {wI-:v:pref}
+▶ {maH:n:1h,nolink}: {chaH:n} / {bIH:n} = {DI-:v:pref}
+
+Verbien etuliitteet, kun {maH:n:1h,nolink} on objekti:
+▶ {SoH:n}: {maH:n:1h,nolink} = {ju-:v:pref}
+▶ {tlhIH:n}: {maH:n:1h,nolink} = {che-:v:pref}
+▶ {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n}: {maH:n:1h,nolink} = {nu-:v:pref}
+
+Pakollinen verbin etuliite, kun kohde on {maH:n:1h,nolink}, on {gho-:v:pref}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -497,6 +557,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -504,6 +565,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -517,6 +579,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="definition_ru">десять (числообразующий элемент)</column>
       <column name="definition_zh_HK">十（數字形成元素） [AUTOTRANSLATED]</column>
       <column name="definition_pt">dezena (elemento formador de um número)</column>
+      <column name="definition_fi">kymmenen (vain yhdyssanan jälkiosana)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wa':n:num}, {vatlh:n:num}</column>
@@ -527,6 +590,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="notes_ru">Заметьте, что это числообразующий элемент, а не число само по себе. Число десять будет -{wa'maH:n:num}. Дословно переводится, как "один десять".</column>
       <column name="notes_zh_HK">請注意，這是一個數字形成元素，而不是數字本身。數字十是{wa'maH:n:num}，字面意思是“十”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que este é um elemento de formação de números, e não um número em si. O número dez é {wa'maH:n:num}, literalmente "um dez", em Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä on lukua muodostava elementti eikä itse numero. Numero kymmenen on {wa'maH:n:num}, kirjaimellisesti "yksi kymmenen", Klingonissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -536,6 +600,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -543,6 +608,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -556,6 +622,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="definition_ru">белок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蛋白 [AUTOTRANSLATED]</column>
       <column name="definition_pt">proteína</column>
+      <column name="definition_fi">proteiini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngam'eQ:n}</column>
@@ -566,6 +633,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -575,6 +643,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -582,6 +651,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -595,6 +665,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="definition_ru"> большая чаша, большая миска</column>
       <column name="definition_zh_HK">碗（大）</column>
       <column name="definition_pt">tigela (grande)</column>
+      <column name="definition_fi">(iso) kulho</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chatlh:n:1}, {Duq:n}</column>
@@ -605,6 +676,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="notes_ru">Это большая миска, используемая для подачи {chatlh:n:1}, который обедающий вливает в {Duq:n} чтобы есть.[1, стр.99]</column>
       <column name="notes_zh_HK">這是一個大碗，用來盛裝{chatlh:n:1}，食客倒入{Duq:n}中食用。[1, p.99] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma tigela grande, usada para servir {chatlh:n:1}, que os clientes despejam em um {Duq:n} para comer.[1, p.99] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on iso kulho, jota käytetään {chatlh:n:1}: n tarjoilemiseen, jonka ruokalaiset kaatavat {Duq:n}: een syömään.[1, p.99] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Ten-pin bowling" is a popular game.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -614,6 +686,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -621,6 +694,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -634,6 +708,7 @@ The imperative verb prefix when {maH:n:1h,nolink} is the object is {gho-:v:pref}
       <column name="definition_ru">хорошо (выражение удовлетворения)</column>
       <column name="definition_zh_HK">好！</column>
       <column name="definition_pt">bom (expressando satisfação)</column>
+      <column name="definition_fi">Hyvä! (ilmaisee tyytyväisyyttä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{majQa':excl}</column>
@@ -656,6 +731,9 @@ Detta ord har inte känslan av "god" som används i en hälsning, till exempel "
       <column name="notes_pt">Esta é uma exclamação que expressa satisfação. Para ver o verbo (ou adjetivo) que significa "ser bom", consulte {QaQ:v}.
 
 Essa palavra não tem o sentido de "bom" quando usada em uma saudação, como "bom dia" ou "boa noite". Embora haja uma expressão idiomática em Klingon, {maj ram:sen:nolink}, que é usada de maneira semelhante a "boa noite", na verdade significa algo como "Bom, (é) noite" .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on huutomerkki, joka ilmaisee tyytyväisyyden. Katso verbi (tai adjektiivi), joka tarkoittaa "olla hyvä", katso {QaQ:v}.
+
+Tällä sanalla ei ole sanaa "hyvä", jota käytetään tervehdyksessä, kuten "hyvää huomenta" tai "hyvää yötä". Vaikka Klingonissa on idiomaattinen ilmaisu {maj ram:sen:nolink}, jota käytetään samalla tavalla kuin "hyvää yötä", se tarkoittaa itse asiassa jotain "hyvää, (se on) yötä".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TNK:src}, "Good morning" is given as {maj po:excl:nolink}, "Good afternoon" as {maj pov:excl:nolink}, and "Good evening" as {maj choS:excl:nolink}. In {DS9 - The Sword of Kahless:src}, Jadzia Dax and Kor said {maj ram:excl:nolink} to each other as she headed for bed.
 
 The writers who came up with this apparently looked up words for "good" and "night" and strung them together without regard for grammar or meaning.</column>
@@ -667,6 +745,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -674,6 +753,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.119:src}</column>
     </table>
     <table name="mem">
@@ -687,6 +767,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">отлично сработано, очень хорошо (выражение удовлетворения)</column>
       <column name="definition_zh_HK">做得好！</column>
       <column name="definition_pt">bem feito, muito bom</column>
+      <column name="definition_fi">Hyvin tehty!, Oikein hyvä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maj:excl}</column>
@@ -697,6 +778,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru">Первый элемент этого слова выглядит как {maj:excl}. Второй элемент может быть связан с {Qap:v:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞的第一個元素似乎是{maj:excl}。第二元素可以與{Qap:v:1}有關。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O primeiro elemento desta palavra parece ser {maj:excl}. O segundo elemento pode estar relacionado a {Qap:v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan ensimmäinen osa näyttää olevan {maj:excl}. Toinen elementti voi liittyä {Qap:v:1}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -706,6 +788,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -713,6 +796,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -726,6 +810,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">плитка, черепица, кафель</column>
       <column name="definition_zh_HK">瓦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">azulejo, telha, ladrilho</column>
+      <column name="definition_fi">laatta, levy</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mutlh:v}, {teSra':n}</column>
@@ -736,6 +821,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru">Это относится к части материала, используемого в строительстве. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指用於建築的一塊材料。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um pedaço de material usado na construção. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa rakennusmateriaaleihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Mahjong (麻將) is a Chinese game played with tiles.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -745,6 +831,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -752,6 +839,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.09:src}</column>
     </table>
     <table name="mem">
@@ -765,6 +853,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">мозаика [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鑲嵌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mosaico</column>
+      <column name="definition_fi">mosaiikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -775,6 +864,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{majyang:n}, {mIllogh:n}</column>
       <column name="examples"></column>
@@ -784,6 +874,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -791,6 +882,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -804,6 +896,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">плиточник, слой плитки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">磚瓦、瓦片層 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ladrilhador</column>
+      <column name="definition_fi">laatoittaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -814,6 +907,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru">Это относится к человеку, который укладывает плитку, как при строительстве пола. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是像鋪地板一樣鋪設瓷磚的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa que coloca azulejos, como na construção de um piso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, joka laatii laatat, kuten rakennettaessa lattiaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{majyang:n}, {mutlh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -823,6 +917,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -830,6 +925,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.10:src}</column>
     </table>
     <table name="mem">
@@ -843,6 +939,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">бизнес, дело, обязанность</column>
       <column name="definition_zh_HK">生意、公業</column>
       <column name="definition_pt">Comércio, negócios, empresa</column>
+      <column name="definition_fi">kauppa, liike, yritys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Huq:v}, {Suy:n}, {tlhong:v}, {ghunta:n}</column>
@@ -853,6 +950,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -865,6 +963,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -872,6 +971,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -885,6 +985,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">торговая марка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">商標</column>
       <column name="definition_pt">marca comercial</column>
+      <column name="definition_fi">tavaramerkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -895,6 +996,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is usually {malja' permey:n:nolink} in canon.</column>
       <column name="components">{malja':n}, {per:n}</column>
       <column name="examples">
@@ -905,6 +1007,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -912,6 +1015,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}, [2] {SkyBox cards:src}</column>
     </table>
     <table name="mem">
@@ -925,6 +1029,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">солдат</column>
       <column name="definition_zh_HK">士兵（單數）</column>
       <column name="definition_pt">soldado</column>
+      <column name="definition_fi">sotilas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -935,6 +1040,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru">Слово {mangpu':n@@mang:n, -pu':n} редко используется, и несет смысловую нагрузку, что есть люди, которые создают группу. Слово {negh:n} фокусируется на группе, как на подразделении. {QaS:n:1h} похож на {negh:n:nolink}, но исключает офицеров.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">單詞{mangpu':n@@mang:n, -pu':n}很少使用，帶有這樣的概念，即由個人組成該組。 {negh:n}將小組作為一個單元來關注。 {QaS:n:1h}與{negh:n:nolink}類似，但不包括人員。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra {mangpu':n@@mang:n, -pu':n} é raramente usada e carrega a noção de que há indivíduos que compõem o grupo. O {negh:n} foca o grupo como uma unidade. {QaS:n:1h} é semelhante ao {negh:n:nolink}, mas exclui oficiais.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sanaa {mangpu':n@@mang:n, -pu':n} käytetään harvoin, ja siinä on käsitys, että ryhmän muodostavat yksilöt. {negh:n} keskittyy ryhmään yhtenä kokonaisuutena. {QaS:n:1h} on samanlainen kuin {negh:n:nolink}, mutta ei sisällä virkamiehiä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{negh:n}</column>
       <column name="examples"></column>
@@ -944,6 +1050,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -951,6 +1058,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.50:src}</column>
     </table>
     <table name="mem">
@@ -964,6 +1072,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">армия</column>
       <column name="definition_zh_HK">軍隊</column>
       <column name="definition_pt">exército</column>
+      <column name="definition_fi">armeija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -974,6 +1083,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru">Это относится ко всем {negh:n} вместе.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Refere-se a todos os {negh:n} juntos.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kaikkiin {negh:n}: een. [2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mang:n}, {ghom:n}</column>
       <column name="examples"></column>
@@ -983,6 +1093,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -990,6 +1101,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.50:src}</column>
     </table>
     <table name="mem">
@@ -1003,6 +1115,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">кадет</column>
       <column name="definition_zh_HK">學員</column>
       <column name="definition_pt">cadete</column>
+      <column name="definition_fi">kadetti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1013,6 +1126,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru">Это не используется, как звание.[1, p.53]</column>
       <column name="notes_zh_HK">這不用作標題。[1, p.53] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não é usado como um título.[1, p.53] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä ei käytetä otsikkona.[1, p.53] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mang:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -1022,6 +1136,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1029,6 +1144,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1043,6 +1159,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">станция (поезд) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">站（火車） [AUTOTRANSLATED]</column>
       <column name="definition_pt">estação (trem)</column>
+      <column name="definition_fi">juna-asema</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lupwI' mIr:n}</column>
@@ -1053,6 +1170,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru">Это место, где средний / дальний транспорт прибывает и уходит.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是中長途運輸到達和離開的地方。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um local onde o transporte de médio / longo alcance chega e parte.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on paikka, jonne keski- / pitkän matkan kuljetus saapuu ja lähtee[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1062,6 +1180,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1069,6 +1188,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1082,6 +1202,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="definition_ru">объявлять, провозглашать</column>
       <column name="definition_zh_HK">宣布、宣告</column>
       <column name="definition_pt">proclamar</column>
+      <column name="definition_fi">julistaa, ilmoittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vep:n}</column>
@@ -1092,6 +1213,7 @@ The writers who came up with this apparently looked up words for "good" and "nig
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{SkyBox 31:src} has the line {ghoS tlhIngan SuvwI' maq:sen:nolink}, where {maq:v:nolink} is used without {'e':n:pro}, but it is not known whether this is a typo or a feature of how {maq:v:nolink} is used.
 
 This was used to translate "print" or "output" (i.e., display something to the user, such as the value of a variable) for Klingon Blockly.[2]</column>
@@ -1103,6 +1225,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1110,6 +1233,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <table name="mem">
@@ -1123,6 +1247,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">священник, жрица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">牧師，女祭司 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sacerdote, sacerdotisa</column>
+      <column name="definition_fi">pappi, papitar</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lalDan:n}, {bulvar:n}</column>
@@ -1133,6 +1258,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">Это слово нейтрально в гендерном отношении. Если требуется различие, добавьте {loD:n} или {be':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞不分性別。如果需要區分，請添加{loD:n}或{be':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é neutra em termos de gênero. Se for necessária uma distinção, adicione {loD:n} ou {be':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on sukupuolineutraali. Jos tarvitaan eroa, lisää {loD:n} tai {be':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This seems to consist of "proclaim" ({maq:v}) and "see" ({legh:v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1142,6 +1268,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1149,6 +1276,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1162,6 +1290,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">дружок, дружбан, приятель, близкий друг мужского пола лица мужского пола</column>
       <column name="definition_zh_HK">老兄、老友記</column>
       <column name="definition_pt">amigo, colega, amigo íntimo masculino de um homem</column>
+      <column name="definition_fi">kaveri, ystävä (miehen läheinen miesystävä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaj:n}, {jup:n}, {ruS:n}</column>
@@ -1172,6 +1301,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">Слово используется одним лицом мужского пола, адресуемое другому лицу(того же пола), являющемуся близким другом. Использование этого слова в других контекстах может быть сочтено оскорбительным или обидным. Слово может происходить от {may' qoch:n@@may':n, qoch:n}. Не является редким для Клингонского отца, который адресует подобное слово сыну {maqoch:n:nolink}, но не наоборот.</column>
       <column name="notes_zh_HK">一個男性用這個詞來稱呼另一個是密友的男性。在其他情況下使用此詞可能會被視為侮辱性或冒犯性的。該詞可能源自{may' qoch:n@@may':n, qoch:n}。克林崗人的父親稱呼兒子為{maqoch:n:nolink}並不少見，但反之亦然。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada por um homem para se dirigir a outro homem que é um amigo próximo. O uso dessa palavra em outros contextos pode ser considerado ofensivo ou ofensivo. A palavra pode derivar de {may' qoch:n@@may':n, qoch:n}. Não é incomum um pai klingon se dirigir a seu filho como {maqoch:n:nolink}, mas não o contrário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksi mies käyttää tätä sanaa puhuessaan toiselle miehelle, joka on läheinen ystävä. Tämän sanan käyttöä muissa yhteyksissä voidaan pitää loukkaavana tai loukkaavana. Sana voi johtua sanasta {may' qoch:n@@may':n, qoch:n}. Ei ole harvinaista, että klingonilainen isä kääntyy poikansa puoleen {maqoch:n:nolink}, mutta ei päinvastoin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"My coach". See also {qoch:n}. Note that {maqoch:sen@@ma-:v, qoch:v} may be read as a sentence.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1181,6 +1311,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">buddy, bff</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1188,6 +1319,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru">приятель, дружбан</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1201,6 +1333,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">знамение, предзнаменование, знак</column>
       <column name="definition_zh_HK">徵兆、兆頭</column>
       <column name="definition_pt">presságio</column>
+      <column name="definition_fi">merkki, enne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maQmIgh:n}, {Degh:n:1}</column>
@@ -1211,6 +1344,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word can also mean "signal" in the sense of a sign that some action should be taken. This meaning comes from the opera {'u':src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1232,6 +1366,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
    Потерять его гордость и заявить притязания на трон."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">signal</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1239,6 +1374,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 17 (2010):src}, [2] {'u':src}, [3] {paq'batlh p.62-63:src}</column>
     </table>
     <table name="mem">
@@ -1252,6 +1388,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">темное предзнаменование, знак злого пришествия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">凶兆</column>
       <column name="definition_pt">presságio escuro, sinal da vinda do mal</column>
+      <column name="definition_fi">paha enne, merkki lähestyvästä pahasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1262,6 +1399,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{maQ:n}, {mIgh:v}</column>
       <column name="examples"></column>
@@ -1271,6 +1409,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1278,6 +1417,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 1.3, Sept. 1992:src}</column>
     </table>
     <table name="mem">
@@ -1291,6 +1431,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">С целью преуспеть, мы атакуем</column>
       <column name="definition_zh_HK">為了成功，我們進行攻擊。</column>
       <column name="definition_pt">Para ter sucesso, atacamos.</column>
+      <column name="definition_fi">Me hyökkäämme menestyäksemme.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1301,6 +1442,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ma-:v}, {Qap:v:1}, {-meH:v}, {ma-:v}, {HIv:v}</column>
       <column name="examples"></column>
@@ -1310,6 +1452,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1317,6 +1460,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.183:src}</column>
     </table>
     <table name="mem">
@@ -1330,6 +1474,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">использовать большой палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用大腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">usar o dedão do pé</column>
+      <column name="definition_fi">käyttää isovarvasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaD:n:1}</column>
@@ -1340,6 +1485,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This little piggy went to market.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1349,6 +1495,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1356,6 +1503,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1369,6 +1517,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">большой палец, первый палец</column>
       <column name="definition_zh_HK">大腳趾、第一個腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dedo grande do pé, primeiro dedo do pé</column>
+      <column name="definition_fi">isovarvas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaD:n:1}</column>
@@ -1379,6 +1528,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This little piggy went to the market.</column>
       <column name="components">{mar:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1388,6 +1538,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1395,6 +1546,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1408,6 +1560,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Мара</column>
       <column name="definition_zh_HK">「馬拉」</column>
       <column name="definition_pt">Mara</column>
+      <column name="definition_fi">Mara</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1418,6 +1571,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">Мара является женой Канга (смотрите {qeng:n:name}) и офицером по науке, которая появилась в эпизоде {TOS - Day of the Dove:src}.</column>
       <column name="notes_zh_HK">瑪拉（Mara）是康的妻子（見{qeng:n:name}）和科學官員，曾出現在{TOS - Day of the Dove:src}中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Mara é a esposa de Kang (veja {qeng:n:name}) e oficial de ciências, que apareceu no episódio {TOS - Day of the Dove:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Mara on Kangin vaimo (ks.{qeng:n:name}) ja tiedepäällikkö, joka esiintyi jaksossa {TOS - Day of the Dove:src}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1427,6 +1581,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1434,6 +1589,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1447,6 +1603,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Марк Окранд</column>
       <column name="definition_zh_HK">馬克·奧克蘭德</column>
       <column name="definition_pt">Marc Okrand</column>
+      <column name="definition_fi">Marc Okrand</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{matlh:n:name}</column>
@@ -1457,6 +1614,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">Обратите внимание, что {marq:n:nolink} и {'oqranD:n:nolink} не следуют правильной фонологии клингона, поскольку они являются частью имени пришельца. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Observe que {marq:n:nolink} e {'oqranD:n:nolink} não seguem a fonologia adequada do Klingon, pois fazem parte de um nome alienígena. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että {marq:n:nolink} ja {'oqranD:n:nolink} eivät noudata oikeaa klingonifonologiaa, koska ne ovat osa ulkomaalaisten nimeä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1466,6 +1624,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1473,6 +1632,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Conlanging:src}</column>
     </table>
     <table name="mem">
@@ -1486,6 +1646,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Эдди (вода) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">渦流（水） [AUTOTRANSLATED]</column>
       <column name="definition_pt">redemoinho (água)</column>
+      <column name="definition_fi">pyörre (vedessä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IrmeD:n}, {pep'en:n}</column>
@@ -1496,6 +1657,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">Это относится к движению воды. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指水的運動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um movimento da água. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa veden liikkumiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1505,6 +1667,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1512,6 +1675,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1525,6 +1689,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Марцелл</column>
       <column name="definition_zh_HK">馬塞勒斯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Marcellus</column>
+      <column name="definition_fi">Marcellus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -1535,6 +1700,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1544,6 +1710,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1551,6 +1718,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -1564,6 +1732,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Марток</column>
       <column name="definition_zh_HK">「馬托」</column>
       <column name="definition_pt">Martok</column>
+      <column name="definition_fi">Martok</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rotarran:n:name}</column>
@@ -1574,6 +1743,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1583,6 +1753,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1590,6 +1761,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1603,6 +1775,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Клингон балет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗芭蕾舞團 [AUTOTRANSLATED]</column>
       <column name="definition_pt">balé Klingon</column>
+      <column name="definition_fi">klingonien baletti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI':v}</column>
@@ -1613,6 +1786,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word appears to contain {mar:v} "use the big toe", but it's unclear where the rest of the word comes from.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1622,6 +1796,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1629,6 +1804,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1642,6 +1818,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">луна</column>
       <column name="definition_zh_HK">月</column>
       <column name="definition_pt">lua</column>
+      <column name="definition_fi">kuu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jar:n}, {bav:v}, {SIbDoH:n}, {Hov:n}, {yuQ:n}, {jul:n}</column>
@@ -1652,6 +1829,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1663,6 +1841,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">satellite</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1670,6 +1849,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1683,6 +1863,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">предпочитать</column>
       <column name="definition_zh_HK">偏、寧</column>
       <column name="definition_pt">preferir</column>
+      <column name="definition_fi">pitää jostakin enemmän, pitää jotakin parempana, suosia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qaq:v}, {wIv:v}</column>
@@ -1693,6 +1874,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1703,6 +1885,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1710,6 +1893,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1723,6 +1907,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Лунный свет</column>
       <column name="definition_zh_HK">月光</column>
       <column name="definition_pt">luz da lua</column>
+      <column name="definition_fi">kuutamo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1733,6 +1918,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{maS:n}, {wov:n:hyp,nolink}</column>
       <column name="examples"></column>
@@ -1742,6 +1928,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1749,6 +1936,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1762,6 +1950,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">полумесяц</column>
       <column name="definition_zh_HK">月牙</column>
       <column name="definition_pt">lua crescente</column>
+      <column name="definition_fi">kuunsirppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maS:n}, {maS'e' So'bogh pagh:n}</column>
@@ -1772,6 +1961,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">Выражение использовано для того, чтобы описать форму {betleH:n}.</column>
       <column name="notes_zh_HK">此表達式用於描述{betleH:n}的形狀。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta expressão é usada para descrever a forma do {betleH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä lauseketta käytetään kuvaamaan {betleH:n}-muotoa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{maS:n}, {-'e':n}, {loQ:adv}, {So':v:1}, {-be':v}, {-bogh:v}, {QIb:n}</column>
       <column name="examples">
@@ -1793,6 +1983,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
    Они ответили, что оно изогнуто в виде полумесяца."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1800,6 +1991,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.138-139:src}</column>
     </table>
     <table name="mem">
@@ -1813,6 +2005,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">полнолуние [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滿月</column>
       <column name="definition_pt">lua cheia</column>
+      <column name="definition_fi">täysikuu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maS:n}, {maS'e' loQ So'be'bogh QIb:n}</column>
@@ -1823,6 +2016,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">В оригинальной клингонской версии {yulyuS qaySar:n:name} (Юлий Цезарь) титульный персонаж предупрежден, чтобы остерегаться {maS'e' So'bogh pagh:n:nolink}. Неясно, почему это было изменено на «иды» марта в переводе.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Na versão original em klingon de {yulyuS qaySar:n:name} (Julius Caesar), o personagem titular é avisado para tomar cuidado com o {maS'e' So'bogh pagh:n:nolink}. Não está claro por que isso foi alterado para os "ides" de março na tradução.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{yulyuS qaySar:n:name}: n (Julius Caesar) alkuperäisessä klingoniversiossa nimimerkkiä varoitetaan varovaisuudesta {maS'e' So'bogh pagh:n:nolink}: n kanssa. On epäselvää, miksi tämä muutettiin käännöksessä maaliskuun "ideiksi" .[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{maS:n}, {-'e':n}, {So':v:1}, {-bogh:v}, {pagh:n:1h}</column>
       <column name="examples"></column>
@@ -1832,6 +2026,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ides</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1839,6 +2034,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2015.03.22:src}</column>
     </table>
     <table name="mem">
@@ -1852,6 +2048,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Чтобы выжить, мы должны расширяться</column>
       <column name="definition_zh_HK">為了生存，我們必須擴大。</column>
       <column name="definition_pt">Para sobreviver, precisamos expandir.</column>
+      <column name="definition_fi">Selviytyäksemme meidän on laajennuttava.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1862,6 +2059,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ma-:v}, {taH:v:1}, {-meH:v}, {ma-:v}, {Sach:v:1}, {-nIS:v}</column>
       <column name="examples"></column>
@@ -1871,6 +2069,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1878,6 +2077,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.11:src}</column>
     </table>
     <table name="mem">
@@ -1891,6 +2091,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Проклятия между нами бегут, как вода</column>
       <column name="definition_zh_HK">在我們之間，咒語像水一樣流淌。</column>
       <column name="definition_pt">Entre nós, os insultos correm como água.</column>
+      <column name="definition_fi">Kun olemme yhdessä, kiroukset muistuttavat virtaavaa vettä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1901,6 +2102,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1910,6 +2112,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">QI'lop</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1917,6 +2120,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -1930,6 +2134,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">стрелок, оружейник</column>
       <column name="definition_zh_HK">砲手</column>
       <column name="definition_pt">artilheiro</column>
+      <column name="definition_fi">ampuja, tykkimies</column>
       <column name="synonyms">{baHwI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1941,6 +2146,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{matHa', DoS jonta' neH.:sen}</column>
@@ -1950,6 +2156,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shooter</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1957,6 +2164,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru">стрелок</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1970,6 +2178,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">быть верным, быть лояльным</column>
       <column name="definition_zh_HK">忠心</column>
       <column name="definition_pt">ser leal</column>
+      <column name="definition_fi">olla uskollinen, lojaali</column>
       <column name="synonyms"></column>
       <column name="antonyms">{matlhHa':v}</column>
       <column name="see_also"></column>
@@ -1980,6 +2189,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1989,6 +2199,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1996,6 +2207,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2009,6 +2221,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">Мальц</column>
       <column name="definition_zh_HK">「馬爾茨」</column>
       <column name="definition_pt">Maltz</column>
+      <column name="definition_fi">Maltz</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{marq 'oqranD:n:name}</column>
@@ -2019,6 +2232,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">Мальц это пленник от Федерации, который живёт в подвале Марка Окранда, и который является источником знаний Федерации о Клингонском языке.</column>
       <column name="notes_zh_HK">馬爾茨（Maltz）是聯邦的囚徒，住在馬克·奧克蘭（Marc Okrand）的地下室，並且是聯邦對克林崗語的很多了解的來源。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Maltz é um prisioneiro da Federação que vive no porão de Marc Okrand e é a fonte de grande parte do conhecimento da Federação sobre a língua Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maltz on federaation vanki, joka asuu Marc Okrandin kellarissa ja josta lähde on suuri osa federaation klingonin kielen tuntemuksesta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2028,6 +2242,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2035,6 +2250,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2048,6 +2264,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">быть неверным, быть нелояльным</column>
       <column name="definition_zh_HK">違心</column>
       <column name="definition_pt">ser desleal</column>
+      <column name="definition_fi">olla epälojaali, uskoton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{matlh:v}</column>
       <column name="see_also">{romuluSngan:n}</column>
@@ -2058,6 +2275,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{matlh:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -2067,6 +2285,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2074,6 +2293,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2087,6 +2307,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">печень [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肝</column>
       <column name="definition_pt">fígado</column>
+      <column name="definition_fi">maksa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2097,6 +2318,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru">Слово для печени везде {chej:n}, но в некоторых регионах это слово используется в качестве альтернативы. [1, p.28] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">肝臟這個詞到處都是{chej:n}，但是在某些地區，這個詞被用作替代。[1, p.28] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra fígado é {chej:n} em todos os lugares, mas em algumas regiões essa palavra é usada como alternativa.[1, p.28] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maksan sana on {chej:n} kaikkialla, mutta joillakin alueilla tätä sanaa käytetään vaihtoehtona.[1, p.28] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The regions where this word is used are not specified in {KGT:src}.[1, p.28]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2106,6 +2328,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2113,6 +2336,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2126,6 +2350,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">скрепка</column>
       <column name="definition_zh_HK">紙夾</column>
       <column name="definition_pt">clipe de papel</column>
+      <column name="definition_fi">paperiliitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nav:n}</column>
@@ -2136,6 +2361,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2145,6 +2371,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2152,6 +2379,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2165,6 +2393,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">обижать, задевать</column>
       <column name="definition_zh_HK">得罪</column>
       <column name="definition_pt">ofender</column>
+      <column name="definition_fi">loukata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIch:v}</column>
@@ -2175,6 +2404,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2184,6 +2414,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2191,6 +2422,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2204,6 +2436,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">быть сумасшедшим, быть безумным</column>
       <column name="definition_zh_HK">瘋了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser louco, ser maluco</column>
+      <column name="definition_fi">olla hullu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2214,6 +2447,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2223,6 +2457,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2230,6 +2465,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2243,6 +2479,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="definition_ru">быть честным, быть счастливым</column>
       <column name="definition_zh_HK">平心而論 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser justo</column>
+      <column name="definition_fi">olla reilu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ruv:n}</column>
@@ -2253,6 +2490,7 @@ This was used to translate "print" or "output" (i.e., display something to the u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"My Fair Lady" or "Mayfair".
 
 It's unclear what sense of "fair" is meant by this word.</column>
@@ -2264,6 +2502,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2271,6 +2510,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2284,6 +2524,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">тесьма, узелки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">編織物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trança, nós</column>
+      <column name="definition_fi">punos, solmu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2294,6 +2535,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru">Это относится к переплетению волокон, часто декоративных. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指通常是裝飾性的纖維編織。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um tecido de fibras, geralmente decorativo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kuitujen kudontaan, usein koristeelliseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"My car (does) not work."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2303,6 +2545,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2310,6 +2553,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2323,6 +2567,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">сверхпроводимость [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">超導 [AUTOTRANSLATED]</column>
       <column name="definition_pt">supercondutividade</column>
+      <column name="definition_fi">suprajohtavuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuyDar:n}</column>
@@ -2333,6 +2578,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru">Для «быть сверхпроводящим», скажем {maySon chIw:sen@@maySon:n, chIw:v} «выразить сверхпроводимость» или тому подобное. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{maySon chIw:sen@@maySon:n, chIw:v}表示“超導”或“表達超導”等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para "seja supercondutor", diga {maySon chIw:sen@@maySon:n, chIw:v} "expresse supercondutividade" ou algo semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sillä "ole suprajohtava", sano {maySon chIw:sen@@maySon:n, chIw:v} "ilmaise suprajohtavuutta" tai vastaavaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2342,6 +2588,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2349,6 +2596,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2362,6 +2610,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">боевой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥（個別戰鬥）</column>
       <column name="definition_pt">batalha</column>
+      <column name="definition_fi">taistelu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{che'ron:n}, {Suv:v}, {yol:n}, {noH:n}, {ghob:v}</column>
@@ -2372,6 +2621,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru">Это слово относится к конкретной (конкретной) битве, в то время как {vIq:n} относится к битве или бою как к концепции. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞指的是特定的（具體的）戰鬥，而{vIq:n}則指的是戰鬥或戰鬥。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se refere a uma batalha específica (concreta), enquanto {vIq:n} se refere à batalha ou combate como um conceito. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa tiettyyn (konkreettiseen) taisteluun, kun taas {vIq:n} viittaa taisteluun tai taisteluun käsitteenä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2381,6 +2631,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2388,6 +2639,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -2401,6 +2653,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">боевая песня [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">戰歌</column>
           <column name="definition_pt">música de batalha</column>
+      <column name="definition_fi">taistelulaulu</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{bom:n}, {may' ghe'naQ:n}, {may' bom pIm bom:sen}</column>
@@ -2411,6 +2664,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{may':n}, {bom:n}</column>
           <column name="examples"></column>
@@ -2420,6 +2674,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2427,6 +2682,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -2440,6 +2696,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">говорить совсем о другом [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">完全談論另一件事 [AUTOTRANSLATED]</column>
           <column name="definition_pt">para falar inteiramente de outro assunto</column>
+      <column name="definition_fi">puhua kokonaan toisesta asiasta</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2450,6 +2707,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru">Буквальное значение этого идиоматического выражения - «петь другую боевую песню». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這種慣用語的字面意思是“唱另一首戰歌”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">O significado literal dessa expressão idiomática é "cantar uma canção de batalha diferente". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän idiomaattisen ilmaisun kirjaimellinen merkitys on "laulaa erilainen taistelulaulu". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{may' bom:n}, {pIm:v}, {bom:v}</column>
           <column name="examples">
@@ -2460,6 +2718,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2467,6 +2726,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.118:src}</column>
         </table>
         <table name="mem">
@@ -2480,6 +2740,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">боевая опера [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">戰鬥歌劇</column>
           <column name="definition_pt">ópera de batalha</column>
+      <column name="definition_fi">taisteluooppera</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{bom:n}, {ghe'naQ:n}, {jachwI'na':n}</column>
@@ -2490,6 +2751,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{may':n}, {ghe'naQ:n}</column>
           <column name="examples"></column>
@@ -2499,6 +2761,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2506,6 +2769,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {paq'batlh p.xix:src}</column>
         </table>
         <table name="mem">
@@ -2519,6 +2783,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">фиктивная битва [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">模擬戰鬥</column>
           <column name="definition_pt">batalha simulada</column>
+      <column name="definition_fi">näytöstaistelu</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2529,6 +2794,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{may':n}, {ngeb:v}</column>
           <column name="examples"></column>
@@ -2538,6 +2804,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2545,6 +2812,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {CK:src}</column>
         </table>
         <table name="mem">
@@ -2558,6 +2826,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">адреналин, адреналин [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">腎上腺素，腎上腺素 [AUTOTRANSLATED]</column>
           <column name="definition_pt">adrenalina, epinefrina</column>
+      <column name="definition_fi">adrenaliini</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2568,6 +2837,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{may':n}, {rImbey:n}</column>
           <column name="examples"></column>
@@ -2577,6 +2847,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2584,6 +2855,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -2597,6 +2869,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">бронежилет [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">身體護具 [AUTOTRANSLATED]</column>
           <column name="definition_pt">armadura corporal</column>
+      <column name="definition_fi">haarniska, taistelupuku, luotiliivit</column>
           <column name="synonyms">{SIryoD:n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2607,6 +2880,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{may':n}, {Sut:n}</column>
           <column name="examples"></column>
@@ -2616,6 +2890,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">armour, body armour</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2623,6 +2898,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
         </table>
         <table name="mem">
@@ -2636,6 +2912,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">запись битвы [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">戰鬥記錄</column>
           <column name="definition_pt">registro de batalha</column>
+      <column name="definition_fi">selostus taistelusta</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2646,6 +2923,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{may':n}, {ta:n}</column>
           <column name="examples">
@@ -2656,6 +2934,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2663,6 +2942,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.184:src}</column>
         </table>
         <table name="mem">
@@ -2676,6 +2956,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">Жду битвы.</column>
           <column name="definition_zh_HK">我在等待戰鬥。</column>
           <column name="definition_pt">Eu aguardo batalha.</column>
+      <column name="definition_fi">Odotan taistelua.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2686,6 +2967,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru">Это было сказано Ворфом, во время его ритуала посвящения.</column>
           <column name="notes_zh_HK">這是沃爾夫（在克林崗）在《提升儀式》中所說的。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso foi falado por Worf (em Klingon) durante seu Rito de Ascensão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän puhui Worf (Klingonissa) ylösnousemusriitin aikana. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -2695,6 +2977,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">nentay</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2702,6 +2985,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNG - The Icarus Factor:src}</column>
         </table>
         <table name="mem">
@@ -2715,6 +2999,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">Боевая тревога!</column>
           <column name="definition_zh_HK">戰爭警戒狀態！</column>
           <column name="definition_pt">Alerta de batalha!</column>
+      <column name="definition_fi">Taisteluhälytys!</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2725,6 +3010,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{may':n}, {yI-:v}, {ghuH:v}</column>
           <column name="examples"></column>
@@ -2734,6 +3020,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">red alert</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2741,6 +3028,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru">красная тревога</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Star Trek III:src}</column>
         </table>
         <table name="mem">
@@ -2754,6 +3042,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">Когда воин идёт в битву, он не оставляет своих друзей</column>
           <column name="definition_zh_HK">戰士去戰鬥時不會拋棄他的朋友。</column>
           <column name="definition_pt">Quando um guerreiro vai para uma batalha, ele não abandona seus amigos.</column>
+      <column name="definition_fi">Kun soturi menee taisteluun, hän ei hylkää ystäviään.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2764,6 +3053,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{may':n}, {-Daq:n}, {jaH:v}, {-DI':v}, {SuvwI':n}, {jup:n}, {-pu':n}, {-Daj:n}, {lon:v}, {-be':v}</column>
           <column name="examples"></column>
@@ -2773,6 +3063,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2780,6 +3071,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.38:src}</column>
         </table>
         <table name="mem">
@@ -2793,6 +3085,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="definition_ru">Клингон не убегает от битв</column>
           <column name="definition_zh_HK">克林崗人不會逃避他的戰鬥。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Um Klingon não foge de suas batalhas.</column>
+      <column name="definition_fi">Klingoni ei pakene taisteluistaan.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2803,6 +3096,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -2812,6 +3106,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2819,6 +3114,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.91:src}</column>
         </table>
     <table name="mem">
@@ -2833,6 +3129,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">боевой крейсер</column>
       <column name="definition_zh_HK">戰艦</column>
       <column name="definition_pt">cruzador de batalha</column>
+      <column name="definition_fi">taisteluristeilijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2843,6 +3140,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{may':n}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -2852,6 +3150,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2859,6 +3158,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2872,6 +3172,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">боевое снаряжение, защита, полный комплект брони и оружия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥裝備、全副武裝、全套盔甲和武器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">equipamento de batalha, panóplia, conjunto completo de armaduras e armas</column>
+      <column name="definition_fi">taisteluvarustus (mukaan lukien kaikki panssarit ja aseet)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{luch:n}</column>
@@ -2882,6 +3183,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{may':n}, {luch:n}</column>
       <column name="examples"></column>
@@ -2891,6 +3193,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">armour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2898,6 +3201,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2911,6 +3215,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">боевой порядок</column>
       <column name="definition_zh_HK">陣勢、陣容、戰鬥序列</column>
       <column name="definition_pt">matriz de batalha</column>
+      <column name="definition_fi">taistelujärjestys tai -ryhmitys?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaH:n}</column>
@@ -2921,6 +3226,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2930,6 +3236,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">formation</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2937,6 +3244,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2950,6 +3258,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">аккордеон, концертина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手風琴、六角琴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acordeão, concertina</column>
+      <column name="definition_fi">harmonikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Heng:v}, {rey:v}</column>
@@ -2960,6 +3269,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru">Это тип {SuSDeq:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種{SuSDeq:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de {SuSDeq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen {SuSDeq:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Myron Floren, accordionist on "The Lawrence Welk Show".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2969,6 +3279,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2976,6 +3287,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2989,6 +3301,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">вмещать, приспосабливать</column>
       <column name="definition_zh_HK">容納 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acomodar</column>
+      <column name="definition_fi">mukauttaa, mukautua, adaptoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moS:v}</column>
@@ -2999,6 +3312,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">MO accommodated the filmmakers by changing {qama':sen@@qa-:v, ma':v} to mean "prisoner" while {Star Trek III:src} was being filmed. See {qama'pu' jonta' neH.:sen}</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3008,6 +3322,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3015,6 +3330,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3028,6 +3344,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">Mauk-to'Vor ритуал [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Mauk-to'Vor儀式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ritual de Mauk-to'Vor</column>
+      <column name="definition_fi">Mauk-to'Vor-rituaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ma'veq:n}, {'aDanjI':n:extcan}</column>
@@ -3038,6 +3355,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru">Смертельный ритуал, который позволяет тому, кто потерял честь, умереть достойно и почить в Стовокорре, будучи убитым. Ритуал проводит член дома, в котором состоит Клингон, или кто-то достаточно близкий.</column>
       <column name="notes_zh_HK">一種死亡儀式，使失去榮譽的人能夠被死於室友或同等親密的人光榮殺死，從而死得很好，去了Sto-Vo-Kor。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um ritual de morte que permite que alguém que perdeu a honra morra bem e vá para Sto-Vo-Kor sendo honrosamente morto por um companheiro de casa ou alguém igualmente próximo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kuoleman rituaali, joka antaa kunnian menettäneelle mahdollisuuden kuolla hyvin ja mennä Sto-Vo-Koriin tappamalla kunnia-arvoinen kaveri tai joku yhtä läheinen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is written as {ma' to'vor:n:nolink} in the glossary to {Diplomatic Implausibility:src}, but the space appears to be a typo, as the word appears as {ma'to'vor:n:nolink} in the glossary to {A Good Day to Die:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3047,6 +3365,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3054,6 +3373,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DS9 - Sons of Mogh:src}, [2] {Diplomatic Implausibility:src}, [3] {A Good Day to Die:src}</column>
     </table>
     <table name="mem">
@@ -3067,6 +3387,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">М'Век (тип ножа)</column>
       <column name="definition_zh_HK">刀的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de faca</column>
+      <column name="definition_fi">eräs veitsi, mevak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3077,6 +3398,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru">М'Век это церемониальный нож, используемый для ритуала Мактовор ({ma'to'vor:n}).</column>
       <column name="notes_zh_HK">“ M'veQ”是“ Mauk To'Vor”（{ma'to'vor:n}）儀式中使用的禮刀。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O "M'veQ" é uma faca cerimonial usada no ritual de "Mauk To'Vor" ({ma'to'vor:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"M’eQ" on seremoniallinen veitsi, jota käytetään "Mauk To'Vor" ({ma'to'vor:n}) -rituaalissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word's spelling was confirmed by MO. However, in the glossary to the non-canon {A Good Day to Die:src}, DeCandido writes this as {mevaq:n:nolink} "mevak dagger".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3086,6 +3408,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mevaq</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3093,6 +3416,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DS9 - Sons of Mogh:src}, [2] {KLI mailing list 1999.02.12:src}, [3] {KLI mailing list 2010.12.29:src}, [4] {paq'batlh p.184:src}</column>
     </table>
     <table name="mem">
@@ -3106,6 +3430,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">гость</column>
       <column name="definition_zh_HK">客人</column>
       <column name="definition_pt">hóspede</column>
+      <column name="definition_fi">vieras</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'elI'jaH:n}</column>
@@ -3116,6 +3441,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3125,6 +3451,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3132,6 +3459,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3145,6 +3473,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">отель, гостиница</column>
       <column name="definition_zh_HK">客棧、旅館</column>
       <column name="definition_pt">hotel</column>
+      <column name="definition_fi">hotelli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa'mey:n:hyp}</column>
@@ -3155,6 +3484,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3164,6 +3494,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3171,6 +3502,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.219,245:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -3184,6 +3516,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">торговать, вести торговлю</column>
       <column name="definition_zh_HK">貿易 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comércio</column>
+      <column name="definition_fi">käydä kauppaa jollakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tam:v:2}, {qa':v}</column>
@@ -3194,6 +3527,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Latin "mercari", from whence merchant, merchandise, etc.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3205,6 +3539,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
 ▶ {nom yer mechmeH Quj} "Торговая игра с быстрыми сделками"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3212,6 +3547,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3225,6 +3561,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">ланч</column>
       <column name="definition_zh_HK">午餐</column>
       <column name="definition_pt">almoço</column>
+      <column name="definition_fi">lounas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIQ:n}, {'uQ:n}, {pov:n}, {pem:n}</column>
@@ -3235,6 +3572,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is the reverse of {ghem:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3244,6 +3582,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3251,6 +3590,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3264,6 +3604,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">конец (палки, веревки и т. д.), другой конец от {'er'In:n} [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結束（棍棒、繩索等）、另一端來自{'er'In:n} [AUTOTRANSLATED]</column>
       <column name="definition_pt">fim (de vara, corda, etc.), outro fim de {'er'In:n}</column>
+      <column name="definition_fi">(kepin, köyden tms.) pää (vastakkainen pää on {'er'In:n})</column>
       <column name="synonyms">{'er'In:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{DIn:n}, {qa'rI':n}</column>
@@ -3274,6 +3615,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這可以指的是繩子，木棒或其他任何一端，但是一旦您任意選擇一個叫{megh'an:n:nolink}的一端，另一端稱為{'er'In:n:nolink}。在進行此初始參考之前，可以將任一端稱為{'er'In:n:nolink}或{megh'an:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä voi viitata köyden, kepin tai mihin tahansa päähän, mutta kun olet mielivaltaisesti päättänyt kutsumaan {megh'an:n:nolink}, toisen pään nimi on {'er'In:n:nolink}. Ennen kuin teet tämän alkuperäisen viitteen, kumpaakin päätä voidaan kutsua joko {'er'In:n:nolink} tai {megh'an:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a private joke referring to a specific person.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3283,6 +3625,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3290,6 +3633,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -3303,6 +3647,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">Мостик (корабельный термин)</column>
       <column name="definition_zh_HK">艦橋</column>
       <column name="definition_pt">ponte (de um navio)</column>
+      <column name="definition_fi">komentosilta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choQ:n}</column>
@@ -3313,6 +3658,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru">Для слова мост(сооружение через реку), смотрите {QI:n}.</column>
       <column name="notes_zh_HK">越過河流或連接兩個位置的橋樑的名稱是{QI:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra para o tipo de ponte que atravessa um rio ou conecta dois locais é {QI:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sana sellaiselle sillalle, joka kulkee joen yli tai yhdistää kaksi sijaintia, on {QI:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3322,6 +3668,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3329,6 +3676,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3342,6 +3690,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">искусство, искусство, культура [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">藝術、文化</column>
       <column name="definition_pt">artes, as artes, a cultura</column>
+      <column name="definition_fi">taide, kulttuuri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meHghem Qat:n}, {Hoy:v}, {nugh:n}</column>
@@ -3366,6 +3715,9 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_pt">Não existe uma palavra única para "arte" ou "obra de arte", no sentido de peças individuais de arte visual (pintura, escultura, etc.).
 
 {meHghem:n:nolink} é um termo maior e mais abrangente que abrange "as artes" ou "arte" em oposição a "ciência". Inclui música, teatro, dança, etc., bem como artes visuais. É "cultura" nesse sentido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei ole olemassa yhtä sanaa "taide" tai "taideteos" kuvataiteen yksittäisten kappaleiden (maalaus, veistos jne.) Merkityksessä.
+
+{meHghem:n:nolink} on isompi, kattavampi termi, joka kattaa "taiteen" tai "taiteen", toisin kuin "tiede". Se sisältää musiikkia, teatteria, tanssia jne. Sekä kuvataidetta. Se on "kulttuuri" tässä mielessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The fact that there is no single word for "art" or "artwork" is stated on {KGT p.79:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3375,6 +3727,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3382,6 +3735,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3395,6 +3749,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">популярная культура [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">流行文化</column>
       <column name="definition_pt">cultura popular</column>
+      <column name="definition_fi">populaarikulttuuri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3405,6 +3760,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{meHghem:n}, {Qat:v}</column>
       <column name="examples">
@@ -3415,6 +3771,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pop culture</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3422,6 +3779,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Pop Culture Hero Coalition announcement:src} ({KLI mailing list 2016.11.30:src})</column>
     </table>
     <table name="mem">
@@ -3435,6 +3793,7 @@ It's unclear what sense of "fair" is meant by this word.</column>
       <column name="definition_ru">уходить, покидать, отправляться</column>
       <column name="definition_zh_HK">走、離開</column>
       <column name="definition_pt">sair, partir</column>
+      <column name="definition_fi">lähteä, mennä pois jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{paw:v}</column>
       <column name="see_also"></column>
@@ -3473,6 +3832,11 @@ För att uttrycka att du lämnar en person eller ett objekt (snarare än en plat
 Embora {mej:v:nolink} se refira simplesmente a deixar a localização atual, {tlheD:v} geralmente implica sair em uma jornada, com um objetivo ou destino em mente. Nos dois casos, o objeto é o local de onde você sai ou sai.[4]
 
 Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere {lon:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohdassa {TNK:src} {DaH jImej:sen:nolink}-tekstiä käytetään Terran-ilmaisulle "hyvästi" .[2] Tämä tarkoittaa kirjaimellisesti "Lähden nyt". Klingon tietysti vain lähti, ilman tarpeettomia herkkuja, kuten ilmoittamalla aikomuksestaan ​​tehdä niin.
+
+Vaikka {mej:v:nolink} viittaa yksinkertaisesti nykyisen sijaintinsa jättämiseen, {tlheD:v} tarkoittaa yleensä matkalle lähtöä tavoitetta tai määränpäätä ajatellen. Molemmissa tapauksissa esine on paikka, josta poistut tai jolta poistut.[4]
+
+Harkitse {lon:v}, jos haluat ilmaista henkilön tai esineen (eikä sijainnin) jättämisen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3484,6 +3848,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
 ▶ {bIghHa' DamejDI' pagh QaS yInob.:sen@@bIghHa':n, Da-:v, mej:v, -DI':v, pagh:n:2,num, QaS:n:1, yI-:v, nob:v} "Уходи из тюрьмы свободно."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bye, goodbye</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3491,6 +3856,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="search_tags_ru">прощай, досвидания</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {TNK:src}, [3] {Klingon Monopoly:src}, [4] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -3504,6 +3870,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="definition_ru">фартук (одежда) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">圍裙（衣服） [AUTOTRANSLATED]</column>
       <column name="definition_pt">avental (vestuário)</column>
+      <column name="definition_fi">esiliina</column>
       <column name="synonyms">{pInHom:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3514,6 +3881,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The idiom "apron strings" refers to one's ties to one's parents, which one leaves ({mej:v}) when one is married ({nay:v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3523,6 +3891,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3530,6 +3899,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -3543,6 +3913,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="definition_ru">артерия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動脈 [AUTOTRANSLATED]</column>
       <column name="definition_pt">artéria</column>
+      <column name="definition_fi">valtimo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paw'aD:n}, {'aD:n}</column>
@@ -3553,6 +3924,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="notes_ru">Это было сокращено со временем от {mejmeH 'aD:n@@mej:v, -meH:v, 'aD:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">隨著時間的推移，從{mejmeH 'aD:n@@mej:v, -meH:v, 'aD:n}開始縮短了時間。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso foi reduzido com o tempo do {mejmeH 'aD:n@@mej:v, -meH:v, 'aD:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä lyhennettiin ajan myötä {mejmeH 'aD:n@@mej:v, -meH:v, 'aD:n}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Major artery".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3562,6 +3934,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3569,6 +3942,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -3583,6 +3957,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="definition_ru">костный мозг, костный мозг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">骨髓</column>
       <column name="definition_pt">medula óssea</column>
+      <column name="definition_fi">luuydin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hom:n:1}, {'awje':n}</column>
@@ -3593,6 +3968,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3602,6 +3978,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3609,6 +3986,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3622,6 +4000,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="definition_ru">Мелота</column>
       <column name="definition_zh_HK">Melota [AUTOTRANSLATED]</column>
       <column name="definition_pt">Melota</column>
+      <column name="definition_fi">Melota</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'aqtu':n:name}, {ghe'naQ:n}</column>
@@ -3632,6 +4011,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="notes_ru">Персонаж известной клингонской оперы</column>
       <column name="notes_zh_HK">著名的克林崗歌劇中的角色。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um personagem de uma famosa ópera Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hahmo kuuluisassa Klingon-oopperassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3641,6 +4021,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3648,6 +4029,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -3661,6 +4043,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="definition_ru">каталог</column>
       <column name="definition_zh_HK">目錄、編目</column>
       <column name="definition_pt">Catálogo</column>
+      <column name="definition_fi">luettelo, listaus, katalogi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{De':n}, {qawHaq:n}, {tetlh:n}, {gher:v}, {HIDjolev:n}, {buv:n}, {vun:v}</column>
@@ -3671,6 +4054,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3680,6 +4064,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3687,6 +4072,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3700,6 +4086,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="definition_ru">иметь площадь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">面積為 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tem uma área de</column>
+      <column name="definition_fi">olla pinta-alaltaan jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{morgh:n}, {mun'a':n}, {muq:v}, {'aD:v}, {juch:v}</column>
@@ -3710,6 +4097,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3719,6 +4107,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3726,6 +4115,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>
     <table name="mem">
@@ -3739,6 +4129,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="definition_ru">пластик, пластмасса</column>
       <column name="definition_zh_HK">塑料、膠</column>
       <column name="definition_pt">plástico</column>
+      <column name="definition_fi">muovi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baS:n}, {Sor Hap:n}, {'al'on:n}</column>
@@ -3749,6 +4140,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3758,6 +4150,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3765,6 +4158,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3778,6 +4172,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="definition_ru">причина, мотив, логичное мышление, тема, субъект, предмет обсуждения</column>
       <column name="definition_zh_HK">理性、動機、邏輯思維、主題、主題、主題 [AUTOTRANSLATED]</column>
       <column name="definition_pt">razão, motivo, pensamento lógico, tema, assunto, tópico</column>
+      <column name="definition_fi">syy, motiivi, järki; aihe, teema</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mo':n:2}, {ngoQ:n}, {ghanroq:n}, {meq:v}, {pon:v}</column>
@@ -3788,6 +4183,7 @@ Para expressar a saída de uma pessoa ou objeto (em vez de um local), considere 
       <column name="notes_ru">Это может быть использовано, чтобы упомянуть о теме разговора, обсуждения, разговора и т.д.</column>
       <column name="notes_zh_HK">這可以用來指代對話，故事等的主題，主題或主題。（也就是說，它描述了對話或故事的“原因”或“動機”。） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para se referir ao tópico, assunto ou tema de uma conversa, história etc. (isto é, descreve a "razão" ou "motivo" da conversa ou história). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää viittaamaan keskustelun, tarinan jne. Aiheeseen, aiheeseen tai teemaan (ts. Se kuvaa keskustelun tai tarinan "syytä" tai "motiivia".) [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined as "reason" in {TKD:src} and as "motive" in the word lists in {KGT:src}. It is also glossed as "logical thinking" (in the sense of "motive") in the body of {KGT:src} on p.154. At {qep'a' 25 (2018):src}, its definition was expanded to include "topic, subject, theme".
 
 This was also used for the "logic" menu (instructions about program flow control) in Klingon Blockly.[3]</column>
@@ -3800,6 +4196,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3807,6 +4204,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {KLI mailing list 2014.11.26:src}, [4] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -3820,6 +4218,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">рассуждать, аргументировать, мыслить логически</column>
       <column name="definition_zh_HK">理由、邏輯思考 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pensar logicamente</column>
+      <column name="definition_fi">ajatella järjellä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tIw:v}</column>
       <column name="see_also">{meq:n}, {'aq:v}, {pon:v}</column>
@@ -3830,6 +4229,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined only as "reason" in {TKD:src}. The definition was later expanded.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3839,6 +4239,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3846,6 +4247,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -3859,6 +4261,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">тип судебного разбирательства</column>
       <column name="definition_zh_HK">法律訴訟、類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de processo legal</column>
+      <column name="definition_fi">eräs klingonien oikeusprosessi, mek'ba</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ruv:n}, {teblaw':n}, {yoj:n}</column>
@@ -3869,6 +4272,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">Это часть разбирательства или аппеляции, когда заслушано доказательство</column>
       <column name="notes_zh_HK">這是聽到證據的審判或上訴部分。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a parte de um julgamento ou recurso em que as evidências são ouvidas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on osa oikeudenkäyntiä tai muutoksenhakua, jossa todisteet kuullaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3878,6 +4282,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3885,6 +4290,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {The Star Trek Encyclopedia:src}</column>
     </table>
     <table name="mem">
@@ -3898,6 +4304,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">Меклет(тип оружия)</column>
       <column name="definition_zh_HK">武器類型、mek'leth [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de arma, mek'leth</column>
+      <column name="definition_fi">eräs teräase, mek'leth</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{betleH:n}</column>
@@ -3908,6 +4315,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">{meqleH:n:nolink} также называется {meqleH matlh:n:nolink}, чтобы отличить от {betleH:n}, который звучит похоже.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">O {meqleH:n:nolink} também é chamado de {meqleH matlh:n:nolink}, para diferenciá-lo do som semelhante {betleH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{meqleH:n:nolink}: tä kutsutaan myös {meqleH matlh:n:nolink}: ksi, jotta se erotettaisiin vastaavasta kuulostavasta {betleH:n}: sta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3917,6 +4325,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3924,6 +4333,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3937,6 +4347,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">Мекро'вак. Название региона</column>
       <column name="definition_zh_HK">Mekro'vak州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Região de Mekro'vak</column>
+      <column name="definition_fi">Mekro'vakin alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{letlh:n:2}, {ngep'oS:n}, {Sep Hol Sar:n}</column>
@@ -3947,6 +4358,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">В некоторых диалектах в данном регионе, {letlh:n:2} относится только к лестнице, соединённой с кораблём, а {ngep'oS:n} от носится ко всем остальным видам лестниц.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Em alguns dialetos dessa região, {letlh:n:2} refere-se apenas à escada conectada a um navio e {ngep'oS:n} refere-se a todos os outros tipos de escada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Joillakin tämän alueen murteilla {letlh:n:2} viittaa vain alukseen kytkettyihin portaikkoihin, ja {ngep'oS:n} viittaa kaikkiin muihin portaikkoihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} on p.29 and not in the glossary. It appears as {meqro'vaq:n:nolink} and not as {meqro'vaq Sep:n:nolink}, but it is described as a region (see {Sep:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3956,6 +4368,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3963,6 +4376,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3976,6 +4390,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">гореть, сжигать, обжечь, спалить, получить ожог</column>
       <column name="definition_zh_HK">燒</column>
       <column name="definition_pt">queimar</column>
+      <column name="definition_fi">polttaa, palaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIQ:v}</column>
@@ -3986,6 +4401,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">Если нет объекта, тогда субъект это вещь, которая горит, например {meQtaHbogh qachDaq Suv qoH neH.:sen}[2] Если есть объект, тогда субъект сжигает объект, например., {to'waQ meQ vutwI'.}[3] {meQ:v:nolink} может также использоваться для прикладных вещей, например, {Ha'DIbaHmey meQ Sop 'e' tIv tera'nganpu'@@Ha'DIbaH:n:1, -mey:n, meQ:v, Sop:v, 'e':n, tIv:v, tera'ngan:n, -pu':n}.[4]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Jos kohdetta ei ole, aihe on asia, joka polttaa, esim. {meQtaHbogh qachDaq Suv qoH neH.:sen}[2] Jos on objekti, kohde polttaa objektia, esim. {to'waQ meQ vutwI'.}[3] {meQ:v:nolink} voidaan käyttää myös adjektiivisesti, esim. {Ha'DIbaHmey meQ Sop 'e' tIv tera'nganpu'@@Ha'DIbaH:n:1, -mey:n, meQ:v, Sop:v, 'e':n, tIv:v, tera'ngan:n, -pu':n}.DONOTTRANSLATE6[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the sentence from {CK:src}, {tIv:sen:nolink} should have been {lutIv:sen:nolink} since {tera'nganpu':n:nolink} is plural.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3995,6 +4411,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4002,6 +4419,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW p.111:src}, [3] {KGT p.191:src}, [4] {CK:src}</column>
     </table>
     <table name="mem">
@@ -4015,6 +4433,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">Флаг революции Кейлеса</column>
       <column name="definition_zh_HK">「凱勒斯」的革命旗幟</column>
       <column name="definition_pt">bandeira revolucionária do Kahless</column>
+      <column name="definition_fi">Kahlessin vallankumouslippu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joqwI':n}</column>
@@ -4025,6 +4444,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">Это "флаг единства и революции" использовался {qeylIS'e' lIjlaHbe'bogh vay':n:name} чтобы сплотить его войска.</column>
       <column name="notes_zh_HK">這是唐諾蘭特用來集結部隊的“團結與革命的旗幟”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é "a bandeira da unidade e da revolução" usada por {qeylIS'e' lIjlaHbe'bogh vay':n:name} para reunir suas tropas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on "yhtenäisyyden ja vallankumouksen lippu", jota {qeylIS'e' lIjlaHbe'bogh vay':n:name} käyttää joukkojensa kokoamiseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{meQ:v}, {bogh:v}, {nom:adv}</column>
       <column name="examples">
@@ -4058,6 +4478,7 @@ This was also used for the "logic" menu (instructions about program flow control
    И революции."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4065,6 +4486,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.138-139:src}</column>
     </table>
     <table name="mem">
@@ -4078,6 +4500,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">Только глупец сражается в горящем доме</column>
       <column name="definition_zh_HK">只有傻瓜在燃燒的房屋裡打架。</column>
       <column name="definition_pt">Apenas um tolo luta em uma casa em chamas.</column>
+      <column name="definition_fi">Vain tyhmä taistelee palavassa talossa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4088,6 +4511,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{meQ:v}, {-taH:v}, {-bogh:v}, {qach:n}, {-Daq:n}, {Suv:v}, {qoH:n}, {neH:adv}</column>
       <column name="examples"></column>
@@ -4097,6 +4521,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4104,6 +4529,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.111:src}</column>
     </table>
     <table name="mem">
@@ -4117,6 +4543,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">удивлять, поражать, заставать врасплох</column>
       <column name="definition_zh_HK">震驚</column>
       <column name="definition_pt">surpreender</column>
+      <column name="definition_fi">yllättää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yay':v}, {Duq:v}, {pay':adv}</column>
@@ -4127,6 +4554,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4137,6 +4565,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4144,6 +4573,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4157,6 +4587,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">быть объединенным, быть смешанным вместе [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結合在一起 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser combinado, ser misturado</column>
+      <column name="definition_fi">olla yhdistetty, sekoitettu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIr:v}, {DuD:v}, {SuyDar:n}</column>
@@ -4167,6 +4598,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">Это также используется в контексте физики, где это относится к явлению квантовой суперпозиции. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也用在物理環境中，它指的是量子疊加現象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é usado no contexto da física, onde se refere ao fenômeno da superposição quântica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään myös fysiikan yhteydessä, jossa se viittaa kvantti-superposition ilmiöön. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Merge".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4176,6 +4608,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">superposition, superpose</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4183,6 +4616,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4196,6 +4630,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">морской узел [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結</column>
       <column name="definition_pt">nó</column>
+      <column name="definition_fi">solmu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meS:v:1}</column>
@@ -4206,6 +4641,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4215,6 +4651,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4222,6 +4659,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4235,6 +4673,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">узел, завязать узел [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">打結</column>
       <column name="definition_pt">dar um nó</column>
+      <column name="definition_fi">solmia</column>
       <column name="synonyms"></column>
       <column name="antonyms">{meSHa':v:1}</column>
       <column name="see_also">{meS:n}, {meS:v:2}, {nIq:v}, {bagh:v}</column>
@@ -4245,6 +4684,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4256,6 +4696,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4263,6 +4704,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4276,6 +4718,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">шифровать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">加密 [AUTOTRANSLATED]</column>
       <column name="definition_pt">criptografar</column>
+      <column name="definition_fi">salata</column>
       <column name="synonyms">{So':v:2}</column>
       <column name="antonyms">{meSHa':v:2}</column>
       <column name="see_also">{meS:v:1}</column>
@@ -4286,6 +4729,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4295,6 +4739,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4302,6 +4747,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4315,6 +4761,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">развязать узел</column>
       <column name="definition_zh_HK">unknot、解開一個結 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desatar um nó, desatar um nó</column>
+      <column name="definition_fi">avata (solmu)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{meS:v:1}</column>
       <column name="see_also">{meSHa':v:2}</column>
@@ -4325,6 +4772,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{meS:v:1}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -4334,6 +4782,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4341,6 +4790,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4354,6 +4804,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">расшифровывать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">解碼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">decifrar</column>
+      <column name="definition_fi">purkaa (salaus)</column>
       <column name="synonyms">{So'Ha':v:2}</column>
       <column name="antonyms">{meS:v:2}</column>
       <column name="see_also">{meSHa':v:1}, {baghHa':v}</column>
@@ -4364,6 +4815,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">與{So'Ha':v:2,nolink}一樣，這意味著進行解密的人可以提前知道自己在做什麼，並且不會破解代碼。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assim como no {So'Ha':v:2,nolink}, isso implica que a pessoa que está executando a descriptografia sabe o que está fazendo com antecedência e não está decifrando um código.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kuten {So'Ha':v:2,nolink}: n kohdalla, tämä tarkoittaa, että salauksen salauksen tekijä tietää, mitä hän tekee etuajassa eikä halkeile koodia.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{meS:v:2}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -4373,6 +4825,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4380,6 +4833,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4393,6 +4847,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">большой духовой инструмент [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大型管樂器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">instrumento de sopro grande</column>
+      <column name="definition_fi">eräs iso puhallinsoitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngujlep:n}, {Heng:v}</column>
@@ -4403,6 +4858,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">Это инструмент, который состоит из блокирующих трубок. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種由互鎖管組成的儀器。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um instrumento que consiste em tubos interligados. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on instrumentti, joka koostuu lukitusputkista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A "noisy mess". Note that the words {meS:v:1h} and {meS:n} did not exist when this word was published.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4412,6 +4868,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4419,6 +4876,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4432,6 +4890,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">останавливаться, прекращать, прерывать, останавливать, пресекать</column>
       <column name="definition_zh_HK">停止</column>
       <column name="definition_pt">parar, cessar</column>
+      <column name="definition_fi">lopettaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yev:v}, {vIH:v}, {bup:v}, {taD:v}</column>
@@ -4442,6 +4901,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">Когда используется в качестве команды, это слово значит прекратить что-либо делать. Это слово не используется чтобы приказать что-либо выключить.[2]</column>
       <column name="notes_zh_HK">當用作命令時，此詞表示停止做某事。它不會用於停止設備（例如引擎）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando usada como comando, essa palavra significa parar de fazer algo. Não seria usado para parar um dispositivo (como um motor).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun sitä käytetään komentona, tämä sana tarkoittaa lopettaa tekemästä jotain. Sitä ei käytetä laitteen (kuten moottorin) pysäyttämiseen[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The only object this verb has taken in canon is {'e':n:pro}, and in every case the subject of {mev:v:nolink} has been identical to the subject of the sentence-as-object. It seems that the subject is what stops or ceases, even when there is an object. It is notable that {mevmoH:v@@mev:v, -moH:v} appears on {KGT p.154:src} as "cause [someone] to stop".</column>
       <column name="components"></column>
       <column name="examples">
@@ -4453,6 +4913,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4460,6 +4921,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -4473,6 +4935,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">Стоп, этого достаточно! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">停下來，夠了！</column>
       <column name="definition_pt">Pare, é o suficiente</column>
+      <column name="definition_fi">Lopeta, nyt riittää!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mev:v}, {yap:v}</column>
@@ -4483,6 +4946,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4492,6 +4956,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4499,6 +4964,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.113:src}</column>
     </table>
     <table name="mem">
@@ -4512,6 +4978,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">совмещать, вставлять, сцеплять, чередовать, мешать с [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">匹配，適合，互鎖，交錯，網格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">encaixar, intertravar com algo, combinar</column>
+      <column name="definition_fi">sopia johonkin, punoutua yhteen, limittyä/lomittua jonkin kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nel:v}</column>
@@ -4522,6 +4989,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">Это используется для носка, перчаток и т. Д., Прилегающих к ноге, руке или тому, что подходит. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它用於襪子，手套等，可以放在腳，手或其他合適的東西上。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para uma meia, luva etc., encaixando-se em um pé, mão ou o que for apropriado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään sukkaan, käsineeseen jne., Joka sopii jalkaan, käteen tai mihin tahansa sopivaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4537,6 +5005,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4544,6 +5013,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.01.22:src}</column>
     </table>
     <table name="mem">
@@ -4557,6 +5027,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">сладкая кукуруза [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">甜玉米</column>
       <column name="definition_pt">milho doce</column>
+      <column name="definition_fi">maissi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIr:n}</column>
@@ -4567,6 +5038,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="notes_ru">Это то, что клингоны называют терранской сладкой кукурузой (кукурузой). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人種甜玉米（玉米）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que os klingons chamariam de milho doce terráqueo (milho). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-sokerimaissiksi (maissi). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4576,6 +5048,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">maize</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4583,6 +5056,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4596,6 +5070,7 @@ This was also used for the "logic" menu (instructions about program flow control
       <column name="definition_ru">квадратная (форма) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">正方形</column>
       <column name="definition_pt">quadrado (forma)</column>
+      <column name="definition_fi">neliö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{buq'Ir:n}, {gho:n}, {mey':n}, {letbaQ:n}, {loS reD mey':n}</column>
@@ -4616,6 +5091,9 @@ Detta ord kan också hänvisa till "diamant" -dräkten i ett kortlek med spelkor
       <column name="notes_pt">Este é tecnicamente um {letbaQ HoS:n@@letbaQ:n, HoS:v}.
 
 Esta palavra também pode se referir ao naipe de "diamante" em um baralho de cartas (consulte {Degh:n:1}) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on teknisesti {letbaQ HoS:n@@letbaQ:n, HoS:v}.
+
+Tämä sana voi viitata myös "timanttipukuun" pelikorttipakassa (katso {Degh:n:1}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4625,6 +5103,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4632,6 +5111,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 12 (2005):src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4645,6 +5125,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">многоугольник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">多角形</column>
       <column name="definition_pt">polígono</column>
+      <column name="definition_fi">monikulmio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ra'Duch:n}, {meyrI':n}, {letbaQ:n}, {DujtlhuQ:n}, {'Impey':n}, {tut:n:2}, {yergh:n}</column>
@@ -4655,6 +5136,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">N-сторонний многоугольник - это {n reD mey':n:nolink} для n> 3. Например: {loS reD mey':n}, {vagh reD mey':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">n邊的多邊形是n> 3的{n reD mey':n:nolink}。例如：{loS reD mey':n}、{vagh reD mey':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">N-puolinen monikulmio on {n reD mey':n:nolink} arvolle n> 3. Esimerkiksi: {loS reD mey':n}, {vagh reD mey':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4664,6 +5146,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4671,6 +5154,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -4684,6 +5168,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">тетя (сестра мамы) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">阿姨（媽媽的妹妹） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tia (irmã da mãe)</column>
+      <column name="definition_fi">täti (äidin sisar)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoS:n}, {'IrneH:n}</column>
@@ -4694,6 +5179,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Дитя {me':n:nolink} - это {tey':n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{me':n:nolink}的孩子是{tey':n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O filho de um {me':n:nolink} é um {tey':n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{me':n:nolink}: n lapsi on {tey':n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Aunt "Em" from The Wizard of Oz.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4703,6 +5189,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mother's sister</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4710,6 +5197,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -4723,6 +5211,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">тетя (жена брата матери) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">阿姨（母親的兄弟的妻子） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tia (esposa do irmão da mãe)</column>
+      <column name="definition_fi">äidin veljen vaimo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoS:n}, {'IrneH:n}</column>
@@ -4733,6 +5222,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{me':n}, {'e'nal:n}</column>
       <column name="examples"></column>
@@ -4742,6 +5232,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mother's brother's wife</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4749,6 +5240,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -4762,6 +5254,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">крест (+), ex (×) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">交叉（+、×）</column>
       <column name="definition_pt">cruz</column>
+      <column name="definition_fi">risti (+, ×)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vech:v}, {neq:v}</column>
@@ -4772,6 +5265,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4781,6 +5275,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4788,6 +5283,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4801,6 +5297,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">сектор, зона</column>
       <column name="definition_zh_HK">部門、區域 [AUTOTRANSLATED]</column>
       <column name="definition_pt">setor, zona</column>
+      <column name="definition_fi">sektori, vyöhyke</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4811,6 +5308,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4820,6 +5318,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4827,6 +5326,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4840,6 +5340,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">колония, поселение</column>
       <column name="definition_zh_HK">殖民地 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colônia</column>
+      <column name="definition_fi">siirtokunta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuQ:n}</column>
@@ -4850,6 +5351,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4859,6 +5361,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4866,6 +5369,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4879,6 +5383,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">быть злым, быть порочным, быть зловещим</column>
       <column name="definition_zh_HK">是邪惡的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser mau</column>
+      <column name="definition_fi">olla paha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maQmIgh:n}, {molor:n:name}</column>
@@ -4889,6 +5394,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4898,6 +5404,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4905,6 +5412,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4918,6 +5426,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">быть удостоенным чести [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">羞辱、墮落</column>
       <column name="definition_pt">ser anteriormente honrado</column>
+      <column name="definition_fi">olla aiemmin kunnioitettu</column>
       <column name="synonyms">{web:v:1}</column>
       <column name="antonyms"></column>
       <column name="see_also">{lu:v}, {quv:v}, {HoQ:v}, {Qaq:v}, {naDHa':v}, {tuH:v}, {qIch:v}, {quvHa':v}, {Deq:v}</column>
@@ -4928,6 +5437,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Утрата чести подразумевается этим глаголом, который используется как прилагательное для описания того, кто упал с благодати. Это не относится к кому-то, кого бы назвали {'utlh:n}, слово, которое подразумевает добровольный, почетный выход на пенсию. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個動詞暗示著失去榮譽，該動詞被用作形容形容從恩典中墮落的人的形容詞。它不適用於被稱為{'utlh:n}的人，這個詞表示自願，光榮的退休。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A perda de honra está implícita nesse verbo, que é usado como adjetivo para descrever alguém que caiu da graça. Não é aplicável a alguém que seria descrito como {'utlh:n}, uma palavra que implica uma aposentadoria voluntária e honrada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kunniamenetyksestä seuraa tämä verbi, jota käytetään adjektiivina kuvaamaan armosta kaatunutta. Sitä ei sovelleta henkilöön, jota kuvataan nimellä {'utlh:n}, sana, joka merkitsee vapaaehtoista, kunniallista eläkkeelle siirtymistä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Richard "Mil"house Nixon.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4943,6 +5453,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be formerly honored</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4950,6 +5461,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, Sept. 2003:src}, [2] {paq'batlh p.146-147:src}</column>
     </table>
     <table name="mem">
@@ -4963,6 +5475,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">изображение, (визуальное) изображение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">圖片、（視覺）描繪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">imagem, foto, representação (visual)</column>
+      <column name="definition_fi">kuva (piirros, valokuva, sarjakuva, kuvake tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nagh beQ:n}, {mIllogh qonwI':n}</column>
@@ -4973,6 +5486,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Это слово может использоваться для любого вида изображения, включая рисунки, фотографии, карикатуры, значки на компьютерах 21-го века и так далее. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞可以用於任何形式的描繪，包括繪圖，照片，卡通，21世紀計算機上的圖標等等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra pode ser usada para qualquer tipo de representação, incluindo desenhos, fotografias, desenhos animados, ícones nos computadores do século XXI etc. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää kaikenlaiseen kuvaukseen, mukaan lukien piirustukset, valokuvat, sarjakuvia, kuvakkeet 2000-luvun tietokoneissa ja niin edelleen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a combination of the Latin word for "thousand" with the Greek word for "word".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4982,6 +5496,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">image, photograph</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4989,6 +5504,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2010:src}</column>
     </table>
     <table name="mem">
@@ -5002,6 +5518,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">камера [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">影相機</column>
       <column name="definition_pt">câmera</column>
+      <column name="definition_fi">kamera</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5012,6 +5529,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mIllogh:n}, {qon:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5021,6 +5539,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">photograph</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5028,6 +5547,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5041,6 +5561,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">пленка (для камеры) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">膠片（用於影相機）</column>
       <column name="definition_pt">filme (para câmera)</column>
+      <column name="definition_fi">filmi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5051,6 +5572,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mIllogh qonwI':n}, {qoSta':n}</column>
       <column name="examples"></column>
@@ -5060,6 +5582,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5067,6 +5590,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5080,6 +5604,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">тип животных, сабля медведь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、劍熊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, urso sabre</column>
+      <column name="definition_fi">eräs eläin, sapelikarhu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5090,6 +5615,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Smilodon".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5099,6 +5625,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5106,6 +5633,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5119,6 +5647,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">плюшевый медведь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">泰迪熊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">urso teddy</column>
+      <column name="definition_fi">nalle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5129,6 +5658,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mIl'oD:n}, {ngeb:v}</column>
       <column name="examples"></column>
@@ -5138,6 +5668,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5145,6 +5676,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5158,6 +5690,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">задерживать, откладывать, медлить, мешкать</column>
       <column name="definition_zh_HK">延遲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atrasar</column>
+      <column name="definition_fi">hidastella, viivytellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lum:v}</column>
@@ -5168,6 +5701,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5178,6 +5712,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5185,6 +5720,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5198,6 +5734,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">глаз</column>
       <column name="definition_zh_HK">眼睛</column>
       <column name="definition_pt">olho</column>
+      <column name="definition_fi">silmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lur:n}, {valQav:n}, {Separ:n}, {Huy':n}, {mInyoD:n}, {muylIS:n}</column>
@@ -5208,6 +5745,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5217,6 +5755,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5224,6 +5763,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5237,6 +5777,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">веко</column>
       <column name="definition_zh_HK">眼皮</column>
       <column name="definition_pt">pálpebra</column>
+      <column name="definition_fi">silmäluomi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn:n}, {muylIS:n}</column>
@@ -5247,6 +5788,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mIn:n}, {yoD:n}</column>
       <column name="examples"></column>
@@ -5256,6 +5798,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5263,6 +5806,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}, [2] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5276,6 +5820,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">солнцезащитные очки</column>
       <column name="definition_zh_HK">太陽眼鏡</column>
       <column name="definition_pt">óculos escuros</column>
+      <column name="definition_fi">aurinkolasit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{neqratlh:n}</column>
@@ -5286,6 +5831,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Обратите внимание, что это слово в единственном числе, в отличие от английского слова «солнцезащитные очки». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，該單詞是單數形式，與英語單詞“ sunglasses”不同。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que essa palavra é singular, diferentemente da palavra em inglês "óculos de sol". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä sana on yksikkö, toisin kuin englanninkielinen sunglasses. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mIn:n}, {Qan:v}, {-wI':v}, {nguv:v}</column>
       <column name="examples"></column>
@@ -5295,6 +5841,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5302,6 +5849,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5315,6 +5863,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">оптический обман</column>
       <column name="definition_zh_HK">光學錯覺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ilusão de ótica</column>
+      <column name="definition_fi">optinen illuusio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn yuqwI':n}</column>
@@ -5325,6 +5874,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mIn:n}, {toj:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5334,6 +5884,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5341,6 +5892,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -5354,6 +5906,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">выполнять магию [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">表演魔術 [AUTOTRANSLATED]</column>
       <column name="definition_pt">realizar mágica</column>
+      <column name="definition_fi">taikoa, huijata silmää</column>
       <column name="synonyms">{'IDnar lIl:sen}</column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn yuqwI':n}, {gho''ong:n}</column>
@@ -5364,6 +5917,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mIn:n}, {yuq:v}</column>
       <column name="examples"></column>
@@ -5373,6 +5927,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5380,6 +5935,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -5393,6 +5949,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">волшебник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">魔術師</column>
       <column name="definition_pt">mágico</column>
+      <column name="definition_fi">taikuri</column>
       <column name="synonyms">{'IDnar lIlwI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn yuq:sen}, {mIn tojwI':n}</column>
@@ -5403,6 +5960,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Это самый распространенный способ обращения к человеку, который выполняет магию. Для истинного волшебника или колдуна см. {'IDnar pIn'a':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是提到魔術師的最常見方式。有關真正的巫師或巫師，請參見{'IDnar pIn'a':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é a maneira mais comum de se referir a uma pessoa que executa mágica. Para um verdadeiro mago ou feiticeiro, consulte {'IDnar pIn'a':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleisin tapa viitata taikuutta tekevään henkilöön. Katso oikea velho tai velho, katso {'IDnar pIn'a':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mIn:n}, {yuq:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5412,6 +5970,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5419,6 +5978,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -5432,6 +5992,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">слеза [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">淚珠</column>
       <column name="definition_pt">lágrima</column>
+      <column name="definition_fi">kyynel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5442,6 +6003,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Хотя у клингонов нет родного слова о капле слезы, они понимают, что этот термин означает каплю жидкости, исходящую из глаза. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">儘管克林崗人沒有流淚的母語，但他們會理解這個術語是指從眼中滴落的液體。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Embora os klingons não tenham uma palavra nativa para uma gota de lágrima, eles entenderiam esse termo para se referir a uma gota de líquido proveniente do olho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikka klingoneilla ei ole natiivisanaa pisaran kyyneleestä, he ymmärtäisivät tämän termin tarkoittavan silmästä tulevaa nestepisaraa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mIn:n}, {'onroS:n}</column>
       <column name="examples"></column>
@@ -5451,6 +6013,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5458,6 +6021,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5471,6 +6035,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">быть богатым</column>
       <column name="definition_zh_HK">富有</column>
       <column name="definition_pt">ser rico</column>
+      <column name="definition_fi">olla rikas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chep:v}, {mIp:n}, {Huch:n}</column>
@@ -5481,6 +6046,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5490,6 +6056,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5497,6 +6064,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5510,6 +6078,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">богатство, богатство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">財富</column>
       <column name="definition_pt">riqueza</column>
+      <column name="definition_fi">rikkaus, vauraus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIp:v}, {Huch:n}</column>
@@ -5520,6 +6089,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5529,6 +6099,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5536,6 +6107,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5549,6 +6121,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">механизм, аппарат, машинное оборудование</column>
       <column name="definition_zh_HK">機械</column>
       <column name="definition_pt">maquinaria</column>
+      <column name="definition_fi">koneisto, mekanismi</column>
       <column name="synonyms">{jo':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{jan:n:1}</column>
@@ -5559,6 +6132,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5568,6 +6142,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5575,6 +6150,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5588,6 +6164,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">жарить во фритюре [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">油炸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fritar</column>
+      <column name="definition_fi">uppopaistaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meQ:v}, {'Im:v}</column>
@@ -5598,6 +6175,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to McDonald's, which is known as "Mickey D's".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5607,6 +6185,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5614,6 +6193,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 6.2, p.20, Jun. 1997:src}</column>
     </table>
     <table name="mem">
@@ -5627,6 +6207,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">лоб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">額頭</column>
       <column name="definition_pt">testa</column>
+      <column name="definition_fi">otsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quch:n}</column>
@@ -5637,6 +6218,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A Klingon forehead looks like it's deep-fried.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5646,6 +6228,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5653,6 +6236,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5666,6 +6250,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">цепь</column>
       <column name="definition_zh_HK">鎖鏈</column>
       <column name="definition_pt">cadeia, corrente</column>
+      <column name="definition_fi">ketju</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlharwIl:n}</column>
@@ -5676,6 +6261,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Это может быть использовано, как метафора(см. {mIr:n:2}). Кроме того, если все ясно, его можно использовать как сленговый термин для обозначения {wIyqap:n} или {lanSoy:n} (хотя, вероятно, не {wev:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">也可以隱喻或像徵性地使用它（請參閱{mIr:n:2}）。同樣，如果情況清楚的話，它可以用作a語來表示{wIyqap:n}或{lanSoy:n}（儘管可能不是{wev:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä voidaan käyttää myös vertauskuvallisesti tai symbolisesti (katso {mIr:n:2}). Lisäksi, jos asiat ovat selvät, sitä voidaan käyttää slangiterminä tarkoittamaan {wIyqap:n} tai {lanSoy:n} (tosin todennäköisesti ei {wev:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5685,6 +6271,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5692,6 +6279,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5705,6 +6293,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">полоса [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">條紋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">faixa</column>
+      <column name="definition_fi">-putki (esim. voittoputki, tappioputki tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIr:n:1}</column>
@@ -5715,6 +6304,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{QapwI' mIr:n}, {yay mIr:n}, {lujwI' mIr:n}, {quvHa'ghach mIr:n}, {qaD mIr:n}</column>
@@ -5724,6 +6314,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5731,6 +6322,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5744,6 +6336,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">(курительная) трубка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">煙斗</column>
       <column name="definition_pt">cachimbo</column>
+      <column name="definition_fi">(tupakka)piippu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIch:n}, {pur:v}, {por:n}, {toba'qo:n}</column>
@@ -5754,6 +6347,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Meerschaum", also known as sepiolite, is a material from which some smoking pipes are made.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5763,6 +6357,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5770,6 +6365,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.07.03:src}</column>
     </table>
     <table name="mem">
@@ -5783,6 +6379,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">быть смущенным, быть беспорядочным</column>
       <column name="definition_zh_HK">混淆、迷、一頭煙</column>
       <column name="definition_pt">ser confuso</column>
+      <column name="definition_fi">olla hämmentynyt, olla ymmällään, olla sekava (henkilöstä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rel:v}, {mIS:n}, {mISmoH:v}, {DuD:v}</column>
@@ -5793,6 +6390,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Это относится к умственной путанице.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指精神錯亂。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à confusão mental.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkiseen sekaannukseen[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Mish" mash.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5802,6 +6400,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5809,6 +6408,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5822,6 +6422,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="definition_ru">смущение, путаница</column>
       <column name="definition_zh_HK">混亂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">confusão</column>
+      <column name="definition_fi">sekaannus, hämmennys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIS:v}</column>
@@ -5832,6 +6433,7 @@ Esta palavra também pode se referir ao naipe de "diamante" em um baralho de car
       <column name="notes_ru">Шекспировская пьеса {paghmo' tIn mIS:sen:nolink}, дословно "Велико смущение из ничего", было переведено, как "Много шума из ничего" {tlhIngan Hol yejHaD:n}.</column>
       <column name="notes_zh_HK">莎士比亞的戲劇《 {paghmo' tIn mIS:sen:nolink}》的字面意思是“無所事事，這是巨大的困惑”，而{tlhIngan Hol yejHaD:n}已將其翻譯為英語，“無所事事”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Shakespearen näytelmä {paghmo' tIn mIS:sen:nolink}, kirjaimellisesti "Hämmennys on suuri ei mitään johtuen", on {tlhIngan Hol yejHaD:n} kääntänyt englanniksi nimellä "Much Ado About Nothing". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Mish" mash.
 
 This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column>
@@ -5843,6 +6445,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5850,6 +6453,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
         <table name="mem">
@@ -5863,6 +6467,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
           <column name="definition_ru">смущаться, путаться</column>
           <column name="definition_zh_HK">迷惑 [AUTOTRANSLATED]</column>
           <column name="definition_pt">confundir</column>
+      <column name="definition_fi">sekoittaa, hämmentää jotakuta, saada joku ymmälleen</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5873,6 +6478,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
           <column name="notes_ru">Это относится к умственной путанице.[2] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是指精神錯亂。[2] [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso se refere à confusão mental.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkiseen sekaannukseen[2] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{mIS:v}, {-moH:v}</column>
           <column name="examples"></column>
@@ -5882,6 +6488,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5889,6 +6496,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
         </table>
     <table name="mem">
@@ -5902,6 +6510,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="definition_ru">мрамор (материал) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大理石（材質） [AUTOTRANSLATED]</column>
       <column name="definition_pt">mármore (material)</column>
+      <column name="definition_fi">marmori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nagh:n}</column>
@@ -5912,6 +6521,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="notes_ru">Это относится к породе кристаллического известняка, часто метаморфизованной и имеющей полосатый или закрученный вид, используемой в качестве строительного или скульптурного материала. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指經常變質並具有條紋或漩渦狀外觀的結晶石灰岩岩石，用作建築或雕刻材料。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a rochas de calcário cristalino, muitas vezes metamorfoseadas e com aparência de listras ou turbilhão, usadas como material de construção ou escultura. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kiteistä kalkkikiveä, joka on usein metamorfoitunut ja jolla on raidallinen tai pyörteinen ulkonäkö ja jota käytetään rakennus- tai veistosmateriaalina. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5921,6 +6531,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5928,6 +6539,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5941,6 +6553,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="definition_ru">Миштак</column>
       <column name="definition_zh_HK">？Mishtak [AUTOTRANSLATED]</column>
       <column name="definition_pt">?Mishtak</column>
+      <column name="definition_fi">?Mishtak (eräs kuuluisa kuvanveistäjä?)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hew chenmoHwI':n}</column>
@@ -5951,6 +6564,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="notes_ru">Это имя скульптора, который создал круги кровной клятвы ({'Iw 'Ip ghomey:n}).</column>
       <column name="notes_zh_HK">這是製作“血誓界”（{'Iw 'Ip ghomey:n}）的雕刻家的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome do escultor que fez Círculos de Juramento de Sangue ({'Iw 'Ip ghomey:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kuvanveistäjän nimi, joka teki verivalan ympyrät ({'Iw 'Ip ghomey:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The English spelling of this name was never given in {KCD:src}. The spelling is therefore uncertain.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5960,6 +6574,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5967,6 +6582,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -5980,6 +6596,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="definition_ru">быть подходящим, подходящим, подходящим для ситуации [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">適當、適合、適合的情況 [AUTOTRANSLATED]</column>
       <column name="definition_pt">apropriado, adequado, adequado à situação</column>
+      <column name="definition_fi">olla sopiva, olla soveltuva</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yem:v}</column>
       <column name="see_also">{wogh:v}</column>
@@ -5990,6 +6607,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Meet" (archaic English adjective meaning suitable or proper).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5999,6 +6617,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6006,6 +6625,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -6019,6 +6639,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="definition_ru">кузница (металл) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鍛造（金屬） [AUTOTRANSLATED]</column>
       <column name="definition_pt">forjar (metal)</column>
+      <column name="definition_fi">takoa, työstää (metallia)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qu:v}, {baS laSvargh:n}, {vIncha':n}, {QumeH ngaSwI':n}</column>
@@ -6029,6 +6650,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6038,6 +6660,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6045,6 +6668,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6058,6 +6682,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="definition_ru">меньший парус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小颿</column>
       <column name="definition_pt">vela menor</column>
+      <column name="definition_fi">pienempi purje?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SolDeS:n}, {bIQ Duj:n}, {SuS:n}</column>
@@ -6068,6 +6693,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6077,6 +6703,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6084,6 +6711,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -6097,6 +6725,7 @@ This was clarified to mean "mental confusion" at {qep'a' 24 (2017):src}.</column
       <column name="definition_ru">шлем</column>
       <column name="definition_zh_HK">頭盔</column>
       <column name="definition_pt">capacete</column>
+      <column name="definition_fi">kypärä, päähine, hattu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIv je DaS:n}, {nach:n}</column>
@@ -6121,6 +6750,9 @@ Se {mIvDaq pogh cha':sen} för ett formspråk som involverar {mIv:n:nolink}. [AU
       <column name="notes_pt">Em {TNK:src}, {mIv:n:1,nolink} é usado para "chapéu".
 
 Veja {mIvDaq pogh cha':sen} para um idioma envolvendo {mIv:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{TNK:src}: ssä {mIv:n:1,nolink}: ta käytetään "hattuun".
+
+Katso kohdasta {mIvDaq pogh cha':sen} idioomi, johon liittyy {mIv:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6130,6 +6762,7 @@ Veja {mIvDaq pogh cha':sen} para um idioma envolvendo {mIv:n:nolink}. [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hat, cap</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6137,6 +6770,7 @@ Veja {mIvDaq pogh cha':sen} para um idioma envolvendo {mIv:n:nolink}. [AUTOTRANS
       <column name="search_tags_ru">шапка, шляпа</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6150,6 +6784,7 @@ Veja {mIvDaq pogh cha':sen} para um idioma envolvendo {mIv:n:nolink}. [AUTOTRANS
       <column name="definition_ru">металлический горшок с плоским дном [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">金屬平底鍋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vaso de fundo plano metálico</column>
+      <column name="definition_fi">metallinen tasapohjainen kattila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6160,6 +6795,7 @@ Veja {mIvDaq pogh cha':sen} para um idioma envolvendo {mIv:n:nolink}. [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6169,6 +6805,7 @@ Veja {mIvDaq pogh cha':sen} para um idioma envolvendo {mIv:n:nolink}. [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6176,6 +6813,7 @@ Veja {mIvDaq pogh cha':sen} para um idioma envolvendo {mIv:n:nolink}. [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6189,6 +6827,7 @@ Veja {mIvDaq pogh cha':sen} para um idioma envolvendo {mIv:n:nolink}. [AUTOTRANS
       <column name="definition_ru">дело было отложено или перенесено [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一件事已被推遲或重新安排 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um assunto foi adiado ou remarcado</column>
+      <column name="definition_fi">asiaa on lykätty tai se on siirretty</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6213,6 +6852,9 @@ Detta formspråk har sitt ursprung i {HenrI' vagh:n:name}, ett spel av {wIlyam S
       <column name="notes_pt">Esta expressão significa literalmente "exibir uma luva no capacete" e é usada para transmitir a ideia de que um assunto foi adiado ou remarcado. A frase assume várias formas, conforme apropriado para as partes no compromisso. Por exemplo, {mIvwIjDaq poghlIj vIcha':sen:nolink} "Eu exibo sua luva em meu capacete" implica que o assunto adiado é entre o falante e o destinatário.
 
 Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ilmaisu tarkoittaa kirjaimellisesti "näyttää hansikas kypärässä", ja sitä käytetään ajatuksen antamiseen siitä, että asiaa on lykätty tai se on siirretty uudelleen. Lausekkeella on useita muotoja, kuten sitoumuksen osapuolet sopivat. Esimerkiksi {mIvwIjDaq poghlIj vIcha':sen:nolink} "Näytän hansikkaasi kypärässäni" tarkoittaa, että lykätty asia on puhujan ja vastaanottajan välillä.
+
+Tämän sanaston alkuperä on {HenrI' vagh:n:name}, {wIlyam SeQpIr:n:name}: n näytelmä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6222,6 +6864,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">postpone, postponement, reschedule, rescheduling</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6229,6 +6872,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.125:src}</column>
     </table>
     <table name="mem">
@@ -6242,6 +6886,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="definition_ru">металлический горшок с плоским дном [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">金屬平底鍋</column>
       <column name="definition_pt"> panela de fundo plano de metal</column>
+      <column name="definition_fi">metallinen tasapohjainen kattila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6252,6 +6897,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="notes_ru">Это {bargh:n} из металла. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是由金屬製成的{bargh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um {bargh:n} feito de metal. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on metallista valmistettu {bargh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6261,6 +6907,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6268,6 +6915,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6281,6 +6929,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="definition_ru">полностью одетый (как для церемониального дела) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">穿著整齊（至於儀式） [AUTOTRANSLATED]</column>
       <column name="definition_pt">completamente vestido (como para um caso cerimonial)</column>
+      <column name="definition_fi">täysin pukeutunut (seremoniaan tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SeQ:v}</column>
@@ -6291,6 +6940,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="notes_ru">Обратите внимание, что эта идиома не соответствует правильной грамматике, так как обычно {je:conj} будет в конце. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，該慣用語沒有遵循正確的語法，因為通常{je:conj}將在結尾。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que esse idioma não segue a gramática apropriada, pois normalmente o {je:conj} estaria no final. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä idioma ei noudata oikeaa kielioppia, sillä tavallisesti {je:conj} olisi lopussa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mIv:n:1}, {je:conj}, {DaS:n}</column>
       <column name="examples">
@@ -6301,6 +6951,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6308,6 +6959,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.107:src}</column>
     </table>
     <table name="mem">
@@ -6321,6 +6973,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="definition_ru">корона [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">王冠</column>
       <column name="definition_pt">coroa</column>
+      <column name="definition_fi">kruunu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6331,6 +6984,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="notes_ru">Это церемониальный головной убор, который носят некоторые императоры. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一些皇帝佩戴的禮儀頭飾。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um capacete cerimonial usado por alguns imperadores. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on seremoniallinen päähine, jota jotkut keisarit käyttävät. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mIv:n:1}, {-'a':n}</column>
       <column name="examples"></column>
@@ -6340,6 +6994,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6347,6 +7002,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6360,6 +7016,7 @@ Este idioma tem sua origem em {HenrI' vagh:n:name}, uma peça de {wIlyam SeQpIr:
       <column name="definition_ru">шрам (от раны) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">疤痕（來自傷口） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cicatriz (de ferida)</column>
+      <column name="definition_fi">arpi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taq:v}, {roptoj:n}, {SanDIy:n}, {pe''egh:v}, {Hampong:n}, {gher'ID:n}</column>
@@ -6374,6 +7031,9 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on arpi, joka on seurausta haavasta (riippumatta haavan tapahtumisesta) .[1]
+
+Laskenta {mIvwa'mey:n@@mIvwa':n, -mey:n} lasketaan yhteen tai pisteet. Tätä käytetään myös "väestönlaskennassa" tai "henkilöstömäärässä" .[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as just "scar", with an accompanying explanation of the kinds of scars.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6383,6 +7043,7 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tally, score</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6390,6 +7051,7 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -6403,6 +7065,7 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="definition_ru">подсчет, статистика [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">統計分析、統計 [AUTOTRANSLATED]</column>
       <column name="definition_pt">análise de dados, estatísticas</column>
+      <column name="definition_fi">analyysi, tilastot [AUTOTRANSLATED]</column>
       <column name="synonyms">{mI' poj:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{pe''egh:v}</column>
@@ -6413,6 +7076,7 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mIvwa':n}, {-mey:n}, {poj:n}</column>
       <column name="examples"></column>
@@ -6422,6 +7086,7 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6429,6 +7094,7 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -6442,6 +7108,7 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="definition_ru">процедура, процесс, шаг, этап процесса</column>
       <column name="definition_zh_HK">程序、過程、步驟、階段（在一個過程中） [AUTOTRANSLATED]</column>
       <column name="definition_pt">procedimento, processo, etapa, estágio (em um processo), receita, fórmula</column>
+      <column name="definition_fi">menettely, prosessi, kehityskulku?; askel, vaihe (prosessissa); resepti, kaava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nab:n}, {HIl'aD:n}</column>
@@ -6452,6 +7119,7 @@ A tally or score is kept by counting {mIvwa'mey:n@@mIvwa':n, -mey:n}. This is al
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined as "procedure, process" in {TKD:src}, as "step, stage (in a process)" in {KGT:src}, and expanded to include "recipe, formula (prodecure, process)" at {qep'a' 26 (2019):src}.
 
 This was used to refer to a concept in computer programming, namely, a compartmentalized piece of computer code which has inputs and outputs and is used over and over, in Klingon Blockly.[3]</column>
@@ -6463,6 +7131,7 @@ This was used to refer to a concept in computer programming, namely, a compartme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6470,6 +7139,7 @@ This was used to refer to a concept in computer programming, namely, a compartme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT:src}, [3] {KLI mailing list 2014.11.26:src}, [4] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -6483,6 +7153,7 @@ This was used to refer to a concept in computer programming, namely, a compartme
       <column name="definition_ru">хвастаться, похвастать, бахвалиться</column>
       <column name="definition_zh_HK">吹牛、作大</column>
       <column name="definition_pt">gabar</column>
+      <column name="definition_fi">kerskailla, ylpeillä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nguq:v}, {'eDjen:n}</column>
@@ -6493,6 +7164,7 @@ This was used to refer to a concept in computer programming, namely, a compartme
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Me, me, me!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6502,6 +7174,7 @@ This was used to refer to a concept in computer programming, namely, a compartme
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6509,6 +7182,7 @@ This was used to refer to a concept in computer programming, namely, a compartme
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6522,6 +7196,7 @@ This was used to refer to a concept in computer programming, namely, a compartme
       <column name="definition_ru">Число, номер</column>
       <column name="definition_zh_HK">數目、號碼</column>
       <column name="definition_pt">número</column>
+      <column name="definition_fi">luku, numero</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{togh:v}, {mob:v:2}, {mobHa':v}</column>
@@ -6536,6 +7211,9 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
 Когда число используется для нумерации чего-то, в отличие от счёта, оно следует за существительным. Порядковые номера сформированы с {-DIch:n:num,suff}. Повторы сформированы с помощью {-logh:n:num,suff}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Luku muodostavia elementtejä ovat {maH:n:2,num}, {vatlh:n:num}, {SaD:n:num} ({SanID:n:num}), {netlh:n:num}, {bIp:n:num}, {'uy':n:num}, {Saghan:n:num}.
+
+Kun numeroa käytetään numeroinnissa (merkinnöissä), toisin kuin laskemisessa, se seuraa substantiivia. Järjestysnumerot muodostetaan {-DIch:n:num,suff}: llä. Toistot muodostetaan {-logh:n:num,suff}: llä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6547,6 +7225,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
 ▶ {ghogh HablI' mI' yIper:sen:nolink} "Каков номер телефона?"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6554,6 +7233,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
         <table name="mem">
@@ -6567,6 +7247,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="definition_ru">нечетное число [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">奇數</column>
           <column name="definition_pt">número ímpar</column>
+      <column name="definition_fi">pariton luku</column>
           <column name="synonyms"></column>
           <column name="antonyms">{mI' mobHa':n}</column>
           <column name="see_also"></column>
@@ -6577,6 +7258,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{mI':n}, {mob:v:2}</column>
           <column name="examples"></column>
@@ -6586,6 +7268,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6593,6 +7276,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
         </table>
         <table name="mem">
@@ -6606,6 +7290,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="definition_ru">четное число [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">偶數</column>
           <column name="definition_pt">numero par</column>
+      <column name="definition_fi">parillinen luku</column>
           <column name="synonyms"></column>
           <column name="antonyms">{mI' mob:n}</column>
           <column name="see_also"></column>
@@ -6616,6 +7301,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{mI':n}, {mobHa':v}</column>
           <column name="examples"></column>
@@ -6625,6 +7311,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6632,6 +7319,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
         </table>
         <table name="mem">
@@ -6645,6 +7333,7 @@ When a number is used for numbering (labeling), as opposed to counting, it follo
           <column name="definition_ru">умри, игра в кости с числами [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">骰子、色子</column>
           <column name="definition_pt">dados, dados com números</column>
+      <column name="definition_fi">(numero)noppa</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{ngutlh nagh:n}, {SuD:v:2}, {qeylIS mInDu':n}, {Haw:v}</column>
@@ -6669,6 +7358,9 @@ Verbetet {'al:v:2} används för slumpmässiga nummer ({mI' 'al:n}). [AUTOTRANSL
           <column name="notes_pt">Em {Klingon Monopoly:src}, {mI' naghmey:n:nolink} se refere aos dados de jogo. O verbo {ronmoH:v@@ron:v:1, -moH:v} é usado para a ação de lançar ou rolar os dados.
 
 O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohdassa {Klingon Monopoly:src} {mI' naghmey:n:nolink} viittaa pelaaviin noppiin. Verbiä {ronmoH:v@@ron:v:1, -moH:v} käytetään noppien heittämiseen tai heittämiseen.
+
+Verbiä {'al:v:2} käytetään satunnaislukuihin ({mI' 'al:n}). [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{mI':n}, {nagh:n}</column>
           <column name="examples">
@@ -6680,6 +7372,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de">Spielwürfel</column>
           <column name="search_tags_fa"></column>
@@ -6687,6 +7380,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Klingon Monopoly:src}</column>
         </table>
         <table name="mem">
@@ -6700,6 +7394,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="definition_ru">анализ чисел, статистика [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">數字分析、統計 [AUTOTRANSLATED]</column>
           <column name="definition_pt">análise numérica, estatísticas</column>
+      <column name="definition_fi">number analysis, statistics [AUTOTRANSLATED]</column>
           <column name="synonyms">{mIvwa'mey poj:n}</column>
           <column name="antonyms"></column>
           <column name="see_also">{pe''egh:v}</column>
@@ -6710,6 +7405,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{mI':n}, {poj:n}</column>
           <column name="examples"></column>
@@ -6719,6 +7415,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6726,6 +7423,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
         </table>
         <table name="mem">
@@ -6739,6 +7437,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="definition_ru">математика [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">數學</column>
           <column name="definition_pt">matemática</column>
+      <column name="definition_fi">matematiikka</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{mI' tej:n}, {ghIqtu':n}, {wItte':n}</column>
@@ -6749,6 +7448,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This was used in Klingon Blockly. The usage was vetted by Marc Okrand.[1]</column>
           <column name="components">{mI':n}, {QeD:n}</column>
           <column name="examples"></column>
@@ -6758,6 +7458,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">math, maths</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6765,6 +7466,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2014.11.26:src}</column>
         </table>
         <table name="mem">
@@ -6778,6 +7480,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="definition_ru">математик [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">數學家</column>
           <column name="definition_pt">matemático</column>
+      <column name="definition_fi">matemaatikko</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{mI'QeD:n}, {tej:n}</column>
@@ -6788,6 +7491,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word appeared in the booklet with a space, despite {mI'QeD:n:nolink} (revealed earlier) and {'otlhtej:n} (in the same booklet) being written without a space.</column>
           <column name="components">{mI':n}, {tej:n}</column>
           <column name="examples"></column>
@@ -6797,6 +7501,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">mI'tej</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6804,6 +7509,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -6817,6 +7523,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="definition_ru">случайное число [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">隨機數 [AUTOTRANSLATED]</column>
           <column name="definition_pt">número aleatório</column>
+      <column name="definition_fi">satunnaisluku</column>
           <column name="synonyms">{Du'Hom mI':n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -6827,6 +7534,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{mI':n}, {'al:v:2}</column>
           <column name="examples"></column>
@@ -6836,6 +7544,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6843,6 +7552,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 26 (2019):src}</column>
         </table>
     <table name="mem">
@@ -6856,6 +7566,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">танцевать, бегать на месте, заниматься художественной гимнастикой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">跳舞、跑到位、做健美操 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dançar, correr no lugar, fazer ginástica</column>
+      <column name="definition_fi">tanssia, voimistella, juosta paikallaan, tehdä liikkeitä rytmissä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moQbara':n}, {marvargh:n}, {mI'wI':n}, {pIqcho':n}</column>
@@ -6866,6 +7577,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6875,6 +7587,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">exercise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6882,6 +7595,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6895,6 +7609,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">танцор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">舞蹈家 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dançarino</column>
+      <column name="definition_fi">tanssija, voimistelija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI'wI' much:n}</column>
@@ -6905,6 +7620,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mI':v}, {-wI':v}</column>
       <column name="examples">{qul mI'wI':n}</column>
@@ -6914,6 +7630,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6921,6 +7638,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -6934,6 +7652,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">танцевальное шоу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">舞蹈表演 [AUTOTRANSLATED]</column>
       <column name="definition_pt">show de dança</column>
+      <column name="definition_fi">tanssiesitys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qe' much:n}</column>
@@ -6944,6 +7663,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru">Это можно использовать для перевода «кабаре», если шоу кабаре полностью или почти полностью состоит из танцев, но это особая и нечастая ситуация. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果歌舞表演全部或幾乎全部由舞蹈組成，則可用於翻譯“ cabaret”，但這是一種特殊且不常見的情況。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para traduzir "cabaré" se o show de cabaré consistir total ou quase inteiramente em dança, mas essa é uma situação especial e pouco frequente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää kääntämään "kabaree", jos kabareesitys koostuu kokonaan tai melkein kokonaan tanssista, mutta se on erityinen ja harvinainen tilanne. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mI'wI':n}, {much:n}</column>
       <column name="examples"></column>
@@ -6953,6 +7673,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cabaret</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6960,6 +7681,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -6973,6 +7695,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">спираль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">螺線</column>
       <column name="definition_pt">espiral</column>
+      <column name="definition_fi">kierre, spiraali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ver:v:1}</column>
@@ -6983,6 +7706,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Jacob Bernouilli refered to the logarithmic spiral as "spira mirabilis".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6992,6 +7716,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6999,6 +7724,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -7012,6 +7738,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">М'Линд</column>
       <column name="definition_zh_HK">M'Lind [AUTOTRANSLATED]</column>
       <column name="definition_pt">M'Lind</column>
+      <column name="definition_fi">M'Lind</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7022,6 +7749,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru">Это отец {Qa'taq:n:name}.</column>
       <column name="notes_zh_HK">這是{Qa'taq:n:name}的父親。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o pai de {Qa'taq:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {Qa'taq:n:name}: n isä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7031,6 +7759,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7038,6 +7767,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {The Klingon Art of War:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -7051,6 +7781,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">быть одному, быть одиноким</column>
       <column name="definition_zh_HK">一個人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser sozinho</column>
+      <column name="definition_fi">olla yksin, olla yksinäinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tay':v}, {nIteb:adv}, {neH:adv}, {'ub:v}</column>
@@ -7061,6 +7792,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Alone in a "mob".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7070,6 +7802,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7077,6 +7810,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7090,6 +7824,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">быть странным (используется в математике) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">奇（數學）</column>
       <column name="definition_pt">ser ímpar (usado em matemática)</column>
+      <column name="definition_fi">olla pariton (luku)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mobHa':v}</column>
       <column name="see_also"></column>
@@ -7100,6 +7835,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru">Нечетное число {mI' mob:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">奇數是{mI' mob:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um número ímpar é {mI' mob:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Pariton luku on {mI' mob:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7109,6 +7845,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7116,6 +7853,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -7129,6 +7867,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">быть четным (используется в математике) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">偶（數學）</column>
       <column name="definition_pt">ser par (usado em matemática)</column>
+      <column name="definition_fi">olla parillinen (luku)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mob:v:2}</column>
       <column name="see_also"></column>
@@ -7139,6 +7878,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru">Четное число - {mI' mobHa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">偶數是{mI' mobHa':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um número par é {mI' mobHa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Parillinen luku on {mI' mobHa':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mob:v:2}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -7148,6 +7888,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7155,6 +7896,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -7168,6 +7910,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">старший</column>
       <column name="definition_zh_HK">優越 [AUTOTRANSLATED]</column>
       <column name="definition_pt">superior</column>
+      <column name="definition_fi">esimies, ylempiarvoinen (upseeri tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bay'eS:n}</column>
       <column name="see_also">{pIn:n:1}, {nIv:v}</column>
@@ -7178,6 +7921,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7187,6 +7931,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7194,6 +7939,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7207,6 +7953,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">торопиться, спешить</column>
       <column name="definition_zh_HK">匆忙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">apressar</column>
+      <column name="definition_fi">kiirehtiä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nom:adv}, {Do Qe':n}</column>
@@ -7217,6 +7964,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This may be a reference to "Depeche Mode". "Dépêcher" means to "to hurry" in French. However, {Qov:n:name} asked MO about this and he answered he didn't remember if it was deliberate.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7228,6 +7976,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
 ▶ {moD Soj:sen:nolink} "пища торопится" (подпись в {Do Qe':n})[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7235,6 +7984,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.102:src}</column>
     </table>
     <table name="mem">
@@ -7248,6 +7998,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">быть разочарованным, быть несостоявшимся</column>
       <column name="definition_zh_HK">感到沮喪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser frustrado</column>
+      <column name="definition_fi">olla turhautunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bergh:v}</column>
@@ -7258,6 +8009,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7267,6 +8019,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7274,6 +8027,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7287,6 +8041,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">Мог</column>
       <column name="definition_zh_HK">Mogh [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mogh</column>
+      <column name="definition_fi">Mogh</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mogh:v}</column>
@@ -7297,6 +8052,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru">Отец Ворфа. Смотрите {wo'rIv:n:name}.</column>
       <column name="notes_zh_HK">沃爾夫的父親。參見{wo'rIv:n:name}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O pai de Worf. Consulte {wo'rIv:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Worfin isä. Katso {wo'rIv:n:name}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7306,6 +8062,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7313,6 +8070,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7326,6 +8084,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">быть уродливым, быть некрасивым</column>
       <column name="definition_zh_HK">難看、醜象、肉酸</column>
       <column name="definition_pt">ser feio</column>
+      <column name="definition_fi">olla ruma</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'IH:v}</column>
       <column name="see_also"></column>
@@ -7336,6 +8095,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7345,6 +8105,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7352,6 +8113,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7365,6 +8127,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">оказывать чрезмерное влияние на [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">對...施加不當影響 [AUTOTRANSLATED]</column>
       <column name="definition_pt">exercer influência indevida sobre</column>
+      <column name="definition_fi">vaikuttaa kohtuuttomasti johonkuhun</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIgh:v}, {-moH:v}</column>
@@ -7375,6 +8138,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7384,6 +8148,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7391,6 +8156,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7404,6 +8170,7 @@ O verbo {'al:v:2} é usado para números aleatórios ({mI' 'al:n}). [AUTOTRANSLA
       <column name="definition_ru">префикс</column>
       <column name="definition_zh_HK">前綴</column>
       <column name="definition_pt">prefixo</column>
+      <column name="definition_fi">etuliite, prefiksi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mojaq:n}</column>
       <column name="see_also"></column>
@@ -7438,6 +8205,19 @@ See under {wot:n} for the verb suffixes.</column>
 Смотрите {wot:n} для глагольных суффиксов.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin kielessä verbien etuliitteet ilmaisevat sekä subjektia että objektia.
+
+Katso seuraavien pronominien artikkeleista niitä koskevat etuliitteet:
+▶ {jIH:n:1h}
+▶ {maH:n:1h}
+▶ {SoH:n}
+▶ {tlhIH:n}
+▶ {ghaH:n}/{'oH:n}
+▶ {chaH:n}/{bIH:n}
+
+Katso artikkelissa {pagh:n:1h} objektittoman verbin etuliite, ja artikkelissa {-lu':v:suff} passiivin etuliite.
+
+Katso artikkelissa {wot:n} verbipäätteet.</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7447,6 +8227,7 @@ See under {wot:n} for the verb suffixes.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7454,6 +8235,7 @@ See under {wot:n} for the verb suffixes.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7467,6 +8249,7 @@ See under {wot:n} for the verb suffixes.</column>
       <column name="definition_ru">трапеция [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">梯形 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trapézio</column>
+      <column name="definition_fi">puolisuunnikas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loS reD mey':n}</column>
@@ -7477,6 +8260,7 @@ See under {wot:n} for the verb suffixes.</column>
       <column name="notes_ru">Это относится к четырехугольнику без параллельных сторон. Если он имеет параллельные стороны, он называется {qarpal:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指沒有平行邊的四邊形。如果側面平行，則稱為{qarpal:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um quadrilátero sem lados paralelos. Se tiver lados paralelos, é chamado de {qarpal:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa nelikulmioon, jossa ei ole yhdensuuntaisia ​​sivuja. Jos sillä on yhdensuuntaiset sivut, sitä kutsutaan {qarpal:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The word "trapezium" also refers to a bone ({Hom:n:1}) in the wrist ({yeb:n:1}).
 
 In British English, this word refers to what would be called a general irregular quadrilateral (whereas the word "trapezium" refers to what in American English would be called a "trapezoid").</column>
@@ -7488,6 +8272,7 @@ In British English, this word refers to what would be called a general irregular
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7495,6 +8280,7 @@ In British English, this word refers to what would be called a general irregular
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7508,6 +8294,7 @@ In British English, this word refers to what would be called a general irregular
       <column name="definition_ru">становиться, делаться, случаться</column>
       <column name="definition_zh_HK">成為</column>
       <column name="definition_pt">tornar-se</column>
+      <column name="definition_fi">tulla joksikin, muuttua joksikin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7518,6 +8305,7 @@ In British English, this word refers to what would be called a general irregular
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7528,6 +8316,7 @@ In British English, this word refers to what would be called a general irregular
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7535,6 +8324,7 @@ In British English, this word refers to what would be called a general irregular
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7548,6 +8338,7 @@ In British English, this word refers to what would be called a general irregular
       <column name="definition_ru">суффикс</column>
       <column name="definition_zh_HK">後綴</column>
       <column name="definition_pt">sufixo</column>
+      <column name="definition_fi">pääte, (jälki)liite, suffiksi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{moHaq:n}</column>
       <column name="see_also">{QaghHommeyHeylIjmo':n}, {bIQong'eghqangchoHmoHlaHchu'pu'neSchugh:v}</column>
@@ -7572,6 +8363,9 @@ Det finns fem typer av substantivsuffix och nio typer av verbsuffikser i Klingon
       <column name="notes_pt">Esta palavra também pode ser escrita {mojaQ:n:nolink}.
 
 Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Klingon, para os quais ver {DIp:n} e {wot:n}, respectivamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voidaan myös kirjoittaa {mojaQ:n:nolink}.
+
+Klingonissa on viiden tyyppisiä substantiiviliitteitä ja yhdeksän tyyppisiä verbiliitteitä, joista ks. {DIp:n} ja {wot:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7581,6 +8375,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7588,6 +8383,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7601,6 +8397,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="definition_ru">{mojaq:n}</column>
       <column name="definition_zh_HK">{mojaq:n}</column>
       <column name="definition_pt">{mojaq:n}</column>
+      <column name="definition_fi">{mojaq:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7611,6 +8408,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7620,6 +8418,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7627,6 +8426,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7640,6 +8440,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="definition_ru">хоронить, погрузить, похоронить</column>
       <column name="definition_zh_HK">埋葬 [AUTOTRANSLATED]</column>
       <column name="definition_pt">enterrar</column>
+      <column name="definition_fi">haudata</column>
       <column name="synonyms"></column>
       <column name="antonyms">{molHa':v}</column>
       <column name="see_also">{mol:n}, {lom:n}, {nol:n}, {QemjIq:n}, {ghevjur:n}</column>
@@ -7650,6 +8451,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Mole"; also, reverse of {lom:n}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7671,6 +8473,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
    Вся его ярость сфокусировалась в одном дуновении"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7678,6 +8481,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.159:src}</column>
     </table>
     <table name="mem">
@@ -7691,6 +8495,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="definition_ru">раскапывать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">挖出 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desenterrar</column>
+      <column name="definition_fi">kaivaa ylös</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mol:v}</column>
       <column name="see_also">{mol:n}, {tlhan:v}, {ghaw:v}, {'an'or:n}</column>
@@ -7701,6 +8506,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="notes_ru">Это может быть использовано для кости или ископаемого. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能用於骨骼或化石。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para um osso ou um fóssil. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää luuhun tai fossiiliin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mol:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -7710,6 +8516,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7717,6 +8524,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -7730,6 +8538,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="definition_ru">могила</column>
       <column name="definition_zh_HK">墳 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sepultura</column>
+      <column name="definition_fi">hauta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mol:v}, {molHa':v}, {lom:n}, {nol:n}, {QemjIq:n}</column>
@@ -7740,6 +8549,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Mole"; also, reverse of {lom:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7749,6 +8559,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7756,6 +8567,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7769,6 +8581,7 @@ Existem cinco tipos de sufixos nominais e nove tipos de sufixos verbais em Kling
       <column name="definition_ru">Молор</column>
       <column name="definition_zh_HK">Molor [AUTOTRANSLATED]</column>
       <column name="definition_pt">Molor</column>
+      <column name="definition_fi">Molor</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7793,6 +8606,9 @@ Det finns ett formspråk, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSL
       <column name="notes_pt">Este é o tirano maligno ({HI''a':n}) derrotado por {qeylIS'e' lIjlaHbe'bogh vay':n:name}, como recontado no {paq'batlh:n}.
 
 Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on paha tyranni ({HI''a':n}), jonka {qeylIS'e' lIjlaHbe'bogh vay':n:name} on voittanut, kuten {paq'batlh:n} kertoo.
+
+On idioomi, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7802,6 +8618,7 @@ Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7809,6 +8626,7 @@ Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7822,6 +8640,7 @@ Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">Столица</column>
       <column name="definition_zh_HK">首都</column>
       <column name="definition_pt">capital (de um lugar)</column>
+      <column name="definition_fi">pääkaupunki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7832,6 +8651,7 @@ Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Q calls Picard "mon capitaine".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7841,6 +8661,7 @@ Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7848,6 +8669,7 @@ Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7861,6 +8683,7 @@ Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">улыбка, улыбка, насмешка, рычание, ухмылка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">微笑、咧嘴笑、冷笑、咆哮、傻笑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sorrir</column>
+      <column name="definition_fi">hymyillä, virnistää, virnuilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hagh:v}</column>
@@ -7871,6 +8694,7 @@ Existe um idioma, {mIgh; molor rur@@mIgh:v, molor:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to the Mona Lisa. {mon'a':sen:nolink} means "Is she smiling?"
 
 This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained that it can also mean "snarl" and "smirk" in a message on the msn newsgroup.[2]</column>
@@ -7882,6 +8706,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7889,6 +8714,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1996.08.06:src}</column>
     </table>
     <table name="mem">
@@ -7902,6 +8728,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="definition_ru">водоросли [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">海藻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">algas</column>
+      <column name="definition_fi">levä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{namchIl:n}</column>
@@ -7912,6 +8739,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7921,6 +8749,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7928,6 +8757,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7941,6 +8771,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="definition_ru">шея</column>
       <column name="definition_zh_HK">頸部</column>
       <column name="definition_pt">pescoço</column>
+      <column name="definition_fi">kaula</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nach:n}, {volchaH:n}, {mong Ha'quj:n}, {mongDech:n}, {'achler:n}, {chayqa':n}</column>
@@ -7951,6 +8782,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7960,6 +8792,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7967,6 +8800,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7980,6 +8814,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="definition_ru">галстук, галстук [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">領帶</column>
       <column name="definition_pt">gravata</column>
+      <column name="definition_fi">solmio, kravatti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'quj:n}</column>
@@ -7990,6 +8825,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mong:n}, {Ha'quj:n}</column>
       <column name="examples"></column>
@@ -7999,6 +8835,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">neck tie, bowtie, bow tie</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8006,6 +8843,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8019,6 +8857,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="definition_ru">воротник, ошейник, хомут, шиворот</column>
       <column name="definition_zh_HK">領兒</column>
       <column name="definition_pt">colarinho</column>
+      <column name="definition_fi">kaulus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8029,6 +8868,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mong:n}, {Dech:n:nolink,hyp} or {Dech:v}</column>
       <column name="examples"></column>
@@ -8038,6 +8878,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8045,6 +8886,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8058,6 +8900,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="definition_ru">манги манги [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">mong'em機動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">manobra mong'em</column>
+      <column name="definition_fi">mong'em-manööveri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{way':v}, {'achler:n}</column>
@@ -8068,6 +8911,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="notes_ru">Парирование, когда вы засовываете меч или другое острое оружие за шею, чтобы блокировать атаку сзади. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一種格擋，在此格擋中，您將劍或其他有刃武器插入脖子後方，以阻止後方的攻擊。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um desvio em que você enfia uma espada ou outra arma afiada atrás do pescoço para bloquear um ataque pela retaguarda. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Parry, jossa työnnät miekan tai muun terävän aseen kaulasi taakse estääkseen hyökkäyksen takaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mong:n}, {'em:n}</column>
       <column name="examples"></column>
@@ -8077,6 +8921,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8084,6 +8929,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -8097,6 +8943,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="definition_ru">роба, халат, мантия</column>
       <column name="definition_zh_HK">長袍</column>
       <column name="definition_pt">roupão</column>
+      <column name="definition_fi">kaapu, viitta; iltapuku?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sut:n}, {ngup:n:1}, {paH:n}, {'eSqa':n}</column>
@@ -8107,6 +8954,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8116,6 +8964,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8123,6 +8972,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8136,6 +8986,7 @@ This word is defined in {KGT:src} as "smile, grin, sneer".[1]  It is explained t
       <column name="definition_ru">бить (что-то с орудием) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擊敗（帶工具的東西） [AUTOTRANSLATED]</column>
       <column name="definition_pt">batida (instrumento batido com bastão)</column>
+      <column name="definition_fi">iskeä, lyödä (aseella tai työkalulla)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chu':v:3}, {qIp:v}</column>
@@ -8166,6 +9017,11 @@ Observera att verbet som används för ett hjärtslag är {joq:v}. [AUTOTRANSLAT
 Também é usado para bater {'In:n} (compare com {tlhaw':v} e {weq:v}) .[1, p.75]
 
 Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään ilmoittamaan kaksintaistelun alkamisesta.[1, p.68]
+
+Sitä käytetään myös {'In:n}: n voittamiseen (vertaa {tlhaw':v} ja {weq:v}).
+
+Huomaa, että sydämenlyönnissä käytetty verbi on {joq:v}.[1, p.75] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8175,6 +9031,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8182,6 +9039,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8195,6 +9053,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">синяк [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">挫傷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">hematoma</column>
+      <column name="definition_fi">mustelma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ban:v}, {Hampong:n}</column>
@@ -8205,6 +9064,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru">Это синяк, который вы можете видеть, но который не является открытой раной. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">您可以看到這是一種瘀傷，但這不是開放的傷口。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um hematoma que você pode ver, mas que não é uma ferida aberta. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on mustelma, jonka näet, mutta joka ei ole avoin haava. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8214,6 +9074,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8221,6 +9082,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8234,6 +9096,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">Сфера</column>
       <column name="definition_zh_HK">領域 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esfera</column>
+      <column name="definition_fi">pallo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{buq'Ir:n}</column>
@@ -8244,6 +9107,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru">Это слово также используется, чтобы упомяуть о шипованной головке на конце {Daqtagh:n}.</column>
       <column name="notes_zh_HK">此詞還用於指代{Daqtagh:n}末端的尖刺鞍。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra também é usada para se referir ao pomo cravado no final de um {Daqtagh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään myös viittaamaan {Daqtagh:n}: n lopussa olevaan piikkiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8253,6 +9117,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pommel</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8260,6 +9125,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru">головка</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8273,6 +9139,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">Мок'бара</column>
       <column name="definition_zh_HK">Mok'bara（武術形式） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mok'bara (forma de artes marciais)</column>
+      <column name="definition_fi">eräs taistelulaji, mok'bara</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tonSaw':n}, {lol:v:1}, {much:v:3}, {mI':v}, {lol:n}</column>
@@ -8283,6 +9150,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8292,6 +9160,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8299,6 +9168,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8312,6 +9182,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">купол [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">圓頂、半球</column>
       <column name="definition_pt">cúpula, domo</column>
+      <column name="definition_fi">kupoli, kupu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8322,6 +9193,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{moQ:n}, {bID:n}</column>
       <column name="examples"></column>
@@ -8331,6 +9203,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hemisphere, semisphere</column>
       <column name="search_tags_de">Hemisphäre</column>
       <column name="search_tags_fa"></column>
@@ -8338,6 +9211,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -8351,6 +9225,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">быть проворным, быть ловким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要敏捷、要靈巧 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser ágil, ser destro</column>
+      <column name="definition_fi">olla ketterä, notkea; olla kätevä, näppärä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Soy':v:1}</column>
       <column name="see_also">{pe'vIl roS:sen}</column>
@@ -8361,6 +9236,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru">В зависимости от контекста можно также сказать {Soy'Ha':v@@Soy':v:1, -Ha':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據上下文，也可以說{Soy'Ha':v@@Soy':v:1, -Ha':v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Dependendo do contexto, pode-se também dizer {Soy'Ha':v@@Soy':v:1, -Ha':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kontekstista riippuen voidaan sanoa myös {Soy'Ha':v@@Soy':v:1, -Ha':v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8370,6 +9246,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8377,6 +9254,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8390,6 +9268,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">Морат</column>
       <column name="definition_zh_HK">Morath [AUTOTRANSLATED]</column>
       <column name="definition_pt">Morath</column>
+      <column name="definition_fi">Morath</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghobchuq loDnI'pu':n}, {qanjIt:n:name}</column>
@@ -8400,6 +9279,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru">Это брат {qeylIS'e' lIjlaHbe'bogh vay':n:name}.</column>
       <column name="notes_zh_HK">這是{qeylIS'e' lIjlaHbe'bogh vay':n:name}的兄弟。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o irmão de {qeylIS'e' lIjlaHbe'bogh vay':n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {qeylIS'e' lIjlaHbe'bogh vay':n:name}: n veli. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8409,6 +9289,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8416,6 +9297,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -8429,6 +9311,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">протестовать, возражать, опротестовывать</column>
       <column name="definition_zh_HK">抗議</column>
       <column name="definition_pt">protestar</column>
+      <column name="definition_fi">osoittaa mieltä, protestoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bep:v}</column>
@@ -8439,6 +9322,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8448,6 +9332,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8455,6 +9340,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8468,6 +9354,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">единица площади (27 квадратных {'ujmey:n @@'uj:n, -mey:n}) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">面積單位（27平方{'ujmey:n@@'uj:n, -mey:n}） [AUTOTRANSLATED]</column>
       <column name="definition_pt">unidade de área (27 quadrados {'ujmey:n@@'uj:n, -mey:n})</column>
+      <column name="definition_fi">eräs pinta-alan yksikkö (27 neliö-{'uj:n}:ia})</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{men:v}, {mun'a':n}, {'uj:n}</column>
@@ -8478,6 +9365,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8487,6 +9375,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8494,6 +9383,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8507,6 +9397,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">идти на компромисс</column>
       <column name="definition_zh_HK">妥協 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer compromisso</column>
+      <column name="definition_fi">tehdä kompromissi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ma':v}</column>
@@ -8517,6 +9408,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8526,6 +9418,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8533,6 +9426,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8546,6 +9440,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">быть ошеломленным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">給打蒙了</column>
       <column name="definition_pt">ser atordoado</column>
+      <column name="definition_fi">olla tainnutettu?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{roSHa'moH:v}, {Duq:v}</column>
@@ -8556,6 +9451,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru">Это означает, что вы оказались в бессознательном состоянии или в ошеломленном состоянии в результате удара (кулаком или снарядом и т. Д.). Это будет использовано для того, чтобы быть сбитым фазером, «настроенным на оглушение». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著由於被拳頭或彈丸等擊打而失去知覺或進入頭昏眼花的狀態。這將被移相器“設置為擊暈”擊中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa ficar inconsciente ou atordoado como resultado de ser atingido (por um punho ou um projétil, etc.). Isso seria usado para ser atingido por um phaser "configurado para atordoar". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa, että hän joutuu tajuttomaksi tai hämmentyneeseen tilaan osuman seurauksena (nyrkillä tai ammuksella jne.). Tätä käytetään siihen, että phaser osuu "tainnutukseen". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8565,6 +9461,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8572,6 +9469,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -8585,6 +9483,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">быть обычным, быть стандартным, быть нормальным</column>
       <column name="definition_zh_HK">平常、標準、普通、正常</column>
       <column name="definition_pt">ser habitual, ser no padrão, ser normal</column>
+      <column name="definition_fi">olla tavallinen, olla normaali, olla vakio-</column>
       <column name="synonyms"></column>
       <column name="antonyms">{motlhbe':v}, {qub:v}</column>
       <column name="see_also">{le':v}, {le'be':v}</column>
@@ -8595,6 +9494,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {TKD:src}, this is defined only as "be usual".[1] In {SkyBox 14:src}, {nISwI' HIch motlh:n:nolink} is translated as "standard hand held disruptor".[2] In the {BoP:src} poster, {qughDo motlh:n:nolink} is translated as "normal cruising speed".[3]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8604,6 +9504,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8611,6 +9512,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 14:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src}), [3] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -8624,6 +9526,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">обычно, как обычно, как и ожидалось [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通常、普通、如預期</column>
       <column name="definition_pt">normalmente, tipicamente, conforme o esperado</column>
+      <column name="definition_fi">yleensä, tyypillisesti, odotetusti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{motlhHa':adv}</column>
       <column name="see_also">{pIj:adv}, {jaS:adv}, {roD:adv}, {rut:adv}</column>
@@ -8634,6 +9537,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8647,6 +9551,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
   "В отличие от большинства судов Звездного флота, главный экран на Клингонском корабле обычно покрыт сложной прицельной сеткой."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8654,6 +9559,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 3:src}</column>
     </table>
         <table name="mem">
@@ -8667,6 +9573,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
           <column name="definition_ru">быть необычным</column>
           <column name="definition_zh_HK">不尋常、不平常</column>
           <column name="definition_pt">ser não usual</column>
+      <column name="definition_fi">olla epätavallinen</column>
           <column name="synonyms"></column>
           <column name="antonyms">{motlh:v}</column>
           <column name="see_also"></column>
@@ -8677,6 +9584,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{motlh:v}, {-be':v}</column>
           <column name="examples"></column>
@@ -8686,6 +9594,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8693,6 +9602,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
     <table name="mem">
@@ -8706,6 +9616,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">верх стопы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頂部 [AUTOTRANSLATED]</column>
       <column name="definition_pt">peito do pé, topo do pé</column>
+      <column name="definition_fi">jalkapöytä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qam:n}, {ngIb:n:1}, {bem:n}, {chap:n}</column>
@@ -8716,6 +9627,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8725,6 +9637,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8732,6 +9645,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8745,6 +9659,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">«Сегодня был хороший день, чтобы умереть». [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">“今天是美好的一天。” [AUTOTRANSLATED]</column>
       <column name="definition_pt">"Hoje foi um bom dia para morrer."</column>
+      <column name="definition_fi">"Tänään oli hyvä päivä kuolla."</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8755,6 +9670,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru">Это восклицание архаично. Это было сказано Кахлессом Лукаре. Современный эквивалент {Heghlu'meH QaQ jajvam.:sen} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種感嘆是古老的。 Kahless對盧卡拉講過這句話。現代的等價於{Heghlu'meH QaQ jajvam.:sen} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa exclamação é arcaica. Foi falado por Kahless a Lukara. O equivalente moderno é {Heghlu'meH QaQ jajvam.:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä huutomerkki on arkaainen. Kahless puhui sen Lukaralle. Moderni vastine on {Heghlu'meH QaQ jajvam.:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8764,6 +9680,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">today was a good day to die</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8771,6 +9688,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8784,6 +9702,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">рогатка</column>
       <column name="definition_zh_HK">彈弓 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estilingue</column>
+      <column name="definition_fi">ritsa, katapultti, linko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuS:v:1}</column>
@@ -8794,6 +9713,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Moebius strip".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8803,6 +9723,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8810,6 +9731,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8823,6 +9745,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">клетка</column>
       <column name="definition_zh_HK">籠</column>
       <column name="definition_pt">cela</column>
+      <column name="definition_fi">häkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIghHa':n}</column>
@@ -8833,6 +9756,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8842,6 +9766,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8849,6 +9774,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8862,6 +9788,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">мотив, мотивация, основания, причина, обоснование [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動機、動機、理由、理由、理由 [AUTOTRANSLATED]</column>
       <column name="definition_pt">motivo, motivação, razão</column>
+      <column name="definition_fi">motiivi, motivaatio, syy, järki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meq:n}, {ngoQ:n}, {-mo':n}, {-mo':v}</column>
@@ -8872,6 +9799,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru">Значение и использование этого жаргонного слова объяснено на {KGT p.154:src}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此語的含義和用法在{KGT p.154:src}上進行了說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O significado e o uso dessa palavra de gíria são explicados no {KGT p.154:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän slangisanan merkitys ja käyttö selitetään {KGT p.154:src}-sivulla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8882,6 +9810,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8889,6 +9818,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8902,6 +9832,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">Дом Мо'каи</column>
       <column name="definition_zh_HK">Mo'Kai之家 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Casa de Mo'Kai</column>
+      <column name="definition_fi">Mo'Kain huone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuq:n}, {choH'a':n}</column>
@@ -8912,6 +9843,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="notes_ru">Это дом {'uj'IllI':n:name}</column>
       <column name="notes_zh_HK">這是{'uj'IllI':n:name}的房子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a casa do {'uj'IllI':n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {'uj'IllI':n:name}-talo. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8921,6 +9853,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8928,6 +9861,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Battle at the Binary Stars:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -8941,6 +9875,7 @@ Observe que o verbo usado para uma pulsação é {joq:v}. [AUTOTRANSLATED]</colu
       <column name="definition_ru">Морская [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">莫爾斯卡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Morska</column>
+      <column name="definition_fi">Morska</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qurbuSwI':n}</column>
@@ -8963,6 +9898,11 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on planeetta, josta on tullut osa Klingonin imperiumia. Tällä planeetalla klingonin murre on korvannut kaikki, paitsi alun perin puhutut kielet, [2, p.17]
+
+Morskanin murteessa {tlh:sen:nolink} tavun lopussa lausutaan kuten "ts" (kuten "kissoilla"), kun taas alussa se lausutaan kuten {ghl:sen:nolink}. {H:sen:nolink} tavujen alussa lausutaan kuten "h" (kuten "hattu"), kun taas sitä ei lausuta lainkaan tavujen päissä. Tavujen alussa oleva {Q:sen:nolink} lausutaan samalla tavoin kuin tavallinen {H:sen:nolink}.[2, p.22]
+
+Morskanin murre ei lisää loppuliitettä {-'e':n:suff} aiheen substantiiville lauseessa "olla". Kun se on läsnä, se palvelee tavallista tarkennustoimintoa[2, p.24] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Morskan dialect is featured in {Star Trek VI:src}, in a scene involving border guards on the way to {rura' pente':n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8972,6 +9912,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8979,6 +9920,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8992,6 +9934,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="definition_ru">Морскан (человек) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">莫斯坎（人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Morskan (pessoa)</column>
+      <column name="definition_fi">morskalainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9002,6 +9945,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mo'rISqa':n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -9011,6 +9955,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9018,6 +9963,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9031,6 +9977,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="definition_ru">он/она/оно/они(действие)-мне</column>
       <column name="definition_zh_HK">他、它、他們、它們：我</column>
       <column name="definition_pt">ele/ela-eu, eles-eu</column>
+      <column name="definition_fi">hän/se/he/ne-minua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{vI-:v:pref}</column>
       <column name="see_also">{nu-:v:pref}</column>
@@ -9041,6 +9988,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n}: {jIH:n:1h} = {mu-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9050,6 +9998,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">he-me, she-me, it-me</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9057,6 +10006,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="search_tags_ru">он-мне, она-мне, оно-мне</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9070,6 +10020,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="definition_ru">быть законным</column>
       <column name="definition_zh_HK">合法</column>
       <column name="definition_pt">ser legal (de acordo com a lei)</column>
+      <column name="definition_fi">olla laillinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hat:v}</column>
       <column name="see_also"></column>
@@ -9080,6 +10031,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9089,6 +10041,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9096,6 +10049,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9109,6 +10063,7 @@ Den morskanska dialekten sätter inte suffixet {-'e':n:suff} på ämnet substant
       <column name="definition_ru">представлять</column>
       <column name="definition_zh_HK">演出、表演（音樂） [AUTOTRANSLATED]</column>
       <column name="definition_pt">apresentar, presentear</column>
+      <column name="definition_fi">antaa, luovuttaa (lahja, palkinto tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{much:n}, {nob:n}, {nob:v}</column>
@@ -9131,6 +10086,9 @@ Detta verb används också i musik ({much:v:2}) och kampsport ({much:v:3}). [AUT
       <column name="notes_pt">Em um contexto geral, esta palavra significa "apresentar", como em "apresentar um presente" a alguém.[2]
 
 Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yleisesti ottaen tämä sana tarkoittaa "esittämistä", kuten "lahjan esittäminen" jollekin.
+
+Tätä verbiä käytetään myös musiikissa ({much:v:2}) ja taistelulajeissa ({much:v:3}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9140,6 +10098,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9147,6 +10106,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9160,6 +10120,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">исполнять (музыка)</column>
       <column name="definition_zh_HK">表演（音樂） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tocar (música)</column>
+      <column name="definition_fi">esiintyä, esittää (musiikkia)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{much:n}, {bom:v}, {bom:n}, {QoQ:n}, {nob:v}, {DawI':n}</column>
@@ -9170,6 +10131,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Это глагол {much:v:1} применяется к музыке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是應用於音樂的動詞{much:v:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o verbo {much:v:1} aplicado à música. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on verbi {much:v:1}, jota sovelletaan musiikkiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9179,6 +10141,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9186,6 +10149,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9199,6 +10163,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">strike a pose or stance (martial arts) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擺姿勢或姿勢（武術） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer uma pose ou postura (artes marciais)</column>
+      <column name="definition_fi">ottaa asento (taistelulajissa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moQbara':n}</column>
@@ -9209,6 +10174,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Это глагол {much:v:1}, применяемый к боевым искусствам, где он означает удар по позе или стойке (см. {lol:v:1}). Объект - это имя позы или позиции, которое обычно заканчивается на {tonSaw':n}. Если контекст понятен, {tonSaw':n:nolink} можно не указывать. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是應用於武術的動詞{much:v:1}，意為擺出姿勢或姿態（請參閱{lol:v:1}）。對像是姿勢或姿態的名稱，通常以{tonSaw':n}結尾。如果上下文清楚，則可以忽略{tonSaw':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o verbo {much:v:1} aplicado às artes marciais, onde significa fazer uma pose ou uma postura (ver {lol:v:1}). O objeto é o nome da pose ou postura, que geralmente termina em {tonSaw':n}. Se o contexto estiver claro, {tonSaw':n:nolink} pode ser deixado de fora. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on verbi {much:v:1}, jota sovelletaan taistelulajeihin, jossa se tarkoittaa lyöntiä asentoon tai asentoon (katso {lol:v:1}). Kohde on asennon tai asennon nimi, joka yleensä päättyy kohtaan {tonSaw':n}. Jos asiayhteys on selkeä, {tonSaw':n:nolink} voidaan jättää pois. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9220,6 +10186,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9227,6 +10194,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -9240,6 +10208,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">презентация</column>
       <column name="definition_zh_HK">介紹 [AUTOTRANSLATED]</column>
       <column name="definition_pt">apresentação</column>
+      <column name="definition_fi">(musiikin, näytelmän tms.) esitys, näytös</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{much:v:1}, {DawI':n}, {muchpa':n}, {HaSta ta:n}, {wab ta:n}</column>
@@ -9250,6 +10219,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Это может быть использовано для чего-то наподобие шоу или кино.[2] Тем не менее, не совсем корректно для обозначения "медиа" в общем.[3]</column>
       <column name="notes_zh_HK">可以將其用於諸如表演或電影之類的東西。[2]但是，一般而言，表達“媒體”並不完全正確。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para algo como um programa ou um filme.[2] No entanto, não é certo expressar expressões "mídia" em geral.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää esimerkiksi ohjelmassa tai elokuvassa.[2] Ei kuitenkaan ole aivan oikein ilmaista "media" yleensä.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9259,6 +10229,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">show, movie</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9266,6 +10237,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru">шоу, фильм</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2017.11.20:src}, [3] {KLI mailing list 2018.02.25:src}</column>
     </table>
         <table name="mem">
@@ -9279,6 +10251,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">костюм [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">服裝 [AUTOTRANSLATED]</column>
           <column name="definition_pt">traje</column>
+      <column name="definition_fi">rooliasu (näytelmässä tms.)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{qab jech:n}</column>
@@ -9289,6 +10262,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru">Это костюм в том смысле, в каком он использовался в постановке. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是舞台劇中所使用的服裝。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este é um traje no sentido usado em uma peça de teatro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on puku siinä mielessä, jota käytetään näyttämössä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{much:n}, {jech:n}</column>
           <column name="examples"></column>
@@ -9298,6 +10272,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9305,6 +10280,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
         </table>
         <table name="mem">
@@ -9318,6 +10294,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">актовый зал [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">禮堂 [AUTOTRANSLATED]</column>
           <column name="definition_pt">auditório</column>
+      <column name="definition_fi">auditorio</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{much qach:n}, {much yaH:n}, {DawI':n}</column>
@@ -9328,6 +10305,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru">Это относится к комнате, в которой происходит представление. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是指表演所在的房間。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Refere-se à sala em que uma performance ocorre. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa huoneeseen, jossa esitys tapahtuu. [AUTOTRANSLATED]</column>
           <column name="hidden_notes">Maltz revealed this word to translate "Bloomsbury Theatre" for the {Festival of the Spoken Nerd DVD:src}, but it ended up not being used on the DVD itself.</column>
           <column name="components">{much:n}, {pa':n:1}</column>
           <column name="examples"></column>
@@ -9337,6 +10315,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">theatre, theater, stage</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9344,6 +10323,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2015.03.16:src}</column>
         </table>
         <table name="mem">
@@ -9357,6 +10337,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">театр [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">劇院、戲院</column>
           <column name="definition_pt">teatro</column>
+      <column name="definition_fi">teatteri</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{muchpa':n}, {much yaH:n}, {DawI':n}</column>
@@ -9367,6 +10348,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru">Это относится ко всему зданию, включая аудиторию, лобби, гардеробные и т. Д. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是指整個建築，包括禮堂，大廳，更衣室等。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Refere-se a todo o edifício, incluindo o auditório, o saguão, os provadores e assim por diante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa koko rakennusta, mukaan lukien auditorio, aula, pukuhuoneet ja niin edelleen. [AUTOTRANSLATED]</column>
           <column name="hidden_notes">Maltz revealed this word to translate "Bloomsbury Theatre" for the {Festival of the Spoken Nerd DVD:src}, but it ended up not being used on the DVD itself.</column>
           <column name="components">{much:n}, {qach:n}</column>
           <column name="examples"></column>
@@ -9376,6 +10358,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">theatre</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9383,6 +10366,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2015.03.16:src}</column>
         </table>
         <table name="mem">
@@ -9396,6 +10380,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">кабаре (местоположение) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">歌舞表演（地點） [AUTOTRANSLATED]</column>
           <column name="definition_pt">cabaré (localização)</column>
+      <column name="definition_fi">kabaree (näyttämö)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9406,6 +10391,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru">Это относится к месту, такому как ночной клуб или ресторан, где есть еда / напитки и шоу ({Qe' much:n}). [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">指的是諸如夜總會或餐廳之類的地點，那裡有食物/飲料以及表演（{Qe' much:n}）。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Refere-se ao local, como uma boate ou restaurante, onde há comida / bebida junto com um show ({Qe' much:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa sijaintiin, kuten yökerhoon tai ravintolaan, jossa on ruokaa / juomaa yhdessä esityksen kanssa ({Qe' much:n}). [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{much:n}, {Qe':n}</column>
           <column name="examples"></column>
@@ -9415,6 +10401,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9422,6 +10409,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
         </table>
         <table name="mem">
@@ -9435,6 +10423,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">музыкант [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">音樂家</column>
           <column name="definition_pt">múisico</column>
+      <column name="definition_fi">muusikko</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9445,6 +10434,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{much:v:2}, {-wI':v}</column>
           <column name="examples"></column>
@@ -9454,6 +10444,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9461,6 +10452,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -9474,6 +10466,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">этап [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">階段 [AUTOTRANSLATED]</column>
           <column name="definition_pt">etapa</column>
+      <column name="definition_fi">näyttämö, lava</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{jorchan velqa':n}, {DawI':n}, {muchpa':n}, {much qach:n}</column>
@@ -9484,6 +10477,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru">Это относится к месту, специально предназначенному для проведения презентаций, таких как игры. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是指專門用於表演表演（例如戲劇）的地方。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Refere-se a um local especificamente designado para a apresentação de apresentações, como peças de teatro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa paikkaan, joka on nimenomaisesti tarkoitettu esitysten, kuten näytelmien, esittämiseen. [AUTOTRANSLATED]</column>
           <column name="hidden_notes">The term {DawI' yaH:n@@DawI':n, yaH:n} was used for "stage" in Hamlet.</column>
           <column name="components">{much:n}, {yaH:n}</column>
           <column name="examples"></column>
@@ -9493,6 +10487,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9500,6 +10495,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
         </table>
     <table name="mem">
@@ -9513,6 +10509,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">атмосфера</column>
       <column name="definition_zh_HK">大氣層 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atmosfera</column>
+      <column name="definition_fi">ilmakehä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chal:n}, {ghor:n:1}, {rewve':n}, {lay:n:2h}</column>
@@ -9523,6 +10520,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Слово для погоды, означающее состояние атмосферы, это тоже самое слово, как и для атмосферы (смотрите {muD:n:2}).[2]</column>
       <column name="notes_zh_HK">天氣一詞，即大氣層的狀態，與大氣層本身是相同的詞（請參閱{muD:n:2}）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra clima, que significa o estado da atmosfera, é a mesma que para a própria atmosfera (consulte {muD:n:2}).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sääsana, joka tarkoittaa ilmakehän tilaa, on sama sana kuin itse ilmakehässä (katso {muD:n:2}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9532,6 +10530,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9539,6 +10538,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
     </table>
     <table name="mem">
@@ -9552,6 +10552,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">погода (в целом) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">天氣（一般情況下） [AUTOTRANSLATED]</column>
       <column name="definition_pt">clima (em geral)</column>
+      <column name="definition_fi">sää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIS:v}, {SuS:n}, {jev:v:1}, {Heq:v}, {peD:v}, {cheq:v}, {vung:v}, {jul:n}, {'eng:n}, {'aq:v}</column>
@@ -9562,6 +10563,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">天氣一詞，即大氣狀態，與大氣本身是相同的詞（請參閱{muD:n:1}）。當查詢特定時間和/或地點的天氣條件時，使用表達式{muD Dotlh:n}。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra clima, que significa o estado da atmosfera, é a mesma palavra que a atmosfera em si (consulte {muD:n:1}). Ao indagar sobre as condições meteorológicas em um horário e / ou local específico, a expressão {muD Dotlh:n} é usada.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sääsana, joka tarkoittaa ilmakehän tilaa, on sama sana kuin itse ilmakehässä (katso {muD:n:1}). Kun tiedustellaan sääolosuhteita tiettynä ajankohtana ja / tai paikassa, käytetään ilmaisua {muD Dotlh:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Mood".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9571,6 +10573,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9578,6 +10581,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
     </table>
         <table name="mem">
@@ -9591,6 +10595,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">weather (at any given moment) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">天氣（在任何特定時刻） [AUTOTRANSLATED]</column>
           <column name="definition_pt">clima (em um determinado momento)</column>
+      <column name="definition_fi">säätila</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{SIS:v}, {SuS:n}, {jev:v:1}, {Heq:v}, {peD:v}, {cheq:v}, {vung:v}, {jul:n}, {'eng:n}, {'aq:v}, {muD 'umber:n}</column>
@@ -9601,6 +10606,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK">在大氣層狀態下，克林崗語中的“天氣”一詞只是{muD:n:2}，與大氣層本身（{muD:n:1}）相同。查詢特定時間和/或地點的天氣條件時使用表達式{muD Dotlh:n:nolink}。[2] [AUTOTRANSLATED]</column>
           <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin sana "sää" ilmakehän tilassa on vain {muD:n:2}, sama sana kuin itse ilmakehälle ({muD:n:1}). Ilmaisua {muD Dotlh:n:nolink} käytetään, kun tiedustellaan sääolosuhteita tiettynä aikana ja / tai paikassa.[2] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{muD:n:2}, {Dotlh:n}</column>
           <column name="examples"></column>
@@ -9610,6 +10616,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9617,6 +10624,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
         </table>
         <table name="mem">
@@ -9630,6 +10638,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">самолет [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">飛機</column>
           <column name="definition_pt">avião</column>
+      <column name="definition_fi">lentokone</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Duj:n:1}, {vergh:n}, {vergh:v}, {puv:v}, {'or:v}</column>
@@ -9640,6 +10649,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{muD:n:1}, {Duj:n:1}</column>
           <column name="examples"></column>
@@ -9649,6 +10659,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">aeroplane, plane, jet</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9656,6 +10667,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -9669,6 +10681,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">система управления атмосферой [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">大氣控制系統</column>
           <column name="definition_pt">sistema de controle atmosférico</column>
+      <column name="definition_fi">säänhallintajärjestelmä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{yIntagh:n}</column>
@@ -9679,6 +10692,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{muD:n:1}, {ngeb:v}, {SeHwI' pat:n}</column>
           <column name="examples"></column>
@@ -9688,6 +10702,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9695,6 +10710,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -9708,6 +10724,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">Атмосферные двигатели взлета / посадки [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">大氣起飛/降落推進器 [AUTOTRANSLATED]</column>
           <column name="definition_pt">propulsores atmosféricos de decolagem / pouso</column>
+      <column name="definition_fi">ilmakehässä käytettävä lähtö- tai laskeutumismoottori</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{'eDSeHcha:n}</column>
@@ -9718,6 +10735,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru">Это слово во множественном числе. Его единственная форма неизвестна. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這個詞是複數的。其單數形式未知。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esta palavra é plural. Sua forma singular é desconhecida. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on monikko. Sen yksikkömuotoa ei tunneta. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{muD:n:1}, {-Daq:n}, {'eDSeHcha:n}, {lu-:v}, {laQ:v}, {-lu':v}, {-bogh:v}</column>
           <column name="examples"></column>
@@ -9727,6 +10745,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9734,6 +10753,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -9747,6 +10767,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="definition_ru">климат [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">氣候 [AUTOTRANSLATED]</column>
           <column name="definition_pt">clima</column>
+      <column name="definition_fi">ilmasto</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{muD Dotlh:n}</column>
@@ -9757,6 +10778,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="notes_ru">Это означает «климат», как в «родном мире клингонов очень жаркий климат». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這意味著“氣候”，就像“克林崗家庭環境非常炎熱”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso significa "clima", como em "o mundo natal dos Klingon tem um clima muito quente". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "ilmastoa", kuten "Klingonin kotimaailmassa on erittäin kuuma ilmasto". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -9766,6 +10788,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9773,6 +10796,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
         </table>
     <table name="mem">
@@ -9786,6 +10810,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">переводить</column>
       <column name="definition_zh_HK">翻譯</column>
       <column name="definition_pt">traduzir</column>
+      <column name="definition_fi">kääntää (teksti tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hoch Holmey mughwI':n}, {jIyweS:n}</column>
@@ -9796,6 +10821,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is similar to {magh:v}, and as the proverb goes, "a translator is a traitor".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9805,6 +10831,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9812,6 +10839,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9825,6 +10853,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">Мугато</column>
       <column name="definition_zh_HK">mugato [AUTOTRANSLATED]</column>
       <column name="definition_pt">mugato</column>
+      <column name="definition_fi">eräs eläin, mugato</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9835,6 +10864,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Одна из наиболее заметных животных форм на {nural:n}.</column>
       <column name="notes_zh_HK">{nural:n}上最著名的原生動物形式之一。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma das formas mais notáveis ​​de animais nativos no {nural:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksi {nural:n}: n merkittävimmistä alkuperäisistä eläinmuodoista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9844,6 +10874,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9851,6 +10882,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9864,6 +10896,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">подзаголовок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">字幕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">subtítulo</column>
+      <column name="definition_fi">tekstitys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9874,6 +10907,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Это подразумевает перевод и не используется для скрытых подписей. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著翻譯，並且不用於隱藏式字幕。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso implica tradução e não é usado para legendas ocultas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa käännöstä, eikä sitä käytetä tekstityksiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was actually given in the plural {mughbogh permey:n:nolink} as "subtitles".</column>
       <column name="components">{mugh:v}, {-bogh:v}, {per:n}</column>
       <column name="examples"></column>
@@ -9883,6 +10917,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9890,6 +10925,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -9903,6 +10939,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">переводчик</column>
       <column name="definition_zh_HK">翻譯者</column>
       <column name="definition_pt">tradutor</column>
+      <column name="definition_fi">kääntäjä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9913,6 +10950,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Если это относится к человеку, то, его форма во множественном числе принимает {-pu':n:suff} суффикс. Если это относится к устройству, то форма во множественном числе принимает {-mey:n:suff} суффикс.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Se isso se refere a uma pessoa, seu plural recebe o sufixo {-pu':n:suff}. Se se referir a um dispositivo, seu plural recebe o sufixo {-mey:n:suff}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos tämä viittaa henkilöön, sen monikko vie {-pu':n:suff}-jälkiliitteen. Jos se viittaa laitteeseen, sen monikko vie {-mey:n:suff}-jälkiliitteen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mugh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -9922,6 +10960,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9929,6 +10968,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9942,6 +10982,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">казнить, предавать смерти</column>
       <column name="definition_zh_HK">處死</column>
       <column name="definition_pt">executar, matar</column>
+      <column name="definition_fi">teloittaa, lopettaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIb:v}, {HoH:v}</column>
@@ -9952,6 +10993,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9962,6 +11004,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9969,6 +11012,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -9982,6 +11026,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">быть неверным, быть некорректным, быть неправильным</column>
       <column name="definition_zh_HK">錯</column>
       <column name="definition_pt">ser errado</column>
+      <column name="definition_fi">olla väärässä, olla väärin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lugh:v}</column>
       <column name="see_also">{Qagh:v}, {bIQ ngaS HIvje'.:sen}</column>
@@ -9992,6 +11037,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Заметьте, что это значит "быть неверным, фактически неправильным", в отличии от {waS:v} "что-то не так, идти наперекосяк".</column>
       <column name="notes_zh_HK">請注意，這意味著“不正確，實際上是錯誤的”，而不是{waS:v}“不對，就算錯了”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que isso significa "estar incorreto, factualmente errado", em oposição a {waS:v} "estar errado, errado". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä tarkoittaa "ole väärä, tosiasiallisesti väärä", toisin kuin {waS:v} "ole väärin, väärin". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10001,6 +11047,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">incorrect</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10008,6 +11055,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -10021,6 +11069,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">быть упрямым, быть упорным</column>
       <column name="definition_zh_HK">頑固 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser teimoso</column>
+      <column name="definition_fi">olla itsepäinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qu'vatlh:n:extcan}</column>
@@ -10031,6 +11080,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Stubborn as a "mule".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10040,6 +11090,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10047,6 +11098,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10060,6 +11112,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">вкус, чувство вкуса [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">品嚐（味道）</column>
       <column name="definition_pt">saborear, sentir sabores</column>
+      <column name="definition_fi">maistaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wejwa':n}, {jat:n}, {tlhorgh:v}, {'ey:v}, {largh:v}, {Huy:v:2}, {jIy:v}</column>
@@ -10070,6 +11123,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Не путайте это с {waH:v:2}, что означает «вкус» в том смысле, что вы пробуете пищу, чтобы увидеть, правильно ли она приготовлена, или определить, нравится ли она вам.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Älä sekoita tätä {waH:v:2}: een, mikä tarkoittaa "makua" siinä mielessä, että kokeilet ruokaa sen selvittämiseksi, onko se valmistettu oikein, tai sen selvittämiseksi, pidetäänkö siitä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10079,6 +11133,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sense flavours</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10086,6 +11141,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.07.13:src}</column>
     </table>
     <table name="mem">
@@ -10099,6 +11155,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">вмешиваться, являться помехой</column>
       <column name="definition_zh_HK">干預 [AUTOTRANSLATED]</column>
       <column name="definition_pt">intervir</column>
+      <column name="definition_fi">puuttua, sekaantua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Haq:v:2}, {nIS:v}</column>
@@ -10109,6 +11166,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">People who joined the "Moon"ies were often subjected to a deprogramming process known as intervention.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10118,6 +11176,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10125,6 +11184,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -10138,6 +11198,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">единица площади [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">面積單位 [AUTOTRANSLATED]</column>
       <column name="definition_pt">unidade de área</column>
+      <column name="definition_fi">eräs pinta-alan yksikkö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{men:v}, {morgh:n}</column>
@@ -10148,6 +11209,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Один {mun'a':n:nolink} - это 729 {morghmey:n@@morgh:n, -mey:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一個{mun'a':n:nolink}是729 {morghmey:n@@morgh:n, -mey:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um {mun'a':n:nolink} é 729 {morghmey:n@@morgh:n, -mey:n}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksi {mun'a':n:nolink} on 729 {morghmey:n@@morgh:n, -mey:n}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10157,6 +11219,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10164,6 +11227,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -10177,6 +11241,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">источник, подлинник, первоисточник</column>
       <column name="definition_zh_HK">來源、起源</column>
       <column name="definition_pt">origem</column>
+      <column name="definition_fi">alkuperä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hal:n}, {nompuq:n}</column>
@@ -10187,6 +11252,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10196,6 +11262,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10203,6 +11270,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10216,6 +11284,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">удар, столкновение, толчок, забастовка, стачка</column>
       <column name="definition_zh_HK">影響、罷工 [AUTOTRANSLATED]</column>
       <column name="definition_pt">impacto</column>
+      <column name="definition_fi">iskeä, lyödä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tap:v}</column>
@@ -10226,6 +11295,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10247,6 +11317,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
    Вся его ярость сфокусировалась в одном дуновении"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10254,6 +11325,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.159:src}</column>
     </table>
     <table name="mem">
@@ -10267,6 +11339,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">молоток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">錘子</column>
       <column name="definition_pt">martelo</column>
+      <column name="definition_fi">vasara</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pach moQ:n}, {mup:v}, {tap:v}, {Hut'In:n}, {SommI':n}</column>
@@ -10277,6 +11350,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Существует идиома {HoSghaj; mupwI' rur}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{HoSghaj; mupwI' rur}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {HoSghaj; mupwI' rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {HoSghaj; mupwI' rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mup:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -10286,6 +11360,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10293,6 +11368,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10306,6 +11382,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">Держите молоток! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">繼續拿著錘子！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Continue segurando o martelo!</column>
+      <column name="definition_fi">Jatka vasaran pitelemistä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10316,6 +11393,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mupwI':n}, {yI-:v}, {'uch:v:1}, {-taH:v}</column>
       <column name="examples"></column>
@@ -10325,6 +11403,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10332,6 +11411,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.120:src}</column>
     </table>
     <table name="mem">
@@ -10345,6 +11425,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">молоток (для удара по музыкальному инструменту) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">槌（用於敲擊樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">marreta (para bater em um instrumento musical)</column>
+      <column name="definition_fi">(soittimen) vasara</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moq:v}, {'In:n}</column>
@@ -10355,6 +11436,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mupwI':n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -10364,6 +11446,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10371,6 +11454,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10384,6 +11468,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">иметь объем [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有一個量 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter o volume de (som)</column>
+      <column name="definition_fi">olla tilavuudeltaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{juv:v}, {tlho'ren:n}, {tIn:v}, {mach:v}, {men:v}</column>
@@ -10394,6 +11479,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10403,6 +11489,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10410,6 +11497,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10423,6 +11511,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">ненавидеть, питать отвращение</column>
       <column name="definition_zh_HK">憎恨、討厭</column>
       <column name="definition_pt">odiar, detestar</column>
+      <column name="definition_fi">vihata, inhota</column>
       <column name="synonyms"></column>
       <column name="antonyms">{muSHa':v}</column>
       <column name="see_also">{par:v}</column>
@@ -10433,6 +11522,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10442,6 +11532,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10449,6 +11540,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10462,6 +11554,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">люблю [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">喜愛</column>
       <column name="definition_pt">amar</column>
+      <column name="definition_fi">rakastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{muS:v}</column>
       <column name="see_also">{parHa':v}, {parmaq:n}</column>
@@ -10472,6 +11565,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{muS:v}, {-Ha':v}</column>
       <column name="examples">
@@ -10487,6 +11581,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">beloved, adore</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10494,6 +11589,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.114-115:src}</column>
     </table>
     <table name="mem">
@@ -10508,6 +11604,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">быть эгоистичным</column>
       <column name="definition_zh_HK">自私</column>
       <column name="definition_pt">ser egoísta</column>
+      <column name="definition_fi">olla itsekäs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qur:v}, {var:v}</column>
@@ -10518,6 +11615,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10527,6 +11625,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10534,6 +11633,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10548,6 +11648,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">вид(биология)</column>
       <column name="definition_zh_HK">物種</column>
       <column name="definition_pt">espécies</column>
+      <column name="definition_fi">laji, rotu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Segh:n}, {buv:n}, {yagh:n}</column>
@@ -10558,6 +11659,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10567,6 +11669,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10574,6 +11677,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10587,6 +11691,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">простейшее [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">原蟲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">protozoário</column>
+      <column name="definition_fi">alkueläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10597,6 +11702,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="notes_ru">Название, буквально «Вид № 1», оказалось не точным с научной точки зрения, но оно застряло. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個名字的字面意思是“ Species＃1”（物種＃1），從科學上講並不准確，但是卻卡住了。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O nome, literalmente "Espécie #1", acabou não sendo cientificamente preciso, mas permaneceu. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nimi, kirjaimellisesti "Laji # 1", ei osoittautunut tieteellisesti tarkaksi, mutta se juuttui. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mut:n}, {wa':n:num}</column>
       <column name="examples"></column>
@@ -10606,6 +11712,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10613,6 +11720,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -10626,6 +11734,7 @@ Este verbo também é usado em música ({much:v:2}) e artes marciais ({much:v:3}
       <column name="definition_ru">построить, собрать, собрать, изготовить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">建造、組裝、拼湊、製造 [AUTOTRANSLATED]</column>
       <column name="definition_pt">construir, montar, fabricar, produzir</column>
+      <column name="definition_fi">rakentaa, koota, kasata, valmistaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lagh:v}</column>
       <column name="see_also">{'ay':n}, {chenmoH:v}, {vIqraq:n}, {ngogh:n}, {qatlhDa':n}, {majyang:n}, {jom:v}</column>
@@ -10664,6 +11773,11 @@ När den appliceras på {tlhIm:n}, betyder {mutlh:v:nolink} att montera mattan. 
 Uma pessoa que conserta coisas é um {tI'wI':n}. A maioria dos {mutlhwI'pu':n:nolink} também são {tI'wI'pu':n:nolink}.
 
 Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O verbo para colocar um tapete é {vel:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{mutlhwI':n:nolink} on henkilö, joka kokoaa asioita yhteen.
+
+Henkilö, joka korjaa asioita, on {tI'wI':n}. Useimmat {mutlhwI'pu':n:nolink} ovat myös {tI'wI'pu':n:nolink}.
+
+Kun sitä levitetään {tlhIm:n}: lle, {mutlh:v:nolink} tarkoittaa maton kokoamista. Verbi maton asettamisesta on {vel:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The original definition given on the {KLI mailing list:src} was "construct, assemble, put together". This word was also defined as "manufacture, construct, put together" in the {Saarbrücken qepHom'a' 2016:src} booklet.</column>
       <column name="components"></column>
       <column name="examples">
@@ -10678,6 +11792,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10685,6 +11800,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.09:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -10698,6 +11814,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">присоединять, присоединяться</column>
       <column name="definition_zh_HK">加入 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Juntar</column>
+      <column name="definition_fi">liittyä, tulla jäseneksi tai osaksi jotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuv:n}, {muvchuqmoH:v}, {muvmoH:v}, {tay':v}, {tuqnIgh:n}, {Sap:v}</column>
@@ -10708,6 +11825,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The {paq'batlh:src} example suggests that the subject becomes a part or member of the object. The medical instrument example seems to suggest otherwise, but device names are often abbreviated.</column>
       <column name="components"></column>
       <column name="examples">
@@ -10719,6 +11837,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10726,6 +11845,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.179:src}</column>
     </table>
     <table name="mem">
@@ -10739,6 +11859,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">объединяться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">團結 [AUTOTRANSLATED]</column>
       <column name="definition_pt">unir</column>
+      <column name="definition_fi">yhdistää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{muv:v}, {tay':v}</column>
@@ -10749,6 +11870,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru">Субъект объединяет, а объекты объединяются. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">主體團結起來，而對象則團結起來。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O sujeito faz a união, enquanto os objetos estão unidos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde tekee yhdistämisen, kun taas objektit ovat yhdistettyjä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{muv:v}, {-chuq:v}, {-moH:v}</column>
       <column name="examples">
@@ -10759,6 +11881,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10766,6 +11889,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.179:src}</column>
     </table>
     <table name="mem">
@@ -10779,6 +11903,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">рекрутировать, вербовать, нанимать на работу</column>
       <column name="definition_zh_HK">招 [AUTOTRANSLATED]</column>
       <column name="definition_pt">recrutar</column>
+      <column name="definition_fi">värvätä, rekrytoida johonkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuv:n}</column>
@@ -10789,6 +11914,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru">Смотрите {qawmoH:v} для примера того, как использовать глагол, подобный этому.</column>
       <column name="notes_zh_HK">有關如何使用此類動詞的示例，請參見{qawmoH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja {qawmoH:v} para um exemplo de como usar um verbo como este. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {qawmoH:v}-esimerkki siitä, miten tämän kaltaista verbiä käytetään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{muv:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -10798,6 +11924,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10805,6 +11932,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -10819,6 +11947,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">инициация, введение, посвящение во что-то</column>
       <column name="definition_zh_HK">入會儀式</column>
       <column name="definition_pt">iniciação</column>
+      <column name="definition_fi">juhlallinen jäseneksi ottaminen tai vihkiminen, initiaatioriitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{muv:v}, {tay:n:2}</column>
@@ -10829,6 +11958,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{muv:v} or {muv:n:hyp,nolink}, {tay:n:2}</column>
       <column name="examples"></column>
@@ -10838,6 +11968,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10845,6 +11976,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -10858,6 +11990,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">ресница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">睫毛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cílios</column>
+      <column name="definition_fi">silmäripsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn:n}, {mInyoD:n}</column>
@@ -10869,6 +12002,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">From the Latin "cilium".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10878,6 +12012,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10885,6 +12020,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -10898,6 +12034,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">слово</column>
       <column name="definition_zh_HK">字</column>
       <column name="definition_pt">palavra</column>
+      <column name="definition_fi">sana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mu'mey Doy':n}, {mu'mey ghoQ:n}, {mu'mey qar:n}, {mu'mey ru':n}</column>
@@ -10908,6 +12045,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10917,6 +12055,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10924,6 +12063,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10937,6 +12077,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">словарь</column>
       <column name="definition_zh_HK">字典</column>
       <column name="definition_pt">dicionário</column>
+      <column name="definition_fi">sanakirja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10948,6 +12089,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mu':n}, {ghom:n}</column>
       <column name="examples"></column>
@@ -10957,6 +12099,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10964,6 +12107,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10977,6 +12121,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">усталые слова [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">累了的話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">palavras cansadas</column>
+      <column name="definition_fi">väsyneet sanat</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mu'mey ghoQ:n}</column>
       <column name="see_also">{no' Hol:n}, {mu'mey qar:n}</column>
@@ -10987,6 +12132,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru">Именно так словарь, используемый старшими клингонами в повседневной речи, упоминается младшими клингонами. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是年輕的克林崗人如何引用老年人的克林崗人在日常講話中使用的詞彙。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É assim que o vocabulário usado pelos klingons mais velhos na fala cotidiana é referido pelos klingons mais jovens. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Näin nuoremmat klingonit viittaavat vanhempien klingonilaisten jokapäiväisessä puheessa käyttämään sanastoon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mu':n}, {-mey:n}, {Doy':v}</column>
       <column name="examples"></column>
@@ -10996,6 +12142,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11003,6 +12150,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.35:src}</column>
     </table>
     <table name="mem">
@@ -11016,6 +12164,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">сленг, свежие слова [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">俚語、新鮮的話語 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gírias, novas palavras</column>
+      <column name="definition_fi">slangi, puhekieli, tuoreet sanat</column>
       <column name="synonyms">{Hol ghoQ:n}</column>
       <column name="antonyms">{mu'mey Doy':n}</column>
       <column name="see_also">{no' Hol:n}</column>
@@ -11026,6 +12175,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru">Это относится к лексике, используемой младшими клингонами. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指年輕的克林崗人使用的詞彙。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao vocabulário usado pelos klingons mais jovens. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa nuorten klingonilaisten käyttämään sanastoon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined only as "slang" in the {KGT:src} word lists, and erroneously written as {mu'mey qhoQ:n:nolink} in the K-E side. It is glossed as "fresh words" in the body text.</column>
       <column name="components">{mu':n}, {-mey:n}, {ghoQ:v:1}</column>
       <column name="examples"></column>
@@ -11035,6 +12185,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11042,6 +12193,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.35,142:src}</column>
     </table>
     <table name="mem">
@@ -11055,6 +12207,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">точные слова [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">準確的話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">palavras precisas</column>
+      <column name="definition_fi">kirjakieli, yleiskieli, täsmälliset sanat</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hol ghoQ:n}</column>
       <column name="see_also">{mu'mey Doy':n}</column>
@@ -11065,6 +12218,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru">Те, кто не любит сленг, ссылаются на стандартные слова, используя это выражение. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">那些不喜歡語的人使用此表達式來引用標准單詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Aqueles que não gostam de gírias se referem a palavras comuns usando essa expressão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ne, jotka eivät pidä slangista, viittaavat tavanomaisiin sanoihin käyttämällä tätä ilmaisua. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mu':n}, {-mey:n}, {qar:v}</column>
       <column name="examples"></column>
@@ -11074,6 +12228,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11081,6 +12236,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.143:src}</column>
     </table>
     <table name="mem">
@@ -11094,6 +12250,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">временные слова [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">臨時的話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">palavras temporárias</column>
+      <column name="definition_fi">korosteiset ja kieliopin vastaiset sanat, väliaikaiset sanat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pabHa':v}</column>
@@ -11104,6 +12261,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru">Это относится к словам или фразам, придуманным для определенного случая, которые намеренно нарушают грамматические правила воздействия. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指為特定場合創造的單詞或短語，並且故意違反語法規則以產生影響。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a palavras ou frases cunhadas para uma ocasião específica e que intencionalmente violam regras gramaticais de impacto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa sanoja tai lauseita, jotka on luotu tiettyyn tilanteeseen ja jotka tahallaan rikkovat kielioppisääntöjä vaikutuksiltaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mu':n}, {-mey:n}, {ru':v:1}</column>
       <column name="examples"></column>
@@ -11113,6 +12271,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11120,6 +12279,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.176:src}</column>
     </table>
     <table name="mem">
@@ -11133,6 +12293,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">проклинать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">詛咒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">insulto</column>
+      <column name="definition_fi">kirous</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11143,6 +12304,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mu':n}, {qaD:n}</column>
       <column name="examples"></column>
@@ -11152,6 +12314,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11159,6 +12322,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -11172,6 +12336,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">проклятие войны, вид спорта [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">詛咒戰、一種運動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">guerra de insultos, um tipo de esporte</column>
+      <column name="definition_fi">kiroussota (eräänlainen urhelulaji)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11182,6 +12347,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mu'qaD:n}, {veS:n}</column>
       <column name="examples"></column>
@@ -11191,6 +12357,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11198,6 +12365,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -11211,6 +12379,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">словарь</column>
       <column name="definition_zh_HK">詞彙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vocabulário</column>
+      <column name="definition_fi">sanasto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11221,6 +12390,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mu':n}, {tay':v}</column>
       <column name="examples"></column>
@@ -11230,6 +12400,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11237,6 +12408,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -11250,6 +12422,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="definition_ru">предложение(грамматика)</column>
       <column name="definition_zh_HK">句子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">frase</column>
+      <column name="definition_fi">lause</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11260,6 +12433,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mu':n}, {tlhegh:n}</column>
       <column name="examples"></column>
@@ -11269,6 +12443,7 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11276,5 +12451,6 @@ Quando aplicado ao {tlhIm:n}, {mutlh:v:nolink} significa montar o carpete. O ver
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>

--- a/mem-09-n.xml
+++ b/mem-09-n.xml
@@ -10154,7 +10154,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
 
 Englanninkieliset kysymykset vastaavat usein luonnollisemmin Klingonin vaatimuksia. Jos haluat kysyä "mitä" -kysymyksen, harkitse sen sijaan komennon käyttämistä verbillä, kuten {ngu':v}. [2] Harkitse esimerkiksi {per:v}, {ja':v}, {Del:v} jne.
 
-Huomaa myös, että "Mitkä ovat tilauksesi?" ilmaistaan ​​Klingonissa nimellä {chay 'jura'?: sen} Katso {chay':ques}.[2]{chay' jura'?:sen} [AUTOTRANSLATED]</column>
+Huomaa myös, että "Mitkä ovat tilauksesi?" ilmaistaan ​​Klingonissa nimellä {chay 'jura'?:sen} Katso {chay':ques}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10505,7 +10505,7 @@ Huomaa myös, että "Mitkä ovat tilauksesi?" ilmaistaan ​​Klingonissa nimel
       <column name="notes_ru">Является укороченным вариантом фразы {nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v}</column>
       <column name="notes_zh_HK">這是在修剪過的克林崗語中。問“你說了什麼？”的語法方式會是{nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso está no Klingon cortado. A maneira gramatical de perguntar "O que você disse?" seria {nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v} [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Tämä on leikattu Klingon. Kieliopillinen tapa kysyä "Mitä sanoit?" olisi {nuq Dajatlh?: sen @@ nuq: ques, Da-: v, jatlh: v}{nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on leikattu Klingon. Kieliopillinen tapa kysyä "Mitä sanoit?" olisi {nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10562,11 +10562,11 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_pt"></column>
       <column name="notes_fi">Tämä huutomerkki ei vastaa "hei". Tervehdytetyn osapuolen odotetaan yksinkertaisesti aloittavan puhumisen eikä palauttavan tervehdyksen
 
-Huomaa, että tämä huutomerkki on leikattu klingon. Kieliopillinen tapa kysyä "Mitä haluat?" olisi {nuq DaneH?: sen @@ nuq: ques, Da-: v, neH: v} [2]
+Huomaa, että tämä huutomerkki on leikattu klingon. Kieliopillinen tapa kysyä "Mitä haluat?" olisi {nuq DaneH?:sen@@nuq:ques, Da-:v, neH:v} [2]
 
 Katso Gowronin sanovan tämä: {YouTube video:url:http://youtu.be/s10kg0C_hSM}
 
-Katso oppitunti tästä sanasta: {YouTube video:url:http://youtu.be/auqS6FR_RDE}[2; 3]{nuq DaneH?:sen@@nuq:ques, Da-:v, neH:v} [AUTOTRANSLATED]</column>
+Katso oppitunti tästä sanasta: {YouTube video:url:http://youtu.be/auqS6FR_RDE}[2; 3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>

--- a/mem-09-n.xml
+++ b/mem-09-n.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {n:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{n:sen:nolink}</column>
       <column name="definition_pt">a consoante {n:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {n:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">планировать</column>
       <column name="definition_zh_HK">計劃、預定</column>
       <column name="definition_pt">planejar</column>
+      <column name="definition_fi">suunnitella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hech:v}, {QuS:v}, {ren:v}, {nab:n}, {Degh:v:slang}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Это слово использовано для планирования события, стратегии боя, и т.д.,но не для планирования какого-то физического объекта. (Для этого, используйте слово {ren:v}.)</column>
       <column name="notes_zh_HK">該詞用於事件的計劃，戰鬥策略等，但不用於設計物理對象（該詞是{ren:v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra é usada para o planejamento de um evento, uma estratégia de batalha etc., mas não para o design de um objeto físico (a palavra para isso é {ren:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään tapahtuman, taistelustrategian jne. Suunnitteluun, mutta ei fyysisen objektin suunnitteluun (sana {ren:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -68,6 +74,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">schedule</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -75,6 +82,7 @@
       <column name="search_tags_ru">расписание</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -88,6 +96,7 @@
       <column name="definition_ru">план, процедура</column>
       <column name="definition_zh_HK">計劃、程序 [AUTOTRANSLATED]</column>
       <column name="definition_pt">plano, procedimento</column>
+      <column name="definition_fi">suunnitelma, menettely</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIw:n}, {nab:v}</column>
@@ -98,6 +107,7 @@
       <column name="notes_ru">Это слово относится к планированию события, а не физического объекта (например чертежа, для которого более подходящее слово {pu'jIn:n}).</column>
       <column name="notes_zh_HK">這個詞指的是事件的計劃，而不是指物理對象的計劃（即藍圖，可能是{pu'jIn:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se ao planejamento de um evento, e não ao plano de um objeto físico (isto é, um blueprint, que seria um {pu'jIn:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa tapahtuman suunnitteluun, ei fyysisen objektin (eli suunnitelman, joka olisi {pu'jIn:n}) suunnitelmaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -107,6 +117,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">schedule</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -114,6 +125,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -127,6 +139,7 @@
       <column name="definition_ru">голова(часть тела)</column>
       <column name="definition_zh_HK">頭</column>
       <column name="definition_pt">cabeça</column>
+      <column name="definition_fi">pää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qab:n}, {mong:n}, {jIb:n}, {Quch:n}, {DughrI':n}</column>
@@ -137,6 +150,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -146,6 +160,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -153,6 +168,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -166,6 +182,7 @@
       <column name="definition_ru">хвалить, восхвалять, прельщать, утверждать, одобрять</column>
       <column name="definition_zh_HK">讚美、讚揚、贊同 [AUTOTRANSLATED]</column>
       <column name="definition_pt">elogiar, recomendar, aprovar</column>
+      <column name="definition_fi">kehua, kiittää, antaa tunnustus tai hyväksyntä, suositella</column>
       <column name="synonyms"></column>
       <column name="antonyms">{naDHa':v}</column>
       <column name="see_also">{tIch:v}, {vuv:v}, {naD:n}</column>
@@ -176,6 +193,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -185,6 +203,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -192,6 +211,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -205,6 +225,7 @@
       <column name="definition_ru">похвала</column>
       <column name="definition_zh_HK">讚許 [AUTOTRANSLATED]</column>
       <column name="definition_pt">elogio</column>
+      <column name="definition_fi">kiitos, kunniamaininta, palkinto, tunnustus, suositus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naD:v}</column>
@@ -215,6 +236,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -224,6 +246,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -231,6 +254,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -244,6 +268,7 @@
       <column name="definition_ru">Рекомендательный список [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">表彰名單 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Lista de Comendações</column>
+      <column name="definition_fi">kiitoslista?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -254,6 +279,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{naD:n}, {tetlh:n}</column>
       <column name="examples"></column>
@@ -263,6 +289,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -270,6 +297,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -283,6 +311,7 @@
       <column name="definition_ru">здесь</column>
       <column name="definition_zh_HK">這裡、這邊</column>
       <column name="definition_pt">aqui, por aqui</column>
+      <column name="definition_fi">täällä, täälläpäin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa':n:2}, {Dat:n}, {vogh:n}</column>
@@ -293,6 +322,7 @@
       <column name="notes_ru">Это слово никогда не следует за локационным суффиксом {-Daq:n:suff}. ({TKD 3.3.5:src})</column>
       <column name="notes_zh_HK">該詞後不帶位置後綴{-Daq:n:suff}。 （{TKD 3.3.5:src}） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra nunca é seguida pelo sufixo locativo {-Daq:n:suff}. ({TKD 3.3.5:src}) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa ei koskaan seuraa paikallinen loppuliite {-Daq:n:suff}. ({TKD 3.3.5:src}) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -304,6 +334,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -311,6 +342,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -324,6 +356,7 @@
       <column name="definition_ru">Уходи!</column>
       <column name="definition_zh_HK">走開！</column>
       <column name="definition_pt">Vá embora!</column>
+      <column name="definition_fi">Mene pois!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -334,6 +367,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">There is a typo in {TKD:src}, an extra space after {naDev:sen:nolink}.</column>
       <column name="components">{naDev:n}, {-vo':n}, {yI-:v}, {ghoS:v:1}</column>
       <column name="examples"></column>
@@ -343,6 +377,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -350,6 +385,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -363,6 +399,7 @@
       <column name="definition_ru">Принеси(те) это сюда!</column>
       <column name="definition_zh_HK">帶這件事物過來！ </column>
       <column name="definition_pt">Traga isso aqui!</column>
+      <column name="definition_fi">Tuo se tänne!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -373,6 +410,7 @@
       <column name="notes_ru">Это команда, данная животному (или подчиненному), чтобы получить объект. Это в обрезанном клингоне. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是給動物（或下屬）獲取對象的命令。它在修剪的克林崗語中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um comando dado a um animal (ou subordinado) para buscar um objeto. Está no Klingon cortado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on komento, joka annetaan eläimelle (tai alaiselle) objektin hakemiseksi. Se on leikattu Klingon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -382,6 +420,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fetch</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -389,6 +428,7 @@
       <column name="search_tags_ru">получать, доставать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -402,6 +442,7 @@
       <column name="definition_ru">Здесь повсюду клингоны</column>
       <column name="definition_zh_HK">這裡有克林崗人。</column>
       <column name="definition_pt">Há Klingons por aqui.</column>
+      <column name="definition_fi">Täällä on klingoneja.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -412,6 +453,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{naDev:n}, {tlhIngan:n}, {-pu':n}, {tu'lu':v}</column>
       <column name="examples"></column>
@@ -421,6 +463,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -428,6 +471,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -441,6 +485,7 @@
       <column name="definition_ru">порицать, не одобрять, относиться неодобрительно</column>
       <column name="definition_zh_HK">推薦、不贊成 [AUTOTRANSLATED]</column>
       <column name="definition_pt">discordar, desaprovar</column>
+      <column name="definition_fi">torjua tai kieltää joku, suositella jotakuta vastaan, olla hyväksymättä jotakuta</column>
       <column name="synonyms"></column>
       <column name="antonyms">{naD:v}</column>
       <column name="see_also">{qIch:v}, {mIl:v}</column>
@@ -451,6 +496,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{naD:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -460,6 +506,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -467,6 +514,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -480,6 +528,7 @@
       <column name="definition_ru">порицание, неодобрение, осуждение</column>
       <column name="definition_zh_HK">discommendation [AUTOTRANSLATED]</column>
       <column name="definition_pt">discomendação</column>
+      <column name="definition_fi">moite, suositus jotakuta vastaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -490,6 +539,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{naD:v}, {-Ha':v}, {-ghach:v}</column>
       <column name="examples"></column>
@@ -499,6 +549,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -506,6 +557,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -519,6 +571,7 @@
       <column name="definition_ru">повторное одобрение</column>
       <column name="definition_zh_HK">建議 [AUTOTRANSLATED]</column>
       <column name="definition_pt">re-comendação</column>
+      <column name="definition_fi">jälleensuositus?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -529,6 +582,7 @@
       <column name="notes_ru">Это является актом отмены чьего-то осуждения ({naDHa'ghach:n}).</column>
       <column name="notes_zh_HK">這是消除某人的不雅行為的行為（{naDHa'ghach:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o ato de desfazer a recomendação de alguém ({naDHa'ghach:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on toimenpide, jolla kumotaan jonkun suositus ({naDHa'ghach:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{naD:v}, {-qa':v}, {-ghach:v}</column>
       <column name="examples"></column>
@@ -538,6 +592,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -545,6 +600,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -558,6 +614,7 @@
       <column name="definition_ru">камень, скала, керамический материал</column>
       <column name="definition_zh_HK">岩石、石頭、陶瓷材料 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rocha, pedra, material cerâmico</column>
+      <column name="definition_fi">kivi, keraamiikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'an:v:2}, {Hew:n}, {De'lor:n}, {Hotnagh:n}, {lIvrI':n}, {mISjennegh:n}</column>
@@ -568,6 +625,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined as "rock, stone" in {TKD:src} and as "ceramic material" in {KGT:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -577,6 +635,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -584,6 +643,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -597,6 +657,7 @@
       <column name="definition_ru">каменное панно (произведение искусства, похожее на картину) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">石板（藝術品、類似於繪畫） [AUTOTRANSLATED]</column>
       <column name="definition_pt">painel de pedra (obras de arte, semelhante a uma pintura)</column>
+      <column name="definition_fi">kivitaulu (taideteos)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rItlh:n}, {DIj:v:2}, {ngoH:v:2}, {vol:n}</column>
@@ -607,6 +668,7 @@
       <column name="notes_ru">Это буквально означает «плоский камень», но значение было расширено, чтобы включить вырезанные, вырезанные или нарисованные на нем произведения искусства. Посмотрите {mIllogh:n} для более общего слова для «изображения». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“平坦的岩石”，但其含義已擴展到包括雕刻，切割或繪畫的藝術品。參見{mIllogh:n}以獲得“圖片”的更通用詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "pedra chata", mas o significado foi estendido para incluir obras de arte esculpidas, entalhadas ou pintadas nela. Consulte {mIllogh:n} para obter uma palavra mais geral para "figura". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "tasaista kalliota", mutta merkitystä on laajennettu koskemaan siihen veistettyjä, viillettyjä tai maalattuja taideteoksia. Kohdasta {mIllogh:n} on yleisempi sana "kuva". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nagh:n}, {beQ:v}</column>
       <column name="examples"></column>
@@ -616,6 +678,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">carving</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -623,6 +686,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -636,6 +700,7 @@
       <column name="definition_ru">панцирь (животного) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">貝殼、硬殼</column>
       <column name="definition_pt">concha (de um animal)</column>
+      <column name="definition_fi">(eläimen) kuori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pel'aQ:n:1}</column>
@@ -646,6 +711,7 @@
       <column name="notes_ru">Для этого используется суффикс множественного числа {-Du':n:suff}, независимо от того, находится ли оболочка на животном или нет. Но если скорлупа (от животного) сломана, и кусок или ее части используются для чего-то, тогда множественное число принимает {-mey:n:suff}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">無論外殼是否仍在動物身上，都採用後綴{-Du':n:suff}。但是，如果將貝殼（從動物身上取出）弄碎了，並用一塊或幾塊貝殼來做某事，則復數取為{-mey:n:suff}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso leva o sufixo plural {-Du':n:suff}, se a concha ainda está no animal ou não. Mas se a casca (fora do animal) é quebrada e um pedaço ou pedaços dela são usados ​​para alguma coisa, então o plural leva {-mey:n:suff}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä vie monikon loppuliitteen {-Du':n:suff} riippumatta siitä, onko kuori eläimessä vai ei. Mutta jos kuori (pois eläimestä) hajotetaan ja siitä käytetään palaa tai paloja mihinkään, monikko ottaa {-mey:n:suff}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nagh:n}, {DIr:n}</column>
       <column name="examples"></column>
@@ -655,6 +721,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -662,6 +729,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KLI mailing list 2019.01.22:src}</column>
     </table>
     <table name="mem">
@@ -675,6 +743,7 @@
       <column name="definition_ru">узда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">抑制 [AUTOTRANSLATED]</column>
       <column name="definition_pt">meio-fio, borda da calçada</column>
+      <column name="definition_fi">reunakivi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taw:n}</column>
@@ -685,6 +754,7 @@
       <column name="notes_ru">Это относится к поднятому краю дороги или улицы. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指道路或街道的凸起邊緣。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à margem elevada de uma estrada ou rua. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tien tai kadun korotettuun reunaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nagh:n}, {HeH:n}</column>
       <column name="examples"></column>
@@ -694,6 +764,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -701,6 +772,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -714,6 +786,7 @@
       <column name="definition_ru">драгоценный камень [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">寶石</column>
       <column name="definition_pt">pedra preciosa</column>
+      <column name="definition_fi">jalokivi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIl:v}, {tlhIl:n}, {qut:n}</column>
@@ -724,6 +797,7 @@
       <column name="notes_ru">Известные типы драгоценных камней включают {qevaS:n}, {Separ:n}, {DItlhon:n} и {patmor:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">已知的寶石類型包括{qevaS:n}，{Separ:n}，{DItlhon:n}和{patmor:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os tipos conhecidos de pedras preciosas incluem {qevaS:n}, {Separ:n}, {DItlhon:n} e {patmor:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tunnettuja jalokivityyppejä ovat {qevaS:n}, {Separ:n}, {DItlhon:n} ja {patmor:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nagh:n}, {boch:v}</column>
       <column name="examples"></column>
@@ -733,6 +807,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -740,6 +815,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -753,6 +829,7 @@
       <column name="definition_ru">фрукт, овощ</column>
       <column name="definition_zh_HK">水果、蔬菜</column>
       <column name="definition_pt">frutas, vegetais</column>
+      <column name="definition_fi">hedelmä, vihannes</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baQ:v:2}, {DeH:v}, {Du' naH:n}, {naH tlhab:n}, {ghub:n}, {qurgh:n}, {'oQqar:n}, {'aquta':n}, {yub:n}, {tIr:n}, {yob:v}, {wIj:v}, {yotlh:n}</column>
@@ -763,6 +840,7 @@
       <column name="notes_ru">Сам по себе, {naH:n} обоычно относится к {Du' naH:n} больше, чем {naH tlhab:n}.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{naH:n} viittaa sinänsä yleensä {Du' naH:n}: een {naH tlhab:n}: een.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -772,6 +850,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -779,6 +858,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT p.89:src}</column>
     </table>
     <table name="mem">
@@ -792,6 +872,7 @@
       <column name="definition_ru">овощные дни [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蔬菜日 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dias vegetais</column>
+      <column name="definition_fi">"vihannespäivät" (Paavo Cajanderin suomentamana "kevätaika"), nuoruus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -802,6 +883,7 @@
       <column name="notes_ru">Эта идиома относится к молодости (время до достижения возраста, который считается подходящим для вступления в брак). Впервые на нем произнес {tlhI'yopatra':n:name}, в пьесе {'antonI' tlhI'yopatra' je:sen:nolink} - {wIlyam SeQpIr:n:name}. В популярной версии спектакля Federation Standard это переводится как «салатные дни». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個成語是指一個人的年輕時期（達到適合結婚年齡的時間）。它最初是由{tlhI'yopatra':n:name}在{wIlyam SeQpIr:n:name}的戲劇{'antonI' tlhI'yopatra' je:sen:nolink}中說的。在流行的聯合會標準版本中，這被翻譯為“沙拉天”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta expressão se refere aos dias de juventude (um período antes de atingir uma idade considerada apropriada para o casamento). Foi falado pela primeira vez por {tlhI'yopatra':n:name}, na peça {'antonI' tlhI'yopatra' je:sen:nolink} de {wIlyam SeQpIr:n:name}. Na popular versão da peça do Federation Standard, isso é traduzido como "dias de salada". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sanamuoto viittaa nuoruuden päiviin (aika ennen avioliittoon sopivaksi katsotun ikän saavuttamista). Sen puhui ensin {tlhI'yopatra':n:name}, näytelmässä {'antonI' tlhI'yopatra' je:sen:nolink} {wIlyam SeQpIr:n:name}. Näytelmän suositussa Federation Standard -versiossa tämä käännetään "salaattipäivinä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{naH:n}, {jaj:n}, {-mey:n}</column>
       <column name="examples">
@@ -812,6 +894,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">youth, young, salad days</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -819,6 +902,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.110:src}</column>
     </table>
     <table name="mem">
@@ -832,6 +916,7 @@
       <column name="definition_ru">vegetable knife, fruit knife (small knife) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">菜刀、水果刀（小刀）</column>
       <column name="definition_pt">faca de legumes, faca de frutas (faca pequena)</column>
+      <column name="definition_fi">vihannesveitsi, hedelmäveitsi (pieni veitsi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -842,6 +927,7 @@
       <column name="notes_ru">Существует идиома {jejHa'; naH taj rur}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{jejHa'; naH taj rur}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {jejHa'; naH taj rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {jejHa'; naH taj rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{naH:n}, {taj:n}</column>
       <column name="examples"></column>
@@ -851,6 +937,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -858,6 +945,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -871,6 +959,7 @@
       <column name="definition_ru">дикие фрукты, овощи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">野果、蔬菜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">frutas silvestres, vegetais</column>
+      <column name="definition_fi">villihedelmä tai -vihannes</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yob:v}</column>
@@ -881,6 +970,7 @@
       <column name="notes_ru">Это относится к фруктам или овощам, выращенным не на ферме, в отличие от {Du' naH:n}.[1, p.89] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與{Du' naH:n}.[1, p.89]相反，這是指不在農場上種植的水果或蔬菜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a frutas ou vegetais que não são cultivados em uma fazenda, ao contrário de {Du' naH:n}.[1, p.89] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa hedelmiä tai vihanneksia, joita ei ole kasvatettu tilalla, toisin kuin {Du' naH:n}.[1, p.89] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{naH:n}, {tlhab:v}</column>
       <column name="examples"></column>
@@ -890,6 +980,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -897,6 +988,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -910,6 +1002,7 @@
       <column name="definition_ru">чертополох [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">薊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cardo</column>
+      <column name="definition_fi">ohdake</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -934,6 +1027,9 @@ Förväxla inte detta ord med {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra também é escrita {neHjej:n:nolink}.
 
 Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on myös kirjoitettu {neHjej:n:nolink}.
+
+Älä sekoita tätä sanaa {naQjej:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the body text of {KGT:src}, this word is spelled {naHjej:n:nolink}, with a note that it literally means "sharp fruit".[1, p.88] However, it is spelled {neHjej:n:nolink} in both the E-K and K-E word lists.</column>
       <column name="components">{naH:n}, {jej:v}</column>
       <column name="examples"></column>
@@ -943,6 +1039,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -950,6 +1047,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -963,6 +1061,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">орех, орехи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">堅果</column>
       <column name="definition_pt">noz, nozes</column>
+      <column name="definition_fi">pähkinä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -973,6 +1072,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{naH:n}, {let:v}</column>
       <column name="examples"></column>
@@ -982,6 +1082,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -989,6 +1090,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1002,6 +1104,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">скорлупа ореха [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">堅果殼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">casca de noz</column>
+      <column name="definition_fi">pähkinänkuori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1012,6 +1115,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Один обычно {choptaH:v} на гайке, затем {tlhIS:v} кусочки скорлупы. [1, p.87] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Yksi tyypillisesti {choptaH:v} mutterissa, sitten {tlhIS:v} palan kuori.[1, p.87] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{naHlet:n}, {yub:n}</column>
       <column name="examples"></column>
@@ -1021,6 +1125,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1028,6 +1133,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1041,6 +1147,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">яма (фруктов) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">坑（水果） [AUTOTRANSLATED]</column>
       <column name="definition_pt">caroço  (de fruta)</column>
+      <column name="definition_fi">hedelmän kivi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1051,6 +1158,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{naH:n}, {nagh:n}</column>
       <column name="examples"></column>
@@ -1060,6 +1168,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1067,6 +1176,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1080,6 +1190,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть враждебным, злым, недружественным, антагонистическим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">是敵對的、惡意的、不友好的、敵對的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser hostil, malicioso, hostil, antagônico</column>
+      <column name="definition_fi">olla vihamielinen, pahantahtoinen, epäystävällinen, julma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naS:v}</column>
@@ -1090,6 +1201,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">While this word was created as a retrofit (see the example sentence), its creation may also have been influenced by its similarity to {naS:v} and {natlh:v:2}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1100,6 +1212,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1107,6 +1220,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -1120,6 +1234,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">мечтать</column>
       <column name="definition_zh_HK">發夢</column>
       <column name="definition_pt">sonhar</column>
+      <column name="definition_fi">uneksia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suchtuv:n}, {Qong:v}, {robwIl:n}, {luvnup:n}</column>
@@ -1130,6 +1245,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Этот глагол может принимать содержимое или объект мечтания в качестве объекта.[2] Он используется только для сновидений, происходящих во сне, но не для фантазий или надежд на что-то, ни для галлюцинаций (см. {'ergh:v}) .[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞可以將夢的內容或主題作為對象。[2]僅用於在睡眠中發生的夢，不用於幻想或希望某件事，也不用於幻覺（請參見{'ergh:v}）。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo pode tomar o conteúdo ou assunto de um sonho como um objeto.[2] É usado apenas para o sonho que ocorre durante o sono, e não para fantasiar ou esperar por algo, nem para alucinações (para as quais ver {'ergh:v}) .[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi voi ottaa unelman sisällön tai aiheen esineeksi.[2]{'ergh:v}[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{qul naj:n}</column>
@@ -1139,6 +1255,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1146,6 +1263,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}, [3] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1159,6 +1277,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">колыбельная</column>
       <column name="definition_zh_HK">催眠曲</column>
       <column name="definition_pt">canção de ninar</column>
+      <column name="definition_fi">kehtolaulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}</column>
@@ -1169,6 +1288,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{naj:v}, {-moH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1178,6 +1298,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1185,6 +1306,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1198,6 +1320,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">брачный вызов [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">配偶挑戰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desafio de companheiro</column>
+      <column name="definition_fi">parinmuodostushaaste?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1208,6 +1331,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Кажется, что это слово состоит из {nal:n:hyp} (компонент, также найденный в {loDnal:n}, {be'nal:n} и {'Ipnal:n}) и {qaD:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">看來這個詞是由{nal:n:hyp}（也在{loDnal:n}，{be'nal:n}和{'Ipnal:n}中找到的組件）和{qaD:n}組成的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Parece que essa palavra é composta por {nal:n:hyp} (um componente encontrado também em {loDnal:n}, {be'nal:n} e {'Ipnal:n}) e {qaD:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Näyttää siltä, ​​että tämä sana koostuu {nal:n:hyp}: stä (komponentti löytyy myös {loDnal:n}, {be'nal:n} ja {'Ipnal:n}) ja {qaD:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nal:n:hyp}, {qaD:n}</column>
       <column name="examples"></column>
@@ -1217,6 +1341,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1224,6 +1349,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1237,6 +1363,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">хлорофилл [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">葉綠素 [AUTOTRANSLATED]</column>
       <column name="definition_pt">clorofila</column>
+      <column name="definition_fi">klorofylli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{monQIv:n}, {ghav:n}, {jul:n}, {por:n}, {San'emDer:n}, {tI:n}, {'otlh:n}</column>
@@ -1247,6 +1374,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Cloris Leachman ({lIchman:sen:nolink}) played the character Phyllis on The Mary Tylor Moore Show.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1256,6 +1384,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1263,6 +1392,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1276,6 +1406,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">знакомое начало песни [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一首熟悉的歌曲開頭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">o começo familiar de uma música</column>
+      <column name="definition_fi">kappaleen tuttu alku</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'o'megh:n}</column>
       <column name="see_also">{lIH:v:2}</column>
@@ -1286,6 +1417,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Услышав только эту короткую часть начала песни, слушатель узнает мелодию. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">聽完歌曲開頭的這一小部分後，聽眾便會認出該樂曲。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Depois de ouvir apenas essa pequena parte do começo da música, o ouvinte reconhecerá a música. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kuultuaan vain tämän lyhyen osan kappaleen alusta kuuntelija tunnistaa kappaleen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Name that tune."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1295,6 +1427,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">start</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1302,6 +1435,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1315,6 +1449,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">лапа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物掌、爪</column>
       <column name="definition_pt">pata</column>
+      <column name="definition_fi">tassu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pach:n}, {targh:n}, {ghop:n}, {qam:n}, {gham:n}, {lem:n}</column>
@@ -1325,6 +1460,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1334,6 +1470,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1341,6 +1478,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1354,6 +1492,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">выдалбливать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">挖出 [AUTOTRANSLATED]</column>
       <column name="definition_pt">arrancar</column>
+      <column name="definition_fi">taltata, kovertaa, kaivertaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hew:n}, {tey:v:1}, {ghItlh:v}</column>
@@ -1364,6 +1503,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1373,6 +1513,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1380,6 +1521,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1393,6 +1535,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">использовать четвертый палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">使用第四個腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">usar o quarto dedo do pé</column>
+      <column name="definition_fi">käyttää neljättä varvasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaD:n:1}</column>
@@ -1403,6 +1546,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This little piggy had none.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1412,6 +1556,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1419,6 +1564,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1432,6 +1578,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">удар боевых искусств [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">武術踢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pontapé de artes marciais</column>
+      <column name="definition_fi">suorittaa eräs potku taistelulajissa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pup:v:3,t}</column>
@@ -1442,6 +1589,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">{HQ 10.2:src} говорит, что это относится к «особенно эффективному удару боевых искусств». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{HQ 10.2:src}說，這是指“一種特別有效的武術踢法”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">{HQ 10.2:src} diz que isso se refere a "um chute particularmente eficaz nas artes marciais". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{HQ 10.2:src} sanoo, että tämä viittaa "erityisen tehokkaaseen taistelulajien potkuun". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's not entirely clear whether this is a verb or a noun.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1451,6 +1599,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1458,6 +1607,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1471,6 +1621,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">долото [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鑿 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cinzel</column>
+      <column name="definition_fi">taltta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1481,6 +1632,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nan:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1490,6 +1642,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1497,6 +1650,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1510,6 +1664,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">четвертый палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">第四個腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">quarto dedo do pé</column>
+      <column name="definition_fi">neljäs varvas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaD:n:1}</column>
@@ -1520,6 +1675,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This little piggy had none.</column>
       <column name="components">{nan:v:2}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1529,6 +1685,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1536,6 +1693,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1549,6 +1707,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть простым, быть незамысловатым</column>
       <column name="definition_zh_HK">簡單</column>
       <column name="definition_pt">ser simples</column>
+      <column name="definition_fi">olla yksinkertainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qatlh:v}</column>
       <column name="see_also"></column>
@@ -1559,6 +1718,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1568,6 +1728,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1575,6 +1736,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1588,6 +1750,7 @@ Não confunda esta palavra com {naQjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть полным, быть целым(всеобъемлющим), быть законченным</column>
       <column name="definition_zh_HK">充實、整體、完整、完整 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser cheio, todo, inteiro, completo</column>
+      <column name="definition_fi">olla täysi, täydellinen, kokonainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dol:n}, {teb:v}</column>
@@ -1612,6 +1775,9 @@ Observera att när {naQ:v:nolink} används adjektivt betyder det "ett komplett X
       <column name="notes_pt">O verbo {naQmoH:v@@naQ:v, -moH:v} é usado para preencher formulários (ver {yu'muD:n}).
 
 Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X completo". Compare isso com {Hoch:n} após um substantivo, que significa "todos de X". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbiä {naQmoH:v@@naQ:v, -moH:v} käytetään lomakkeiden täyttämiseen (katso {yu'muD:n}).
+
+Huomaa, että kun {naQ:v:nolink}: ta käytetään adjektiivisesti, se tarkoittaa "täydellistä X". Vertaa tätä {Hoch:n}-substantiiviin, joka tarkoittaa "kaikki X". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1623,6 +1789,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
 ▶ {cha' choQmey naQ tu'lu' 'ej tep choQ bIngDaq lo' law' bID choQ tu'lu':sen:nolink} "Две полных палубы и вполовину полезная палуба под грузовой отсек"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1630,6 +1797,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1643,6 +1811,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="definition_ru">трость, розга, палка, посох, жезл</column>
       <column name="definition_zh_HK">棒、棍、枴杖</column>
       <column name="definition_pt">bastão, vara</column>
+      <column name="definition_fi">keppi, sauva, tikku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaS:n}, {qa'vaQ:n}, {'oy'naQ:n}, {SIyech:n}</column>
@@ -1653,6 +1822,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined as "cain, staff" in {TKDA:src}, but "cain" appears to have been a misspelling of "cane". It was subsequently glossed as "stick" in {HQ 12.2:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1662,6 +1832,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cain</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1669,6 +1840,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1682,6 +1854,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="definition_ru">конский хвост [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">馬尾巴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rabo de cavalo</column>
+      <column name="definition_fi">poninhäntä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qeb:n:2}, {DaQ:n}, {choljaH:n}</column>
@@ -1692,6 +1865,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso pode ter se originado com a pronúncia do dialeto {Qotmagh Sep:n} em {DaQ:n}.[1, p.154] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on voinut syntyä {Qotmagh Sep:n}-murteen ääntämällä sanaa {DaQ:n}.[1, p.154] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1701,6 +1875,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1708,6 +1883,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1721,6 +1897,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="definition_ru">палка (использована для игры на ударном иструменте)</column>
       <column name="definition_zh_HK">棒（用於擊打打擊樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">bastão (usado para golpear instrumento de percussão)</column>
+      <column name="definition_fi">(rummun tms.) kapula</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moq:v}, {'In:n}</column>
@@ -1731,6 +1908,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{naQ:n:1}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -1740,6 +1918,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1747,6 +1926,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1760,6 +1940,7 @@ Observe que quando {naQ:v:nolink} é usado adjetivamente, significa "um X comple
       <column name="definition_ru">копьё</column>
       <column name="definition_zh_HK">矛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lança</column>
+      <column name="definition_fi">keihäs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1784,6 +1965,9 @@ Förväxla inte detta ord med {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Partes de uma lança são seu eixo {tIH:n:2} e sua ponta de lança {QIn:n:2}. Os tipos de lanças incluem {ghIntaq:n:1} e {chonnaQ:n}.
 
 Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Keihään osat ovat sen akseli {tIH:n:2} ja sen keihäänpää {QIn:n:2}. Keihään tyyppejä ovat {ghIntaq:n:1} ja {chonnaQ:n}.
+
+Älä sekoita tätä sanaa {naHjej:n}-sanaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{naQ:n:1}, {jej:v}</column>
       <column name="examples"></column>
@@ -1793,6 +1977,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">javelin</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1800,6 +1985,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru">дротик</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1813,6 +1999,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">стрелка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">箭</column>
       <column name="definition_pt">flecha</column>
+      <column name="definition_fi">nuoli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1823,6 +2010,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это не слово для клингонского оружия, это то, что клингон назвал бы снарядными боеприпасами (например, с Земли). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不是克林崗武器的意思，而是克林崗人稱其為彈藥的彈藥（例如來自地球的彈藥）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta não é uma palavra para armas Klingon, é o que um Klingon chamaria de munição de projétil (por exemplo, da Terra). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei ole sana Klingonin aseille, vaan sitä, mitä Klingon kutsuisi ammuksen ammuksiksi (esim. Maasta). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{naQjej:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -1832,6 +2020,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1839,6 +2028,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1852,6 +2042,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">кисть дьявола (клингонское животное) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刷魔鬼（克林崗動物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">diabo da escova (um animal klingon)</column>
+      <column name="definition_fi">eräs klingonien eläin, harjapaholainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'er:n}</column>
@@ -1862,6 +2053,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Стандартное название федерации для этого животного, "кисть дьявола", не имеет ничего общего с именем клингона. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種動物的聯邦標準名稱“ brush devil”與克林崗語名稱無關。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O nome padrão da federação para este animal, "brush devil", não tem nada a ver com o nome klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän eläimen federaation standardinimellä "harjapaholainen" ei ole mitään tekemistä Klingonin nimen kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1871,6 +2063,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1878,6 +2071,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1891,6 +2085,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">отражать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">反映 [AUTOTRANSLATED]</column>
       <column name="definition_pt">refletir</column>
+      <column name="definition_fi">heijastaa, peilata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chItlh:v}, {neSlo':n}, {SIla':n}</column>
@@ -1901,6 +2096,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это зеркальное отражение/обратное изображение в смысле «отражать»; сравнить {'et:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是“反射”的鏡像/反面感；比較{'et:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse é o sentido de imagem refletida/imagem reversa de "refletir"; compare {'et:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on peilikuvan / käänteiskuvan "heijastuksen" tunne; vertaa {'et:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The request was related to beams of light reflecting off of mirrors and beam-splitters.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1910,6 +2106,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1917,6 +2114,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1930,6 +2128,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">появляться, появиться, предстать, проявиться, проступать</column>
       <column name="definition_zh_HK">出現</column>
       <column name="definition_pt">aparecer</column>
+      <column name="definition_fi">ilmestyä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngab:v}</column>
       <column name="see_also">{nargh:v:2}</column>
@@ -1940,6 +2139,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1949,6 +2149,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1956,6 +2157,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1969,6 +2171,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">совершать побег, совершать бегство</column>
       <column name="definition_zh_HK">逃逸、逃走</column>
       <column name="definition_pt">escapar</column>
+      <column name="definition_fi">paeta, karata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Haw':v}, {jun:v}, {nargh:v:1}</column>
@@ -1979,6 +2182,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Этот глагол использован идиоматически с {'eb:n} чтобы описать упущенные или потерянные возможности.[4]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esse verbo é usado idiomaticamente com {'eb:n} para descrever oportunidades perdidas ou perdidas.[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään idiomaattisesti {'eb:n}: n kanssa kuvaamaan menetettyjä tai menetettyjä mahdollisuuksia.[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1990,6 +2194,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1997,6 +2202,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT p.117:src}, [3] {TKW p.145:src}, [4] {s.e 1998.01.18:src}</column>
     </table>
     <table name="mem">
@@ -2010,6 +2216,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Если дух воина не ушел, битва по прежнему продолжается</column>
       <column name="definition_zh_HK">如果戰士的靈魂沒有逃脫，戰鬥仍在繼續。</column>
       <column name="definition_pt">Se o espírito do guerreiro não escapou, a batalha ainda continua.</column>
+      <column name="definition_fi">Taistelu jatkuu niin kauan, kun soturin henki ei ole vielä karannut.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeghDI' SuvwI' nargh SuvwI' qa'.:sen}</column>
@@ -2020,6 +2227,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nargh:v:2}, {-be':v}, {-chugh:v}, {SuvwI':n}, {qa':n}, {taH:v:1}, {may':n}</column>
       <column name="examples"></column>
@@ -2029,6 +2237,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2036,6 +2245,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.147:src}</column>
     </table>
     <table name="mem">
@@ -2049,6 +2259,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть порочным</column>
       <column name="definition_zh_HK">惡毒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser cruel</column>
+      <column name="definition_fi">olla ilkeä, julma, paha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wIH:v}, {naH:v}</column>
@@ -2059,6 +2270,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Есть идиома, {naS; norgh rur@@naS:v, norgh:n, rur:v}.[1, p.132]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Existe um idioma, {naS; norgh rur@@naS:v, norgh:n, rur:v}.[1, p.132] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {naS; norgh rur@@naS:v, norgh:n, rur:v}.[1, p.132] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Nas"ty.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2068,6 +2280,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2075,6 +2288,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2088,6 +2302,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">последний пункт в списке</column>
       <column name="definition_zh_HK">列表中的最後一項 [AUTOTRANSLATED]</column>
       <column name="definition_pt">último item de uma lista</column>
+      <column name="definition_fi">luettelon viimeinen kohta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghu'lIS:n}, {tetlh:n}, {HochDIch:n}, {Qav:v}</column>
@@ -2098,6 +2313,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это специальный термин для последнего элемента в списке, который можно использовать вместо, например, {mu' HochDIch:n@@mu':n, HochDIch:n} для списка слов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是列表中最後一項的特殊術語，可以代替例如單詞列表的{mu' HochDIch:n@@mu':n, HochDIch:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse é um termo especial para o último item de uma lista, que pode ser usado no lugar de, por exemplo, {mu' HochDIch:n@@mu':n, HochDIch:n} para obter uma lista de palavras. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on erityinen termi luettelon viimeiselle kohteelle, jota voidaan käyttää sanan {mu' HochDIch:n@@mu':n, HochDIch:n} sijasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Last, but "not least".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2107,6 +2323,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2114,6 +2331,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -2127,6 +2345,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">использовать, потреблять, расходовать, истощать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用完、消耗</column>
       <column name="definition_pt">usar, consumir, gastar, drenar</column>
+      <column name="definition_fi">kuluttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loj:v}, {natlh:v:2}</column>
@@ -2137,6 +2356,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It is unclear if {tlhuch:v} "exhaust" means "to use something up completely".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2146,6 +2366,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">deplete</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2153,6 +2374,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 33:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -2166,6 +2388,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть предосудительным, быть отвратительным, быть презренным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">應該受到譴責、噁心、卑鄙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser repreensível, ser nojento, ser desprezível</column>
+      <column name="definition_fi">olla tuomittava, halveksittava, inhottava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngIm:v}, {'up:v}, {'eyHa':v}, {SaS:v:2,slang}, {natlh:v:1}</column>
@@ -2176,6 +2399,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Slangi-merkityksessään tämä verbi ei ota objektia.[1, p.155] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2185,6 +2409,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2192,6 +2417,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2205,6 +2431,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">бумага, лист бумаги</column>
       <column name="definition_zh_HK">紙、一張紙</column>
       <column name="definition_pt">papel, folha de papel</column>
+      <column name="definition_fi">paperi, paperiarkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mavjop:n}, {'echletHom:n}, {nav qatwI':n}, {tenwal:n}</column>
@@ -2215,6 +2442,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Кусок бумаги имеет два {Dopmey:n@@Dop:n, -mey:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一張紙上有兩個{Dopmey:n@@Dop:n, -mey:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um pedaço de papel tem dois {Dopmey:n@@Dop:n, -mey:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Paperilla on kaksi {Dopmey:n@@Dop:n, -mey:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was originally defined as just "paper"[1], but was expanded to mean "sheet of paper" as well later.[4]</column>
       <column name="components"></column>
       <column name="examples">
@@ -2226,6 +2454,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
 ▶ {Quj wa'DIch MONOPOLY Huch nav qa' tlhIngan QaS:sen:nolink} "Клингонские силы заменяют оригинальные счета Монополии"[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2233,6 +2462,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}, [3] {Klingon Monopoly:src}, [4] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2246,6 +2476,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Аппарат факсимильной связи</column>
       <column name="definition_zh_HK">傳真機 [AUTOTRANSLATED]</column>
       <column name="definition_pt">maquina de fax</column>
+      <column name="definition_fi">faksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghogh HablI':n}</column>
@@ -2256,6 +2487,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nav:n}, {HablI':n}</column>
       <column name="examples"></column>
@@ -2265,6 +2497,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2272,6 +2505,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.2, p.20, Jun. 1996:src}</column>
     </table>
     <table name="mem">
@@ -2285,6 +2519,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">конверт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">信封 [AUTOTRANSLATED]</column>
       <column name="definition_pt">envelope</column>
+      <column name="definition_fi">kirjekuori</column>
       <column name="synonyms">{nav vaH:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{HIjmeH chaw':n}</column>
@@ -2295,6 +2530,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nav:n}, {qat:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2304,6 +2540,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2311,6 +2548,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -2324,6 +2562,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">письмо (сообщение написано на бумаге) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">信（郵件）</column>
       <column name="definition_pt">carta (mensagem escrita em papel)</column>
+      <column name="definition_fi">kirje</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jabbI'ID:n}, {nav vaH:n}</column>
@@ -2334,6 +2573,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nav:n}, {QIn:n:1}</column>
       <column name="examples"></column>
@@ -2343,6 +2583,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2350,6 +2591,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2363,6 +2605,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">конверт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">信封</column>
       <column name="definition_pt">envelope</column>
+      <column name="definition_fi">kirjekuori</column>
       <column name="synonyms">{nav qatwI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{nav QIn:n}, {vev:v}</column>
@@ -2373,6 +2616,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">В контексте {vaH:n} само по себе достаточно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在上下文中，{vaH:n}本身就足夠了。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No contexto, {vaH:n} por si só é suficiente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kontekstissa {vaH:n} itsessään riittää. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nav:n}, {vaH:n}</column>
       <column name="examples"></column>
@@ -2382,6 +2626,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2389,6 +2634,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2402,6 +2648,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">эскадрилья, эскадра, отряд, дивизион</column>
       <column name="definition_zh_HK">隊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esquadrão</column>
+      <column name="definition_fi">laivue, eskaaderi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2412,6 +2659,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">{nawlogh:n:nolink} может или не может принадлежать к {yo':n}.</column>
       <column name="notes_zh_HK">{nawlogh:n:nolink}可能屬於或不屬於{yo':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um {nawlogh:n:nolink} pode ou não pertencer a um {yo':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{nawlogh:n:nolink} voi kuulua {yo':n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2421,6 +2669,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2428,6 +2677,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2441,6 +2691,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">иметь доступ, обращаться к чему-то</column>
       <column name="definition_zh_HK">訪問 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acessar</column>
+      <column name="definition_fi">päästä johonkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2451,6 +2702,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {TKD:src}, this word is listed as a noun in the E-K side, and as a verb in the K-E side.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2460,6 +2712,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2467,6 +2720,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2480,6 +2734,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">доступ</column>
       <column name="definition_zh_HK">訪問 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acesso</column>
+      <column name="definition_fi">pääsy</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{De' naw'wI':n}</column>
@@ -2490,6 +2745,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {TKD:src}, this word is listed as a noun in the E-K side, and as a verb in the K-E side.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2499,6 +2755,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2506,6 +2763,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2519,6 +2777,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">удаленное, маленькое, безлюдное место [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">偏遠、小、荒涼的地方 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lugar remoto, pequeno e desolado</column>
+      <column name="definition_fi">syrjäinen, pieni, asumaton paikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2529,6 +2788,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">NowWhat is a planet in {The Hitchhiker's Guide to the Galaxy:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2538,6 +2798,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2545,6 +2806,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2558,6 +2820,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">выходить замуж</column>
       <column name="definition_zh_HK">嫁</column>
       <column name="definition_pt">casar (a esposa faz isso)</column>
+      <column name="definition_fi">naida joku (vaimo tekee tämän)</column>
       <column name="synonyms">{tlhogh:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{Saw:v}, {tlhogh:n}, {be'nal:n}</column>
@@ -2568,6 +2831,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">{naychuq:v@@nay:v, -chuq:v} может быть понято, как брак между двумя женщинами.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{naychuq:v@@nay:v, -chuq:v} ymmärrettäisiin kahden naisen välisestä samaa sukupuolta olevasta avioliitosta.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">MO confirmed at {qep'a' 4 (1997):src} that {Saw:v:nolink} and {nay:v:nolink} come from "sure" and "no" said with a Southern drawl.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2577,6 +2841,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2584,6 +2849,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2017.07.13:src}</column>
     </table>
     <table name="mem">
@@ -2597,6 +2863,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">блюдо(еда)</column>
       <column name="definition_zh_HK">一道菜</column>
       <column name="definition_pt">curso, prato (em uma refeição)</column>
+      <column name="definition_fi">ruokalaji</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIQ:n}, {megh:n}, {'uQ:n}, {ghem:n}</column>
@@ -2607,6 +2874,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2616,6 +2884,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2623,6 +2892,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2636,6 +2906,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">будь соленым, будь солоноватым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鹹</column>
       <column name="definition_pt">ser salgado</column>
+      <column name="definition_fi">olla suolainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wIb:v}, {na'ran:n}, {popSop:n}</column>
@@ -2646,6 +2917,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The chemical symbol for the element sodium is Na, from the Latin "natrium".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2655,6 +2927,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2662,6 +2935,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2675,6 +2949,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">будь уверен, будь определен, будь уверен, будь уверен [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">確定、明確、積極、確定 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter certeza, ser definitivo, ser positivo</column>
+      <column name="definition_fi">olla (täysin) varma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIch:n}, {bej:v:2,slang}, {-na':n}</column>
@@ -2685,6 +2960,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2694,6 +2970,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2701,6 +2978,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2714,6 +2992,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">тип фруктов [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">水果類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de fruta</column>
+      <column name="definition_fi">eräs makea hedelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wIb:v}, {na':v:1}, {Su'ghar qut:n}, {HaQchor:n}, {tera' na'ran:n}, {tera' na'ran'a':n}, {tera' na'ran wIb:n}</column>
@@ -2724,6 +3003,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Этот фрукт сладок. {na'ran rur} описывает что-то сладкое на вкус. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個水果很甜。 {na'ran rur}描述了一些甜味的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa fruta é doce. O {na'ran rur} descreve algo de sabor doce. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä hedelmä on makea. {na'ran rur} kuvaa jotain makeaa makua. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Sanskrit word for orange is "naarang".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2733,6 +3013,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sweet</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2740,6 +3021,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2753,6 +3035,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">клюв, вексель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鳥嘴</column>
       <column name="definition_pt">bico, focinho</column>
+      <column name="definition_fi">nokka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{neb:n:2}, {bo'Degh:n}, {wom:v}</column>
@@ -2763,6 +3046,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Neb" is an old English word for "nose", which is related to the modern word "nib".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2772,6 +3056,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2779,6 +3064,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2792,6 +3078,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">сопло [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">噴嘴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bocal</column>
+      <column name="definition_fi">suutin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{neb:n:1}</column>
@@ -2802,6 +3089,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Essa palavra refere-se a bicos de foguetes, mangueiras etc., e leva o sufixo {-mey:n}, pois a conexão com a parte do corpo foi perdida.[1] (Esta é uma exceção ao padrão geral de palavras para a parte do corpo que retém o sufixo {-Du':n} quando eles são usados ​​para se referir a outras coisas, à medida que o significado dessa palavra que não é parte do corpo se tornou lexicalizado.[2]) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa rakettien, letkujen jne. Suuttimiin ja vie monikon {-mey:n}, koska yhteys rungon osaan on kadonnut. kun niitä käytetään viittaamaan muihin asioihin, koska tämän sanan ei-ruumiinosa-merkitys on muuttunut leksikalisoituneeksi.[2])[1]{-Du':n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2811,6 +3099,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2818,6 +3107,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}, [2] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -2831,6 +3121,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">саркофаг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">石棺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sarcófago</column>
+      <column name="definition_fi">sarkofagi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nev'aQ:n}, {pel'aQ:n:2}, {jItuj'ep:n}, {'Impey':n}</column>
@@ -2841,6 +3132,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это связано с ритуалом и честью и представляет собой нечто большее, чем просто хранилище. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這與儀式和榮譽有關，而不僅僅是一個存儲庫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso está associado a ritual e honra, e é muito mais do que apenas um repositório. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä liittyy rituaaleihin ja kunniaan, ja se on paljon enemmän kuin vain arkisto. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2850,6 +3142,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mausoleum</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2857,6 +3150,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -2870,6 +3164,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть боковым, двигаться боком, двигаться горизонтально, быть горизонтальным</column>
       <column name="definition_zh_HK">打橫、橫步、橫向移動</column>
       <column name="definition_pt">ser lateral, mover lateralmente</column>
+      <column name="definition_fi">olla sivulla, liikkua sivusuunnassa tai sivuttain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIm:v:2}, {Dav:v:2}</column>
@@ -2880,6 +3175,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2889,6 +3185,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2896,6 +3193,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2909,6 +3207,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">солдаты</column>
       <column name="definition_zh_HK">士兵（眾數）</column>
       <column name="definition_pt">soldados</column>
+      <column name="definition_fi">sotilaat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mangghom:n}</column>
@@ -2919,6 +3218,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Значение данного слова очень похоже на {QaS:n:1h}, но включает в себя офицеров ({yaS:n}).[1]</column>
       <column name="notes_zh_HK">該詞的含義與{QaS:n:1h}相似，但其中包括官員（{yaS:n}）。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O significado desta palavra é semelhante ao de {QaS:n:1h}, mas inclui oficiais ({yaS:n}).[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan merkitys on samanlainen kuin sanalla {QaS:n:1h}, mutta se sisältää upseerit ({yaS:n}).[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word is grammatically singular and the correct pronoun is {ghaH:n}. In the first edition of the {paq'batlh:src}, the pronoun {chaH:n} was incorrectly used and the word was erroneously treated as grammatically plural in some places.[2]</column>
       <column name="components">{mang:n}</column>
       <column name="examples"></column>
@@ -2928,6 +3228,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2935,6 +3236,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2020.08.17:src}</column>
     </table>
     <table name="mem">
@@ -2948,6 +3250,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Нег'Вар(название крейсера)</column>
       <column name="definition_zh_HK">Negh'Var（船隻） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Negh'Var (navio)</column>
+      <column name="definition_fi">eräs alusluokka, Negh'Var</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}</column>
@@ -2958,6 +3261,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Неясно, почему язык Федерации исказил произношение этого слова, добавив лишний {qaghwI':n}.</column>
       <column name="notes_zh_HK">目前尚不清楚，為什麼聯邦標準會通過添加多餘的{qaghwI':n}來破壞該單詞的拼寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não está claro por que o Federation Standard corrompeu a ortografia desta palavra adicionando um {qaghwI':n} estranho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On epäselvää, miksi Federation Standard turmeli tämän sanan oikeinkirjoituksen lisäämällä vieraan {qaghwI':n}-sanan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2967,6 +3271,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2974,6 +3279,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2987,6 +3293,7 @@ Não confunda esta palavra com {naHjej:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">только, просто, только что, всего-лишь</column>
       <column name="definition_zh_HK">只是</column>
       <column name="definition_pt">apenas, meramente</column>
+      <column name="definition_fi">vain, pelkästään, ainoastaan</column>
       <column name="synonyms"></column>
       <column name="antonyms">{neHHa':adv}</column>
       <column name="see_also">{nIteb:adv}, {mob:v:1}</column>
@@ -3011,6 +3318,9 @@ Detta adverbial kan också följa ett substantiv, i vilket fall det betyder "bar
       <column name="notes_pt">Isso segue o verbo que modifica e tem o efeito de banalizar a ação.
 
 Este adverbial também pode seguir um substantivo, caso em que significa "apenas" ou "sozinho". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä seuraa verbiä, jota se muuttaa, ja sillä on vaikutuksen trivialisointi.
+
+Tämä adverbi voi myös seurata substantiivia, jolloin se tarkoittaa "vain" tai "yksin". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3042,6 +3352,7 @@ Este adverbial também pode seguir um substantivo, caso em que significa "apenas
 ▶ {'ang'eghQo' quv Hutlhbogh jagh neH ghobtaHvIS ghaH.:sen}</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">alone</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3049,6 +3360,7 @@ Este adverbial também pode seguir um substantivo, caso em que significa "apenas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 5.4:src}</column>
     </table>
     <table name="mem">
@@ -3062,6 +3374,7 @@ Este adverbial também pode seguir um substantivo, caso em que significa "apenas
       <column name="definition_ru">хотеть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">想 [AUTOTRANSLATED]</column>
       <column name="definition_pt">querer</column>
+      <column name="definition_fi">haluta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIn:v}</column>
@@ -3082,6 +3395,9 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
 Смотрите урок по этому слову: {YouTube video:url:http://youtu.be/JyeePTUXVa8}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kun tämä on verbi lauseobjektirakenteen toisessa virkkeessä, {'e':n:pro}- tai {net:n:pro}-sanoja ei käytetä.
+
+Katso oppitunti tästä sanasta: {YouTube video:url:http://youtu.be/JyeePTUXVa8}[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The rule that {'e':n:pro} shouldn't be used has occasionally been violated in canon.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3094,6 +3410,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3101,6 +3418,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.2.5:src}, [2] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -3114,6 +3432,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="definition_ru">Не только</column>
       <column name="definition_zh_HK">不僅 [AUTOTRANSLATED]</column>
       <column name="definition_pt">não somente</column>
+      <column name="definition_fi">ei vain, ei pelkästään, ei ainoastaan</column>
       <column name="synonyms"></column>
       <column name="antonyms">{neH:adv}</column>
       <column name="see_also"></column>
@@ -3124,6 +3443,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The example Klingon sentence was presented to Marc Okrand by Chris Lipscombe. Okrand then translated it into English.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3135,6 +3455,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
 ▶ {tlhIngan Hol neHHa' vIjatlh.:sen@@tlhIngan Hol:n, neHHa':adv, vI-:v, jatlh:v} "Я говорю не только на Клингонском", или "Я говорю на многих языках, включая Клингонский".</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3142,6 +3463,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2017.07.28:src}</column>
     </table>
     <table name="mem">
@@ -3155,6 +3477,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="definition_ru">{naHjej:n}</column>
       <column name="definition_zh_HK">{naHjej:n}</column>
       <column name="definition_pt">{naHjej:n}</column>
+      <column name="definition_fi">{naHjej:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3165,6 +3488,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3174,6 +3498,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3181,6 +3506,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3194,6 +3520,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="definition_ru">Нейтральная зона</column>
       <column name="definition_zh_HK">中性區 [AUTOTRANSLATED]</column>
       <column name="definition_pt">zona neutra</column>
+      <column name="definition_fi">neutraali vyöhyke</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3204,6 +3531,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"We want it."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3213,6 +3541,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3220,6 +3549,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3233,6 +3563,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="definition_ru">искать, производить поиски, ожидать кого-то, разыскивать</column>
       <column name="definition_zh_HK">尋找</column>
       <column name="definition_pt">procurar por</column>
+      <column name="definition_fi">etsiä jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIl:v}</column>
@@ -3243,6 +3574,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="notes_ru">Смотрите пример для иллюстрации разницы между этим словом и {Sam:v}.</column>
       <column name="notes_zh_HK">請參見示例，以了解此單詞和{Sam:v}之間的差異。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja o exemplo para uma ilustração da diferença entre esta palavra e {Sam:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso esimerkistä tämän sanan ja {Sam:v}: n välinen ero. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3253,6 +3585,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3260,6 +3593,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3273,6 +3607,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="definition_ru">Зонд</column>
       <column name="definition_zh_HK">探測 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sonda</column>
+      <column name="definition_fi">luotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3283,6 +3618,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nej:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3292,6 +3628,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3299,6 +3636,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3312,6 +3650,7 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/JyeePTUXVa8} [AUT
       <column name="definition_ru">матч, пара, карта на [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">匹配、配對、映射到 [AUTOTRANSLATED]</column>
       <column name="definition_pt">combinar, emparelhar, mapear para</column>
+      <column name="definition_fi">täsmätä, käydä yksiin, sopia yhteen, kuvautua johonkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rap:v}, {nIb:v}, {mey:v}</column>
@@ -3338,6 +3677,11 @@ När det används för objekt som kommer i par, som strumpor och handskar, är m
 Gramaticamente, esse verbo funciona como {rur:v}. Pode-se dizer {A nel B:sen:nolink} "B corresponde a A" ou {nelchuq A B je:sen:nolink} "A e B correspondem um ao outro" .[2]
 
 Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um item do par, e o objeto é o outro.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää, jos sormenjäljet ​​vastaavat toisiaan (katso {nItlh Su'nIm:n} ja {nItlh Su'nIm vem:n}).
+
+Kieliopillisesti tämä verbi toimii kuten {rur:v}. Voidaan sanoa, että {A nel B:sen:nolink} "B vastaa A" tai {nelchuq A B je:sen:nolink} "A ja B vastaavat toisiaan".
+
+Kun sitä käytetään esineisiin, jotka tulevat pareittain, kuten sukat ja käsineet, kohde on parin yksi esine ja esine on toinen.[1][2][3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Nell Carter was a regular panelist on the TV show "Match Game".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3347,6 +3691,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3354,6 +3699,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}, [2] {KLI mailing list 2018.11.20:src}, [3] {KLI mailing list 2019.01.22:src}</column>
     </table>
     <table name="mem">
@@ -3367,6 +3713,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">идеально вписывается, идеально вписывается [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">完美貼合、完美貼合 [AUTOTRANSLATED]</column>
       <column name="definition_pt">encaixar perfeitamente</column>
+      <column name="definition_fi">sopia täydellisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qay'mol teSra':n}</column>
@@ -3377,6 +3724,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru">Это может быть использовано для кусок головоломки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可用於拼圖中的一塊。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para uma peça de um quebra-cabeça. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää palapelin palaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nel:v}, {-chu':v}</column>
       <column name="examples"></column>
@@ -3386,6 +3734,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3393,6 +3742,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -3406,6 +3756,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">partner (for objects which come in matching pairs) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">夥伴（用於配對匹配的對象） [AUTOTRANSLATED]</column>
       <column name="definition_pt">par (para objetos que vêm em pares correspondentes)</column>
+      <column name="definition_fi">(jonkin) pari (toinen parin osapuolista toiselle)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3416,6 +3767,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru">Это слово используется для обозначения партнера предметов, которые входят в пары, таких как носки и перчатки и тому подобное. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞用來指成對的對象的伴侶，例如襪子和手套等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada para se referir ao parceiro de objetos que vêm em pares, como meias e luvas e similares. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään pareittain tulevien esineiden, kuten sukkien, käsineiden ja vastaavien, kumppaniin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nel:v}, {-wI':n}</column>
       <column name="examples"></column>
@@ -3425,6 +3777,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3432,6 +3785,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.01.22:src}</column>
     </table>
     <table name="mem">
@@ -3445,6 +3799,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">лет спустя</column>
       <column name="definition_zh_HK">（幾）年後</column>
       <column name="definition_pt">em ... anos</column>
+      <column name="definition_fi">... vuoden päästä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ben:n:1}</column>
       <column name="see_also">{DIS:n:2}, {pIq:n}</column>
@@ -3455,6 +3810,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3464,6 +3820,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3471,6 +3828,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3484,6 +3842,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">быть зрелым, быть взрослым, быть взрослым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">成熟、成年、成年 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser maduro, ser adulto, ser crescido</column>
+      <column name="definition_fi">olla aikuinen, olla kypsä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nen:n}, {nenchoH:v}, {HojnIy:n}</column>
@@ -3494,6 +3853,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3503,6 +3863,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3510,6 +3871,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3523,6 +3885,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">рост, созревание [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">成長、成熟 [AUTOTRANSLATED]</column>
       <column name="definition_pt">crescimento, maturação</column>
+      <column name="definition_fi">kasvaminen, aikuistuminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nen:v}</column>
@@ -3533,6 +3896,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3542,6 +3906,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3549,6 +3914,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3562,6 +3928,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">взрослеть, становиться зрелым, вырастать</column>
       <column name="definition_zh_HK">成熟、長大</column>
       <column name="definition_pt">amadurecer, crescer</column>
+      <column name="definition_fi">kasvaa, aikuistua, tulla kypsemmäksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3572,6 +3939,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nen:v}, {-choH:v}</column>
       <column name="examples"></column>
@@ -3581,6 +3949,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3588,6 +3957,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3602,6 +3972,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">Возраст взросления</column>
       <column name="definition_zh_HK">提升時代 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Idade da Ascensão</column>
+      <column name="definition_fi">Ylösnousemuksen ikä [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nentay:n}, {peHghep:n}</column>
@@ -3612,6 +3983,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nen:n} or {nen:v}, {ghep:n:hyp}</column>
       <column name="examples">
@@ -3625,6 +3997,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
   "Возраст взросления знаменует новый уровень духовных достижений Клингонским воином. Посвященный должен пройти сквозь строй воинов, которые проверяют его с помощью жезлов боли."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3632,6 +4005,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {SkyBox 9:src}</column>
     </table>
     <table name="mem">
@@ -3645,6 +4019,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">Обряд взросления</column>
       <column name="definition_zh_HK">升天儀式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Rito de Ascensão</column>
+      <column name="definition_fi">Ylösnousemuksen riitti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lopno':n}, {'oy'naQ:n}, {nenghep:n}, {nen:n}, {tay:n:2}, {nentay cha'DIch:n}</column>
@@ -3655,6 +4030,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nen:n}, {tay:n:2}</column>
       <column name="examples"></column>
@@ -3664,6 +4040,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3671,6 +4048,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3684,6 +4062,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">Второй обряд взросления</column>
       <column name="definition_zh_HK">提升的第二次儀式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Segundo Rito de Ascensão</column>
+      <column name="definition_fi">Toinen ylösnousemusriitti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nentay:n}</column>
@@ -3694,6 +4073,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nentay:n}, {cha'DIch:n:1,num}</column>
       <column name="examples"></column>
@@ -3703,6 +4083,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3710,6 +4091,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.65:src}</column>
     </table>
     <table name="mem">
@@ -3723,6 +4105,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">лгать, выдумывать, врать, привирать</column>
       <column name="definition_zh_HK">騙子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mentira</column>
+      <column name="definition_fi">valehdella</column>
       <column name="synonyms"></column>
       <column name="antonyms">{vIt:v}</column>
       <column name="see_also">{lay':v}, {lay'Ha':v}, {nop:v}, {toj:v}, {ngor:v}, {ghIchwIj DabochmoHchugh ghIchlIj qanob.:sen}</column>
@@ -3733,6 +4116,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3742,6 +4126,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3749,6 +4134,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3762,6 +4148,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">пересекаются [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">相交 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cruzar</column>
+      <column name="definition_fi">leikata (jonkin kanssa/yli)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{me'cheD:n}, {vech:v}, {Don:v}, {leD:v}</column>
@@ -3772,6 +4159,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3781,6 +4169,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3788,6 +4177,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -3801,6 +4191,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">очки, очки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">眼鏡</column>
       <column name="definition_pt">óculos</column>
+      <column name="definition_fi">silmälasit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn QanwI' nguv:n}</column>
@@ -3811,6 +4202,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reversed, this sounds like "Clark Kent".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3820,6 +4212,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3827,6 +4220,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -3840,6 +4234,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">быть хрустящим, быть хрустящим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">脆脆脆 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser crocante, ser tostado</column>
+      <column name="definition_fi">olla rapea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlher:v}</column>
@@ -3850,6 +4245,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru">Это относится к текстуре, а не к звуку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指紋理，而不是聲音。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à textura, não ao som. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa tekstuuria, ei ääntä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Nestlé Crunch".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3859,6 +4255,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3866,6 +4263,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3879,6 +4277,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">маленькое зеркало [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小鏡子</column>
       <column name="definition_pt">espelho pequeno</column>
+      <column name="definition_fi">pieni peili</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nar:v}</column>
@@ -3889,6 +4288,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="notes_ru">Это меньше, чем {SIla':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這比{SIla':n}小。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é menor que um {SIla':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on pienempi kuin {SIla':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Moroni Olsen was the voice of the Magic Mirror in Disney's "Snow White and the Seven Dwarfs".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3898,6 +4298,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3905,6 +4306,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -3918,6 +4320,7 @@ Quando usado para objetos que vêm em pares, como meias e luvas, o sujeito é um
       <column name="definition_ru">тот, который, та(предыдущая тема)</column>
       <column name="definition_zh_HK">（上一個主題） [AUTOTRANSLATED]</column>
       <column name="definition_pt">isso (tópico anterior)</column>
+      <column name="definition_fi">se, tämä (edellinen aihe), että</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'e':n:pro}</column>
@@ -3942,6 +4345,9 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_pt">Este pronome é usado em uma construção de frase como objeto quando a segunda frase tem um sujeito de terceira pessoa indefinido (ou seja, "um" ou "alguém").
 
 Às vezes, {'e':n:pro} com {-lu':v} é usado em vez de {net:n:pro,nolink}. Não está claro por que no momento. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä pronominia käytetään lause-objektirakenteessa, kun toisessa lauseessa on määrittelemätön kolmannen persoonan aihe (ts. "Yksi" tai "joku").
+
+Joskus {'e':n:pro} ja {-lu':v} käytetään {net:n:pro,nolink}: n sijaan. Ei ole selvää miksi tällä hetkellä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3975,6 +4381,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
 ▶ {SIS 'e' 'aqlu':sen@@SIS:v, 'e':n, 'aq:v, -lu':v} "it is predicted that it will rain" (see {'aq:v})[4]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3982,6 +4389,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.2.5:src}, [2] {TKW p.125:src}, [3] {Klingon Monopoly:src}, [4] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3995,6 +4403,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">Десять тысяч</column>
       <column name="definition_zh_HK">萬</column>
       <column name="definition_pt">dez mil</column>
+      <column name="definition_fi">kymmenentuhatta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI':n}, {SaD:n:num}, {bIp:n:num}</column>
@@ -4005,6 +4414,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_ru">Заметьте, что клингонское слово для "десяти тысяч" не зависит от слов "десять" ({maH:n:2,num}) и "тысяча" ({SaD:n:num}).</column>
       <column name="notes_zh_HK">請注意，“一萬”的克林崗語單詞與“十”（{maH:n:2,num}）和“一千”（{SaD:n:num}）的單詞無關。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Huomaa, että klingonilainen sana "kymmenentuhatta" on riippumaton sanoista "kymmenen" ({maH:n:2,num}) ja "tuhat" ({SaD:n:num,nolink}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4014,6 +4424,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">myriad</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4021,6 +4432,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4034,6 +4446,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">мириада (период десяти тысяч лет)</column>
       <column name="definition_zh_HK">無數（一萬年） [AUTOTRANSLATED]</column>
       <column name="definition_pt">miríade (um período de dez mil anos)</column>
+      <column name="definition_fi">vuosikymmentuhat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vatlh DIS poH:n}, {SaD DIS poH:n}</column>
@@ -4044,6 +4457,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_ru">Чтобы обозначить "десятки тысяч лет назад" или "десятки тысяч лет спустя", {ret:n} и {pIq:n} использованы в соответствующем месте {poH:n}.[1]</column>
       <column name="notes_zh_HK">為了表示“數万年前”或“從現在起數万年”，分別使用{ret:n}和{pIq:n}代替{poH:n}。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Ilmaisemaan "kymmeniä tuhansia vuosia sitten" tai "kymmeniä tuhansia vuosia nyt" käytetään {ret:n} ja {pIq:n} vastaavasti {poH:n}: n sijasta.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{netlh:n:num}, {DIS:n:2}, {poH:n}</column>
       <column name="examples"></column>
@@ -4053,6 +4467,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4060,6 +4475,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.3, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -4073,6 +4489,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">бедро, плечо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大腿，上臂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">coxa, antebraço</column>
+      <column name="definition_fi">reisi, olkavarsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'neH:n}, {reStav:n}, {qIv:n}, {DeSqIv:n}</column>
@@ -4083,6 +4500,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_ru">Это относится к части тела выше колена или локтя. Если необходимо провести различие, этому слову может предшествовать {'uS:n} или {DeS:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指膝蓋或肘部以上的身體部位。如果有必要進行區分，則可以在{'uS:n}或{DeS:n:1}之前加上這個詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à parte do corpo acima do joelho ou cotovelo. Se for necessário fazer uma distinção, esta palavra pode ser precedida por {'uS:n} ou {DeS:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa polven tai kyynärpään yläpuolella olevaan ruumiinosaan. Jos on tarpeen tehdä ero, tämän sanan edessä voi olla {'uS:n} tai {DeS:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Dutch word "boven" meaning "above" is found in the words for "thigh" and "upper arm", respectively "bovenbeen" and "bovenarm".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4092,6 +4510,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4099,6 +4518,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -4112,6 +4532,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">тип кастрюли с ручками (используется для приготовления пищи) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有帶把手的鍋類型（用於食物準備）</column>
       <column name="definition_pt">tipo de panela com alças (usada para preparação de alimentos)</column>
+      <column name="definition_fi">eräs kahvoilla varastettu kattila (käytetään ruoan valmistukseen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bargh:n}</column>
@@ -4122,6 +4543,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_ru">Его дескрипторы называются {DeSqIvDu':n:nolink} (см. {DeSqIv:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Sen kahvoja kutsutaan nimellä {DeSqIvDu':n:nolink} (katso {DeSqIv:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4131,6 +4553,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4138,6 +4561,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4151,6 +4575,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">саркофаг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">石棺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sarcófago</column>
+      <column name="definition_fi">sarkofagi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nebeylI':n}, {pel'aQ:n:2}, {jItuj'ep:n}, {'Impey':n}</column>
@@ -4161,6 +4586,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_ru">Это относится к повседневному саркофагу, который является строго утилитарным. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指嚴格意義上的日常石棺。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um sarcófago cotidiano, que é estritamente utilitário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa jokapäiväiseen sarkofagiin, joka on ehdottomasti utilitaristista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Maltz said that {nev'aQ:n:nolink} and {nebeylI':n:nolink} ({nev'aQ:n:nolink} more frequently) are used for some sort of flying coffins.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4170,6 +4596,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">coffin</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4177,6 +4604,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -4190,6 +4618,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">старшина</column>
       <column name="definition_zh_HK">自耕農 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agente</column>
+      <column name="definition_fi">vapaa talonpoika [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4200,6 +4629,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_ru">Это девятый ранг {yaS:n}.</column>
       <column name="notes_zh_HK">這是{yaS:n}的第9位。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nono ranking do {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {yaS:n}: n 9. sijoitus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4209,6 +4639,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4216,6 +4647,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4229,6 +4661,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">Нидерланды</column>
       <column name="definition_zh_HK">荷蘭</column>
       <column name="definition_pt">Os Países Baixos (Holanda)</column>
+      <column name="definition_fi">Alankomaat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4239,6 +4672,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4248,6 +4682,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Holland</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4255,6 +4690,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru">Голландия</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4268,6 +4704,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">Они(действие)-тебе, Они(действие)-вам</column>
       <column name="definition_zh_HK">他們、它們：你</column>
       <column name="definition_pt">Eles-você</column>
+      <column name="definition_fi">he/ne-sinua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Da-:v:pref}</column>
       <column name="see_also">{Du-:v:pref}, {lI-:v:pref}</column>
@@ -4278,6 +4715,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{chaH:n} / {bIH:n}: {SoH:n} = {nI-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4287,6 +4725,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4294,6 +4733,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4307,6 +4747,7 @@ Ibland används {'e':n:pro} med {-lu':v} istället för {net:n:pro,nolink}. Det 
       <column name="definition_ru">Быть идентичным чему-то</column>
       <column name="definition_zh_HK">同一、一毛一樣</column>
       <column name="definition_pt">ser idêntico</column>
+      <column name="definition_fi">olla identtinen</column>
       <column name="synonyms">{rap:v}</column>
       <column name="antonyms">{pIm:v}</column>
       <column name="see_also">{Sar:v}, {rur:v}, {nel:v}, {... X law' ... X puS:sen}</column>
@@ -4341,6 +4782,11 @@ Detta verb används för att uttrycka begreppet att två saker har samma mängd 
 O uso deste verbo não sugere de que maneira as coisas são idênticas, exceto quando é usado na seguinte construção.
 
 Este verbo é usado para expressar o conceito de que duas coisas têm a mesma quantidade de alguma qualidade, de maneira semelhante a {rap:v}, mas com a conotação de precisão. Se a qualidade for mensurável, a conotação é que as duas coisas têm exatamente a mesma quantidade dessa qualidade. Veja o exemplo abaixo.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{nIb:v:nolink}-aihe on identtinen
+
+Tämän verbin käyttö ei osoita, miten asiat ovat identtiset, paitsi jos sitä käytetään seuraavassa rakennelmassa.
+
+Tätä verbiä käytetään ilmaisemaan käsite, että kahdella asialla on sama määrä jonkin verran laatua, samalla tavalla kuin {rap:v}, mutta tarkkuudella. Jos laatu on mitattavissa oleva, merkitys on, että kahdella asialla on täsmälleen sama määrä tätä laatua. Katso alla oleva esimerkki.[3][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4352,6 +4798,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
 ▶ {'ugh ro'qegh'Iwchab, nIb raHta'.:sen:nolink} "Рахт такой же тяжёлый, как кровавый пирог." (т.е они одинакового веса)[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4359,6 +4806,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.2-12, Dec. 1998:src}, [3] {HQ 13.1, p.8-10, Mar. 2004:src}</column>
     </table>
     <table name="mem">
@@ -4372,6 +4820,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="definition_ru">Дежавю</column>
       <column name="definition_zh_HK">既視感、幻覺記憶</column>
       <column name="definition_pt">Dejà vu</column>
+      <column name="definition_fi">déjà vu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leSSov:n}</column>
@@ -4382,6 +4831,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nIb:v}, {poH:n}</column>
       <column name="examples"></column>
@@ -4391,6 +4841,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">deja vu</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4398,6 +4849,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4411,6 +4863,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="definition_ru">аммуниция</column>
       <column name="definition_zh_HK">彈藥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">munição</column>
+      <column name="definition_fi">ampumatarvikkeet, ammukset</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuH:n:1}, {ngat:n:1}</column>
@@ -4421,6 +4874,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4430,6 +4884,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bullets, cartridge</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4437,6 +4892,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="search_tags_ru">пули</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4450,6 +4906,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="definition_ru">пытаться, пробовать, стараться</column>
       <column name="definition_zh_HK">嘗試、試試 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tentar</column>
+      <column name="definition_fi">yrittää, kokeilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4460,6 +4917,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4469,6 +4927,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4476,6 +4935,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4489,6 +4949,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="definition_ru">право(сторона)</column>
       <column name="definition_zh_HK">右邊</column>
       <column name="definition_pt">direito (lado)</column>
+      <column name="definition_fi">oikea (puoli)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{poS:n}</column>
       <column name="see_also">{tlhop:n:1}, {'em:n}, {'et:n:2h}, {'o':n}</column>
@@ -4499,6 +4960,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="notes_ru">При обращении к левой и правой сторонам используются притяжательные суффиксы.[2] См. Также {lurgh:n} для других слов, связанных с пространственными направлениями. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.[2] Consulte também {lurgh:n} para outras palavras relacionadas às direções espaciais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vasemmalle ja oikealle puolelle viitattaessa käytetään omistavia jälkiliitteitä.[2]{lurgh:n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4509,6 +4971,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">starboard</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4516,6 +4979,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="search_tags_ru">правый борт</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2019.08.05:src}</column>
     </table>
     <table name="mem">
@@ -4529,6 +4993,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="definition_ru">красть, воровать, выкрадывать, прокрадываться, угонять</column>
       <column name="definition_zh_HK">偷</column>
       <column name="definition_pt">roubar</column>
+      <column name="definition_fi">varastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hej:v}</column>
@@ -4539,6 +5004,7 @@ Este verbo é usado para expressar o conceito de que duas coisas têm a mesma qu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In slang, to "nick" something is to steal it.
 
 A line which was cut from {Star Trek Into Darkness:src} reveals that the person who is stolen from is marked with {-vo':n}: {'ej jIHvo' nIHDI' jIbup:sen@@'ej:conj, jIH:n:1h, -vo':n, nIH:v, -DI':v, jI-:v, bup:v}.</column>
@@ -4550,6 +5016,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4557,6 +5024,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4570,6 +5038,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">вор, угонщик</column>
       <column name="definition_zh_HK">賊</column>
       <column name="definition_pt">ladrão</column>
+      <column name="definition_fi">varas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4580,6 +5049,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nIH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4589,6 +5059,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4596,6 +5067,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4609,6 +5081,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">утечка, течь</column>
       <column name="definition_zh_HK">洩漏 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vazar</column>
+      <column name="definition_fi">vuotaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIb:n}</column>
@@ -4619,6 +5092,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4628,6 +5102,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4635,6 +5110,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4648,6 +5124,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">быть травянистым, зеленым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">草、青翠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser gramado, verdejante</column>
+      <column name="definition_fi">olla ruohoinen, vehreä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{magh:n}</column>
@@ -4658,6 +5135,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Neil deGrasse Tyson is an American astrophysicist.</column>
       <column name="components"></column>
       <column name="examples">{puH nIl:n}</column>
@@ -4667,6 +5145,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4674,6 +5153,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -4687,6 +5167,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">Молоко</column>
       <column name="definition_zh_HK">奶</column>
       <column name="definition_pt">leite</column>
+      <column name="definition_fi">maito</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noq:n:1}, {qulcher:n}</column>
@@ -4697,6 +5178,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">牛奶很少自己消耗，但是某些生物的牛奶（例如{targh:n}）與其他成分結合在一起可以製成更複雜的飲料。[1, p.95] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O leite raramente é consumido por si só, mas o leite de algumas criaturas, como o {targh:n}, é combinado com outros ingredientes para criar bebidas mais complexas.[1, p.95] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maitoa ei käytetä itsessään harvoin, mutta joidenkin olentojen, kuten {targh:n}, maito yhdistetään muiden ainesosien kanssa monimutkaisempien juomien luomiseksi.[1, p.95] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4706,6 +5188,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4713,6 +5196,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
         <table name="mem">
@@ -4726,6 +5210,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="definition_ru">масло</column>
           <column name="definition_zh_HK">牛油</column>
           <column name="definition_pt">manteiga</column>
+      <column name="definition_fi">voi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4736,6 +5221,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{nIm:n}, {tlhagh:n}</column>
           <column name="examples"></column>
@@ -4745,6 +5231,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4752,6 +5239,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -4765,6 +5253,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="definition_ru">мороженое [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">冰淇淋 [AUTOTRANSLATED]</column>
           <column name="definition_pt">sorvete</column>
+      <column name="definition_fi">jäätelö</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4775,6 +5264,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="notes_ru">Мороженое - это действительно терранская вещь; нет родного клингонского эквивалента. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">冰淇淋確實是人族的事。沒有本地的克林崗語。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Sorvete é realmente uma coisa terráquea; não existe equivalente klingon nativo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jäätelö on todella Terran-asia; kotimaista klingonilaista vastaavaa ei ole. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{nIm:n}, {qulcher:n}, {taD:v}</column>
           <column name="examples"></column>
@@ -4784,6 +5274,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">icecream</column>
           <column name="search_tags_de">Eiscreme, Speiseeis</column>
           <column name="search_tags_fa"></column>
@@ -4791,6 +5282,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -4804,6 +5296,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="definition_ru">сыр</column>
           <column name="definition_zh_HK">起司 [AUTOTRANSLATED]</column>
           <column name="definition_pt">queijo</column>
+      <column name="definition_fi">juusto</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4814,6 +5307,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="notes_ru">Это то, как Клингоны могут упомянуть о куске или о бруске ({ngogh:n:nolink}) земного сыра.</column>
           <column name="notes_zh_HK">這就是克林崗人可能提到的人族奶酪塊或塊（{ngogh:n:nolink}）的方式。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">É assim que os klingons podem se referir a um pedaço ou bloco ({ngogh:n:nolink}) de queijo terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Näin Klingons voi viitata Terran-juuston möhkäleeseen tai lohkoon ({ngogh:n:nolink}). [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{nIm:n}, {wIb:v}, {ngogh:n}</column>
           <column name="examples"></column>
@@ -4823,6 +5317,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4830,6 +5325,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
     <table name="mem">
@@ -4843,6 +5339,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">Нимбус 3</column>
       <column name="definition_zh_HK">祥雲三星</column>
       <column name="definition_pt">Nimbus III</column>
+      <column name="definition_fi">Nimbus III</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4853,6 +5350,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">The Chinese name comes from the movie's subtitles.[2]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4862,6 +5360,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4869,6 +5368,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -4882,6 +5382,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">топливо, горючее</column>
       <column name="definition_zh_HK">汽油 [AUTOTRANSLATED]</column>
       <column name="definition_pt">combustível</column>
+      <column name="definition_fi">polttoaine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4892,6 +5393,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4901,6 +5403,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4908,6 +5411,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4921,6 +5425,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">Сколько топлива у нас есть?</column>
       <column name="definition_zh_HK">我們剩下多少燃料？</column>
       <column name="definition_pt">Quanto combustível temos?</column>
+      <column name="definition_fi">Kuinka paljon polttoainetta meillä on?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4931,6 +5436,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {TKD p.170:src} and {CK:src}, this is given as "How much fuel do we have left?"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4940,6 +5446,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4947,6 +5454,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.70,170:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -4960,6 +5468,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">Япония</column>
       <column name="definition_zh_HK">日本</column>
       <column name="definition_pt">Japão</column>
+      <column name="definition_fi">Japani</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4970,6 +5479,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4979,6 +5489,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4986,6 +5497,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4999,6 +5511,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">ткать, плести, вплетать, сплетать</column>
       <column name="definition_zh_HK">編織 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tecer</column>
+      <column name="definition_fi">kutoa, punoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hut'In tIq:n}, {meS:v:1}</column>
@@ -5009,6 +5522,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru">Это слово описывает действие, которое лучше всего переводить с помощью глагола «плетение», некоторые формы которого включают в себя палочки, называемые {Hut'Inmey tIq:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞描述的活動最好用動詞“編織”來翻譯，動詞的某些形式涉及稱為{Hut'Inmey tIq:n:nolink}的木棍。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra descreve uma atividade melhor traduzida usando o verbo "tecer", algumas formas das quais envolvem paus chamados {Hut'Inmey tIq:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana kuvaa toimintaa, joka on parhaiten käännetty verbillä "kutoa", jonka joissakin muodoissa on tikkuja nimeltä {Hut'Inmey tIq:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">MO revealed this word after being asked about the Klingon word for "knit", and despite defining it to mean "weave", it's fairly clear that it also applies to knitting and crocheting.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5018,6 +5532,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">knit, crochet</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5025,6 +5540,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru">вязать крючком, плести</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.10.28:src}</column>
     </table>
     <table name="mem">
@@ -5038,6 +5554,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">перфоратор, дырокол [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">穿孔器、打孔器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">perfurador, furador</column>
+      <column name="definition_fi">rei'itin, lävistin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'on vevwI':n}</column>
@@ -5048,6 +5565,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru">Для использования такого устройства можно использовать {qIp:v}, {'uy:v} или {ngaH:v}, в зависимости от конкретного устройства. Перфоратор {ghID:v} бумага (или другой материал). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">要使用這樣的設備，取決於特定的設備，可以是{qIp:v}，{'uy:v}或{ngaH:v}。打孔器將對紙張（或其他材料）進行{ghID:v}處理。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tällaisen laitteen käyttämiseksi voi {qIp:v}, {'uy:v} tai {ngaH:v} sen, tietystä laitteesta riippuen. Rei'itin lävistää4 paperin (tai muun materiaalin).{ghID:v} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Reverse of "bodkin".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5057,6 +5575,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5064,6 +5583,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5077,6 +5597,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">программное обеспечение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">軟件</column>
       <column name="definition_pt">Programa (Software)</column>
+      <column name="definition_fi">ohjelmisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5087,6 +5608,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Ada Lovelace wrote that the Analytical Engine "weaves algebraical patterns" (see {nIq:v}) in the manner of the Jacquard loom. Its software was written on punch cards (see {nIqDob:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5096,6 +5618,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">program, app</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5103,6 +5626,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -5116,6 +5640,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">номер версии (основной) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">版本號（專業） [AUTOTRANSLATED]</column>
       <column name="definition_pt">número da versão (principal)</column>
+      <column name="definition_fi">pääversionumero</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qa'meH mI':n}</column>
@@ -5126,6 +5651,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru">Это используется для серьезного обновления программного обеспечения (например, от 2.x до 3.x). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於主要軟件更新（例如，從2.x到3.x）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para uma grande atualização de software (por exemplo, 2.x a 3.x). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään merkittävään ohjelmistopäivitykseen (esim. 2.x - 3.x). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nIqHom:n}, {mI':n}</column>
       <column name="examples"></column>
@@ -5135,6 +5661,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5142,6 +5669,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -5155,6 +5683,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">завтрак</column>
       <column name="definition_zh_HK">早餐</column>
       <column name="definition_pt">café da manhã</column>
+      <column name="definition_fi">aamiainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{po:n}, {'uQ:n}, {ghem:n}</column>
@@ -5165,6 +5694,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5174,6 +5704,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5181,6 +5712,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5194,6 +5726,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">препятствовать, мешать, быть помехой, вмешиваться куда-то, подрывать, разрушать</column>
       <column name="definition_zh_HK">阻礙、干擾（擾亂）、擾亂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dificultar, interferir (com), perturbar</column>
+      <column name="definition_fi">estää, vaikeuttaa, haitata, häiritä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mun:v}, {Haq:v:2}</column>
@@ -5204,6 +5737,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="notes_ru">Чтобы выразить приведение / бросание / создание тени, {QIb:n} может быть использован в качестве субъекта этого глагола. Объект, если указан, будет поверхностью, на которую отбрасывается тень.[4] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了表達投射/投擲/製作陰影，可以將{QIb:n}用作該動詞的主語。如果指定該對象，則將是將陰影投射到其上的表面.[4] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para expressar a projeção / lançamento / criação de uma sombra, {QIb:n} pode ser usado como assunto desse verbo. O objeto, se especificado, seria a superfície na qual a sombra é projetada.[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Varjojen heittämisen / heittämisen / tekemisen ilmaisemista varten {QIb:n}: tä voitaisiin käyttää tämän verbin aiheena. Objekti, jos se on määritelty, olisi pinta, jolle varjo heitetään.[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined in {TKD:src} as "hinder, interfere" and in {TKDA:src} as "disrupt, interfere (with)".
 
 "Trespassing vessel" was translated as {nISbogh Duj:n:nolink} in a deleted scene from the 2009 {Star Trek:src} movie.</column>
@@ -5219,6 +5753,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
   "Клингонский коммуникатор посылает сигнал через подпространственный приемник. Более старые модели были восприимчивы к радиации."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">trespass, shadow</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5226,6 +5761,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="search_tags_ru">посягательство</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKDA:src}, [3] {SkyBox 19:src}, [4] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5239,6 +5775,7 @@ A line which was cut from {Star Trek Into Darkness:src} reveals that the person 
       <column name="definition_ru">дизраптор</column>
       <column name="definition_zh_HK">破壞者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">disruptor</column>
+      <column name="definition_fi">eräs ampuma-ase, häiritsin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bach:v}, {nISwI' beH:n}</column>
@@ -5263,6 +5800,9 @@ Se Gowron säga {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://youtu
       <column name="notes_pt">Esta palavra é usada apenas para a arma Klingon. O termo mais geral para uma arma deste tipo é {pu':n:1}.[1, p.56]
 
 Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://youtu.be/Aadh3qMs7Go} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään vain Klingon-aseeseen. Tämäntyyppisen aseen yleisempi termi on {pu':n:1}.[1, p.56]
+
+Katso Gowronin sanovan {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://youtu.be/Aadh3qMs7Go} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5272,6 +5812,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5279,6 +5820,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5292,6 +5834,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">Дизрапторная винтовка</column>
       <column name="definition_zh_HK">破壞者步槍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rifle disruptor</column>
+      <column name="definition_fi">eräs ampuma-ase, häiritsinkivääri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5302,6 +5845,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is erroneously given as {nISwI' bej:n:nolink} in {KGT p.56,80:src}.</column>
       <column name="components">{nISwI':n}, {beH:n}</column>
       <column name="examples">
@@ -5319,6 +5863,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
    Клингонская дизрапторная винтовка это стандартный ручной дизраптор, прикрепленный к расширенному источнику питания. Это помогает устойчивому прицеливанию для воина и увеличению эффективной дальности для дальнего прицеливания."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5326,6 +5871,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 14:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -5339,6 +5885,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">Дизрапторные батареи</column>
       <column name="definition_zh_HK">破壞者銀行 [AUTOTRANSLATED]</column>
       <column name="definition_pt">banco de disruptores</column>
+      <column name="definition_fi">häiritsinsarja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5349,6 +5896,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru">Это мощные дизрапторы, установленные на корабле.</column>
       <column name="notes_zh_HK">這些是安裝在船上的強大干擾器。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Estes são poderosos disruptores montados em um navio. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nämä ovat voimakkaita häiriöitä alukseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nISwI':n}, {DaH:n}</column>
       <column name="examples"></column>
@@ -5358,6 +5906,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5365,6 +5914,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5378,6 +5928,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">дизрапторный пистолет, ручной дизраптор</column>
       <column name="definition_zh_HK">破壞者手槍、手持破壞者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pistola disruptor, disruptor portátil</column>
+      <column name="definition_fi">eräs ampuma-ase, häiritsinpistooli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5388,6 +5939,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nISwI':n}, {HIch:n}</column>
       <column name="examples"></column>
@@ -5397,6 +5949,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5404,6 +5957,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5417,6 +5971,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">Дизрапторная пушка</column>
       <column name="definition_zh_HK">破壞者大砲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">canhão disruptor</column>
+      <column name="definition_fi">eräs ase, häiritsintykki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngIS:n:extcan}</column>
@@ -5427,6 +5982,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nISwI':n}, {tal:n}</column>
       <column name="examples"></column>
@@ -5436,6 +5992,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5443,6 +6000,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5456,6 +6014,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">будь простым, будь чистым, будь непорочен, незапятнан [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">顯而易見、純潔、沒有腐敗、沒有被污染 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser claro, ser puro, ser incorrupto, ser imaculado</column>
+      <column name="definition_fi">olla siisti, olla puhdas, olla tahraton, olla turmeltumaton</column>
       <column name="synonyms">{watlh:v}</column>
       <column name="antonyms">{qal:v}</column>
       <column name="see_also">{Say':v}</column>
@@ -5466,6 +6025,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Purists are always picking "nit"s. Also, a "neat" alcoholic drink is one served without ice or mixer.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5476,6 +6036,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5483,6 +6044,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5496,6 +6058,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">в одиночестве, наедине, единственно, действовать в одиночку</column>
       <column name="definition_zh_HK">獨自、單獨</column>
       <column name="definition_pt">sozinho, agindo sozinho</column>
+      <column name="definition_fi">yksin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nItebHa':adv}</column>
       <column name="see_also">{mob:v:1}, {neH:adv}</column>
@@ -5506,6 +6069,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5515,6 +6079,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5522,6 +6087,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5535,6 +6101,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">Воин не позволит другу встретить опасность в одиночку.</column>
       <column name="definition_zh_HK">戰士不會畀朋友獨自面對危險。</column>
       <column name="definition_pt">Um guerreiro não deixa um amigo enfrentar o perigo sozinho.</column>
+      <column name="definition_fi">Soturi ei anna ystävän kohdata vaaraa yksin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5545,6 +6112,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nIteb:adv}, {Qob:n}, {qaD:v}, {jup:n}, {'e':n}, {chaw':v}, {-be':v}, {SuvwI':n}</column>
       <column name="examples"></column>
@@ -5554,6 +6122,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5561,6 +6130,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.37:src}</column>
     </table>
     <table name="mem">
@@ -5574,6 +6144,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">Веди свое судно в одиночку</column>
       <column name="definition_zh_HK">單獨駕駛你的船。</column>
       <column name="definition_pt">Navegue sua embarcação sozinho.</column>
+      <column name="definition_fi">Ohjaa alustasi yksin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIteb SuvnIS DevwI'.:sen}</column>
@@ -5584,6 +6155,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nIteb:adv}, {Duj:n:1}, {-lIj:n}, {yI-:v}, {chIj:v}</column>
       <column name="examples"></column>
@@ -5593,6 +6165,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5600,6 +6173,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.63:src}</column>
     </table>
     <table name="mem">
@@ -5613,6 +6187,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">Лидер должен быть в одиночестве</column>
       <column name="definition_zh_HK">領導者必須獨自站立。</column>
       <column name="definition_pt">Um líder deve ficar sozinho.</column>
+      <column name="definition_fi">Johtajan on oltava itsenäinen.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIteb DujlIj yIchIj.:sen}</column>
@@ -5623,6 +6198,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nIteb:adv}, {Suv:v}, {-nIS:v}, {DevwI':n}</column>
       <column name="examples"></column>
@@ -5632,6 +6208,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5639,6 +6216,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.63:src}</column>
     </table>
     <table name="mem">
@@ -5652,6 +6230,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">все вместе [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">共同、一起</column>
       <column name="definition_pt">juntos</column>
+      <column name="definition_fi">yhdessä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nIteb:adv}</column>
       <column name="see_also">{tay':v}, {quq:v}, {tlhej:v}, {-Ha':v:suff}</column>
@@ -5662,6 +6241,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5672,6 +6252,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5679,6 +6260,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5692,6 +6274,7 @@ Veja Gowron dizer {nISwI'mey:n@@nISwI':n, -mey:n}: {YouTube video:url:http://you
       <column name="definition_ru">палец</column>
       <column name="definition_zh_HK">手指</column>
       <column name="definition_pt">dedo</column>
+      <column name="definition_fi">sormi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qeb:n:1}, {ngoH:v:2}, {Heng:v}, {yaD:n:1}, {ghop:n}</column>
@@ -5738,6 +6321,13 @@ O klingon tem cinco verbos correspondentes a cada um dos {nItlh:n:nolink}: {Sen:
 Correspondentemente, os dedos são denominados {SenwI':n} ({rIlwI':n} se pertencer a uma criança), {SIqwI':n}, {qaywI':n}, {qewwI':n} e {qanwI':n}.
 
 Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa mihin tahansa käden numeroon, peukalo mukaan lukien.
+
+Klingonilla on viisi verbiä, jotka vastaavat kutakin {nItlh:n:nolink}: {Sen:v:1}, {SIq:v}, {qay:v}, {qew:v} ja {qan:v:2}. Kun viitataan lapsen peukaloon, käytetään lisäksi {rIl:v:1} {Sen:v:1,nolink}: n sijaan.
+
+Vastaavasti sormia kutsutaan {SenwI':n} ({rIlwI':n}, jos se kuuluu lapselle), {SIqwI':n}, {qaywI':n}, {qewwI':n} ja {qanwI':n}.
+
+Katso selitys näiden sormiverbien käytöstä kohdasta {SIq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The verbs for the fingers come from names of the Finger Lakes in New York State.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5747,6 +6337,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">digit</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5754,6 +6345,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru">палец</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -5767,6 +6359,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">труба [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">喇叭</column>
       <column name="definition_pt">trompete</column>
+      <column name="definition_fi">trumpetti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5777,6 +6370,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nItlh:n}, {gheb:n}</column>
       <column name="examples"></column>
@@ -5786,6 +6380,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5793,6 +6388,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5806,6 +6402,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">пигментная палочка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">顏料棒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bastão de pigmento</column>
+      <column name="definition_fi">maalitikku, pigmenttitikku?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIj:v:2}, {nItlh:n}</column>
@@ -5816,6 +6413,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Это сленг для {rItlh naQ:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{rItlh naQ:n}的語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma gíria para {rItlh naQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on slangia {rItlh naQ:n}: lle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5825,6 +6423,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5832,6 +6431,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5845,6 +6445,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">отпечаток пальца (гребни на кончике пальца) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">指紋（指尖上的脊） [AUTOTRANSLATED]</column>
       <column name="definition_pt">impressão digital (sulcos na ponta do dedo)</column>
+      <column name="definition_fi">sormenjälki (sormessa oleva kuvio)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh Su'nIm vem:n}, {nel:v}</column>
@@ -5855,6 +6456,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Смотрите под {Su'nIm:n} для объяснения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請參閱{Su'nIm:n}下的說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {Su'nIm:n} para uma explicação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso selitys kohdasta {Su'nIm:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nItlh:n}, {Su'nIm:n}</column>
       <column name="examples"></column>
@@ -5864,6 +6466,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5871,6 +6474,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5884,6 +6488,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">отпечаток пальца (отметьте слева от прикосновения) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">指紋（觸摸標記） [AUTOTRANSLATED]</column>
       <column name="definition_pt">impressão digital (marca deixada ao tocar)</column>
+      <column name="definition_fi">sormenjälki (kosketuksen jättämä tahra)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh Su'nIm:n}, {nel:v}, {bo'DIj nompuq:n}</column>
@@ -5894,6 +6499,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Смотрите под {vem:n} для объяснения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請參閱{vem:n}下的說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {vem:n} para uma explicação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso selitys kohdasta {vem:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nItlh:n}, {Su'nIm:n}, {vem:n}</column>
       <column name="examples"></column>
@@ -5903,6 +6509,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5910,6 +6517,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5923,6 +6531,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">клавиатура (компьютерное устройство) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鍵盤</column>
       <column name="definition_pt">teclado (dispositivo de computador)</column>
+      <column name="definition_fi">näppäimistö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'echlet Hab:n}, {'eQway':n}</column>
@@ -5933,6 +6542,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Это относится к устройству ввода компьютера. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指計算機輸入設備。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um dispositivo de entrada do computador. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tietokoneen syöttölaitteeseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nItlh:n}, {'echlet:n}</column>
       <column name="examples"></column>
@@ -5942,6 +6552,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5949,6 +6560,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -5962,6 +6574,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">ноготь</column>
       <column name="definition_zh_HK">指甲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">unha da mão</column>
+      <column name="definition_fi">kynsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{butlh:n:1}, {yaDpach:n}</column>
@@ -5972,6 +6585,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nItlh:n}, {pach:n}</column>
       <column name="examples"></column>
@@ -5981,6 +6595,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nail</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5988,6 +6603,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru">ноготь</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -6001,6 +6617,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">плоский конец пигментной палочки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">顏料棒的平端 [AUTOTRANSLATED]</column>
       <column name="definition_pt">extremidade plana de um bastão de pigmento</column>
+      <column name="definition_fi">pigmenttitikun tasainen pää?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlhpach:n:1}</column>
@@ -6011,6 +6628,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Monikko on {nItlhpachDu':n@@nItlhpach:n:2,-Du':n:suff}.[1, p.80] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6020,6 +6638,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6027,6 +6646,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6040,6 +6660,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">быть превосходящим, превосходить, быть высшего качества</column>
       <column name="definition_zh_HK">要優越 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser superior</column>
+      <column name="definition_fi">olla ylivertainen, ylivoimainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{QIv:v}</column>
       <column name="see_also">{moch:n}</column>
@@ -6050,6 +6671,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6060,6 +6682,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6067,6 +6690,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6080,6 +6704,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">пижама</column>
       <column name="definition_zh_HK">睡衣</column>
       <column name="definition_pt">pijamas</column>
+      <column name="definition_fi">pyjama</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6090,6 +6715,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6099,6 +6725,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6106,6 +6733,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6119,6 +6747,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">призрак, видение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">幽靈、幻影 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fantasma, aparição</column>
+      <column name="definition_fi">kummitus, aave, haamu, ilmestys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qa':n}</column>
@@ -6129,6 +6758,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Это относится к тому, что, кажется, появляется, но на самом деле не существует. Это не относится к призраку или духу и весьма отличается от {qa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指似乎已出現但實際上不存在的東西。它不指鬼魂或鬼魂，與{qa':n}完全不同。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a algo que parece aparecer, mas não está realmente lá. Não se refere a um fantasma ou espírito e é bem diferente de {qa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa johonkin, joka näyttää ilmestyvän, mutta ei oikeastaan ​​ole siellä. Se ei viittaa aaveeseen tai henkeen, ja on aivan erilainen kuin {qa':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This refers to a {Saarbrücken qepHom'a':src} participant named "Nima" who never showed up. Also, in German, "niemand" means "nobody".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6138,6 +6768,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6145,6 +6776,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2008.11.23:src}</column>
     </table>
     <table name="mem">
@@ -6158,6 +6790,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">быть длинным, быть продолжительным, быть растянутым, быть очень длинным (длительность)</column>
       <column name="definition_zh_HK">很長、很長（持續時間） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser longo, longo (duração)</column>
+      <column name="definition_fi">olla pitkä (kestoltaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngaj:v}</column>
       <column name="see_also"></column>
@@ -6168,6 +6801,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">не путайте это слово с {tIq:v}.</column>
       <column name="notes_zh_HK">不要將此詞與{tIq:v}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda esta palavra com {tIq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita tätä sanaa sanaan {tIq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It says on {TKD p.50:src} that a verb expressing a state or quality can be used "immediately following a noun". The {paq'batlh:src} excerpt is an example of two adjectives on a noun ("long and dangerous battle"), where one of the Klingon verbs uses {-bogh:v:suff}, which suggests two verbs used adjectivally cannot follow one noun.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6183,6 +6817,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6190,6 +6825,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.158-159:src}</column>
     </table>
     <table name="mem">
@@ -6203,6 +6839,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">подарок</column>
       <column name="definition_zh_HK">禮物</column>
       <column name="definition_pt">presente</column>
+      <column name="definition_fi">lahja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'nob:n}, {nob:v}</column>
@@ -6213,6 +6850,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Смотрите также {much:v:1} для идеи "дарения" подарка кому-либо.</column>
       <column name="notes_zh_HK">另請參見{much:v:1}，以“贈送”禮物給某人的想法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja também {much:v:1} para a idéia de "apresentar" um presente a alguém. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso myös {much:v:1}-ajatus lahjan "esittämisestä" jollekulle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6222,6 +6860,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6229,6 +6868,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6242,6 +6882,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">давать, придавать</column>
       <column name="definition_zh_HK">畀</column>
       <column name="definition_pt">dar</column>
+      <column name="definition_fi">antaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhap:v}</column>
       <column name="see_also">{peS:v}, {ghaq:v}, {DIl:v}, {rup:v}, {nob:n}</column>
@@ -6252,6 +6893,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Смотрите также {much:v:1} для идеи "дарения" подарка кому-либо.</column>
       <column name="notes_zh_HK">另請參見{much:v:1}，以“贈送”禮物給某人的想法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja também {much:v:1} para a idéia de "apresentar" um presente a alguém. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso myös {much:v:1}-ajatus lahjan "esittämisestä" jollekulle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6261,6 +6903,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6268,6 +6911,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6281,6 +6925,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">давать обратно, возвращать что-то</column>
       <column name="definition_zh_HK">畀返、還給、送還</column>
       <column name="definition_pt">devolver, retornar</column>
+      <column name="definition_fi">antaa takaisin, palauttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tatlh:v}</column>
@@ -6291,6 +6936,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nob:v}, {-Ha':v}</column>
       <column name="examples">
@@ -6301,6 +6947,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6308,6 +6955,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.189:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6321,6 +6969,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">Не верьте Иридианцам, приносящим дары</column>
       <column name="definition_zh_HK">不要相信帶來禮物的Yridians。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Não confie em Yridians que trazem presentes.</column>
+      <column name="definition_fi">Älä luota lahjoja tuoviin yridialaisiin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6331,6 +6980,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">There is a grammatical error with this sentence. It should be {tIvoqQo':sen@@tI-:v, voq:v, -Qo':v} rather than {yIvoqQo':sen:nolink}.</column>
       <column name="components">{nob:n}, {-mey:n}, {qem:v}, {-bogh:v}, {yIrIDngan:n}, {-pu':n}, {-'e':n}, {yI-:v}, {voq:v}, {-Qo':v}</column>
       <column name="examples"></column>
@@ -6340,6 +6990,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6347,6 +6998,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.189:src}</column>
     </table>
     <table name="mem">
@@ -6360,6 +7012,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">скелет (анатомия) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">骨架（解剖） [AUTOTRANSLATED]</column>
       <column name="definition_pt">esqueleto (anatomia)</column>
+      <column name="definition_fi">luuranko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hom:n:1}, {qal'aq:n}</column>
@@ -6370,6 +7023,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Dem Bones" is a spiritual song about the skeleton.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6379,6 +7033,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6386,6 +7041,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6399,6 +7055,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">Сенсор</column>
       <column name="definition_zh_HK">傳感器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sensor</column>
+      <column name="definition_fi">sensori, anturi, ilmaisin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jem:v}, {chuq:n}, {chuq'a':n}, {HotlhwI':n}, {Hotlh:v:2}</column>
@@ -6409,6 +7066,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6418,6 +7076,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6425,6 +7084,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6438,6 +7098,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">система дистанционного зондирования [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">遙感系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sistema de sensoriamento remoto</column>
+      <column name="definition_fi">etäanturijärjestelmä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QeD pat:n}</column>
@@ -6448,6 +7109,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Это выглядит как {QeD patmey noch patmey je:n:nolink} "наука и системы дистанционного зондирования". [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這似乎是{QeD patmey noch patmey je:n:nolink}的“科學和遙感系統”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso aparece como {QeD patmey noch patmey je:n:nolink} "sistemas de ciência e sensoriamento remoto". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä esiintyy nimellä {QeD patmey noch patmey je:n:nolink} "tiede ja kaukokartoitusjärjestelmät". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{noch:n}, {pat:n}</column>
       <column name="examples"></column>
@@ -6457,6 +7119,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6464,6 +7127,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6477,6 +7141,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">мстить</column>
       <column name="definition_zh_HK">報復、報仇</column>
       <column name="definition_pt">retaliar</column>
+      <column name="definition_fi">kostaa, maksaa takaisin samalla mitalla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bortaS:n}</column>
@@ -6487,6 +7152,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6497,6 +7163,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6504,6 +7171,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6517,6 +7185,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">мститель</column>
       <column name="definition_zh_HK">復仇者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vingador</column>
+      <column name="definition_fi">kostaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6527,6 +7196,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{noD:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -6536,6 +7206,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6543,6 +7214,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -6556,6 +7228,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">терзаться, корчиться от боли</column>
       <column name="definition_zh_HK">翻騰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">contorcer</column>
+      <column name="definition_fi">kiemurella, vääntelehtiä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIS:v}, {ghargh:n}, {qagh:n}, {raHta':n}</column>
@@ -6566,6 +7239,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6575,6 +7249,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6582,6 +7257,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6595,6 +7271,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">судить, оценивать, давать оценку</column>
       <column name="definition_zh_HK">判斷、估計 [AUTOTRANSLATED]</column>
       <column name="definition_pt">julgar, estimar</column>
+      <column name="definition_fi">arvioida, arvostella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chov:v}, {yoj:n}, {loy:v}, {'oD:v}, {nuD:v}</column>
@@ -6605,6 +7282,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Judges are addressed as "Your {Hon:sen:nolink}or".</column>
       <column name="components"></column>
       <column name="examples">
@@ -6615,6 +7293,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6622,6 +7301,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6635,6 +7315,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">Война (индивидуальная война)</column>
       <column name="definition_zh_HK">戰爭（個別戰爭）</column>
       <column name="definition_pt">guerra (uma guerra individual)</column>
+      <column name="definition_fi">sota (yksittäinen sota, ei sotiminen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yol:n}, {may':n}, {ghob:v}</column>
@@ -6645,6 +7326,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Противопоставляется слову {veS:n}, которое относится к концепции ведения военных дейтсвий.[2, стр.47]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Compare isso com {veS:n}, que se refere ao conceito de guerra.[2, p.47] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kontrasti tämä {veS:n}: llä, joka viittaa sodankäynnin käsitteeseen.[2, p.47] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6655,6 +7337,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6662,6 +7345,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6675,6 +7359,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">На войне нет ничего более почетного, чем победа</column>
       <column name="definition_zh_HK">在戰爭中，沒有事比勝利更光榮的。</column>
       <column name="definition_pt">Na guerra, não há nada mais honroso que a vitória.</column>
+      <column name="definition_fi">Sodassa ei ole mitään kunniallisempaa kuin voitto.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6685,6 +7370,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{noH:n}, {ghob:v}, {-lu':v}, {-DI':v}, {yay:n:2}, {quv:v}, {... law':sen}, {Hoch:n}, {quv:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -6694,6 +7380,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">In war, there is nothing more honourable than victory.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6701,6 +7388,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru">На войне нет ничего более почетного, чем победа</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.179:src}</column>
     </table>
     <table name="mem">
@@ -6714,6 +7402,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">Нохвадутский район [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">No'hvadut州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Região de No'hvadut</column>
+      <column name="definition_fi">No'hvadutin alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sep Hol Sar:n}</column>
@@ -6724,6 +7413,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">На диалекте этого региона тосты не используют специальную грамматику, и субъект следует за глаголом в тостах так же, как и в обычных предложениях (см. {-jaj:v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在該地區的方言中，吐司不使用特殊的語法，並且主語中的動詞跟普通句子中的動詞一樣（請參閱{-jaj:v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No dialeto dessa região, as torradas não usam gramática especial, e o sujeito segue o verbo nas torradas, assim como nas frases regulares (consulte {-jaj:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän alueen murteessa paahtoleivät eivät käytä erityistä kielioppia, ja kohde seuraa verbiä paahtoleivissä aivan kuten tavallisissa lauseissa (katso {-jaj:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} on p.26 and not in the glossary. It appears as {noHva'Dut:n:nolink} and not as {noHva'Dut Sep:n:nolink}, but it is implied that this is the name of a region (see {Sep:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6733,6 +7423,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6740,6 +7431,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.26:src}</column>
     </table>
     <table name="mem">
@@ -6753,6 +7445,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">Уничтожение империи, для победы в войне, это победа, а окончание битвы, чтобы спасти империю, не поражение.</column>
       <column name="definition_zh_HK">摧毀帝國贏得戰爭並非勝利，結束拯救帝國的戰鬥並非失敗。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Destruir um império para vencer uma guerra não é vitória, e terminar uma batalha para salvar um império não é derrota.</column>
+      <column name="definition_fi">Valtakunnan tuhoaminen sodan voittamiseksi ei ole voitto, eikä taistelusta vetäytyminen valtakunnan pelastamiseksi ole tappio.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6763,6 +7456,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{noH:n}, {Qap:v:1}, {-meH:v}, {wo':n}, {Qaw':v}, {-lu':v}, {-chugh:v}, {yay:n:2}, {chav:v}, {-be':v}, {-lu':v}, {'ej:conj}, {wo':n}, {choq:v}, {-meH:v}, {may':n}, {DoH:v}, {-lu':v}, {-chugh:v}, {luj:v}, {-be':v}, {-lu':v}</column>
       <column name="examples"></column>
@@ -6772,6 +7466,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6779,6 +7474,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.211:src}</column>
     </table>
     <table name="mem">
@@ -6792,6 +7488,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">предоставлять, давать в долг, одалживать</column>
       <column name="definition_zh_HK">借 [AUTOTRANSLATED]</column>
       <column name="definition_pt">emprestar</column>
+      <column name="definition_fi">lainata (jollekulle), antaa lainaksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngIp:v}</column>
@@ -6802,6 +7499,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6811,6 +7509,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6818,6 +7517,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6831,6 +7531,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">похороны, погребение</column>
       <column name="definition_zh_HK">葬禮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">funeral</column>
+      <column name="definition_fi">hautajaiset</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lom:n}, {mol:v}, {mol:n}, {'aQvoH:n}, {Heghtay:n}, {SonchIy:n}</column>
@@ -6841,6 +7542,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Knoll"; also, reverse of {lon:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6850,6 +7552,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6857,6 +7560,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6870,6 +7574,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">быстро, скоро, часто, срочно</column>
       <column name="definition_zh_HK">快</column>
       <column name="definition_pt">rápido, rapidamente</column>
+      <column name="definition_fi">nopeasti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{QIt:adv}</column>
       <column name="see_also">{moD:v}, {tugh:adv}, {pav:v}
@@ -6883,6 +7588,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6893,6 +7599,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6900,6 +7607,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6913,6 +7621,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">авторитет, доказательства, аттестация, ссылка, цитирование [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">權威、證據、證明、參考、引用 [AUTOTRANSLATED]</column>
       <column name="definition_pt">autoridade, evidência, atestado, referência, citação</column>
+      <column name="definition_fi">todistus, todiste; ennakkotapaus, lähde, viite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hal:n}, {mung:n}, {bo'DIj nompuq:n}</column>
@@ -6923,6 +7632,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The phrase "citation needed" is associated with Wikipedia. "Wiki" means "quick" ({nom:adv}) and "pedia" means "education, child-rearing" ({puq:n}).</column>
       <column name="components"></column>
       <column name="examples">{bo'DIj nompuq:n}</column>
@@ -6932,6 +7642,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6939,6 +7650,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -6952,6 +7664,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">быть гнилым, быть прогнившим, быть протухшим, быть тухлым, быть разложившимся, быть нравственно испорченным</column>
       <column name="definition_zh_HK">爛了</column>
       <column name="definition_pt">ser podre</column>
+      <column name="definition_fi">olla mätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baQ:v:2}, {DeH:v}, {ghoQ:v:1}, {ragh:v}</column>
@@ -6962,6 +7675,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6971,6 +7685,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6978,6 +7693,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6991,6 +7707,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">быть страстным</column>
       <column name="definition_zh_HK">要充滿激情 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser apaixonado</column>
+      <column name="definition_fi">olla intohimoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7001,6 +7718,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru">Есть Клингонская идиома, {nong; vulqangan rur}, которая имеет ироническое значение.</column>
       <column name="notes_zh_HK">具有克林崗語慣用語“ {nong; vulqangan rur}”，具有諷刺意味。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma klingon, {nong; vulqangan rur}, que se entende ironicamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On olemassa klingonin idioomi {nong; vulqangan rur}, joka on tarkoitettu ironisesti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7010,6 +7728,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7017,6 +7736,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7030,6 +7750,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">{qu':v:2,slang}</column>
       <column name="definition_zh_HK">{qu':v:2,slang}</column>
       <column name="definition_pt">{qu':v:2,slang}</column>
+      <column name="definition_fi">{qu':v:2,slang}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7040,6 +7761,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7049,6 +7771,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7056,6 +7779,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.161:src}</column>
     </table>
     <table name="mem">
@@ -7069,6 +7793,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">пропускать что-то, пренебрегать чем-либо</column>
       <column name="definition_zh_HK">忽略 [AUTOTRANSLATED]</column>
       <column name="definition_pt">omitir</column>
+      <column name="definition_fi">jättää pois, olla mainitsematta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nep:v}</column>
@@ -7079,6 +7804,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"NOP" is a no-op, a computer command to do nothing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7088,6 +7814,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7095,6 +7822,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7108,6 +7836,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="definition_ru">сосок</column>
       <column name="definition_zh_HK">乳頭（解剖學） [AUTOTRANSLATED]</column>
       <column name="definition_pt">mamilo (anatomia)</column>
+      <column name="definition_fi">nänni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngob'at:n}, {nIm:n}, {noq:n:2}</column>
@@ -7118,6 +7847,7 @@ Consulte {SIq:v} para obter uma explicação sobre o uso desses verbos de dedo. 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In vulgar English slang, breasts are called "knockers".
 
 It's probably a coincidence, but نوک is also the Persian word for "nipple".</column>
@@ -7129,6 +7859,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tit, teat</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7136,6 +7867,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -7149,6 +7881,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">nipple (on bottles, etc.) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">乳頭（瓶子等） [AUTOTRANSLATED]</column>
       <column name="definition_pt">boquilha (em garrafas, etc.)</column>
+      <column name="definition_fi">tuttipullon tutti, pullon imulaite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noq:n:1}, {bal:n}</column>
@@ -7159,6 +7892,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Это слово имеет суффикс {-Du':n}, так как является расширением значения анатомического термина. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該詞帶有後綴{-Du':n}，因為它是解剖學術語含義的擴展。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra usa o sufixo {-Du':n}, pois é uma extensão do significado do termo anatômico. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana vie päätteen {-Du':n}, koska se on jatkoa anatomisen termin merkitykselle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7168,6 +7902,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7175,6 +7910,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -7188,6 +7924,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Норвегия</column>
       <column name="definition_zh_HK">挪威</column>
       <column name="definition_pt">Noruega</column>
+      <column name="definition_fi">Norja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7198,6 +7935,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7207,6 +7945,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7214,6 +7953,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7227,6 +7967,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Норг (акулоподобное морское существо)</column>
       <column name="definition_zh_HK">動物類型、諾格（鯊魚般的海洋生物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, norg (criatura marinha do tipo tubarão)</column>
+      <column name="definition_fi">eräs hain kaltainen merieläin, norg</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7237,6 +7978,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">有一個成語{naS; norgh rur@@naS:v, norgh:n, rur:v}.[1, p.132] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {naS; norgh rur@@naS:v, norgh:n, rur:v}.[1, p.132] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {naS; norgh rur@@naS:v, norgh:n, rur:v}.[1, p.132] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word first appeared in the novel {Sarek:src} by A. C. Crispin, and was only confirmed to have come from Okrand when it appeared three years later in {KGT:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7246,6 +7988,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shark</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7253,6 +7996,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7266,6 +8010,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">потомок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">後裔 [AUTOTRANSLATED]</column>
       <column name="definition_pt">descendente</column>
+      <column name="definition_fi">jälkeläinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'emrIgh:n}</column>
       <column name="see_also">{puq:n}, {puqbe':n}, {puqloD:n}, {puqnI':n}, {puqnI'be':n}, {puqnI'loD:n}, {'ISyar:n}</column>
@@ -7276,6 +8021,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It was explicitly stated that this takes {-pu':n:suff}.[1]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7285,6 +8031,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">posterity</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7292,6 +8039,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7305,6 +8053,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">есть маленькими глотками, клевать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小口吃、蠶食 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comer em pequenos bocados, mordiscar</column>
+      <column name="definition_fi">syö pienissä suupaloissa, napostella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chop:v}, {ngal:v}, {yIv:v:1}</column>
@@ -7315,6 +8064,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Использование этого глагола является уничижительным (кроме детей и домашних животных). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞的使用是貶義的（兒童和寵物除外）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O uso desse verbo é depreciativo (exceto para crianças e animais de estimação). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbi on halveksiva (lukuun ottamatta lapsia ja lemmikkejä). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is the Yiddish word for nibble, "nosh". It's also similar to the German verb "naschen".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7324,6 +8074,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7331,6 +8082,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7344,6 +8096,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">дезодорант</column>
       <column name="definition_zh_HK">體香劑、除臭劑</column>
       <column name="definition_pt">desodorante</column>
+      <column name="definition_fi">deodorantti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'I':n}</column>
@@ -7354,6 +8107,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Chanel No. 5 was the first perfume launched by Coco Chanel. {noS:sen:nolink} both sounds like "nose" and looks like "No. 5", and {vagh:n:1} means "number five".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7363,6 +8117,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7370,6 +8125,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7383,6 +8139,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">никогда</column>
       <column name="definition_zh_HK">決不 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nunca</column>
+      <column name="definition_fi">ei koskaan</column>
       <column name="synonyms">{paghlogh:adv}, {ghe'torvo' narghDI' qa'pu':sen}</column>
       <column name="antonyms"></column>
       <column name="see_also">{reH:adv}, {rut:adv}, {pIj:adv}, {wej:adv}</column>
@@ -7393,6 +8150,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7404,6 +8162,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
 ▶ {not jegh tlhIngan SuvwI'.:sen:nolink} "Клингонский воин никогда не сдается."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7411,6 +8170,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.178:src}</column>
     </table>
     <table name="mem">
@@ -7424,6 +8184,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Ни один Клингон не нарушит своего слова</column>
       <column name="definition_zh_HK">克林崗沒有打破他的話。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Klingon nunca quebra sua palavra.</column>
+      <column name="definition_fi">Klingoni ei koskaan riko lupaustaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7434,6 +8195,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7443,6 +8205,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7450,6 +8213,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.80:src}</column>
     </table>
     <table name="mem">
@@ -7463,6 +8227,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Secrets never cease. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">秘密從未停止過。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Segredos nunca cessam.</column>
+      <column name="definition_fi">Salaisuudet eivät koskaan lopu.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7473,6 +8238,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7482,6 +8248,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">secrecy proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7489,6 +8256,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -7502,6 +8270,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Только дураки ничего не боятся</column>
       <column name="definition_zh_HK">只有傻瓜是不會害怕。</column>
       <column name="definition_pt">Apenas tolos não têm medo.</column>
+      <column name="definition_fi">Vain tyhmä ei koskaan pelkää.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7512,6 +8281,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{not:adv}, {qoH:n}, {-pu':n}, {-'e':n}, {neH:adv}, {ghIj:v}, {-lu':v}</column>
       <column name="examples"></column>
@@ -7521,6 +8291,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7528,6 +8299,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.105:src}</column>
     </table>
     <table name="mem">
@@ -7541,6 +8313,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Клингоны никогда не блевуют</column>
       <column name="definition_zh_HK">克林崗人從不虛張聲勢。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Os klingons nunca blefam.</column>
+      <column name="definition_fi">Klingonit eivät koskaan bluffaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7551,6 +8324,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7560,6 +8334,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7567,6 +8342,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.46:src}</column>
     </table>
     <table name="mem">
@@ -7580,6 +8356,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Я никогда не видел его/её раньше</column>
       <column name="definition_zh_HK">我從來未見過他。</column>
       <column name="definition_pt">Eu nunca o/a vi antes.</column>
+      <column name="definition_fi">En ole koskaan nähnyt häntä aiemmin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7590,6 +8367,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7599,6 +8377,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7606,6 +8385,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -7619,6 +8399,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">большая черная птица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一隻大黑鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro grande e preto</column>
+      <column name="definition_fi">eräs iso, musta lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7629,6 +8410,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Он далеко не такой большой, как {qa'rol:n}, который действительно большой. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它遠不及{qa'rol:n}這麼大，這確實很大。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não é nem de longe tão grande quanto um {qa'rol:n}, que é realmente grande. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Se ei ole läheskään yhtä suuri kuin {qa'rol:n}, mikä on todella iso. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to "The Raven" by Poe.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7638,6 +8420,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7645,6 +8428,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -7658,6 +8442,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">занавес, драпировка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">窗簾，懸垂性 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cortina, decoração de janela</column>
+      <column name="definition_fi">verho</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qorwagh:n}, {lojmIt:n}</column>
@@ -7668,6 +8453,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Это также может быть использовано для таких вещей, как дверь или ворота, которые открываются и закрываются вертикально, например, Portcullis. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也可以用於垂直打開和關閉的門或門之類的東西，例如吊頂門。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser usado para coisas como uma porta ou portão que se abre e fecha verticalmente, como um portão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää myös esimerkiksi oviin tai portteihin, jotka avautuvat ja sulkeutuvat pystysuunnassa, kuten portcullis. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7678,6 +8464,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">portcullis</column>
       <column name="search_tags_de">Fallgatter, Fallgitter</column>
       <column name="search_tags_fa"></column>
@@ -7685,6 +8472,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -7698,6 +8486,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">быть устаревшим, быть отжившим, быть рудиментарным</column>
       <column name="definition_zh_HK">過時了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser obsoleto</column>
+      <column name="definition_fi">olla vanhentunut, vanhanaikainen, olla käytöstä poistunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7708,6 +8497,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7721,6 +8511,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
 ▶ {notlh tonSaw'lIj.:sen} "Твоя техника ведения боя устарела."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7728,6 +8519,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7741,6 +8533,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Твой аргумент недействителен</column>
       <column name="definition_zh_HK">你的論點是無效的。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Seu argumento é inválido.</column>
+      <column name="definition_fi">Argumenttisi on väärä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7751,6 +8544,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Это идиоматическое выражение дословно значит "Твоя техника ведения боя устарела."</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是“您的戰鬥技巧已過時”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática literalmente significa "Sua técnica de luta é obsoleta". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "taistelutekniikkasi on vanhentunut". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7760,6 +8554,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7767,6 +8562,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 19 (2012):src} ({KLI mailing list 2012.09.01:src})</column>
     </table>
     <table name="mem">
@@ -7780,6 +8576,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">чужак, чужой, пришелец, посторонний, иностранец</column>
       <column name="definition_zh_HK">外星人、局外人、外國人</column>
       <column name="definition_pt">estrangeiro, forasteiro</column>
+      <column name="definition_fi">muukalainen, ulkopuolinen, ulkomaalainen</column>
       <column name="synonyms">{Hur'Iq:n}</column>
       <column name="antonyms">{Sung:n}</column>
       <column name="see_also">{nov:v}</column>
@@ -7790,6 +8587,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7799,6 +8597,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7806,6 +8605,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7819,6 +8619,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">быть чужаком, быть пришельцем, быть иностранцем, быть чужим, быть посторонним</column>
       <column name="definition_zh_HK">是外國人、外星人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser estrangeiro, alien</column>
+      <column name="definition_fi">olla ulkomaalainen; olla vieras, outo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nov:n}</column>
@@ -7829,6 +8630,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7838,6 +8640,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7845,6 +8648,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7858,6 +8662,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">быть знаменитым, быть известным, быть хорошо известным, быть прославленным</column>
       <column name="definition_zh_HK">出名、著名</column>
       <column name="definition_pt">ser famoso, conhecido</column>
+      <column name="definition_fi">olla kuuluisa, olla hyvin tunnettu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7868,6 +8673,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The definition in {TKD:src} has "well known" with a space instead of a hyphen.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7877,6 +8683,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fame</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7884,6 +8691,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7897,6 +8705,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">предки</column>
       <column name="definition_zh_HK">祖先們</column>
       <column name="definition_pt">antepassados</column>
+      <column name="definition_fi">esivanhemmat, esi-isät</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ISyar:n}</column>
@@ -7907,6 +8716,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Это относится к культурным или социальным предкам или предкам (которые не обязательно связаны кровью). Для прямого предка, см. {'emrIgh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指文化或社會的祖先或先輩（不一定與血緣關係）。有關直接祖先的信息，請參閱{'emrIgh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a ancestrais ou antepassados ​​culturais ou sociais (que não são necessariamente relacionados pelo sangue). Para um ancestral direto, consulte {'emrIgh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kulttuurisiin tai yhteiskunnallisiin esi-isiin tai esivanhempiin (jotka eivät välttämättä ole verisukulaisia). Katso suoraa esi-isää kohdasta {'emrIgh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qempa':n:inhps}</column>
       <column name="examples"></column>
@@ -7916,6 +8726,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7923,6 +8734,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -7936,6 +8748,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="definition_ru">эпоха предков [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">祖先時代 [AUTOTRANSLATED]</column>
           <column name="definition_pt">era dos antepassados</column>
+      <column name="definition_fi">esi-isien aikakausi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{bov tIQ:n}</column>
@@ -7946,6 +8759,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="notes_ru">Это относится к периоду в палеонтологии, более позднему, чем {bov tIQ:n}. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是指比{bov tIQ:n}最近的古生物學時期。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso se refere a um período em paleontologia mais recente que o {bov tIQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa paleontologian ajanjaksoon, joka on uudempi kuin {bov tIQ:n}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{no':n}, {bov:n}</column>
           <column name="examples"></column>
@@ -7955,6 +8769,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7962,6 +8777,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
         </table>
         <table name="mem">
@@ -7975,6 +8791,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="definition_ru">предок висит (настенный орнамент) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">祖先壁皮（壁毯）</column>
           <column name="definition_pt">Tapeçaria ancestral (ornamento de parede)</column>
+      <column name="definition_fi">esi-isäseinävaate?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7985,6 +8802,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{no':n}, {DIr:n}</column>
           <column name="examples"></column>
@@ -7994,6 +8812,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8001,6 +8820,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -8014,6 +8834,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="definition_ru">древний язык, язык предков [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">古老語言、祖先語言</column>
           <column name="definition_pt">idioma antigo, idioma dos ancestrais</column>
+      <column name="definition_fi">esivanhempien kieli, vanha klingon</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{mu'mey Doy':n}, {mu'mey ghoQ:n}</column>
@@ -8024,6 +8845,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This is defined as "ancient language" in the glossary of {KGT:src}, but glossed as "ancestors' language" on p.12.</column>
           <column name="components">{no':n}, {Hol:n}</column>
           <column name="examples"></column>
@@ -8033,6 +8855,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8040,6 +8863,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -8053,6 +8877,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="definition_ru">генеалогия [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">家譜 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Genealogia</column>
+      <column name="definition_fi">sukututkimus</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{rayQeD:n}, {QeD:n}, {no'tej:n}</column>
@@ -8063,6 +8888,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{no':n}, {QeD:n}</column>
           <column name="examples"></column>
@@ -8072,6 +8898,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8079,6 +8906,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 26 (2019):src}</column>
         </table>
         <table name="mem">
@@ -8092,6 +8920,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="definition_ru">специалист по генеалогии [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">家譜學家 [AUTOTRANSLATED]</column>
           <column name="definition_pt">genealogista</column>
+      <column name="definition_fi">sukututkija</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{no'QeD:n}, {tej:n}</column>
@@ -8102,6 +8931,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word does not appear in canon, but is an obvious construction based on {no'QeD:n:nolink}.</column>
           <column name="components">{no':n}, {tej:n}</column>
           <column name="examples"></column>
@@ -8111,6 +8941,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">no' tej</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8118,6 +8949,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -8132,6 +8964,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">гостиная, гостиная, салон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">客廳，休息室，客廳 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sala de estar, salão</column>
+      <column name="definition_fi">olohuone, salonki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa':n:1}</column>
@@ -8142,6 +8975,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Salon" backwards.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8151,6 +8985,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">salon</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8158,6 +8993,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8171,6 +9007,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">сера [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">硫黃</column>
       <column name="definition_pt">enxofre</column>
+      <column name="definition_fi">rikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}</column>
@@ -8181,6 +9018,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Pun: the smell of rotten ({non:v}) egg.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8190,6 +9028,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sulphur</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8197,6 +9036,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -8210,6 +9050,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">лоб</column>
       <column name="definition_zh_HK">額頭</column>
       <column name="definition_pt">testa</column>
+      <column name="definition_fi">otsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quch:n}</column>
@@ -8220,6 +9061,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8229,6 +9071,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8236,6 +9079,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8249,6 +9093,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">он/она/они/оно(действие)-нам</column>
       <column name="definition_zh_HK">他、它、他們、它們：我們</column>
       <column name="definition_pt">ele/ela-nós, eles-nós</column>
+      <column name="definition_fi">hän/se/he/ne-meitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wI-:v:pref}, {DI-:v:pref}</column>
       <column name="see_also">{mu-:v:pref}</column>
@@ -8259,6 +9104,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n}: {maH:n:1h} = {nu-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8268,6 +9114,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">he-us, she-us, it-us</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8275,6 +9122,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru">он-нам, она-нам, они-нам, оно-нам</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8288,6 +9136,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">быть подозреваемым в чем-то, быть подозрительным</column>
       <column name="definition_zh_HK">要懷疑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser suspeito</column>
+      <column name="definition_fi">olla epäilyttävä, arveluttava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIH:v:2}, {qagh Sopbe'!:sen}</column>
@@ -8298,6 +9147,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8307,6 +9157,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8314,6 +9165,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8328,6 +9180,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">предшественник, предок</column>
       <column name="definition_zh_HK">前任 [AUTOTRANSLATED]</column>
       <column name="definition_pt">predecessor</column>
+      <column name="definition_fi">edeltäjä</column>
       <column name="synonyms">{nungwI':n@@nung:v, -wI':v}</column>
       <column name="antonyms">{cho'wI':n@@cho':v, -wI':v}</column>
       <column name="see_also">{nung:v}, {cho':v}, {'ISyar:n}</column>
@@ -8338,6 +9191,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The joke is that the definition of this word is one which is suspect, since {nub:v} means "be suspect". Also, this word is before {nung:v} in {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8348,6 +9202,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8355,6 +9210,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8368,6 +9224,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Трус</column>
       <column name="definition_zh_HK">膽小鬼、懦夫</column>
       <column name="definition_pt">covarde</column>
+      <column name="definition_fi">pelkuri</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yoHwI':n}</column>
       <column name="see_also">{qorvaq:n:name}, {qagh Sopbe'!:sen}</column>
@@ -8378,6 +9235,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Смотрите, как Гаурон говорит {nuchpu':n@@nuch:n, -pu':n}: {YouTube video:url:http://youtu.be/VEQMLy2X2Y8}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Katso Gowronin sanovan {nuchpu':n@@nuch:n, -pu':n}: {YouTube video:url:http://youtu.be/VEQMLy2X2Y8} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8387,6 +9245,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8394,6 +9253,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8407,6 +9267,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">аспирин</column>
       <column name="definition_zh_HK">阿司匹林 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aspirina</column>
+      <column name="definition_fi">aspiriini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wuQ:v}, {'uH:v}</column>
@@ -8417,6 +9278,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuch:n}, {Hergh:n}</column>
       <column name="examples"></column>
@@ -8426,6 +9288,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8433,6 +9296,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8446,6 +9310,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">исследовать, проверять, обследовать, экзаменовать, опрашивать, освидетельствовать</column>
       <column name="definition_zh_HK">檢查 [AUTOTRANSLATED]</column>
       <column name="definition_pt">examinar, testar</column>
+      <column name="definition_fi">tutkia, tarkastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noH:v}, {chov:v}, {Hotlh:v:2}, {yoj:n}, {waH:v:1}, {tob:v}, {Daj:v:2}</column>
@@ -8456,6 +9321,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Nude".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8465,6 +9331,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8472,6 +9339,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8485,6 +9353,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">общество, группа людей с общей культурой</column>
       <column name="definition_zh_HK">社會;一群有共同文化的人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sociedade; grupo de pessoas com cultura compartilhada</column>
+      <column name="definition_fi">yhteiskunta; ryhmä ihmisiä, joilla on sama kulttuuri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tayqeq:n}, {qutluch patlh:n}, {vInDa':n}, {meHghem:n}</column>
@@ -8495,6 +9364,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Не путать с обществом в научном смысле, для которого есть слово {yej'an:n}.[3]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Não confunda isso com uma sociedade no sentido acadêmico, chamado {yej'an:n}.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita tätä tieteellisessä mielessä yhteiskuntaan, jota kutsutaan {yej'an:n}.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8504,6 +9374,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8511,6 +9382,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {HQ 4.4, p.11:src}</column>
     </table>
         <table name="mem">
@@ -8524,6 +9396,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="definition_ru">Социология</column>
           <column name="definition_zh_HK">社會學 [AUTOTRANSLATED]</column>
           <column name="definition_pt">sociologia</column>
+      <column name="definition_fi">sosiologia</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nugh:n}, {QeD:n}, {nughtej:n}</column>
@@ -8534,6 +9407,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word was used in the title of a thesis in sociology, "Klingon as Linguistic Capital: A Sociologic Study of Nineteen Advanced Klingonists" {Hol Sup 'oH tlhIngan Hol'e'; wa'maH Hut tlhIngan Hol po'wI' nughQeD:sen:nolink}, by Yens Wahlgren. This usage was approved by MO.[1]</column>
           <column name="components">{nugh:n}, {QeD:n}</column>
           <column name="examples"></column>
@@ -8543,6 +9417,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8550,6 +9425,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2005.01.18:src}</column>
         </table>
         <table name="mem">
@@ -8563,6 +9439,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="definition_ru">социолог [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">社會學家 [AUTOTRANSLATED]</column>
           <column name="definition_pt">sociólogo</column>
+      <column name="definition_fi">sosiologi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nughQeD:n}, {tej:n}</column>
@@ -8573,6 +9450,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word does not appear in canon, but is an obvious construction based on {nughQeD:n:nolink}.</column>
           <column name="components">{nugh:n}, {tej:n}</column>
           <column name="examples"></column>
@@ -8582,6 +9460,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">nugh tej</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8589,6 +9468,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -8602,6 +9482,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">крутить кулаком в чью-то голову [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">扭轉進入某人的頭部 [AUTOTRANSLATED]</column>
       <column name="definition_pt">torcer a junta na cabeça de alguém</column>
+      <column name="definition_fi">hieroa rystyset jonkun päähän?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8612,6 +9493,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Noogie".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8621,6 +9503,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8628,6 +9511,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8641,6 +9525,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">оружие</column>
       <column name="definition_zh_HK">武器</column>
       <column name="definition_pt">arma</column>
+      <column name="definition_fi">ase</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIch:n}</column>
@@ -8651,6 +9536,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Nuke".</column>
       <column name="components"></column>
       <column name="examples">
@@ -8662,6 +9548,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8669,6 +9556,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8682,6 +9570,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Возможность, вероятность, перспектива</column>
       <column name="definition_zh_HK">可能性 [AUTOTRANSLATED]</column>
       <column name="definition_pt">possibilidade</column>
+      <column name="definition_fi">mahdollisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8692,6 +9581,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">На это влияет произношением слова {DuH:n} в {Qotmagh Sep:n}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tähän vaikuttaa {DuH:n}: n {Qotmagh Sep:n}-ääntäminen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8701,6 +9591,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8708,6 +9599,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8721,6 +9613,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Гордость оружия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">武器的驕傲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Orgulho de Armas</column>
+      <column name="definition_fi">aseteline, Aseiden ylpeys?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quv bey':n}, {betleH bey':n}</column>
@@ -8731,6 +9624,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">{nuH bey':n:nolink} имеет один {betleH:n}, один {naQjej:n} и один {ghop 'etlh:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{nuH bey':n:nolink}具有一個{betleH:n}，一個{naQjej:n}和一個{ghop 'etlh:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um {nuH bey':n:nolink} possui um {betleH:n}, um {naQjej:n} e um {ghop 'etlh:n}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{nuH bey':n:nolink}: llä on yksi {betleH:n}, yksi {naQjej:n} ja yksi {ghop 'etlh:n}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">There is also a picture of one on {TKW p.124:src}.</column>
       <column name="components">{nuH:n:1}, {bey':n}</column>
       <column name="examples"></column>
@@ -8740,6 +9634,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8747,6 +9642,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -8760,6 +9656,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">силовой кабель для оружия (а) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">武器電力管道 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conduíte de força das armas</column>
+      <column name="definition_fi">aseen voimajohdin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8770,6 +9667,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuH:n:1}, {HoS:n:1}, {'och:n}</column>
       <column name="examples"></column>
@@ -8779,6 +9677,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8786,6 +9685,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -8799,6 +9699,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">малое оружие</column>
       <column name="definition_zh_HK">小武器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">armas pequenas</column>
+      <column name="definition_fi">käsiase</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8809,6 +9710,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Despite the English definition, this may not necessarily be plural in Klingon.</column>
       <column name="components">{nuH:n:1}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -8818,6 +9720,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8825,6 +9728,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8838,6 +9742,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Вы выбрали своё оружие, сражайтесь!</column>
       <column name="definition_zh_HK">你選擇了你的武器，打啦！</column>
       <column name="definition_pt">Você escolheu sua arma, então lute!</column>
+      <column name="definition_fi">Olet valinnut aseesi, joten taistele!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8848,6 +9753,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuH:n:1}, {-lIj:n}, {Da-:v}, {wIv:v}, {-pu':v}, {vaj:adv}, {yI-:v}, {Suv:v}</column>
       <column name="examples"></column>
@@ -8857,6 +9763,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8864,6 +9771,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.151:src}</column>
     </table>
     <table name="mem">
@@ -8877,6 +9785,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">арсенал</column>
       <column name="definition_zh_HK">武器庫</column>
       <column name="definition_pt">arsenal</column>
+      <column name="definition_fi">aseistus, asevarasto, arsenaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8887,6 +9796,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuH:n:1}, {-mey:n}</column>
       <column name="examples"></column>
@@ -8896,6 +9806,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8903,6 +9814,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8916,6 +9828,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">офицер по оружию [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">武器官 [AUTOTRANSLATED]</column>
       <column name="definition_pt">oficial de armas</column>
+      <column name="definition_fi">aseupseeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8926,6 +9839,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuH:n:1}, {pIn:n:1}</column>
       <column name="examples"></column>
@@ -8935,6 +9849,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8942,6 +9857,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8955,6 +9871,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Они просканировали нас?</column>
       <column name="definition_zh_HK">他們掃描過我們了嗎？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eles nos escanearam?</column>
+      <column name="definition_fi">Ovatko he skannanneet meidät?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8965,6 +9882,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nu-:v}, {Hotlh:v:2}, {-pu':v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -8974,6 +9892,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8981,6 +9900,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.44:src}</column>
     </table>
     <table name="mem">
@@ -8994,6 +9914,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">рот</column>
       <column name="definition_zh_HK">口</column>
       <column name="definition_pt">boca</column>
+      <column name="definition_fi">suu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jat:n}, {qab:n}, {wuS:n}, {qevpob:n}, {Ho':n:1}, {tlhepQe':n}, {lev:n}, {ghapqa':n}, {repnuj:n}</column>
@@ -9004,6 +9925,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9013,6 +9935,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9020,6 +9943,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9033,6 +9957,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">способствовать, поощрять, продвигать, стимулировать</column>
       <column name="definition_zh_HK">促進 [AUTOTRANSLATED]</column>
       <column name="definition_pt">promover</column>
+      <column name="definition_fi">ylentää; edistää, tukea, mainostaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{patlh:n}, {patlhmoH:v}</column>
@@ -9043,6 +9968,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Данное слово означает, как продвижение кого-то по рангу, так и рекламирование какой-то деятельности или поддержки с какой-то целью.</column>
       <column name="notes_zh_HK">這個詞在提高某人的等級和宣傳一項活動或倡導一項事業的意義上都意味著“促進”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra significa "promover", tanto no sentido de aumentar a classificação de alguém quanto no sentido de anunciar uma atividade ou advogar por uma causa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana tarkoittaa "mainosta" sekä merkityksessä jonkun sijoituksen nostamiseksi että toiminnan mainostamiseksi tai asian puolustamiseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The "Friend of Maltz" certificates are considered by some to be non-canon (since it's unclear which parts of the text came from the KLI and which were provided by Marc Okrand), but the Pop Culture Hero Coalition announcement (which was translated by Marc Okrand) uses {num:v:nolink} with the same meaning.</column>
       <column name="components"></column>
       <column name="examples">
@@ -9058,6 +9984,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
 ▶ {qum DuSaQmeyDaq 'Irghbe'meH ghotpu' nabmey ghojmoH, 'ej pIj tay'taH Doch pIm num.:sen:nolink} "В общих школах, это учит процедурам, чтобы людей не запугивали, и это пропагандирует бесконечное многообразие в бесконечных комбинациях."[4]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">advertise, nominate</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9065,6 +9992,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {matlh jupna':src}, [3] {Klingon Monopoly:src}, [4] {Pop Culture Hero Coalition announcement:src} ({KLI mailing list 2016.11.30:src})</column>
     </table>
     <table name="mem">
@@ -9078,6 +10006,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">предшествовать, предпосылать, стоять или идти перед</column>
       <column name="definition_zh_HK">優於 [AUTOTRANSLATED]</column>
       <column name="definition_pt">preceder</column>
+      <column name="definition_fi">edeltää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nubwI':n}, {vorgh:v}, {veb:v}, {Deq:v}</column>
@@ -9088,6 +10017,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru">Чтобы упомянуть предшествующий день, месяц, или год, используются {Hu':n}, {wen:n}, и {ben:n:1}, соответственно.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Para se referir ao dia, mês ou ano anterior, considere usar {Hu':n}, {wen:n} e {ben:n:1}, respectivamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat viitata edelliseen päivään, kuukauteen tai vuoteen, harkitse {Hu':n}-, {wen:n}- ja {ben:n:1}-vastaavien käyttöä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">While {nungbogh:v:nolink} precedes a noun, {veb:v:nolink} comes after one.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9097,6 +10027,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">previous, prior, before, last</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9104,6 +10035,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9117,6 +10049,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">гибридный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雜種 [AUTOTRANSLATED]</column>
       <column name="definition_pt">híbrido</column>
+      <column name="definition_fi">hybridi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boqyIn:n}</column>
@@ -9127,6 +10060,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reverse combination of {Ham:v} "be high-pitched" and {ngun:v} "perch" (like a bird does). "High" + "bird" = "hybrid".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9136,6 +10070,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9143,6 +10078,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9156,6 +10092,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">уменьшать, идти на убывание, уменьшаться</column>
       <column name="definition_zh_HK">減少 [AUTOTRANSLATED]</column>
       <column name="definition_pt">diminuir</column>
+      <column name="definition_fi">laskea, vähetä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghur:v}</column>
@@ -9166,6 +10103,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">MO confirmed at {Saarbrücken qepHom'a' 2011:src} that {nup:v:nolink} is intransitive.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9175,6 +10113,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">reduce</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9182,6 +10121,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9195,6 +10135,7 @@ It's probably a coincidence, but نوک is also the Persian word for "nipple".</
       <column name="definition_ru">Что?</column>
       <column name="definition_zh_HK">什麼？</column>
       <column name="definition_pt">o quê?</column>
+      <column name="definition_fi">mikä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9209,6 +10150,11 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sana sopii lauseeseen siinä paikassa, johon vastaus vie .[1] Se toimii kuten pronomini kysymyksissä, joissa englanninkielisissä käännöksissä on "olla".
+
+Englanninkieliset kysymykset vastaavat usein luonnollisemmin Klingonin vaatimuksia. Jos haluat kysyä "mitä" -kysymyksen, harkitse sen sijaan komennon käyttämistä verbillä, kuten {ngu':v}. [2] Harkitse esimerkiksi {per:v}, {ja':v}, {Del:v} jne.
+
+Huomaa myös, että "Mitkä ovat tilauksesi?" ilmaistaan ​​Klingonissa nimellä {chay 'jura'?: sen} Katso {chay':ques}.[2]{chay' jura'?:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9224,6 +10170,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
 ▶ {Dochvam nuq?:sen}</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9231,6 +10178,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.4:src}, [2] {msn 1996.12.12:src}, [3] {CK:src}</column>
     </table>
     <table name="mem">
@@ -9244,6 +10192,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Где?</column>
       <column name="definition_zh_HK">哪裡？</column>
       <column name="definition_pt">onde?</column>
+      <column name="definition_fi">missä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -9255,6 +10204,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru">Это просто {nuq:ques} плюс {-Daq:n:suff}.[1, p.69]</column>
       <column name="notes_zh_HK">這只是{nuq:ques}加上{-Daq:n:suff}。 [1, p.69][AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on vain {nuq:ques} plus {-Daq:n:suff}.[1, p.69] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9264,6 +10214,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9271,6 +10222,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9284,6 +10236,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Куда мне это положить? Что мне с этим делать?</column>
       <column name="definition_zh_HK">我把它放在哪裡？我該怎麼辦？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Onde eu coloco isto? O que eu faço com isto?</column>
+      <column name="definition_fi">Minne panen tämän? Mitä teen tällä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chay' Dochvam vIlo'?:sen}</column>
@@ -9294,6 +10247,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {Doch:n}, {-vam:n}, {vI-:v}, {lan:v}</column>
       <column name="examples"></column>
@@ -9303,6 +10257,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9310,6 +10265,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -9323,6 +10279,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Где я сплю?</column>
       <column name="definition_zh_HK">我在哪裡睡覺？我係邊度瞓?</column>
       <column name="definition_pt">Onde eu durmo?</column>
+      <column name="definition_fi">Missä nukun?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9333,6 +10290,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {jI-:v}, {Qong:v}</column>
       <column name="examples"></column>
@@ -9342,6 +10300,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9349,6 +10308,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -9362,6 +10322,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Where is the beach? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">海灘在哪？</column>
       <column name="definition_pt">Onde é a praia?</column>
+      <column name="definition_fi">Missä ranta on?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIQ'a' HeH:n}</column>
@@ -9372,6 +10333,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {'oH:n:pro}, {bIQ'a' HeH:n}, {-'e':n:suff}</column>
       <column name="examples"></column>
@@ -9381,6 +10343,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9388,6 +10351,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -9401,6 +10365,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Где ванная?</column>
       <column name="definition_zh_HK">洗手間在哪裡？</column>
       <column name="definition_pt">Onde fica o banheiro?</column>
+      <column name="definition_fi">Missä kylpyhuone on?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puchpa':n}</column>
@@ -9411,6 +10376,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru">Смотрите урок по этой фразе: {YouTube video:url:http://youtu.be/EMipQm5JZgI}</column>
       <column name="notes_zh_HK">觀看有關此短語的課程：{YouTube video:url:http://youtu.be/EMipQm5JZgI} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista a uma lição sobre esta frase: {YouTube video:url:http://youtu.be/EMipQm5JZgI} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso oppitunti tästä lauseesta: {YouTube video:url:http://youtu.be/EMipQm5JZgI} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {'oH:n:pro}, {puchpa':n}, {-'e':n:suff}</column>
       <column name="examples"></column>
@@ -9420,6 +10386,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">washroom</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9427,6 +10394,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -9440,6 +10408,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Где хороший ресторан?</column>
       <column name="definition_zh_HK">一家好餐館在哪裡啊？</column>
       <column name="definition_pt">Onde é um bom restaurante?</column>
+      <column name="definition_fi">Missä on hyvä ravintola?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qe':n}</column>
@@ -9450,6 +10419,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {'oH:n:pro}, {Qe':n}, {QaQ:v}, {-'e':n:suff}</column>
       <column name="examples"></column>
@@ -9459,6 +10429,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9466,6 +10437,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -9479,6 +10451,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Где ты держишь шоколад?</column>
       <column name="definition_zh_HK">你把巧克力放在哪裡？</column>
       <column name="definition_pt">Onde você guarda o chocolate?</column>
+      <column name="definition_fi">Missä pidät suklaan?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9489,6 +10462,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {yuch:n}, {Da-:v}, {pol:v}</column>
       <column name="examples"></column>
@@ -9498,6 +10472,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9505,6 +10480,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -9518,6 +10494,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Что ты сказал? А? Что?</column>
       <column name="definition_zh_HK">你說什麼？</column>
       <column name="definition_pt">o que você disse? Hã? que?</column>
+      <column name="definition_fi">mitä sanoit?, mitä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuq:ques}, {jatlh:v}</column>
@@ -9528,6 +10505,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="notes_ru">Является укороченным вариантом фразы {nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v}</column>
       <column name="notes_zh_HK">這是在修剪過的克林崗語中。問“你說了什麼？”的語法方式會是{nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso está no Klingon cortado. A maneira gramatical de perguntar "O que você disse?" seria {nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on leikattu Klingon. Kieliopillinen tapa kysyä "Mitä sanoit?" olisi {nuq Dajatlh?: sen @@ nuq: ques, Da-: v, jatlh: v}{nuq Dajatlh?:sen@@nuq:ques, Da-:v, jatlh:v} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9537,6 +10515,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9544,6 +10523,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -9557,6 +10537,7 @@ Also, note that "What are your orders?" is expressed in Klingon as {chay' jura'?
       <column name="definition_ru">Что тебе нужно? Что ты хочешь?</column>
       <column name="definition_zh_HK">你想要什麼？</column>
       <column name="definition_pt">o que você quer? (saudação)</column>
+      <column name="definition_fi">Mitä haluat? (tervehdys)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuq:ques}, {neH:v}</column>
@@ -9579,6 +10560,13 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
 Смотрите урок по этому слову: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä huutomerkki ei vastaa "hei". Tervehdytetyn osapuolen odotetaan yksinkertaisesti aloittavan puhumisen eikä palauttavan tervehdyksen
+
+Huomaa, että tämä huutomerkki on leikattu klingon. Kieliopillinen tapa kysyä "Mitä haluat?" olisi {nuq DaneH?: sen @@ nuq: ques, Da-: v, neH: v} [2]
+
+Katso Gowronin sanovan tämä: {YouTube video:url:http://youtu.be/s10kg0C_hSM}
+
+Katso oppitunti tästä sanasta: {YouTube video:url:http://youtu.be/auqS6FR_RDE}[2; 3]{nuq DaneH?:sen@@nuq:ques, Da-:v, neH:v} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9588,6 +10576,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hello, greeting, greetings</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9595,6 +10584,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.184:src}, [3] {msn 1997.09.01:src}</column>
     </table>
     <table name="mem">
@@ -9608,6 +10598,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">Какой у тебя номер?</column>
       <column name="definition_zh_HK">你的號碼是什麼？</column>
       <column name="definition_pt">Qual é o seu número?</column>
+      <column name="definition_fi">Mikä on numerosi?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghogh HablI':n}</column>
@@ -9618,6 +10609,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {CK:src}, the Klingon hotel clerk asks the Terran visitor, {nuq mI'lIj, tera'ngan?:sen:nolink} But this question works as well for telephone numbers as it does for hotel guest numbers.</column>
       <column name="components">{nuq:ques}, {mI':n}, {-lIj:n}</column>
       <column name="examples"></column>
@@ -9627,6 +10619,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9634,6 +10627,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -9647,6 +10641,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">{Dochvam nuq?:sen}</column>
       <column name="definition_zh_HK">{Dochvam nuq?:sen}</column>
       <column name="definition_pt">{Dochvam nuq?:sen}</column>
+      <column name="definition_fi">{Dochvam nuq?:sen}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9657,6 +10652,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuq:ques}, {'oH:n}, {Doch:n}, {-vam:n}, {-'e':n}</column>
       <column name="examples"></column>
@@ -9666,6 +10662,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9673,6 +10670,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9686,6 +10684,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">раздражать, мешать, препятствовать, беспокоить, тормошить, докучать, надоедать</column>
       <column name="definition_zh_HK">煩惱、打擾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">irritar, incomodar</column>
+      <column name="definition_fi">ärsyttää, vaivata</column>
       <column name="synonyms">{yIv:v:2}, {berghmoH:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{puQ:v}, {bergh:v}</column>
@@ -9696,6 +10695,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9705,6 +10705,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9712,6 +10713,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9725,6 +10727,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">достоинство, сан, титул</column>
       <column name="definition_zh_HK">尊嚴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dignidade</column>
+      <column name="definition_fi">arvokkuus, ihmisarvo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'quj nge':sen:idiom}, {Hem:v}, {le'yo':n}</column>
@@ -9735,6 +10738,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9744,6 +10748,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9751,6 +10756,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9764,6 +10770,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">Нейрал</column>
       <column name="definition_zh_HK">Neural [AUTOTRANSLATED]</column>
       <column name="definition_pt">Neural</column>
+      <column name="definition_fi">Neural</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuralngan:n}</column>
@@ -9774,6 +10781,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru">Название планеты класса "М", являющейся домом для {mughato':n}.</column>
       <column name="notes_zh_HK">這是{mughato':n}所在地M類行星的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um planeta de classe M que abriga o {mughato':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on luokan M planeetan nimi, jolla asuu {mughato':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9783,6 +10791,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9790,6 +10799,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9803,6 +10813,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">Нейралезец</column>
       <column name="definition_zh_HK">Neuralese [AUTOTRANSLATED]</column>
       <column name="definition_pt">Neuralese</column>
+      <column name="definition_fi">neurallainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nural:n}</column>
@@ -9813,6 +10824,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nural:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -9822,6 +10834,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9829,6 +10842,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9842,6 +10856,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">высмеивать, осмеивать, поднимать на смех</column>
       <column name="definition_zh_HK">嘲笑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ridículo</column>
+      <column name="definition_fi">pitää pilkkanaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaq:v}, {tIch:v}</column>
@@ -9852,6 +10867,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9861,6 +10877,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9868,6 +10885,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9881,6 +10899,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">Персона (гуманойд)</column>
       <column name="definition_zh_HK">人（人形） [AUTOTRANSLATED]</column>
       <column name="definition_pt">pessoa (humanoide)</column>
+      <column name="definition_fi">henkilö</column>
       <column name="synonyms">{ghot:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{Dep:n}, {yoq:n}</column>
@@ -9891,6 +10910,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Quando essa palavra é plural, ela se concentra mais no grupo como um todo do que nos indivíduos. Portanto, {nuvpu':n@@nuv:n, -pu':n} provavelmente seria traduzido como "pessoas" (em vez de "pessoas"), mas essa não é uma regra estrita.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun tämä sana on monikko, se keskittyy enemmän koko ryhmään kuin yksilöihin. Joten {nuvpu':n@@nuv:n, -pu':n} käännetään todennäköisesti "ihmisiksi" (eikä "henkilöiksi"), mutta tämä ei ole tiukka sääntö.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9932,6 +10952,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
    Тысяч, и тех, кто прийдет."[2, p.171]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">people</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9939,6 +10960,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}, [3] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -9952,6 +10974,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="definition_ru">быть особенно маленьким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">特別小 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser particularmente pequeno</column>
+      <column name="definition_fi">olla erityisen pieni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mach:v}</column>
@@ -9962,6 +10985,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="notes_ru">Это часто используется из вещей, которые меньше, чем обычный или ожидаемый размер. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">通常用於小於通常或預期大小的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso geralmente é usado para itens menores que o tamanho usual ou esperado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään usein tavallista tai odotettua kokoa pienemmissä asioissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Made of two letters used as symbols for very small things. The letter "n" is an abbreviation for the prefix "nano", while "u" is often used instead of "μ" as an abbreviation for "micro".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9971,6 +10995,7 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">miniature, tiny</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9978,5 +11003,6 @@ Watch a lesson on this word: {YouTube video:url:http://youtu.be/auqS6FR_RDE}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>

--- a/mem-10-ng.xml
+++ b/mem-10-ng.xml
@@ -2602,7 +2602,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_pt"></column>
       <column name="notes_fi">Tämä sana viittaa henkilöön, vaikka sitä voidaan käyttää sanan "myymälä" tai "myymälä" kääntämiseen asiayhteydessä siinä mielessä, että Klingonissa sanotaan, että menee apteekkiin pikemminkin kuin apteekkiin.
 
-Kohdassa {TNK:src} "Missä kauppa on?" käännetään nimellä {nuqDaq ghaH ngevwI''e '?: sen: nolink} (kirjaimellisesti "missä myyjä on?") Huomaa, että käytetään {ghaH:n}: ta {'oH:n}: n sijaan.{nuqDaq ghaH ngevwI''e'?:sen:nolink} [AUTOTRANSLATED]</column>
+Kohdassa {TNK:src} "Missä kauppa on?" käännetään nimellä {nuqDaq ghaH ngevwI''e'?:sen:nolink} (kirjaimellisesti "missä myyjä on?") Huomaa, että käytetään {ghaH:n}: ta {'oH:n}: n sijaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3036,7 +3036,7 @@ Kohdassa {TNK:src} "Missä kauppa on?" käännetään nimellä {nuqDaq ghaH ngev
       <column name="notes_ru">Слово использовано в {TNK:src} в предложении {nuqDaq puH Duj vIngIp?:sen:nolink}, которое означает "Где я могу взять машину напрокат?" Тем не менее, не совсем ясно, что Клингонское предложение выражает идею, что машина взята напрокат за деньги.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta palavra é usada em {TNK:src} na frase {nuqDaq puH Duj vIngIp?:sen:nolink} para significar "Onde posso alugar (alugar) um carro?" No entanto, não está claro que a sentença de Klingon exprima a ideia de que o carro deve ser emprestado por dinheiro. [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Tätä sanaa käytetään {TNK:src}-lauseessa lauseessa {nuqDaq puH Duj vIngIp?: Sen: nolink} tarkoittamaan "Mistä voin vuokrata (vuokrata) auton?" Ei ole kuitenkaan selvää, että Klingonin lause ilmaisee ajatuksen, että auto on lainattava rahaksi.{nuqDaq puH Duj vIngIp?:sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään {TNK:src}-lauseessa lauseessa {nuqDaq puH Duj vIngIp?:sen:nolink} tarkoittamaan "Mistä voin vuokrata (vuokrata) auton?" Ei ole kuitenkaan selvää, että Klingonin lause ilmaisee ajatuksen, että auto on lainattava rahaksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5320,9 +5320,9 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
-      <column name="notes_fi">Tätä sanaa käytetään harvoin paitsi kysymyksessä {chay 'nguv?: Sen: nolink} tai kun se liitetään {-moH:v}-muotoon muodostaen {nguvmoH:v}.
+      <column name="notes_fi">Tätä sanaa käytetään harvoin paitsi kysymyksessä {chay 'nguv?:sen:nolink} tai kun se liitetään {-moH:v}-muotoon muodostaen {nguvmoH:v}.
 
-{chIS:v}: n ja {qIj:v}: n lisäksi klingonissa on vain kaksi tunnettua värisanaa, {Doq:v} ja {SuD:v:1}. Kaksi viimeksi mainittua sanaa lisätään {-qu':v}: llä ja / tai yhdistetään {chay' nguv?:sen:nolink}0: n ja {Hurgh:v}: n kanssa tarkempien värien viittaamiseksi. Vielä tarkemmin sanottuna käytetään vertailuja, kuten {Doq 'ej Qaj wuS rur:sen}.[1, p.82]{wov:v} [AUTOTRANSLATED]</column>
+{chIS:v}: n ja {qIj:v}: n lisäksi klingonissa on vain kaksi tunnettua värisanaa, {Doq:v} ja {SuD:v:1}. Kaksi viimeksi mainittua sanaa lisätään {-qu':v}: llä ja / tai yhdistetään {wov:v}: n ja {Hurgh:v}: n kanssa tarkempien värien viittaamiseksi. Vielä tarkemmin sanottuna käytetään vertailuja, kuten {Doq 'ej Qaj wuS rur:sen}.[1, p.82] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>

--- a/mem-10-ng.xml
+++ b/mem-10-ng.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {ng:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{ng:sen:nolink}</column>
       <column name="definition_pt">a consoante {ng:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {ng:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">исчезать, пропадать, скрываться, сгинуть</column>
       <column name="definition_zh_HK">消失</column>
       <column name="definition_pt">desaparecer, sumir</column>
+      <column name="definition_fi">kadota</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nargh:v:1}</column>
       <column name="see_also"></column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">обсуждать, спорить, дискутировать, оспаривать</column>
       <column name="definition_zh_HK">辯論</column>
       <column name="definition_pt">debater</column>
+      <column name="definition_fi">väitellä, keskustella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoH:v}, {tlhoch:v}, {pon:v}, {Sol:v}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">быть стабильным, быть устойчивым, быть стойким, быть сбалансированным, быть уравновешенным</column>
       <column name="definition_zh_HK">穩定、穩固</column>
       <column name="definition_pt">ser estável, ser equilibrado</column>
+      <column name="definition_fi">olla vakaa, olla tasapainoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ratlh:v}, {choH:v}, {Duj ngaDHa':n}</column>
@@ -136,6 +149,7 @@
       <column name="notes_ru">Это слово относится к физической стабильности. Чтобы упомянуть о нестабильном человеке, используйте {ngIj:v}.[1, стр.150]</column>
       <column name="notes_zh_HK">這是指物理穩定性。要引用不穩定的人，請使用{ngIj:v}.[1, p.150] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à estabilidade física. Para se referir a uma pessoa instável, use {ngIj:v}.[1, p.150] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa fyysiseen vakauteen. Jos haluat viitata epävakaaseen henkilöön, käytä {ngIj:v}.[1, p.150] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -145,6 +159,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -152,6 +167,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -165,6 +181,7 @@
       <column name="definition_ru">стабилизировать, делать устойчивым</column>
       <column name="definition_zh_HK">穩定、安定</column>
       <column name="definition_pt">estabilizar</column>
+      <column name="definition_fi">vakauttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -175,6 +192,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ngaD:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -184,6 +202,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -191,6 +210,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -204,6 +224,7 @@
       <column name="definition_ru">Стабилизатор (компонет корабля)</column>
       <column name="definition_zh_HK">穩定器（船的組成部分）</column>
       <column name="definition_pt">estabilizador (componente de um navio)</column>
+      <column name="definition_fi">vakaaja (aluksessa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -214,6 +235,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ngaDmoH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -223,6 +245,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -230,6 +253,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -243,6 +267,7 @@
       <column name="definition_ru">встречаться с</column>
       <column name="definition_zh_HK">與……交配</column>
       <column name="definition_pt">acasalar com</column>
+      <column name="definition_fi">paritella jonkun kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nga'chuq:v}, {Sep:v}, {qey'Hav:n}, {'InSep:n}</column>
@@ -261,6 +286,9 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä sanaa voidaan soveltaa sekä ihmisiin että eläimiin.[4]
+
+Käsite "neitsyt" voidaan ilmaista sanalla kirjaimellisesti sanomalla, mikä neitsyt on, esimerkiksi {pagh ngaghpu'bogh be':n@@pagh:n:1, ngagh:v, -pu':v, -bogh:v, be':n} tai {not vay' ngaghpu'bogh be':n@@not:adv, vay':n, ngagh:v, -pu':v, -bogh:v, be':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -271,6 +299,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fuck, sex, virgin</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -278,6 +307,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {PK:src}, [3] {HQ 3.3, p.10-13, Sept. 1994:src}, [4] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -291,6 +321,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">squeeze (an object) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擠壓（一個物體） [AUTOTRANSLATED]</column>
       <column name="definition_pt">espremer (um objeto)</column>
+      <column name="definition_fi">puristaa jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeb:v}, {rey:v}, {qoch:v}</column>
@@ -301,6 +332,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru">Объект этого глагола - это то, что вы сжимаете, например, {Ha'on vevwI':n} или {nIqDob:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞的賓語是您擠壓的東西，例如{Ha'on vevwI':n}或{nIqDob:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto desse verbo é o que você aperta, por exemplo, {Ha'on vevwI':n} ou {nIqDob:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin tarkoitus on puristaa esimerkiksi {Ha'on vevwI':n} tai {nIqDob:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -310,6 +342,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -317,6 +350,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -330,6 +364,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">be short (in duration) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">短（持續時間）</column>
       <column name="definition_pt">ser curto (em duração)</column>
+      <column name="definition_fi">olla lyhyt (kestoltaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nI':v}</column>
       <column name="see_also"></column>
@@ -340,6 +375,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru">Не путайте это слово с {run:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">不要將此詞與{run:v}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda esta palavra com {run:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita tätä sanaa sanaan {run:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -349,6 +385,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">brief</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -356,6 +393,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -369,6 +407,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">пазл, загадка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">拼圖、謎語 [AUTOTRANSLATED]</column>
       <column name="definition_pt">quebra-cabeça, enigma</column>
+      <column name="definition_fi">pulma, arvoitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{poymar:n}, {Qay'mol:n}, {pan:v:2}</column>
@@ -379,6 +418,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru">Это относится к загадке или загадке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指虛構的謎題或謎語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um quebra-cabeça ou enigma inventado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tehtyyn palapeliin tai arvoitukseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{ngaj:v} and {run:v} make two "shorts". Will Shortz is a famous creator of puzzles.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -388,6 +428,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -395,6 +436,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -408,6 +450,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">быть жевательным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有耐嚼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser mastigável</column>
+      <column name="definition_fi">olla sitkeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chop:v}, {choptaH:v}, {noS:v}, {yIv:v:1}</column>
@@ -418,6 +461,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is the Cantonese word for "bite" or "chew" (咬).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -427,6 +471,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -434,6 +479,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -447,6 +493,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">придерживаться, придерживаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">黐</column>
       <column name="definition_pt">aderir, grudar</column>
+      <column name="definition_fi">tarttua, takertua, liimautua, kiinnittyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIr:v}, {nguD:v}</column>
@@ -457,6 +504,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru">То, что застряло, помечено {-Daq:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">被卡住的東西用{-Daq:n}標記。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O que está sendo preso é marcado com {-Daq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Juttu asia on merkitty {-Daq:n}-merkinnällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -466,6 +514,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -473,6 +522,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
         <table name="mem">
@@ -486,6 +536,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
           <column name="definition_ru">придерживаться (что-то другое) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">堅持（其他東西） [AUTOTRANSLATED]</column>
           <column name="definition_pt">grudar (uma coisa na outra)</column>
+      <column name="definition_fi">liimata, kiinnittää jotakin (johonkin)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -496,6 +547,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
           <column name="notes_ru">Объект сделан, чтобы придерживаться чего-то еще, что отмечено {-Daq:n}. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">使該對象粘附到其他物體上，並標有{-Daq:n}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">O objeto foi criado para aderir a outra coisa, marcada com {-Daq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on tehty tarttumaan johonkin muuhun, joka on merkitty {-Daq:n}-merkinnällä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes">This was used in the explanation of {ngam:v} and is given its own entry for convenience.</column>
           <column name="components">{ngam:v}, {-moH:v}</column>
           <column name="examples"></column>
@@ -505,6 +557,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -512,6 +565,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
     <table name="mem">
@@ -525,6 +579,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">глютен [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">麩質 [AUTOTRANSLATED]</column>
       <column name="definition_pt">glúten</column>
+      <column name="definition_fi">gluteeni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maHnaD:n}</column>
@@ -535,6 +590,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Latin word "gluten" means "to stick" ({ngam:v}). The presence of gluten may be important in restaurants ({Qe':n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -544,6 +600,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -551,6 +608,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -564,6 +622,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">житель, обитатель</column>
       <column name="definition_zh_HK">居民</column>
       <column name="definition_pt">habitante</column>
+      <column name="definition_fi">asukas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dab:v}, {Hol:n}, {Sung:n}</column>
@@ -574,6 +633,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">以{-ngan:sen:nolink}結尾的單詞通常被翻譯為“（某地）的人”或類似的意思，但更一般地，它可以僅表示一組生物，而不一定是來自特定位置的某物。[2]例如，{vulqangan:n}指的是“某人Vulcan”，但不知道{qelpIngan:n}是基於地名的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{-ngan:sen:nolink}-loppuinen sana käännetään yleensä "(paikkakunnan) ihmisiksi" tai vastaavaksi, mutta se voi yleisemmin ilmaista vain ryhmän olentoja, ei välttämättä tietystä paikasta tulevia olentoja. [2] viittaa esimerkiksi Vulcan ", mutta {qelpIngan:n}: n ei tiedetä perustuvan paikannimeen.{vulqangan:n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -583,6 +643,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -590,6 +651,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -603,6 +665,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">меняйся, меняйся [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">變化，變化 [AUTOTRANSLATED]</column>
       <column name="definition_pt">variar, ser variado</column>
+      <column name="definition_fi">poiketa, erota (normaalista), vaihdella; olla poikkeava, eroava, olla vaihteleva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sar:v}</column>
@@ -613,6 +676,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru">Этот глагол используется для выражения того, что что-то меняется или отклоняется от нормы или колеблется настолько сильно, что нормы нет. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞用於表示某些事物與規範有差異或有偏差，或者起伏很大以至於沒有規範。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo é usado para expressar que algo está variando ou se desviando da norma, ou está flutuando tanto que não existe uma norma. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään ilmaisemaan, että jokin asia vaihtelee tai poikkeaa normista tai vaihtelee niin paljon, ettei normia ole. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -622,6 +686,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -629,6 +694,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.01.16:src}</column>
     </table>
     <table name="mem">
@@ -642,6 +708,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">военная поддержка</column>
       <column name="definition_zh_HK">支持（軍事術語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">suporte (termo militar)</column>
+      <column name="definition_fi">tuki, huolto (sodassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghaq:v}</column>
@@ -652,6 +719,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -661,6 +729,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -668,6 +737,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -681,6 +751,7 @@ Begreppet "jungfru" kan uttryckas genom att bokstavligen säga vad en jungfru ä
       <column name="definition_ru">быть заблокированным, быть запечатанным, быть закрепленным, быть закрепленным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鎖定、密封、固定、固定 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser trancado, selado, protegido, preso</column>
+      <column name="definition_fi">olla lukittu, olla sinetöity, olla kiinnitetty</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaQHa'moHwI':n}, {SoQ:v}, {ngaQmoH:v:1}, {ngaQHa'moH:v:1}, {Durghang:n}</column>
@@ -705,6 +776,9 @@ För "låsning" på ett mål, se {'uch:v:2}, och överväg också {buS:v}. [AUTO
       <column name="notes_pt">Existe uma expressão idiomática, {ngaQ lojmIt:sen}, que significa que um resultado é inevitável ou um curso de ação irrevogável.
 
 Para "travar" em um destino, consulte {'uch:v:2} e também considere {buS:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On olemassa idiomaattinen ilmaisu {ngaQ lojmIt:sen}, mikä tarkoittaa, että tulos on väistämätön tai toimintatapa peruuttamaton.
+
+Katso kohdasta "lukitseminen" kohteeseen {'uch:v:2} ja ota huomioon myös {buS:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -715,6 +789,7 @@ Para "travar" em um destino, consulte {'uch:v:2} e também considere {buS:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be restrained</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -722,6 +797,7 @@ Para "travar" em um destino, consulte {'uch:v:2} e também considere {buS:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -735,6 +811,7 @@ Para "travar" em um destino, consulte {'uch:v:2} e também considere {buS:v}. [A
       <column name="definition_ru">замок, пломба, закрепить, закрепить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鎖，密封，固定，係緊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">travar, selar, fixar, apertar</column>
+      <column name="definition_fi">lukita, sinetöidä, kiinnittää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngaQHa'moH:v:1}</column>
       <column name="see_also">{Durghang:n}</column>
@@ -745,6 +822,7 @@ Para "travar" em um destino, consulte {'uch:v:2} e também considere {buS:v}. [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ngaQ:v}, {-moH:v}</column>
       <column name="examples">
@@ -755,6 +833,7 @@ Para "travar" em um destino, consulte {'uch:v:2} e também considere {buS:v}. [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -762,6 +841,7 @@ Para "travar" em um destino, consulte {'uch:v:2} e também considere {buS:v}. [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -775,6 +855,7 @@ Para "travar" em um destino, consulte {'uch:v:2} e também considere {buS:v}. [A
       <column name="definition_ru">выйти, выйти [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">登出、退出</column>
       <column name="definition_pt">desconectar, deslogar</column>
+      <column name="definition_fi">kirjautua ulos</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngaQHa'moH:v:2}</column>
       <column name="see_also"></column>
@@ -799,6 +880,9 @@ Man kan säga {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} och så vidare, men detta 
       <column name="notes_pt">Esta é uma extensão do significado de {ngaQmoH:v:1} aplicado a contas ({mab:n:2}).
 
 Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas este é um jargão especial ou forma congelada. Pode ter sido reduzido de uma frase anterior, como {mab Hung lojmIt ngaQmoH:sen@@mab:n:2, Hung:n, lojmIt:n, ngaQmoH:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on laajennus {ngaQmoH:v:1}-merkitykseen, jota sovelletaan tileihin ({mab:n:2}).
+
+Voidaan sanoa {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} ja niin edelleen, mutta tämä on erityinen argot tai jäädytetty muoto. Se on saatettu lyhentää aikaisemmasta lauseesta, kuten {mab Hung lojmIt ngaQmoH:sen@@mab:n:2, Hung:n, lojmIt:n, ngaQmoH:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngaQ:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -808,6 +892,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sign off, log off</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -815,6 +900,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -828,6 +914,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">разблокировать, распечатать, незащищенный, открепить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">解鎖，解封，不安全，解開 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desbloquear, destravar, retirar o selo, desatar, soltar</column>
+      <column name="definition_fi">avata, poistaa/rikkoa sinetti, vapauttaa, irrottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngaQmoH:v:1}</column>
       <column name="see_also"></column>
@@ -838,6 +925,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ngaQ:v}, {-Ha':v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -847,6 +935,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -854,6 +943,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -867,6 +957,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">войти, войти [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">登錄、簽到</column>
       <column name="definition_pt">iniciar sessão, logar</column>
+      <column name="definition_fi">kirjautua sisään</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngaQmoH:v:2}</column>
       <column name="see_also">{mab:n:2}, {qI':v:2}</column>
@@ -877,6 +968,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это расширение значения {ngaQHa'moH:v:1}, применяемого к учетным записям ({mab:n:2}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是應用於帳戶（{mab:n:2}）的{ngaQHa'moH:v:1}含義的擴展。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é uma extensão do significado de {ngaQHa'moH:v:1} aplicado às contas ({mab:n:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on laajennus {ngaQHa'moH:v:1}-merkitykseen, jota sovelletaan tileihin ({mab:n:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngaQ:v}, {-Ha':v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -886,6 +978,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sign on, log on</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -893,6 +986,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -906,6 +1000,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">ключ</column>
       <column name="definition_zh_HK">鍵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chave</column>
+      <column name="definition_fi">avain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lojmIt:n}, {Durghang:n}</column>
@@ -916,6 +1011,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">For something like a keycard, some Klingon speakers unofficially use {lojmIt chaw':n:nolink}.</column>
       <column name="components">{ngaQHa'moH:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -925,6 +1021,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -932,6 +1029,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -945,6 +1043,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">дверь заперта [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">門被鎖了</column>
       <column name="definition_pt">a porta está trancada</column>
+      <column name="definition_fi">ovi on lukossa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -955,6 +1054,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это идиоматическое выражение означает, что ситуация имеет неизбежный результат, или план или обязательство являются твердыми и не могут быть изменены. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語表示情況有不可避免的結果，或者計劃或承諾堅定而不能改變。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa que uma situação tem um resultado inevitável ou um plano ou compromisso é firme e não pode ser alterado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaus tarkoittaa, että tilanteella on väistämätön lopputulos, tai suunnitelma tai sitoutuminen on vakaa eikä sitä voida muuttaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -964,6 +1064,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -971,6 +1072,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.108:src}, [2] {TKW p.186:src}</column>
     </table>
     <table name="mem">
@@ -984,6 +1086,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">быть чудесным, сверхъестественным, чудесным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">神奇、超自然、奇妙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser milagroso, ser sobrenatural, ser maravilhoso</column>
+      <column name="definition_fi">olla ihmeellinen, yliluonnollinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boqHar:n}, {but:v}</column>
@@ -994,6 +1097,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1003,6 +1107,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1010,6 +1115,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -1023,6 +1129,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">содержать что-то внутри себя</column>
       <column name="definition_zh_HK">包含（內有） [AUTOTRANSLATED]</column>
       <column name="definition_pt">conter (ter dentro)</column>
+      <column name="definition_fi">sisältää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dech:v}, {Sev:v}, {wegh:v}, {qoD:n}, {teb:v}, {ghoD:v}, {Sach:v:1}</column>
@@ -1033,6 +1140,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Объектом является вещь, которая содержится внутри. {-Daq:n:suff} необязателен.[2]</column>
       <column name="notes_zh_HK">對像是被包含的東西。 {-Daq:n:suff}是不必要的。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é a coisa que está sendo contida. {-Daq:n:suff} é desnecessário.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on asia, jota pidetään. {-Daq:n:suff} on tarpeeton.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1042,6 +1150,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1049,6 +1158,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -1062,6 +1172,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">контейнер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">容器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">contêiner</column>
+      <column name="definition_fi">astia, säiliö, sisältäjä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bal:n}, {'aplo':n}, {DerlIq:n}, {HaySIn:n}</column>
@@ -1072,6 +1183,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ngaS:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1081,6 +1193,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">box</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1088,6 +1201,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -1101,6 +1215,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">порох</column>
       <column name="definition_zh_HK">火藥</column>
       <column name="definition_pt">pólvora</column>
+      <column name="definition_fi">ruuti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIch:n}</column>
@@ -1111,6 +1226,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Для этого необходимы три ключевых ингредиента: {DIl'on:n}, {ghav:n} и {no'negh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Os três principais ingredientes necessários para fazer isso são {DIl'on:n}, {ghav:n} e {no'negh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kolme avainkomponenttia, joita tarvitaan tämän tekemiseen, ovat {DIl'on:n}, {ghav:n} ja {no'negh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Gunpowder was discovered in China during the Tang dynasty.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1120,6 +1236,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1127,6 +1244,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1140,6 +1258,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">травяной гранулированный хрящ (для приготовления пищи) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">herbed顆粒軟骨（用於食物準備） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cartilagem granulada (para preparação de alimentos)</column>
+      <column name="definition_fi">maustettu jauhettu rusto (käytetään ruoanvalmistuksessa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wamwI' Ha'DIbaH:n}, {HomHap tun:n}</column>
@@ -1150,6 +1269,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это смешивается с {tIr:n} и используется для еды {pID:v:1}. [1, p.89] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">將其與{tIr:n}混合併用於{pID:v:1}食物。[1, p.89] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é misturado com {tIr:n} e usado para {pID:v:1}.[1, p.89] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sekoitetaan {tIr:n}: n kanssa ja sitä käytetään {pID:v:1}-ruoan kanssa.[1, p.89] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Japanese word "karaage" (唐揚げ), referring to food prepared this way, has Tang (as in the Chinese dynasty) as its first character.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1159,6 +1279,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1166,6 +1287,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1179,6 +1301,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">тип плесени [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種模具 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aum tipo de fungo</column>
+      <column name="definition_fi">eräs homesieni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1189,6 +1312,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Буквально «пороховой грибок». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從字面上看，是“火藥木耳”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Literalmente, "fungo da pólvora". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kirjaimellisesti "ruuti sieni". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngat:n:1}, {'atlhqam:n}</column>
       <column name="examples"></column>
@@ -1198,6 +1322,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1205,6 +1330,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1218,6 +1344,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">писательская судорога</column>
       <column name="definition_zh_HK">作家的抽筋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cãibra do escritor</column>
+      <column name="definition_fi">pitkästä kirjoittamisesta johtuva sormien lihasten kouristus?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1228,6 +1355,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">An instance of linguist humour. This is missing from the E-K side of {TKD:src}, where it would've be separated by the word "write" from "worsen" and "worthless".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1237,6 +1365,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1244,6 +1373,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1257,6 +1387,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">большое собакоподобное существо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大型犬科動物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">grande criatura parecida com um canino</column>
+      <column name="definition_fi">eräs suuri koiran tai suden kaltainen eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{targh:n}, {qovIj:n}</column>
@@ -1267,6 +1398,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это похоже на существ, которые сопровождают охранников на {rura' pente':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就像在{rura' pente':n}上陪伴守衛的生物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É como as criaturas que acompanham os guardas no {rura' pente':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kuin olentoja, jotka seuraavat vartijoita {rura' pente':n}-ohjelmassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Backwards, this is "White Fang", the name of the eponymous wolfdog in Jack London's novel.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1276,6 +1408,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">wolf, wolfdog, dog</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1283,6 +1416,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1296,6 +1430,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">разъедать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">侵蝕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">erodir</column>
+      <column name="definition_fi">kuluttaa, murentaa, heikentää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ragh:v}, {Sab:v}</column>
@@ -1306,6 +1441,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это не то, что делает ржавчина; это то, что делают вода, ветер и так далее. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不是鏽的作用。這是水，風等的作用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não é isso que a ferrugem faz; é isso que a água, o vento e assim por diante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä ruoste ei tee; Tätä tekevät vesi, tuuli ja niin edelleen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1315,6 +1451,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Erosion</column>
       <column name="search_tags_fa"></column>
@@ -1322,6 +1459,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1335,6 +1473,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">палочка для смешивания с плоским концом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">混合棒與扁平的槳狀末端 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vareta misturadora com extremidade achatada</column>
+      <column name="definition_fi">lasta; sekoitustikku, jossa on litteä ja leveä pää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'un naQ:n}</column>
@@ -1345,6 +1484,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это {DuDwI':n} с веслообразным концом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個帶有槳狀末端的{DuDwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um {DuDwI':n} com uma extremidade semelhante a um remo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {DuDwI':n}, jonka pää on mela. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1354,6 +1494,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1361,6 +1502,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1374,6 +1516,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">слава [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">榮耀</column>
       <column name="definition_pt">glória</column>
+      <column name="definition_fi">suosio, maine; loisto, mahtavuus?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -1385,6 +1528,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">An English definition has never been given for this word. Its meaning is inferred from the only example of its usage.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1395,6 +1539,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1402,6 +1547,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1415,6 +1561,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">секс, выполнять секс [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">做愛、表演 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sexo, realizar sexo</column>
+      <column name="definition_fi">harrastaa seksiä (jonkun kanssa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngagh:v}, {Sep:v}, {qey'Hav:n}, {'InSep:n}, {ja'chuq:v}</column>
@@ -1425,6 +1572,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Предметом этого глагола являются все вовлеченные стороны. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞的主題是所有參與方。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O assunto deste verbo é todas as partes envolvidas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin aihe on kaikki osapuolet. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The gloss is actually given as "sex (i.e., perform sex; always subject)", which was considered by some to be unclear. The interpretation that this verb indicates that the subject, which must be plural, are engaged in sexual intercourse with each other, was confirmed by MO in July 2013, after its use in a poster for Stonewall's "Some People Are Gay. Get Over It." campaign.</column>
       <column name="components">{nga':v:hyp,nolink}, {-chuq:v}</column>
       <column name="examples"></column>
@@ -1434,6 +1582,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fuck</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1441,6 +1590,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 1.3, Sept. 1992:src}, [2] {Stonewall campaign 2013:src} ({KLI mailing list 2019.03.22:src})</column>
     </table>
     <table name="mem">
@@ -1454,6 +1604,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">быть поддельным, быть подложным, быть ложным, быть ошибочным, быть подставным, быть липовым</column>
       <column name="definition_zh_HK">假</column>
       <column name="definition_pt">ser falsificado, falso</column>
+      <column name="definition_fi">olla väärennetty, olla epäaito, olla väärä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{teH:v}, {'ol:v}, {velqa':n}</column>
@@ -1464,6 +1615,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1473,6 +1625,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1480,6 +1633,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1493,6 +1647,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">долина</column>
       <column name="definition_zh_HK">山谷</column>
       <column name="definition_pt">vale</column>
+      <column name="definition_fi">laakso</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngeng:n}, {ngem:n}, {ngech:n:2}</column>
@@ -1503,6 +1658,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1512,6 +1668,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1519,6 +1676,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1533,6 +1691,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">расщепление женщины [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">女人的乳溝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">decote da mulher</column>
+      <column name="definition_fi">(naisen) rintavako</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngech:n:1}, {ngob'at:n}, {HuD:n:2}</column>
@@ -1543,6 +1702,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1552,6 +1712,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">breasts</column>
       <column name="search_tags_de">Dekolleté, Dekolletee</column>
       <column name="search_tags_fa"></column>
@@ -1559,6 +1720,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 3 (1996):src}</column>
     </table>
     <table name="mem">
@@ -1572,6 +1734,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">быть лёгким, быть спокойным, быть нетрудным, быть непринужденным</column>
       <column name="definition_zh_HK">容易</column>
       <column name="definition_pt">ser fácil</column>
+      <column name="definition_fi">olla helppo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qatlh:v}</column>
@@ -1582,6 +1745,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1591,6 +1755,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1598,6 +1763,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1611,6 +1777,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">отправлять, посылать, присылать</column>
       <column name="definition_zh_HK">發送 [AUTOTRANSLATED]</column>
       <column name="definition_pt">enviar</column>
+      <column name="definition_fi">lähettää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hev:v}</column>
@@ -1621,6 +1788,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1630,6 +1798,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1637,6 +1806,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1650,6 +1820,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">космос, вселенная</column>
       <column name="definition_zh_HK">太虛</column>
       <column name="definition_pt">cosmos</column>
+      <column name="definition_fi">maailmankaikkeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh:n}, {'u':n}</column>
@@ -1660,6 +1831,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1669,6 +1841,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1676,6 +1849,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1689,6 +1863,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">заражать</column>
       <column name="definition_zh_HK">感染 [AUTOTRANSLATED]</column>
       <column name="definition_pt">infectar</column>
+      <column name="definition_fi">tartuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hergh:n}, {rop:n}, {lerup:n}, {vor:v}, {tar:n}, {ghew:n}</column>
@@ -1699,6 +1874,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1708,6 +1884,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1715,6 +1892,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1728,6 +1906,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">привлекать, притягивать, влечь, манить, прельщать, прельстить, приманивать, завлекать, соблазнять</column>
       <column name="definition_zh_HK">吸引、誘惑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atrair</column>
+      <column name="definition_fi">houkutella, vetää puoleensa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhu'moH:v}, {ngelwI':n}</column>
@@ -1738,6 +1917,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Чтобы выразить, что было сделано, чтобы завлечь кого-то, используйте этот глагол с {-meH:v}.</column>
       <column name="notes_zh_HK">要表達誘餌的目的，請將此動詞與{-meH:v}一起使用，例如，“使用太空飛船來吸引/吸引/誘惑他們”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para expressar o que foi feito para atrair alguém, use esse verbo com {-meH:v}, por exemplo, "use uma nave espacial para atrair / atrair / tentar". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Käytä tätä verbiä {-meH:v}: n kanssa ilmaisemaan, mitä tapahtui jonkun syöttiä varten, esim. "Käytä avaruusalusta houkutellaksesi / houkuttelemaan / houkuttelemaan". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1747,6 +1927,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bait</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1754,6 +1935,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -1767,6 +1949,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">травить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">餌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">isca</column>
+      <column name="definition_fi">syötti, houkutin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1777,6 +1960,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это буквально означает «аттрактор» или «соблазнитель». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從字面上看，這意味著“吸引者”或“吸引者”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "atrator" ou "lurer". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "vetovoimaa" tai "houkuttelijaa". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngel:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1786,6 +1970,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1793,6 +1978,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -1806,6 +1992,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">лес, заповедник, заказник, леса</column>
       <column name="definition_zh_HK">樹林、森林</column>
       <column name="definition_pt">floresta, bosque</column>
+      <column name="definition_fi">metsä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngech:n:1}, {ngeng:n}</column>
@@ -1816,6 +2003,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1825,6 +2013,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1832,6 +2021,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1845,6 +2035,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">лесное животное</column>
       <column name="definition_zh_HK">森林動物</column>
       <column name="definition_pt">animal da floresta</column>
+      <column name="definition_fi">metsäeläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1855,6 +2046,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Есть идиома, {tlhab; ngem Ha'DIbaH rur@@tlhab:v, ngem Ha'DIbaH:n, rur:v}.</column>
       <column name="notes_zh_HK">有一個成語{tlhab; ngem Ha'DIbaH rur@@tlhab:v, ngem Ha'DIbaH:n, rur:v}.[1, p.132] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {tlhab; ngem Ha'DIbaH rur@@tlhab:v, ngem Ha'DIbaH:n, rur:v}.[1, p.132] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {tlhab; ngem Ha'DIbaH rur@@tlhab:v, ngem Ha'DIbaH:n, rur:v}.[1, p.132] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngem:n}, {Ha'DIbaH:n:1}</column>
       <column name="examples"></column>
@@ -1864,6 +2056,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1871,6 +2064,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1884,6 +2078,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">преследовать лесных змей [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">追逐森林薩克斯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">perseguir os Sarks da floresta</column>
+      <column name="definition_fi">jahdata metsähaita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qatlh:v}</column>
@@ -1894,6 +2089,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это идиоматическое выражение означает, что что-то сложное. Это часто используется в форме {ngem Sarghmey tlha'laH:sen:nolink}, чтобы описать кого-то, кто способен на трудный подвиг. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語表示有些複雜。它通常以{ngem Sarghmey tlha'laH:sen:nolink}的形式來描述能夠勝任艱辛任務的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa que algo é complexo. É frequentemente usado no formato {ngem Sarghmey tlha'laH:sen:nolink} para descrever alguém que é capaz de um feito difícil. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa, että jokin on monimutkaista. Sitä käytetään usein muodossa {ngem Sarghmey tlha'laH:sen:nolink} kuvaamaan jotakuta, joka kykenee vaikeaan tekoon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1903,6 +2099,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">complexity, difficulty</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1910,6 +2107,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.111:src}</column>
     </table>
     <table name="mem">
@@ -1923,6 +2121,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">онеметь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">麻木了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficar dormente</column>
+      <column name="definition_fi">olla tunnoton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1933,6 +2132,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="notes_ru">Это сказано о частях тела. Для эмоционального онемения используйте {jemHa':v@@jem:v, -Ha':v} или {jemlaHbe':v@@jem:v, -laH:v, -be':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是身體部位。對於情緒麻木，請使用{jemHa':v@@jem:v, -Ha':v}或{jemlaHbe':v@@jem:v, -laH:v, -be':v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sanotaan ruumiinosista. Käytä emotionaalista tunnottomuutta käyttämällä {jemHa':v@@jem:v, -Ha':v} tai {jemlaHbe':v@@jem:v, -laH:v, -be':v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1942,6 +2142,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1949,6 +2150,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1962,6 +2164,7 @@ Pode-se dizer {mab ngaQmoH:sen@@mab:n:2, ngaQmoH:v:2} e assim por diante, mas es
       <column name="definition_ru">озеро</column>
       <column name="definition_zh_HK">湖</column>
       <column name="definition_pt">lago</column>
+      <column name="definition_fi">järvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daqav:n}, {ngech:n:1}, {ngem:n}</column>
@@ -1986,6 +2189,9 @@ Det lavafylta området i en vulkan ({qulHuD:n}) kallas dess {qul ngeng:n}.[2] [A
       <column name="notes_pt">A margem de um lago é seu {ngeng HeH:n}.
 
 A área cheia de lava de um vulcão ({qulHuD:n}) é chamada de {qul ngeng:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Järven ranta on sen {ngeng HeH:n}.
+
+Tulivuoren laavalla täytettyä aluetta ({qulHuD:n}) kutsutaan sen {qul ngeng:n}: ksi.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1995,6 +2201,7 @@ A área cheia de lava de um vulcão ({qulHuD:n}) é chamada de {qul ngeng:n}.[2]
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2002,6 +2209,7 @@ A área cheia de lava de um vulcão ({qulHuD:n}) é chamada de {qul ngeng:n}.[2]
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.78-79:src}</column>
     </table>
     <table name="mem">
@@ -2015,6 +2223,7 @@ A área cheia de lava de um vulcão ({qulHuD:n}) é chamada de {qul ngeng:n}.[2]
       <column name="definition_ru">берег [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">湖邊</column>
       <column name="definition_pt">costa</column>
+      <column name="definition_fi">(järven) ranta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qul ngeng:n}</column>
@@ -2039,6 +2248,9 @@ I {paq'batlh:src} används uttrycket {qul ngeng HeH:n:nolink} för att hänvisa 
       <column name="notes_pt">Isso se refere especificamente à margem de um lago. A costa de um oceano seria chamada de {bIQ'a' HeH:n} e assim por diante.
 
 No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se referir à costa do {qul ngeng:n} dentro do {QIStaq:n}, onde o ambiente é tão hostil à vida que nem mesmo o {tlheng'IQ:n} cresceria. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa nimenomaan järven rannalle. Valtameren rantaa kutsutaan nimellä {bIQ'a' HeH:n} ja niin edelleen.
+
+{paq'batlh:src}: ssa ilmaisua {qul ngeng HeH:n:nolink} käytetään viittaamaan {qul ngeng:n}: n rantaan {QIStaq:n}: n sisällä, jossa ympäristö on niin vihamielinen elämälle, ettei edes {tlheng'IQ:n} kasvaisi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngeng:n}, {HeH:n}</column>
       <column name="examples"></column>
@@ -2048,6 +2260,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2055,6 +2268,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.78-79:src}</column>
     </table>
     <table name="mem">
@@ -2068,6 +2282,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="definition_ru">вид морского существа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">海洋生物的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de criatura marinha</column>
+      <column name="definition_fi">eräs vesieläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2078,6 +2293,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="notes_ru">Это гигантское мифическое существо, с которым {qotar:n} боролся за день.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{qotar:n}奮戰一天的巨大神話生物。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma criatura mítica gigante que {qotar:n} lutou por um dia.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on jättimäinen myyttinen olento, jota {qotar:n} taisteli päivän ajan.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The origin of this word appears to be a mistranslation by Bing translator, which turns "sea creature" into {ngeng roQ:sen:nolink} (with a space). This was then retroactively "vetted" by Marc Okrand after the book's publication.[2]</column>
       <column name="components">{ngeng:n}, {roQ:n:hyp,nolink}</column>
       <column name="examples"></column>
@@ -2087,6 +2303,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2094,6 +2311,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {The Klingon Art of War:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2107,6 +2325,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="definition_ru">переопределять, отменять, отвергать, попирать, задавить, переехать кого-то</column>
       <column name="definition_zh_HK">覆蓋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">anular</column>
+      <column name="definition_fi">kumota, ohittaa, sivuuttaa, syrjäyttää (päätös tms.) ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SeH:v}, {ra':v:1}, {ruQ:v}</column>
@@ -2117,6 +2336,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2126,6 +2346,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2133,6 +2354,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2146,6 +2368,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="definition_ru">лестница, лестница (кроме двери корабля) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">樓梯、樓梯（船門除外） [AUTOTRANSLATED]</column>
       <column name="definition_pt">escadas, escadas (exceto na porta do navio)</column>
+      <column name="definition_fi">portaat, portaikko (ei aluksen ovelle johtava)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2156,6 +2379,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="notes_ru">В некоторых диалектах {meqro'vaq Sep:n} это относится к любой лестнице, кроме {choghvat:n:1}, которая там называется {letlh:n:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在某些{meqro'vaq Sep:n}方言中，它指的是任何樓梯，但{choghvat:n:1}在那兒被稱為{letlh:n:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em alguns dialetos {meqro'vaq Sep:n}, isso se refere a qualquer escada, exceto um {choghvat:n:1}, que é chamado de {letlh:n:2} lá. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Joissakin {meqro'vaq Sep:n}-murteissa tämä viittaa mihin tahansa portaikkoon paitsi {choghvat:n:1}, jota kutsutaan siellä {letlh:n:2}: ksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2165,6 +2389,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2172,6 +2397,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2185,6 +2411,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="definition_ru">врезаться, столкнуться, столкнуться с [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">碰撞</column>
       <column name="definition_pt">chocar, esbarrar, colidir com</column>
+      <column name="definition_fi">törmätä johonkin, tavata sattumalta?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2195,6 +2422,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="notes_ru">Это описывает столкновение чего-то, движущегося с чем-то неподвижным.[1] В отличие от {paw':v:1}, {ngeQ:v:nolink} имеет невинную сторону.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Descreve a colisão de algo se movendo com algo parado.[1] Ao contrário de {paw':v:1}, {ngeQ:v:nolink} tem uma parte inocente.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kuvaa sellaisen törmäämistä, joka liikkuu jonkin paikallaan olevan aseman kanssa.[1]{paw':v:1}{ngeQ:v:nolink}[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2204,6 +2432,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2211,6 +2440,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.157:src}, [2] {HQ 7.4, p.2-12, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -2224,6 +2454,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="definition_ru">теория</column>
       <column name="definition_zh_HK">理論 [AUTOTRANSLATED]</column>
       <column name="definition_pt">teoria</column>
+      <column name="definition_fi">teoria</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qech:n}, {ngoD:n}, {ngong:n}, {bInglan:n}</column>
@@ -2234,6 +2465,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="notes_ru">Это используется для теории в научном смысле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於科學意義上的理論。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para uma teoria no sentido científico. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään teoriaan tieteellisessä mielessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2243,6 +2475,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2250,6 +2483,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2263,6 +2497,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="definition_ru">преломлять [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">衍射 [AUTOTRANSLATED]</column>
       <column name="definition_pt">difratar</column>
+      <column name="definition_fi">taivuttaa (valoa tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2273,6 +2508,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="notes_ru">Это физический термин, относящийся к распространению луча или волн при контакте с узкой апертурой или веществом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個物理術語，是指通過與狹窄的孔徑或物質接觸而散發出來的光束或波。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo físico que se refere à propagação de um feixe ou ondas por contato com uma abertura ou substância estreita. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on fysiikan termi, joka viittaa säteen tai aaltojen leviämiseen kosketuksiin kapean aukon tai aineen kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2282,6 +2518,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2289,6 +2526,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2302,6 +2540,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="definition_ru">продавать, торговать</column>
       <column name="definition_zh_HK">賣</column>
       <column name="definition_pt">vender</column>
+      <column name="definition_fi">myydä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{je':v:1}, {DIl:v}, {Suy:n}</column>
@@ -2312,6 +2551,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2323,6 +2563,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
 ▶ {tlhIlHal yIngev!} "Продай шахту!"[2, стр.191]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2330,6 +2571,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2343,6 +2585,7 @@ No {paq'batlh:src}, a expressão {qul ngeng HeH:n:nolink} é usada para se refer
       <column name="definition_ru">продавец, торговец</column>
       <column name="definition_zh_HK">賣家</column>
       <column name="definition_pt">vendedor</column>
+      <column name="definition_fi">myyjä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suy:n}, {Hergh ngevwI':n}</column>
@@ -2357,6 +2600,9 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
 В {TNK:src}, "Где находится магазин?" переведено, как {nuqDaq ghaH ngevwI''e'?:sen:nolink} Заметьте, что {ghaH:n} предпочтительней, чем {'oH:n}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sana viittaa henkilöön, vaikka sitä voidaan käyttää sanan "myymälä" tai "myymälä" kääntämiseen asiayhteydessä siinä mielessä, että Klingonissa sanotaan, että menee apteekkiin pikemminkin kuin apteekkiin.
+
+Kohdassa {TNK:src} "Missä kauppa on?" käännetään nimellä {nuqDaq ghaH ngevwI''e '?: sen: nolink} (kirjaimellisesti "missä myyjä on?") Huomaa, että käytetään {ghaH:n}: ta {'oH:n}: n sijaan.{nuqDaq ghaH ngevwI''e'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2366,6 +2612,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">store, shop</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2373,6 +2620,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -2386,6 +2634,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">увести, забрать, отобрать, увозить</column>
       <column name="definition_zh_HK">帶走 [AUTOTRANSLATED]</column>
       <column name="definition_pt">levar, retirar</column>
+      <column name="definition_fi">ottaa pois</column>
       <column name="synonyms">{yaHmoH:v@@yaH:v, -moH:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{teq:v}, {yaH:v}, {lel:v}</column>
@@ -2396,6 +2645,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{Ha'quj nge':sen:idiom}</column>
@@ -2405,6 +2655,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2412,6 +2663,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2425,6 +2677,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">лодыжка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">腳踝</column>
       <column name="definition_pt">tornozelo</column>
+      <column name="definition_fi">nilkka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bem:n}, {qam:n}, {mov:n}, {yeb:n:1}, {'uS:n}, {wIlle':n}</column>
@@ -2435,6 +2688,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru">Это также сленговый термин обесценивания ({ngIb:n:2}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也是棄用的語（{ngIb:n:2}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse também é um termo de gíria de descontinuação ({ngIb:n:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on myös slangin poistotermi ({ngIb:n:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is listed in the {KGT:src} word lists as "ankle (also a slang term of deprecation)". The two meanings have been split into separate entries for consistency with other slang terms.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2444,6 +2698,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2451,6 +2706,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2464,6 +2720,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">сленговый термин устаревания [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">de貶詞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gíria termo de depreciação</column>
+      <column name="definition_fi">slang term of deprecation [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2474,6 +2731,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">語的含義受到{ngIb:n:1}的Krotmag發音的影響，聽起來像{ngIm:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse significado de gíria foi influenciado pela pronúncia Krotmag de {ngIb:n:1}, que soa como {ngIm:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tähän slangin merkitykseen vaikutti Krotmag-ääntäminen {ngIb:n:1}, joka kuulostaa {ngIm:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2483,6 +2741,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2490,6 +2749,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.166:src}</column>
     </table>
     <table name="mem">
@@ -2503,6 +2763,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">привести (элемент) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鉛（元素） [AUTOTRANSLATED]</column>
       <column name="definition_pt">chumbo (elemento)</column>
+      <column name="definition_fi">lyijy</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}</column>
@@ -2513,6 +2774,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2522,6 +2784,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2529,6 +2792,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2542,6 +2806,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">быть шумным, непослушным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吵鬧、不守規矩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desordeiros, indisciplinados</column>
+      <column name="definition_fi">olla rähinöivä, levoton, olla kuriton, tottelematon</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Doch:v}, {Qut:v}</column>
@@ -2552,6 +2817,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2561,6 +2827,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2568,6 +2835,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2581,6 +2849,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">осмелиться, дерзнуть, посметь, отважиться</column>
       <column name="definition_zh_HK">敢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ousar</column>
+      <column name="definition_fi">uskaltaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2591,6 +2860,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru">Пример, основанный на {SkyBox 21:src}, скорее означает "иметь мужество сделать что-то", нежели "провоцировать или вызвать кого-то на соревнование".</column>
       <column name="notes_zh_HK">根據{SkyBox 21:src}示例，這意味著“有勇氣做某事”，而不是“挑釁或挑戰某人”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Com base no exemplo {SkyBox 21:src}, isso significa "ter a coragem de fazer alguma coisa", em vez de "provocar ou desafiar alguém". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{SkyBox 21:src}-esimerkin perusteella tämä tarkoittaa "rohkeutta tehdä jotain" eikä "provosoida tai haastaa jotakuta". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example appears to be missing a conjunction.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2604,6 +2874,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
   "Клингонская еда лучше всего подаётся свежей и живой. Несколько человек осмелились съесть гагх, кровяной пирог, или сердце тарга."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nourishment, sustenance</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2611,6 +2882,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru">средства к существованию, питание</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 21:src}</column>
     </table>
     <table name="mem">
@@ -2624,6 +2896,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">быть отрицательно заряженным, иметь отрицательный заряд [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">帶負電</column>
       <column name="definition_pt">ter uma carga negativa, ser carregado negativamente</column>
+      <column name="definition_fi">olla negatiivisesti varautunut</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ruS:v}</column>
       <column name="see_also">{tat:n}, {tem:n}, {pay'an:n}, {HeySel:n}</column>
@@ -2634,6 +2907,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined as "have a negative charge" in the {qep'a' 23 (2016):src} booklet, but was confirmed to be stative afterwards.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2643,6 +2917,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2650,6 +2925,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2663,6 +2939,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">быть гнилым, быть вонючим, быть мерзким</column>
       <column name="definition_zh_HK">腐爛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser podre</column>
+      <column name="definition_fi">olla mätä, olla inhottava, kuvottava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{natlh:v:2}, {'eyHa':v}, {'up:v}</column>
@@ -2673,6 +2950,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2682,6 +2960,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2689,6 +2968,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2702,6 +2982,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">быть бурным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動盪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser turbulento</column>
+      <column name="definition_fi">olla pyörteinen, turbulentti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2712,6 +2993,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2721,6 +3003,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2728,6 +3011,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2741,6 +3025,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">заимствовать, занимать, одалживать, брать на время, давать взаймы</column>
       <column name="definition_zh_HK">借</column>
       <column name="definition_pt">emprestar</column>
+      <column name="definition_fi">lainata (joltakulta), ottaa lainaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noj:v}, {tatlh:v}</column>
@@ -2751,6 +3036,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru">Слово использовано в {TNK:src} в предложении {nuqDaq puH Duj vIngIp?:sen:nolink}, которое означает "Где я могу взять машину напрокат?" Тем не менее, не совсем ясно, что Клингонское предложение выражает идею, что машина взята напрокат за деньги.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta palavra é usada em {TNK:src} na frase {nuqDaq puH Duj vIngIp?:sen:nolink} para significar "Onde posso alugar (alugar) um carro?" No entanto, não está claro que a sentença de Klingon exprima a ideia de que o carro deve ser emprestado por dinheiro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään {TNK:src}-lauseessa lauseessa {nuqDaq puH Duj vIngIp?: Sen: nolink} tarkoittamaan "Mistä voin vuokrata (vuokrata) auton?" Ei ole kuitenkaan selvää, että Klingonin lause ilmaisee ajatuksen, että auto on lainattava rahaksi.{nuqDaq puH Duj vIngIp?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2760,6 +3046,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rent, hire</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2767,6 +3054,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2780,6 +3068,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">один единственный, каждый</column>
       <column name="definition_zh_HK">一個個、每一個</column>
       <column name="definition_pt">um único, cada um</column>
+      <column name="definition_fi">yksittäinen; yksitellen, yksi kerrallaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIq:adv}, {Hoch:n}, {'op:n}</column>
@@ -2790,6 +3079,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru">Это существительное значит, что единственная вещь рассматривается отдельно от остальных, или это последовательность идентичных вещей, рассматриваемых одна за другой. Подобно {Hoch:n} и {'op:n}, оно предшествует тому, что модифицирует.</column>
       <column name="notes_zh_HK">這個名詞表示單個事物被認為與其他事物分開，或者一系列相同的事物被認為是一個接一個的事物。像{Hoch:n}和{'op:n}一樣，它在修改之前。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este substantivo indica que uma única coisa está sendo considerada à parte das outras, ou que uma sequência de coisas idênticas é considerada uma após a outra. Como {Hoch:n} e {'op:n}, precede o que modifica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä substantiivi osoittaa, että yksittäistä asiaa pidetään erillään muista tai että samanlaisten asioiden sarjaa pidetään peräkkäin. Kuten {Hoch:n} ja {'op:n}, se edeltää sitä, mitä se muuttaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2843,6 +3133,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
 ▶ {ngIq gholvo' wa'maH QaS yItlhap.:sen:nolink} "Соберите 10 отрядов от каждого игрока."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2850,6 +3141,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, [2] {paq'batlh:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2863,6 +3155,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="definition_ru">lubricant (special type) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">潤滑劑類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lubrificante (tipo especial)</column>
+      <column name="definition_fi">eräs voiteluaine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nISwI' tal:n}, {watrIn:n}, {QIn:v}</column>
@@ -2873,6 +3166,7 @@ In {TNK:src}, "Where is the shop?" is translated as {nuqDaq ghaH ngevwI''e'?:sen
       <column name="notes_ru">Это тип смазки, используемой в пушках-разрушителях.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是用於破壞性加農炮的一種潤滑劑。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de lubrificante usado em canhões de disruptor.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen voiteluaine, jota käytetään häiritsevissä tykeissä.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The fact that this is used on disruptor cannons comes from the glossary to {Honor Bound:src}.
 
 For a very long time, this was an unofficial word, but it was confirmed by Okrand for a translation of The Wizard of Oz.[2]</column>
@@ -2884,6 +3178,7 @@ For a very long time, this was an unofficial word, but it was confirmed by Okran
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">oil</column>
       <column name="search_tags_de">Öl</column>
       <column name="search_tags_fa"></column>
@@ -2891,6 +3186,7 @@ For a very long time, this was an unofficial word, but it was confirmed by Okran
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Honor Bound:src}, [2] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -2904,6 +3200,7 @@ For a very long time, this was an unofficial word, but it was confirmed by Okran
       <column name="definition_ru">струнный инструмент со смычком, скрипка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">弓弦樂器小提琴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">instrumento de cordas que é curvado, violino</column>
+      <column name="definition_fi">jousisoitin, viulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HurDagh:n}</column>
@@ -2914,6 +3211,7 @@ For a very long time, this was an unofficial word, but it was confirmed by Okran
       <column name="notes_ru">Это разновидность струнного инструмента, играемого на {ngItHel naQ:n@@ngItHel:n, naQ:n:1} («лук», то есть палка, натянутая на нити). Сленговый термин, часто используемый для «лука» - {yan:n}. Ближайший аналог терранов, вероятно, скрипка. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種用{ngItHel naQ:n@@ngItHel:n, naQ:n:1}（“弓”，即用細繩串起來的棍子）演奏的弦樂器。通常用於“弓”的語是{yan:n}。最接近的Terran類似物可能是小提琴。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de instrumento de cordas tocado com um {ngItHel naQ:n@@ngItHel:n, naQ:n:1} (um "arco", ou seja, uma vara com cordões). Uma gíria freqüentemente usada para o "arco" é {yan:n}. O análogo terráqueo mais próximo é provavelmente um violino. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen kielisoitin, jota soitetaan {ngItHel naQ:n@@ngItHel:n, naQ:n:1}-soittimella ("jousi", so. Säikeillä kietoutunut keppi). Slangitermi, jota usein käytetään "jouselle", on {yan:n}. Lähin Terran-analogi on todennäköisesti viulu. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">When written in "xifan hol", {ngItHel:n:nolink} is "fithel", which is a Middle English form of "fiddle".
 
 One of these was used in the production of the opera {'u':src}.</column>
@@ -2925,6 +3223,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2932,6 +3231,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2945,6 +3245,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">застрять (не может двигаться) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">卡住（無法移動） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficar preso (incapaz de se mover)</column>
+      <column name="definition_fi">olla jumissa (kykenemätön liikkumaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIy:v}</column>
@@ -2955,6 +3256,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Это описывает ситуации, например, когда ваша машина застревает в снегу, или Санта застрял в дымоходе, или на пальце застряло кольцо, или гвоздь застрял в куске дерева, и вы не можете вытащить его. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這描述了這樣的情況，例如當您的汽車被困在雪中，聖誕老人被困在煙囪中，戒指或手指上被釘住，釘子被釘在一塊木頭上而無法將其拉出時。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso descreve situações como quando seu carro está preso na neve, ou Papai Noel está preso na chaminé, ou um anel está preso no seu dedo, ou um prego está preso em um pedaço de madeira e você não pode retirá-lo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kuvaa tilanteita, kuten kun auto on juuttunut lumeen, tai joulupukki on jumissa savupiippuun, tai rengas on juuttunut sormellesi tai naula on juuttunut puupalaan etkä voi vetää sitä ulos. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "be stuck" with an explanation, along with a bunch of other words which can be translated into various senses of "be stuck" in English.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2964,6 +3266,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2971,6 +3274,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2984,6 +3288,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">патрулировать, осуществлять патрулирование, стоять в дозоре</column>
       <column name="definition_zh_HK">巡邏 [AUTOTRANSLATED]</column>
       <column name="definition_pt">patrulha</column>
+      <column name="definition_fi">partioida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qugh:v}, {leng:v}</column>
@@ -2994,6 +3299,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3007,6 +3313,7 @@ One of these was used in the production of the opera {'u':src}.</column>
 ▶ {jogh veH lungIv.} "Они патрулируют границу квадранта."[2, p.194]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3014,6 +3321,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3027,6 +3335,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">иметь вес, весить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">重量</column>
       <column name="definition_pt">ter o peso de, pesar</column>
+      <column name="definition_fi">olla painoltaan, painaa jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cheb:n}, {tIS:v}, {'ugh:v}, {juv:v}, {Hap:n}, {HIS:v}, {wa'lay:n}</column>
@@ -3037,6 +3346,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Этот глагол также используется для выражения «под давлением» (как в том, что происходит внутри кабины самолета). Давление воздуха обычно выражается в единицах {chebmey:n@@cheb:n, -mey:n} на {morgh:n}. Чтобы указать, что давление воздуха является правильным, выражение {ngI'chu' muD:sen@@ngI':v, -chu':v, muD:n:1} или {ngI'chu' lay:sen@@ngI':v, -chu':v, lay:n:2h}. Чтобы указать, что это результат процесса, можно сказать, {ngI'choHchu'pu' muD:sen@@ngI':v, -choH:v, -chu':v, -pu':v, muD:n:1}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞也用於表達“加壓”（如飛機機艙內發生的情況）。氣壓通常以{morgh:n}的單位{chebmey:n@@cheb:n, -mey:n}表示。為了表示氣壓正確，表達式為{ngI'chu' muD:sen@@ngI':v, -chu':v, muD:n:1}或{ngI'chu' lay:sen@@ngI':v, -chu':v, lay:n:2h}。為了表明這是一個過程的結果，可以說{ngI'choHchu'pu' muD:sen@@ngI':v, -choH:v, -chu':v, -pu':v, muD:n:1}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä verbiä käytetään myös ilmaisemaan "paineistettu" (kuten mitä tapahtuu lentokoneen matkustamossa). Ilmanpaine ilmaistaan ​​tavallisesti yksikköinä {chebmey:n@@cheb:n, -mey:n} / {morgh:n}. Ilmaisemaan, että ilmanpaine on oikea, ilmaisu on {ngI'chu' muD:sen@@ngI':v, -chu':v, muD:n:1} tai {ngI'chu' lay:sen@@ngI':v, -chu':v, lay:n:2h}. Sen osoittamiseksi, että tämä on prosessin tulos, voidaan sanoa {ngI'choHchu'pu' muD:sen@@ngI':v, -choH:v, -chu':v, -pu':v, muD:n:1}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3046,6 +3356,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mass, pressure, pressurize, pressurise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3053,6 +3364,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3066,6 +3378,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">грудь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">乳房 [AUTOTRANSLATED]</column>
       <column name="definition_pt">peito, mama</column>
+      <column name="definition_fi">rinta</column>
       <column name="synonyms">{HuD:n:2}</column>
       <column name="antonyms"></column>
       <column name="see_also">{noq:n:1}, {ngech:n:2}</column>
@@ -3076,6 +3389,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Это относится к части женской анатомии. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指女性解剖學的一部分。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a uma parte da anatomia feminina. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa naisten anatomian osaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3085,6 +3399,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3092,6 +3407,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3105,6 +3421,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">политика, полис, курс, линия поведения</column>
       <column name="definition_zh_HK">政策 [AUTOTRANSLATED]</column>
       <column name="definition_pt">política</column>
+      <column name="definition_fi">käytäntö, politiikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chut:n}</column>
@@ -3115,6 +3432,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3126,6 +3444,7 @@ One of these was used in the production of the opera {'u':src}.</column>
 ▶ {ngoch luchermeH 'ej wo' San luwuqmeH pa' ghom tlhIngan yejquv DevwI'pu'.:sen:nolink} "Здесь лидеры Клингонского высшего совета встречаются, чтобы определить политику и решать судьбу империи."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">regulation</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3133,6 +3452,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {SkyBox 25:src}</column>
     </table>
     <table name="mem">
@@ -3146,6 +3466,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">кварк (частица) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">夸克（顆粒） [AUTOTRANSLATED]</column>
       <column name="definition_pt">quark (partícula)</column>
+      <column name="definition_fi">kvarkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pay'an:n}</column>
@@ -3156,6 +3477,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Three kinds of quarks are named "strange" ({Huj:v:1}), "up", and "down" ({chong:v:1} means "vertical").</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3165,6 +3487,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3172,6 +3495,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3185,6 +3509,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">факт, обстоятельство, событие</column>
       <column name="definition_zh_HK">事實</column>
       <column name="definition_pt">fato</column>
+      <column name="definition_fi">tosiasia, fakta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nger:n}, {qech:n}, {De':n}, {potlh:n}, {Sov:n}, {vuD:n}</column>
@@ -3195,6 +3520,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3204,6 +3530,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3211,6 +3538,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3224,6 +3552,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">мелочи, пустяки, тривиальный факт</column>
       <column name="definition_zh_HK">瑣事、瑣碎的事實 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trivialidade, fato trivial</column>
+      <column name="definition_fi">nippelitieto, tyhjänpäiväinen tieto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3234,6 +3563,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Trekbits" was translated as {Hov leng ngoDHommey:n:nolink} in {STC 104:src}.</column>
       <column name="components">{ngoD:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -3243,6 +3573,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3250,6 +3581,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -3263,6 +3595,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">блок, кусок, кирпич [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">塊、塊、磚 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bloco, tijolo</column>
+      <column name="definition_fi">lohkare, lohko, palanen, paakku, tiili ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3273,6 +3606,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3285,6 +3619,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3292,6 +3627,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2010:src}</column>
     </table>
     <table name="mem">
@@ -3305,6 +3641,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">кирпичный слой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">磚層 [AUTOTRANSLATED]</column>
       <column name="definition_pt">camada de tijolo</column>
+      <column name="definition_fi">muurari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3315,6 +3652,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Это относится к человеку, который собирает кирпичи во что-то, например, в стену или здание. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指將磚塊組裝成牆或建築物等物體的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa que monta tijolos em algo, como uma parede ou um edifício. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, joka kokoaa tiilet johonkin, kuten seinään tai rakennukseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngogh:n}, {mutlh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3324,6 +3662,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3331,6 +3670,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.10:src}</column>
     </table>
     <table name="mem">
@@ -3344,6 +3684,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">подушка, подкладка</column>
       <column name="definition_zh_HK">枕頭</column>
       <column name="definition_pt">travesseiro</column>
+      <column name="definition_fi">tyyny</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QongDaq:n}, {QongDaq buq:n}</column>
@@ -3354,6 +3695,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Клингоны не имеют подушек, но Мальц сказал, что это то, что он бы этим назвал, если бы ему пришлось как-то это назвать.</column>
       <column name="notes_zh_HK">克林崗人沒有枕頭，但是馬爾茨說，如果他不得不稱呼某種東西的話，他會稱之為枕頭。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Klingons não tem travesseiros, mas Maltz disse que isso seria o que ele chamaria de um, se tivesse que chamá-lo de algo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonilla ei ole tyynyjä, mutta Maltz sanoi, että tätä hän kutsuisi, jos hänen pitäisi kutsua sitä jollakin tavalla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngogh:n}, {tun:v}</column>
       <column name="examples"></column>
@@ -3363,6 +3705,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3370,6 +3713,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2010:src}</column>
     </table>
     <table name="mem">
@@ -3383,6 +3727,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">мазок, пятно, вязкое вещество, липкое вещество</column>
       <column name="definition_zh_HK">塗抹 [AUTOTRANSLATED]</column>
       <column name="definition_pt">difamar</column>
+      <column name="definition_fi">voidella, rasvata; tuhria?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngoH:v:2}</column>
@@ -3393,6 +3738,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Это один из возможных глаголов для использования с {watrIn:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是與{watrIn:n}.[2]一起使用的可能動詞 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um verbo possível para usar com {watrIn:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksi mahdollinen verbi, jota voidaan käyttää {watrIn:n}.[2]: n kanssa [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3402,6 +3748,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3409,6 +3756,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -3422,6 +3770,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">рисовать пальцами</column>
       <column name="definition_zh_HK">用手指畫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pintar com os dedos</column>
+      <column name="definition_fi">maalata sormilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngoH:v:1}, {nItlh:n}, {rItlh:n}, {DIj:v:2}, {nagh beQ:n}, {vol:n}</column>
@@ -3432,6 +3781,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3441,6 +3791,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3448,6 +3799,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3461,6 +3813,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">быть беспокойным, быть неспокойным, быть неугомонным, быть тревожным</column>
       <column name="definition_zh_HK">不安分 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fique inquieto</column>
+      <column name="definition_fi">olla levoton, rauhaton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jotHa':v}</column>
@@ -3471,6 +3824,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3480,6 +3834,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3487,6 +3842,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3500,6 +3856,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">перемещение батлета из горизонтального положения в вертикальное</column>
       <column name="definition_zh_HK">將bat'leth從水平移動到垂直方向 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mover bat'leth da orientação horizontal para a vertical</column>
+      <column name="definition_fi">siirtää bat'leth vaakasuuntaisesta pystysuuntaiseen asentoon</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lev:v}</column>
       <column name="see_also">{betleH:n}, {jop:v:1}, {baQ:v:1}, {way':v}, {chaQ:v}, {jIrmoH:v:1}, {DIj:v:1}</column>
@@ -3510,6 +3867,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3519,6 +3877,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3526,6 +3885,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3539,6 +3899,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">быть гиковатым</column>
       <column name="definition_zh_HK">太怪談了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser nerd</column>
+      <column name="definition_fi">olla nörtti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ven:v}, {ngomwI':n}</column>
@@ -3549,6 +3910,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Это слово описывает кого-то, кто глубоко разбирается в каком-то предмете и много знает, но совершенно необязательно, что принимает участие в связанных мероприятиях.</column>
       <column name="notes_zh_HK">這個詞描述的是一個真正的人，對它了解很多，但不一定參與相關的活動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra descreve alguém que realmente gosta de algo e sabe muito sobre isso, mas não necessariamente participa de atividades relacionadas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana kuvaa henkilöä, joka on todella kiinnostunut jostakin ja tietää siitä paljon, mutta ei välttämättä osallistu siihen liittyvään toimintaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A pencil-"necked" geek (see {mong:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3558,6 +3920,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3565,6 +3928,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Festival of the Spoken Nerd DVD:src}</column>
     </table>
         <table name="mem">
@@ -3578,6 +3942,7 @@ One of these was used in the production of the opera {'u':src}.</column>
           <column name="definition_ru">гик</column>
           <column name="definition_zh_HK">極客 [AUTOTRANSLATED]</column>
           <column name="definition_pt">geek</column>
+      <column name="definition_fi">nörtti</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{venwI':n}, {qatru':n}, {ngom:v}</column>
@@ -3588,6 +3953,7 @@ One of these was used in the production of the opera {'u':src}.</column>
           <column name="notes_ru">Это слово описывает кого-то, кто глубоко разбирается в каком-то предмете и много знает, но совершенно необязательно, что принимает участие в связанных мероприятиях.</column>
           <column name="notes_zh_HK">這個詞描述的是一個真正的人，對它了解很多，但不一定參與相關的活動。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Essa palavra descreve alguém que realmente gosta de algo e sabe muito sobre isso, mas não necessariamente participa de atividades relacionadas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana kuvaa henkilöä, joka on todella kiinnostunut jostakin ja tietää siitä paljon, mutta ei välttämättä osallistu siihen liittyvään toimintaan. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{ngom:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -3597,6 +3963,7 @@ One of these was used in the production of the opera {'u':src}.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3604,6 +3971,7 @@ One of these was used in the production of the opera {'u':src}.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Festival of the Spoken Nerd DVD:src}</column>
         </table>
     <table name="mem">
@@ -3617,6 +3985,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">пузырь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">泡沫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">borbulhar</column>
+      <column name="definition_fi">kuplia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ba'Suq:n}</column>
@@ -3627,6 +3996,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">{ngon:v:nolink}的對象（例如液體，例如沸水）產生或形成氣泡。 {ngonmoH:v@@ngon:v, -moH:v}的主題是將一根吸管吹入一杯水以產生氣泡的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O assunto {ngon:v:nolink} (por exemplo, um líquido como água fervente) produz ou forma bolhas. Uma pessoa soprando através de um canudo em um copo de água para fazer bolhas seria o assunto de {ngonmoH:v@@ngon:v, -moH:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{ngon:v:nolink}-aihe (esimerkiksi neste, kuten kiehuva vesi) tuottaa tai muodostaa kuplia. {ngonmoH:v@@ngon:v, -moH:v}-aihe on henkilö, joka puhaltaa oljen läpi lasilliseen vettä kuplien muodostamiseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3636,6 +4006,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3643,6 +4014,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -3656,6 +4028,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">ностальгия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">懷舊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nostalgia</column>
+      <column name="definition_fi">nostalgia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qaw:v}, {wov'on:n}</column>
@@ -3666,6 +4039,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Это часто является целью {SIQ:v}, чтобы выразить идею «быть ностальгическим». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{SIQ:v}經常以此來表達“懷舊”的想法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Geralmente, esse é o objetivo do {SIQ:v} de expressar a idéia de "ser nostálgico". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on usein {SIQ:v}: n tavoite ilmaista ajatus "olla nostalginen". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">When written in "xifan hol", this is "fonder", as in "absence makes the heart grow fonder".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3675,6 +4049,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3682,6 +4057,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3695,6 +4071,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">эксперимент, опыт</column>
       <column name="definition_zh_HK">實驗</column>
       <column name="definition_pt">experimento</column>
+      <column name="definition_fi">koe, testi, kokeilu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngong:v}, {QeD:n}, {bInglan:n}, {nger:n}, {Qulpa':n}</column>
@@ -3705,6 +4082,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3714,6 +4092,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3721,6 +4100,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3734,6 +4114,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">экспериментировать, ставить опыт</column>
       <column name="definition_zh_HK">試驗</column>
       <column name="definition_pt">experimentar</column>
+      <column name="definition_fi">tehdä koe, kokeilla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{waH:v:1}, {tob:v}, {Daj:v:2}, {Qul:v}, {ngong:n}, {Qulpa':n}</column>
@@ -3744,6 +4125,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3753,6 +4135,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3760,6 +4143,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3773,6 +4157,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">экспериментальный корабль</column>
       <column name="definition_zh_HK">實驗艦</column>
       <column name="definition_pt">navio experimental</column>
+      <column name="definition_fi">koealus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3783,6 +4168,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru">Смотрите пример использования {So'wI':n}.</column>
       <column name="notes_zh_HK">請參閱{So'wI':n}下的示例。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja o exemplo em {So'wI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso esimerkki kohdasta {So'wI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The exact wording on {SkyBox 33:src} is {ngongmeH wa' DujDaq nuHmey nISbe'bogh So'wI' jomlu'pu':sen:nolink}, with {wa':n:num} in between.</column>
       <column name="components">{ngong:v}, {-meH:v}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -3792,6 +4178,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">prototype</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3799,6 +4186,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru">прототип</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 33:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -3812,6 +4200,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">тарелки для еды</column>
       <column name="definition_zh_HK">碟（眾數）</column>
       <column name="definition_pt">pratos (para comer)</column>
+      <column name="definition_fi">lautaset</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3822,6 +4211,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jengva':n:inhps}</column>
       <column name="examples">
@@ -3832,6 +4222,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dishes</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3839,6 +4230,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru">блюда</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3852,6 +4244,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">код [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">碼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">código</column>
+      <column name="definition_fi">koodi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pegh:n}, {chaw' ngoq:n}</column>
@@ -3862,6 +4255,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3871,6 +4265,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3878,6 +4273,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3891,6 +4287,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">закодированное сообщение</column>
       <column name="definition_zh_HK">編碼的消息 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mensagem codificada</column>
+      <column name="definition_fi">koodattu/salattu viesti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3901,6 +4298,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ngoq:n}, {De':n}</column>
       <column name="examples"></column>
@@ -3910,6 +4308,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3917,6 +4316,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -3930,6 +4330,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">цель, задача, намерение, назначение</column>
       <column name="definition_zh_HK">目標、目的</column>
       <column name="definition_pt">objetivo, propósito</column>
+      <column name="definition_fi">tavoite, tarkoitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hech:v}, {meq:n}, {mo':n:2}, {chIch:adv}</column>
@@ -3940,6 +4341,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3949,6 +4351,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3956,6 +4359,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3969,6 +4373,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">жульничать, мошенничать, мухлевать, обдуривать</column>
       <column name="definition_zh_HK">作弊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">enganar, trapacear, trair</column>
+      <column name="definition_fi">huijata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toj:v}, {nep:v}</column>
@@ -3979,6 +4384,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3988,6 +4394,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3995,6 +4402,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4008,6 +4416,7 @@ One of these was used in the production of the opera {'u':src}.</column>
       <column name="definition_ru">растворить, растворять, аннулировать, расторгать, разлагать, разводить</column>
       <column name="definition_zh_HK">溶解 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dissolver</column>
+      <column name="definition_fi">liueta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taS:n}, {Sub:v:1}, {pey:n}</column>
@@ -4026,6 +4435,9 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
 Это слово также найдено в архаичном выражении {ngoS tlhogh cha:sen:nolink} (смотрите {tlhogh:n}), которое сказано во время ритуала развода.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän verbin aihe on asia, joka on hajoamassa.
+
+Tämä sana löytyy myös arkaaisesta lausekkeesta {ngoS tlhogh cha:sen:nolink} (ks.{tlhogh:n}), joka sanotaan avioeron rituaalin aikana.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4047,6 +4459,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
    Так было сказано."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">divorce, disintegrate</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4054,6 +4467,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="search_tags_ru">развод, разложение</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {DS9 - The House of Quark:src}, [3] {paq'batlh p.96-97:src}</column>
     </table>
     <table name="mem">
@@ -4067,6 +4481,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="definition_ru">быть фанатичным</column>
       <column name="definition_zh_HK">要狂熱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser fanático</column>
+      <column name="definition_fi">olla fanaattinen, kiihkomielinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4077,6 +4492,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4086,6 +4502,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4093,6 +4510,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4106,6 +4524,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="definition_ru">быть ответственным, быть сознательным, быть несущим ответственность</column>
       <column name="definition_zh_HK">要負責任 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser responsável</column>
+      <column name="definition_fi">olla vastuullinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIch:v}, {Hovmey Davan.:sen}</column>
@@ -4116,6 +4535,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="notes_ru">Это означает "быть подотчетным, держать ответ". Также может использоваться в смысле "быть достойным доверия, быть здравомыслящим, быть надёжным".[2]</column>
       <column name="notes_zh_HK">這意味著“負責，負責”。也可以在“值得信賴，明智，可靠”的意義上使用它。 {rang:v}.[2]的含義有些重疊 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "ser responsável, ser responsável". Também pode ser usado no sentido de "ser confiável, sensível, confiável". Existe alguma sobreposição de significado com {rang:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "ole vastuussa, ole vastuussa". Sitä voidaan käyttää myös "olla luotettava, järkevä, luotettava". Merkityksessä on jonkin verran päällekkäisyyttä {rang:v}.[2]: n kanssa [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4127,6 +4547,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be accountable, be answerable, be trustworthy, be sensible, be dependable</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4134,6 +4555,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="search_tags_ru">быть подотчетным, держать ответ</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.02:src}</column>
     </table>
     <table name="mem">
@@ -4147,6 +4569,7 @@ Detta ord finns också i det arkaiska uttrycket {ngoS tlhogh cha:sen:nolink} (se
       <column name="definition_ru">быть старым (не новым)</column>
       <column name="definition_zh_HK">舊</column>
       <column name="definition_pt">ser velho (não novo)</column>
+      <column name="definition_fi">olla vanha (ei uusi)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chu':v:1}</column>
       <column name="see_also">{qan:v:1}, {tIQ:v}, {QI'tu':n}</column>
@@ -4171,6 +4594,9 @@ Detta ord används på objekt eller idéer. [2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que em Klingon, há uma palavra diferente para "ser velho (não novo)" ({ngo':v:nolink}) e para "ser velho (não jovem)" ({qan:v:1}).
 
 Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että Klingonissa on erilainen sana "olla vanha (ei uusi)" ({ngo':v:nolink}) kuin "olla vanha (ei nuori)" ({qan:v:1}).
+
+Tätä sanaa käytetään esineisiin tai ideoihin.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4180,6 +4606,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4187,6 +4614,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.130:src}</column>
     </table>
     <table name="mem">
@@ -4200,6 +4628,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть приклеенным к [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">粘在 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser colado a</column>
+      <column name="definition_fi">olla liimattu johonkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngam:v}, {nguDwI':n}</column>
@@ -4210,6 +4639,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4219,6 +4649,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4226,6 +4657,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4239,6 +4671,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">клей [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">膠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cola</column>
+      <column name="definition_fi">liima</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nguD:v}</column>
@@ -4249,6 +4682,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nguD:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4258,6 +4692,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4265,6 +4700,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4278,6 +4714,7 @@ Esta palavra é aplicada a objetos ou idéias.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">тогда, затем, потом, в это время</column>
       <column name="definition_zh_HK">同時、那時</column>
       <column name="definition_pt">então, naquele momento</column>
+      <column name="definition_fi">silloin, tuolloin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIq:adv}, {SIbI':adv}, {pumDI':sen}</column>
@@ -4316,6 +4753,11 @@ Observera att "då" i betydelsen "därefter" är {ghIq:adv}.[1] [AUTOTRANSLATED]
 Para ver um verbo com significado semelhante, consulte {quq:v}. Para um idioma que significa "naquela época", consulte {pumDI':sen}.
 
 Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä adverbiaalia käytetään pääasiassa korostamaan, että yksi tapahtuma tapahtui samanaikaisesti toisen kanssa. Se ei tarkoita "joskus (epämääräistä) aikaa menneisyydessä" tai "joskus (tuntematonta) aikaa tulevaisuudessa".
+
+Katso verbillä, jolla on samanlainen merkitys, {quq:v}. Katso "siihen aikaan" tarkoitetun sanaston kohdasta {pumDI':sen}.
+
+Huomaa, että "silloin" tarkoittaa "myöhemmin" on {ghIq:adv}.[1][1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4326,6 +4768,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4334,6 +4777,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
 ▶ {DungluQ tIHIv. ngugh Qongbe' chaH.:sen:nolink} "Атакуйте их в полдень! Тогда они не будут спать."[1]</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.05:src} (reprinted in {HQ 8.4, p.8, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -4347,6 +4791,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">давать показания [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">作證 [AUTOTRANSLATED]</column>
       <column name="definition_pt">testificar</column>
+      <column name="definition_fi">todistaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nguHwI':n}</column>
@@ -4357,6 +4802,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4366,6 +4812,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4373,6 +4820,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4386,6 +4834,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">свидетель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">見證人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">testemunha</column>
+      <column name="definition_fi">todistaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jantor:n}</column>
@@ -4396,6 +4845,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru">Это относится к человеку, который дает показания в суде. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指在法庭上作證的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa que testemunha em tribunal. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, joka todistaa oikeudessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nguH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4405,6 +4855,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4412,6 +4863,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4425,6 +4877,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">мундштук (духового инструмента) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">喉舌（管樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">bocal (de um instrumento de sopro)</column>
+      <column name="definition_fi">(puhallinsoittimen) suukappale</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meSchuS:n}</column>
@@ -4435,6 +4888,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4444,6 +4898,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4451,6 +4906,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4464,6 +4920,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">окунь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">棲息 [AUTOTRANSLATED]</column>
       <column name="definition_pt">empoleirar-se</column>
+      <column name="definition_fi">istua, kyyhöttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -4474,6 +4931,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru">Если птица приземляется на суше, используется глагол {Saq:v}, а если на воде, то {tlhot:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果有鳥落在陸地上，則使用動詞{Saq:v}；如果是在水上，則使用動詞{tlhot:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se um pássaro pousar na terra, o verbo {Saq:v} é usado, e se estiver na água, então {tlhot:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos lintu laskeutuu maahan, käytetään verbiä {Saq:v} ja jos vedessä, niin {tlhot:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4483,6 +4941,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4490,6 +4949,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4503,6 +4963,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">плащ, капюшон</column>
       <column name="definition_zh_HK">斗篷（服裝） [AUTOTRANSLATED]</column>
       <column name="definition_pt">capa (vestuário)</column>
+      <column name="definition_fi">viitta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mop:n}, {ngup:n:2}</column>
@@ -4513,6 +4974,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4522,6 +4984,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4529,6 +4992,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4542,6 +5006,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">авторитет, власть, один во власти или ответственный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">權威、權力、權威或權力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">autoridade, poder, autoridade ou responsável</column>
+      <column name="definition_fi">auktoriteetti, valta, vallassa tai johdossa oleva henkilö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{woQ:n}, {cho':v}, {qaD:v}, {ngup:n:1}, {ngup'a':n}</column>
@@ -4552,6 +5017,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4561,6 +5027,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4568,6 +5035,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4581,6 +5049,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">Доминион</column>
       <column name="definition_zh_HK">自治領 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O Domínio</column>
+      <column name="definition_fi">Dominion</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{varghwI':n}</column>
@@ -4591,6 +5060,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru">Относится к фракции, что контроллирует большую часть Гамма Квадранта.</column>
       <column name="notes_zh_HK">這是指控制大多數伽瑪象限的派系。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à facção que controla a maior parte do quadrante gama. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ryhmään, joka hallitsee suurinta osaa Gamma-kvadrantista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngup:n:2}, {-'a':n}</column>
       <column name="examples"></column>
@@ -4600,6 +5070,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4607,6 +5078,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -4620,6 +5092,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">быть высокомерным, надменным, тщеславным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傲慢、驕傲、狂妄自大</column>
       <column name="definition_pt">ser arrogante, altivo, vaidoso</column>
+      <column name="definition_fi">olla ylimielinen, kopea, koppava, itserakas, ylpeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eDjen:n}, {le'yo':n}, {Hem:v}, {mIy:v}</column>
@@ -4630,6 +5103,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru">Это нежелательная черта. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是不受歡迎的特徵。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é uma característica indesejável. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ei-toivottu ominaisuus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4639,6 +5113,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4646,6 +5121,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, Sept. 2003:src}</column>
     </table>
     <table name="mem">
@@ -4659,6 +5135,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">мотор</column>
       <column name="definition_zh_HK">發動機 [AUTOTRANSLATED]</column>
       <column name="definition_pt">motor</column>
+      <column name="definition_fi">moottori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jonta':n}</column>
@@ -4669,6 +5146,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4678,6 +5156,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4685,6 +5164,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -4698,6 +5178,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">буква, письменный знак, глиф [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">信、書面字符、標誌符號 [AUTOTRANSLATED]</column>
       <column name="definition_pt">carta, caráter escrito, glifo</column>
+      <column name="definition_fi">kirjain, merkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Degh:n:1}, {pIqaD:n}</column>
@@ -4708,6 +5189,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">克林崗語寫作系統中沒有“大寫”或“小寫”。 {ngutlh tIn:n@@ngutlh:n, tIn:v}和{ngutlh mach:n@@ngutlh:n, mach:v}可以分別用於這些。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin kirjoitusjärjestelmässä ei ole "isoja kirjaimia" tai "pieniä kirjaimia". Näihin voidaan käyttää vastaavasti {ngutlh tIn:n@@ngutlh:n, tIn:v} ja {ngutlh mach:n@@ngutlh:n, mach:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "letter, written character". The additional definition "glyph" comes from {jItuj'ep ngutlh:n:nolink}.</column>
       <column name="components"></column>
       <column name="examples">{jItuj'ep ngutlh:n}</column>
@@ -4717,6 +5199,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4724,6 +5207,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}, [2] {KLI mailing list 2018.02.25:src}</column>
     </table>
     <table name="mem">
@@ -4737,6 +5221,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">умри, игральные кости с буквами [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">骰子用字母 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dado, dados com letras</column>
+      <column name="definition_fi">kirjainnoppa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI' nagh:n}, {SuD:v:2}</column>
@@ -4747,6 +5232,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ngutlh:n}, {nagh:n}</column>
       <column name="examples"></column>
@@ -4756,6 +5242,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Spielwürfel, Würfel</column>
       <column name="search_tags_fa"></column>
@@ -4763,6 +5250,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4776,6 +5264,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">шрифт, гарнитура [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">字型、字體</column>
       <column name="definition_pt">fonte, tipo de letra</column>
+      <column name="definition_fi">kirjasin, kirjasinlaji, fontti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4786,6 +5275,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="notes_ru">Для «жирный» может использоваться {pI':v}. Для «курсива» может использоваться {chongHa':v@@chong:v:1, -Ha':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於“粗體”，可以使用{pI':v}。對於“斜體”，可以使用{chongHa':v@@chong:v:1, -Ha':v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">"Lihavoiduksi" voidaan käyttää {pI':v}. "Kursiiviksi" voidaan käyttää {chongHa':v@@chong:v:1, -Ha':v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ngutlh:n}, {tu'qom:n}</column>
       <column name="examples"></column>
@@ -4795,6 +5285,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bold, italics</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4802,6 +5293,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -4815,6 +5307,7 @@ Observe que "então" no sentido de "subsequentemente" é {ghIq:adv}.[1] [AUTOTRA
       <column name="definition_ru">быть окрашенным, окрашенным, окрашенным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">染色</column>
       <column name="definition_pt">ser tingido, manchado, colorido</column>
+      <column name="definition_fi">olla värjätty</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Doq:v}, {SuD:v:1}, {rItlh:n}, {chum:v}, {qalmuS:n}</column>
@@ -4827,6 +5320,9 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä sanaa käytetään harvoin paitsi kysymyksessä {chay 'nguv?: Sen: nolink} tai kun se liitetään {-moH:v}-muotoon muodostaen {nguvmoH:v}.
+
+{chIS:v}: n ja {qIj:v}: n lisäksi klingonissa on vain kaksi tunnettua värisanaa, {Doq:v} ja {SuD:v:1}. Kaksi viimeksi mainittua sanaa lisätään {-qu':v}: llä ja / tai yhdistetään {chay' nguv?:sen:nolink}0: n ja {Hurgh:v}: n kanssa tarkempien värien viittaamiseksi. Vielä tarkemmin sanottuna käytetään vertailuja, kuten {Doq 'ej Qaj wuS rur:sen}.[1, p.82]{wov:v} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4836,6 +5332,7 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">color, colour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4843,6 +5340,7 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4856,6 +5354,7 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="definition_ru">краситель, морилка, оттенок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">染料、染色、色調 [AUTOTRANSLATED]</column>
       <column name="definition_pt">corante, mancha, tonalidade</column>
+      <column name="definition_fi">väriaine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4866,6 +5365,7 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nguv:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -4875,6 +5375,7 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4882,6 +5383,7 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4895,6 +5397,7 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="definition_ru">насмехаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嘲笑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">zombar</column>
+      <column name="definition_fi">pilkata, ivata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4905,6 +5408,7 @@ Besides {chIS:v} and {qIj:v}, there are only two known color words in Klingon, {
       <column name="notes_ru">На жаргоне это называется {Sen:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">this語是{Sen:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma forma de gíria de dizer isso é {Sen:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Slangitapa sanoa tämä on {Sen:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Written in "xifan hol", this is "fuy". "Fooey" (or "phooey") is an expression of disdain.
 
 The intransitivity of this verb was confirmed during the Q &amp; A session. The target of the scoffing would have to be indicated for example with {-Daq:n:suff}.</column>
@@ -4916,6 +5420,7 @@ The intransitivity of this verb was confirmed during the Q &amp; A session. The 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4923,6 +5428,7 @@ The intransitivity of this verb was confirmed during the Q &amp; A session. The 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4936,6 +5442,7 @@ The intransitivity of this verb was confirmed during the Q &amp; A session. The 
       <column name="definition_ru">идентифицировать, опознавать, распознавать, устанавливать личность</column>
       <column name="definition_zh_HK">鑑定 [AUTOTRANSLATED]</column>
       <column name="definition_pt">identificar</column>
+      <column name="definition_fi">tunnistaa, identifioida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{per:v}</column>
@@ -4946,6 +5453,7 @@ The intransitivity of this verb was confirmed during the Q &amp; A session. The 
       <column name="notes_ru">Вопрос "что" часто лучше всего переводится на Клингонский, используя форму повелительного наклонения этого или похожего глагола.[2]</column>
       <column name="notes_zh_HK">英文中的“ what”問題通常最好使用該動詞或類似動詞的祈使形式翻譯為Klingon。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma pergunta "o que" em inglês geralmente é melhor traduzida para o klingon usando a forma imperativa deste ou de um verbo semelhante.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Englanninkielinen "mitä" -kysymys käännetään usein parhaiten klingoniksi käyttämällä tämän tai vastaavan verbin pakollista muotoa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4958,6 +5466,7 @@ The intransitivity of this verb was confirmed during the Q &amp; A session. The 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">which</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4965,5 +5474,6 @@ The intransitivity of this verb was confirmed during the Q &amp; A session. The 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>

--- a/mem-11-p.xml
+++ b/mem-11-p.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {p:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{p:sen:nolink}</column>
       <column name="definition_pt">a consoante {p:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {p:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">следовать правилам, соблюдать правила</column>
       <column name="definition_zh_HK">遵循（規則） [AUTOTRANSLATED]</column>
       <column name="definition_pt">seguir, obedecer (as regras)</column>
+      <column name="definition_fi">noudattaa (sääntöjä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bIv:v}, {pabHa':v}</column>
       <column name="see_also">{chut:n}, {HeQ:v}, {lob:v}, {pab:n}</column>
@@ -70,6 +75,9 @@ I samband med ett löfte eller ett löfte som har gjorts (se {'Ip:v} och {lay':v
       <column name="notes_pt">Alguns objetos possíveis desse verbo são {pab:n}, {chut:n}, {nab:n}, {'Ip:n}, {lurDech:n}, {quv:n} e {tIgh:n}.
 
 No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:v:nolink} significa "manter" ou "cumprir" .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jotkut tämän verbin mahdollisista kohteista ovat {pab:n}, {chut:n}, {nab:n}, {'Ip:n}, {lurDech:n}, {quv:n} ja {tIgh:n}.
+
+Annetun lupauksen tai lupauksen yhteydessä (katso {'Ip:v} ja {lay':v}) {pab:v:nolink} tarkoittaa "pitämistä" tai "täyttämistä".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -97,6 +105,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
 ▶ {tlhIngan tIgh yIpab:sen:nolink} "Live the Klingon way"[2, p.198-199]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rules, adhere to</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -104,6 +113,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="search_tags_ru">правила</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -117,6 +127,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="definition_ru">не следовать правилам, не соблюдать правила, соблюдать правила неверно, следовать правилам неверно</column>
       <column name="definition_zh_HK">誤入歧途[規則]、錯誤地遵循[規則] [AUTOTRANSLATED]</column>
       <column name="definition_pt">deixar de seguir (as regras), seguir (as regras) incorretamente</column>
+      <column name="definition_fi">rikkoa (sääntöjä), noudattaa (sääntöjä) väärin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pab:v}</column>
       <column name="see_also"></column>
@@ -127,6 +138,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="notes_ru">Описывает явно преднамеренный, слегка извилистый, общий способ конструирования {mu'mey ru':n}.</column>
       <column name="notes_zh_HK">這描述了語法規則的明顯蓄意的輕微彎曲，這是構造{mu'mey ru':n}的常見方法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso descreve uma leve flexão obviamente deliberada das regras gramaticais, uma maneira comum de construir {mu'mey ru':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kuvaa kielioppisääntöjen ilmeisesti tarkoituksellista pientä taipumista, yleistä tapaa rakentaa {mu'mey ru':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pab:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -136,6 +148,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -143,6 +156,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.176:src}</column>
     </table>
     <table name="mem">
@@ -156,6 +170,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="definition_ru">грамматика</column>
       <column name="definition_zh_HK">語法</column>
       <column name="definition_pt">gramática</column>
+      <column name="definition_fi">kielioppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chut:n}, {pab:v}</column>
@@ -166,6 +181,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -175,6 +191,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -182,6 +199,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -195,6 +213,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="definition_ru">часть речи</column>
       <column name="definition_zh_HK">詞類</column>
       <column name="definition_pt">parte do discurso</column>
+      <column name="definition_fi">sanaluokka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -205,6 +224,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pab:n}, {buv:n}</column>
       <column name="examples"></column>
@@ -214,6 +234,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -221,6 +242,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -234,6 +256,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="definition_ru">коготь</column>
       <column name="definition_zh_HK">爪</column>
       <column name="definition_pt">garra</column>
+      <column name="definition_fi">kynsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}, {namwech:n}</column>
@@ -244,6 +267,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="notes_ru">Смотрите {jej:v} и {jejHa':v} для двух идиоматических выражений, в которых участвуют {pach:n:nolink}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Consulte {jej:v} e {jejHa':v} para obter duas expressões idiomáticas envolvendo {pach:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {jej:v} ja {jejHa':v} kahdesta idiomaattisesta lausekkeesta, joihin liittyy {pach:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -253,6 +277,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nail</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -260,6 +285,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="search_tags_ru">ноготь</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -273,6 +299,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="definition_ru">молоток высокого суда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">高閣槌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">martelo do tribunal</column>
+      <column name="definition_fi">(korkeimman oikeuden?) nuija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mupwI':n}</column>
@@ -283,6 +310,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pach:n}, {moQ:n}</column>
       <column name="examples"></column>
@@ -292,6 +320,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gavel, hammer</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -299,6 +328,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -312,6 +342,7 @@ No contexto de um voto ou promessa que foi feito (ver {'Ip:v} e {lay':v}), {pab:
       <column name="definition_ru">ничего, ничто, ноль, никто, ни один</column>
       <column name="definition_zh_HK">沒有、沒有、沒有人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nada, ninguém</column>
+      <column name="definition_fi">ei mitään, ei kukaan</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hoch:n}</column>
       <column name="see_also">{'op:n}, {pagh:n:2}, {'achghej:n}</column>
@@ -336,6 +367,14 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
 Глагольный префикс повелительного наклонения, когда {pagh:n:1h,nolink} является объектом {yI-:v:pref}, есл команда отдана одному лицу, и {pe-:v:pref}, если команда отдана множеству лиц.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Verbien etuliitteet, kun {pagh:n:1h,nolink} on objekti (eli objektia ei ole):
+▶ {jIH:n:1h}: {pagh:n:1h,nolink} = {jI-:v:pref}
+▶ {maH:n:1h}: {pagh:n:1h,nolink} = {ma-:v:pref}
+▶ {SoH:n}: {pagh:n:1h,nolink} = {bI-:v:pref}
+▶ {tlhIH:n}: {pagh:n:1h,nolink} = {Su-:v:pref}
+▶ {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n}: {pagh:n:1h,nolink} = {0:v:pref}
+
+Pakollinen verbi-etuliite, kun kohde on {pagh:n:1h,nolink}, on {yI-:v:pref}, jos komento annetaan yhdelle henkilölle, ja {pe-:v:pref}, jos se annetaan useille ihmisille. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -345,6 +384,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nobody</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -352,6 +392,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -365,6 +406,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="definition_ru">ноль</column>
       <column name="definition_zh_HK">零</column>
       <column name="definition_pt">zero</column>
+      <column name="definition_fi">nolla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pagh:n:1}, {paghlogh:adv}, {paghDIch:n}</column>
@@ -375,6 +417,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -384,6 +427,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -391,6 +435,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -404,6 +449,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="definition_ru">нулевое [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">零 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nulo</column>
+      <column name="definition_fi">"nollas", "ei mikäännes" (jokin joka ei ole)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wa'DIch:n}, {HochDIch:n}</column>
@@ -414,6 +460,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="notes_ru">Это используется для описания того, что ожидалось или могло произойти, но не произошло. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於描述預期發生或可能想到但未發生的事情。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para descrever algo que se esperava que ocorresse, ou que poderia ocorrer, mas que não ocorreu. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään kuvaamaan jotain, jonka odotettiin tapahtuvan tai voisi tapahtua, mutta ei ole tapahtunut. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pagh:n:2,num}, {-DIch:n:num,suff}</column>
       <column name="examples">
@@ -424,6 +471,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -431,6 +479,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.177:src}</column>
     </table>
     <table name="mem">
@@ -444,6 +493,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="definition_ru">никогда</column>
       <column name="definition_zh_HK">決不 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nunca</column>
+      <column name="definition_fi">ei koskaan</column>
       <column name="synonyms">{not:adv}, {ghe'torvo' narghDI' qa'pu':sen}</column>
       <column name="antonyms">{Hochlogh:adv}</column>
       <column name="see_also"></column>
@@ -454,6 +504,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="notes_ru">Это более выразительная альтернатива для {not:adv}.</column>
       <column name="notes_zh_HK">這是{not:adv}的重要替代方案。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma alternativa enfática ao {not:adv}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on painava vaihtoehto {not:adv}: lle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pagh:n:2}, {-logh:n:num,suff}</column>
       <column name="examples">
@@ -464,6 +515,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -471,6 +523,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.178:src}</column>
     </table>
     <table name="mem">
@@ -484,6 +537,7 @@ The imperative verb prefix when {pagh:n:1h,nolink} is the object is {yI-:v:pref}
       <column name="definition_ru">или, или/или (объединение предложений)</column>
       <column name="definition_zh_HK">或者、或者（加入句子） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ou, ou um ou outro (juntando frases)</column>
+      <column name="definition_fi">tai, joko tai (eksklusiivinen tai) (yhdistää lauseita, verbejä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qoj:conj}, {ghap:conj}</column>
@@ -508,6 +562,9 @@ Vid anslutning av flera meningar behövs endast den slutliga konjunktionen. Se e
       <column name="notes_pt">Em Klingon, a conjunção {pagh:conj} não pode ser usada para apresentar duas opções a alguém, como "render-se ou morrer". {bIjegh pagh bIHegh:sen:nolink} significa "você está se rendendo ou está morrendo" (como se o falante não tivesse certeza do que está acontecendo). Em vez disso, a frase deve ser reformulada como "Se você não se render, você morrerá". Consulte {bIjeghbe'chugh vaj bIHegh!:sen} para obter mais informações.
 
 Ao conectar várias frases, apenas a conjunção final é necessária. Veja o exemplo em {qoj:conj}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonissa yhdistelmää {pagh:conj} ei voida käyttää kahden vaihtoehdon esittämiseen jollekin, kuten "antautu tai kuole". {bIjegh pagh bIHegh:sen:nolink} tarkoittaa "annat anteeksi tai kuolet" (ikään kuin puhuja ei ole varma, mitä tapahtuu). Sen sijaan lause on muotoiltava uudelleen seuraavasti: "Jos et anna periksi, kuolet". Katso lisätietoja kohdasta {bIjeghbe'chugh vaj bIHegh!:sen}.
+
+Kun yhdistetään useita lauseita, tarvitaan vain viimeinen yhdistelmä. Katso esimerkki kohdasta {qoj:conj}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -517,6 +574,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -524,6 +582,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -537,6 +596,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">платье, одежда, одеяние</column>
       <column name="definition_zh_HK">禮服、連衣裙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vestido</column>
+      <column name="definition_fi">puku, leninki, mekko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mop:n}, {paH bID:n}</column>
@@ -547,6 +607,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined in {TKD:src} as "gown". In {TNK:src}, it is used for "dress", while {paH bID:n} is used for "skirt".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -556,6 +617,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -563,6 +625,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -576,6 +639,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">юбка, подол</column>
       <column name="definition_zh_HK">短裙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">saia</column>
+      <column name="definition_fi">hame</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paH:n}, {bID:n}, {DIr paH bID:n}</column>
@@ -586,6 +650,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{paH:n}, {bID:n}</column>
       <column name="examples"></column>
@@ -595,6 +660,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -602,6 +668,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -615,6 +682,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">уходить в отставку, слагать полномочия</column>
       <column name="definition_zh_HK">辭職 [AUTOTRANSLATED]</column>
       <column name="definition_pt">renunciar</column>
+      <column name="definition_fi">erota, irtisanoutua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'utlh:n}</column>
@@ -625,6 +693,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -634,6 +703,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -641,6 +711,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -654,6 +725,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">искриться, искрить, давать искры, вспыхивать</column>
       <column name="definition_zh_HK">火花、發出火花 [AUTOTRANSLATED]</column>
       <column name="definition_pt">faísca, emitir faíscas</column>
+      <column name="definition_fi">kipinöidä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qulHom:n}, {bar:v}, {ghon:v}</column>
@@ -664,6 +736,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A flash in the pan.</column>
       <column name="components"></column>
       <column name="examples">
@@ -675,6 +748,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
 ▶ {pan qeylIS betleH 'ej jach molor 'etlh HoS:sen:nolink} "Батлет Кейлеса искрится, и ревет могучий меч Молора."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -682,6 +756,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, [2] {paq'batlh p.166-7:src}</column>
     </table>
     <table name="mem">
@@ -695,6 +770,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">решить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">解決 [AUTOTRANSLATED]</column>
       <column name="definition_pt">resolver, solucionar</column>
+      <column name="definition_fi">ratkaista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -705,6 +781,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru">Это означает определить решение {ngajrun:n}, {poymar:n}, {Qay'mol:n} или так далее. Сленговым способом сказать, что это {SIHHa'moH:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著確定對{ngajrun:n}，{poymar:n}，{Qay'mol:n}等的解決方案。說這句話的語是{SIHHa'moH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa determinar a solução para um {ngajrun:n}, {poymar:n}, {Qay'mol:n} ou assim por diante. Uma forma de gíria para dizer isso é {SIHHa'moH:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa ratkaisun määrittämistä tuotteille {ngajrun:n}, {poymar:n}, {Qay'mol:n} tai niin edelleen. Slangitapa sanoa tämä on {SIHHa'moH:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -714,6 +791,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -721,6 +799,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -734,6 +813,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">срыв (струнный инструмент) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">採（弦樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">depenar (um instrumento de cordas) </column>
+      <column name="definition_fi">näppäillä (kielisoitinta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HurDagh:n}, {yach:v:2}</column>
@@ -744,6 +824,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It's what it sounds like.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -753,6 +834,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -760,6 +842,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -773,6 +856,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">книга</column>
       <column name="definition_zh_HK">書</column>
       <column name="definition_pt">livro</column>
+      <column name="definition_fi">kirja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghItlh:n}, {Se'vIr:n}, {yorgh:n}</column>
@@ -783,6 +867,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Klingon Dictionary was published by Pocket Books. See also {buq:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -792,6 +877,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -799,6 +885,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -812,6 +899,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">Пок</column>
       <column name="definition_zh_HK">學 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Pok</column>
+      <column name="definition_fi">Pok</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -822,6 +910,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru">Сын Торгена ({torghen:n:name}), и главный персонаж голосимуляции в {KCD:src}.</column>
       <column name="notes_zh_HK">Torghn的兒子（{torghen:n:name}），以及{KCD:src}中的Holodeck模擬的主要角色。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O filho de Torghn ({torghen:n:name}) e o personagem principal da simulação de holodeck em {KCD:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Torghnin poika ({torghen:n:name}), ja holodeck-simulaation päähenkilö {KCD:src}: ssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -831,6 +920,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -838,6 +928,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -851,6 +942,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">Передвижная библиотека</column>
       <column name="definition_zh_HK">流動圖書館 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bookmobile</column>
+      <column name="definition_fi">kirjastoauto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -861,6 +953,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{paq:n:1h}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -870,6 +963,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -877,6 +971,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -890,6 +985,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">библиотекарь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">圖書管理員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bibliotecário</column>
+      <column name="definition_fi">kirjastonhoitaja</column>
       <column name="synonyms">{De' QulwI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{paq nojwI' qach:n}, {paq nojwI' tum:n}</column>
@@ -900,6 +996,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{paq:n:1h}, {noj:v}, {-wI':n}</column>
       <column name="examples"></column>
@@ -909,6 +1006,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -916,6 +1014,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -929,6 +1028,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">библиотека (здание) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">圖書館（建築） [AUTOTRANSLATED]</column>
       <column name="definition_pt">biblioteca (edifício)</column>
+      <column name="definition_fi">kirjasto (rakennus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paq nojwI':n}, {paq nojwI' tum:n}</column>
@@ -939,6 +1039,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{paq nojwI':n}, {qach:n}</column>
       <column name="examples"></column>
@@ -948,6 +1049,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -955,6 +1057,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -968,6 +1071,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">library (public) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">圖書館（公共） [AUTOTRANSLATED]</column>
       <column name="definition_pt">biblioteca (pública)</column>
+      <column name="definition_fi">kirjasto(järjestelmä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paq nojwI':n}, {paq nojwI' qach:n}</column>
@@ -978,6 +1082,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{paq nojwI':n}, {tum:n}</column>
       <column name="examples"></column>
@@ -987,6 +1092,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -994,6 +1100,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1007,6 +1114,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">Книга чести</column>
       <column name="definition_zh_HK">榮譽經</column>
       <column name="definition_pt">Livro de Honra</column>
+      <column name="definition_fi">eräs kirja, Kunnian kirja, paq'batlh</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlha'veq:n:name}</column>
@@ -1041,6 +1149,11 @@ Se även {tIq'ghob:n:hyp} för en hypotetisk liknande grammatisk konstruktion. [
 O {paq'batlh:n:nolink} é dividido em três partes principais, intituladas respectivamente {paq'yav:n:nolink} "Ground Book", {paq'raD:n:nolink} "Force Book" e {paq'QIH:n:nolink} "Impact Book".
 
 Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipotética. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjan nimi, jossa kerrotaan {qeylIS'e' lIjlaHbe'bogh vay':n:name}: n legendaarisesta elämästä ja teoista. Huomaa, että kirjan nimi on {no' Hol:n}, ja että nykyaikaisessa standardissa Klingon "Book of Honor" olisi {batlh paq:n:nolink}; heittomerkki edustaa puuttuvaa kielioppielementtiä, joka selittäisi saattamisen osaksi kansallista lainsäädäntöä.[1]
+
+{paq'batlh:n:nolink} on jaettu kolmeen pääosaan, joiden otsikot ovat {paq'yav:n:nolink} "Pohjakirja", {paq'raD:n:nolink} "Voima kirja" ja {paq'QIH:n:nolink} "Vaikutuskirja".
+
+Katso myös hypoteettinen samanlainen kieliopillinen rakenne kohdasta {tIq'ghob:n:hyp}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{paq:n:1h}, {batlh:n}</column>
       <column name="examples"></column>
@@ -1050,6 +1163,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1057,6 +1171,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -1070,6 +1185,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">размышлять (о), размышлять (о), размышлять (о), созерцать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">冥想（on）、cogitate（about）、反思（on）、思考 [AUTOTRANSLATED]</column>
       <column name="definition_pt">meditar (sobre), cogitar (sobre), refletir (sobre), contemplar</column>
+      <column name="definition_fi">mietiskellä, pohdiskella, miettiä, pohtia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qub:v}, {buS:v}, {qIm:v}</column>
@@ -1080,6 +1196,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru">Это слово может (но не обязательно) взять объект, указывающий, о чем медитируют или о чем размышляют. Это не означает «умолять», поэтому «молиться» может не быть подходящим переводом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞可以（但不是必須）帶一個對象，該對象指示正在冥想或思考的事物。它並不表示“ entreat”，因此“ pray”可能不是適當的翻譯。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra pode (mas não precisa) pegar um objeto indicando o que está sendo meditado ou refletido. Não conota "pedido", portanto, "orar" pode não ser uma tradução apropriada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi (mutta ei tarvitse) ottaa esineen, joka osoittaa, mistä mietitään tai mihin heijastetaan. Se ei tarkoita "vetoomusta", joten "rukoilla" ei välttämättä ole sopiva käännös. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1089,6 +1206,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1096,6 +1214,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1109,6 +1228,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">учение, обучение, выучка</column>
       <column name="definition_zh_HK">教導 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ensinamentos</column>
+      <column name="definition_fi">opetus, opetukset</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DuSaQ:n}, {lalDan:n}, {paq:n:1h}, {ghoj:v}, {HaD:v}</column>
@@ -1119,6 +1239,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1128,6 +1249,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1135,6 +1257,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1148,6 +1271,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">не любить, недолюбливать, не нравиться</column>
       <column name="definition_zh_HK">反感、討厭</column>
       <column name="definition_pt">não gostar</column>
+      <column name="definition_fi">ei pitää jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{parHa':v}</column>
       <column name="see_also">{muS:v}</column>
@@ -1158,6 +1282,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1167,6 +1292,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1174,6 +1300,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1187,6 +1314,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">a mid-sized bird with particularly garish coloring (at least from a Klingon point of view) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種中等大小的鳥、顏色特別鮮豔（至少從克林崗的觀點來看） [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro de tamanho médio com cores particularmente berrantes (pelo menos do ponto de vista klingon)</column>
+      <column name="definition_fi">eräs keskikokoinen (ainakin klingonin mielestä) räikeän värinen lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1197,6 +1325,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In golf, "one under par" ({bIng:n} means "under") is known as a "birdie", and golfers have traditionally worn garishly coloured clothing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1206,6 +1335,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">a mid-sized bird with particularly garish colouring</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1213,6 +1343,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1226,6 +1357,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">гипс [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">石膏粉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gesso</column>
+      <column name="definition_fi">kipsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIl:n}</column>
@@ -1236,6 +1368,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru">Это минерал, состоящий из гидратированного сульфата кальция, имеющий ряд применений, в том числе в качестве предшественника гипса. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種由水合硫酸鈣組成的礦物，具有許多用途，包括作為石膏的前體。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um mineral que consiste em sulfato de cálcio hidratado, tendo várias aplicações, inclusive como precursor de gesso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on mineraali, joka koostuu hydratoidusta kalsiumsulfaatista, jolla on useita sovelluksia, myös kipsi-esiasteena. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1245,6 +1378,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1252,6 +1386,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1265,6 +1400,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">быть синтетическим, искусственным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">是合成的、人造的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser sintético, artificial</column>
+      <column name="definition_fi">olla keinotekoinen, synteettinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{but:v}</column>
       <column name="see_also"></column>
@@ -1275,6 +1411,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A combination of "parve" and "margarine"?</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1284,6 +1421,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1291,6 +1429,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Si Vis Pacem, Para Bellum:src}</column>
     </table>
     <table name="mem">
@@ -1304,6 +1443,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">любить, нравиться</column>
       <column name="definition_zh_HK">喜歡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gostar</column>
+      <column name="definition_fi">pitää jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{par:v}</column>
       <column name="see_also">{muSHa':v}</column>
@@ -1314,6 +1454,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{par:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -1323,6 +1464,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1330,6 +1472,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1343,6 +1486,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">любовь, романтика</column>
       <column name="definition_zh_HK">愛情、浪漫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">amor, romance</column>
+      <column name="definition_fi">rakkaus, romantiikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{parmaqqay:n}, {muSHa':v}</column>
@@ -1353,6 +1497,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru">Любовь, клингонский стиль - с гораздо более интенсивным значением, чем английское слово. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗（Klingon）風格的愛情-比英語單詞內涵更深刻。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Amor, estilo Klingon - com conotações muito mais intensas do que a palavra em inglês. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Rakkaus, klingonityyli - paljon voimakkaammalla merkityksellä kuin englanninkielinen sana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1362,6 +1507,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1369,6 +1515,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Diplomatic Implausibility:src}</column>
     </table>
         <table name="mem">
@@ -1382,6 +1529,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
           <column name="definition_ru">романтический компаньон, романтический партнер [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">浪漫伴侶、情人</column>
           <column name="definition_pt">companheiro romântico, parceiro romântico</column>
+      <column name="definition_fi">romanttinen kumppani</column>
           <column name="synonyms">{bang:n}</column>
           <column name="antonyms"></column>
           <column name="see_also">{parmaq:n}</column>
@@ -1392,6 +1540,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
           <column name="notes_ru">Это слово редко используется в прямом обращении. Вместо этого пары называют друг друга {bang pong:n}.[1, p.199] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這個詞很少在直接地址中使用。而是由{bang pong:n}.[1, p.199]互相呼叫 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Essa palavra raramente é usada em endereço direto. Em vez disso, os casais se chamam por {bang pong:n}.[1, p.199] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään harvoin suorassa osoitteessa. Sen sijaan pariskunnat soittavat toisilleen {bang pong:n}.[1, p.199] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -1401,6 +1550,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">darling, dear, love, lover, mate</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1408,6 +1558,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
     <table name="mem">
@@ -1421,6 +1572,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">Дата [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">日期 [AUTOTRANSLATED]</column>
       <column name="definition_pt">encontro</column>
+      <column name="definition_fi">treffit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1431,6 +1583,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru">Это относится к романтическому свиданию или свиданию. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指浪漫或求愛的日子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma data romântica ou de namoro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa romanttiseen tai seurustelupäivään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{parmaq:n}, {qep:n}</column>
       <column name="examples"></column>
@@ -1440,6 +1593,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1447,6 +1601,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1460,6 +1615,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">быть поздним, быть опоздавшим,</column>
       <column name="definition_zh_HK">遲到 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar atrasado</column>
+      <column name="definition_fi">olla myöhässä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eq:v}</column>
@@ -1470,6 +1626,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru">См. {pel'aQDaj ghorpa':sen:idiom} для идиоматического выражения, связанного с запозданием, и {'eb:n} для некоторых примеров того, как выразить понятие «слишком поздно». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Consulte {pel'aQDaj ghorpa':sen:idiom} para obter uma expressão idiomática relacionada ao atraso e {'eb:n} para obter alguns exemplos de como expressar o conceito de "tarde demais". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso viivästykseen liittyvä idiomaattinen lauseke kohdasta {pel'aQDaj ghorpa':sen:idiom} ja {'eb:n} esimerkkejä siitä, miten ilmaisu "liian myöhäistä" ilmaistaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1479,6 +1636,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1486,6 +1644,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {s.e 1998.01.18:src}</column>
     </table>
     <table name="mem">
@@ -1499,6 +1658,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">клингонское растение, напоминающее корицу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肉桂樣克林崗植物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">planta Klingon tipo canela</column>
+      <column name="definition_fi">eräs kanelia muistuttava klingonien kasvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1509,6 +1669,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru">{paSjav:n:nolink} - это клингонское дерево, кора которого режется на полоски и употребляется вместе с определенными продуктами, либо измельчается (например, {ngat:n:2}) и добавляется в некоторые другие виды продуктов. (Иногда его просто срывают с дерева и тут же едят.) Неклингоны, которые едят слишком много {paSjav:n:nolink}, начинают кашлять. Клингоны думают, что это довольно забавно, и никогда не устают от этого. {tera' paSjav:n@@tera':n, paSjav:n} - это способ обозначить корицу.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{paSjav:n:nolink}是一棵克林崗樹，其樹皮被切成條狀並與某些食物一起食用，或者被碾碎（例如{ngat:n:2}）並添加到其他種類的食物中。 （它偶爾會從樹上剝下來，然後在那兒吃。）吃了過多{paSjav:n:nolink}的非克林貢人開始咳嗽。克林貢斯人認為這很有趣，而且從未厭倦。 {tera' paSjav:n@@tera':n, paSjav:n}是指肉桂的一種方式。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{paSjav:n:nolink} on klingonipuu, jonka kuori leikataan nauhoiksi ja syödään yhdessä tiettyjen elintarvikkeiden kanssa tai muuten jauhetaan (kuten {ngat:n:2}) ja lisätään joihinkin muihin elintarvikkeisiin. (Se on joskus vain repitty puusta ja syönyt silloin tällöin.) Ei-klingonilaiset, jotka syövät liikaa {paSjav:n:nolink}: ta, alkavat yskää. Klingonien mielestä tämä on aika hauskaa eikä koskaan näytä väsyttävän sitä. {tera' paSjav:n@@tera':n, paSjav:n} on tapa viitata kaneliin[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1518,6 +1679,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1525,6 +1687,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1538,6 +1701,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">носки</column>
       <column name="definition_zh_HK">襪（眾數）</column>
       <column name="definition_pt">meias</column>
+      <column name="definition_fi">sukat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{waq:n}</column>
@@ -1548,6 +1712,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">說“一雙襪子”的通常方法是{paSlogh chang'eng:n@@paSlogh:n, chang'eng:n}； {tu'mI' chang'eng:n@@tu'mI':n, chang'eng:n}很奇怪，但是可以理解。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A maneira usual de dizer "um par de meias" é {paSlogh chang'eng:n@@paSlogh:n, chang'eng:n}; {tu'mI' chang'eng:n@@tu'mI':n, chang'eng:n} é ímpar, mas seria compreendido.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tavallinen tapa sanoa "sukkapari" on {paSlogh chang'eng:n@@paSlogh:n, chang'eng:n}; {tu'mI' chang'eng:n@@tu'mI':n, chang'eng:n} on pariton, mutta se ymmärretään[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tu'mI':n:inhps}</column>
       <column name="examples"></column>
@@ -1557,6 +1722,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1564,6 +1730,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}, [3] {KLI mailing list 2019.01.22:src}</column>
     </table>
     <table name="mem">
@@ -1577,6 +1744,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">ткань, используемая в коврах и ковриках [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地毯和地毯用織物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tecido usado em tapetes</column>
+      <column name="definition_fi">matoissa ja ryijyissä käytetty kangas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIm:n}</column>
@@ -1587,6 +1755,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="notes_ru">Это не используется для ткани, используемой для одежды, для которой см. {weSjech:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不適用於用於服裝的面料，請參見{weSjech:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não é usado para tecidos usados ​​em roupas, para os quais consulte {weSjech:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä ei käytetä vaatteisiin käytettäviin kankaisiin, joista ks. {weSjech:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1596,6 +1765,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1603,6 +1773,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1616,6 +1787,7 @@ Veja também {tIq'ghob:n:hyp} para uma construção gramatical semelhante hipot�
       <column name="definition_ru">система</column>
       <column name="definition_zh_HK">系統</column>
       <column name="definition_pt">sistema</column>
+      <column name="definition_fi">järjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1640,6 +1812,9 @@ Observera att Klingon-termen för ett stjärnsystem är {Hovtay':n}. [AUTOTRANSL
       <column name="notes_pt">Isso se refere a sistemas no sentido físico (ou parecido com o físico), em oposição a uma metodologia, que é {Ho'DoS:n}.[2]
 
 Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa järjestelmiin fyysisessä (tai fyysisessä) mielessä, toisin kuin metodologia, joka on {Ho'DoS:n}.[2]
+
+Huomaa, että tähtijärjestelmän Klingon-termi on {Hovtay':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1663,6 +1838,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1670,6 +1846,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -1683,6 +1860,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="definition_ru">картофель</column>
       <column name="definition_zh_HK">土豆 [AUTOTRANSLATED]</column>
       <column name="definition_pt">batata</column>
+      <column name="definition_fi">peruna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oQqar:n}</column>
@@ -1693,6 +1871,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="notes_ru">Это то, что Клингоны зовут земным овощем</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族蔬菜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que os klingons chamariam de vegetal terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-vihannekseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1702,6 +1881,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1709,6 +1889,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -1722,6 +1903,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="definition_ru">изумруд [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">翠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esmeralda</column>
+      <column name="definition_fi">smaragdi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naghboch:n}, {DItlhon:n}</column>
@@ -1732,6 +1914,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Emerald is a variety of the mineral beryl. Beryl Patmore is a character on the TV show Downton Abbey.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1741,6 +1924,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1748,6 +1932,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -1761,6 +1946,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="definition_ru">ранг(военный или правительственный), уровень, слой, положение, стаж</column>
       <column name="definition_zh_HK">等級（軍事、政府）、等級、層次、地位 [AUTOTRANSLATED]</column>
       <column name="definition_pt">classificação (militar, governamental), nível, camada, posição</column>
+      <column name="definition_fi">sotilasarvo, taso, sijoitus, asema, luokitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qutluch patlh:n}, {num:v}, {patlh:v}</column>
@@ -1771,6 +1957,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="notes_ru">Смотрите под {yaS:n} для рядов офицеров. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">見{yaS:n}下的軍銜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {yaS:n} as fileiras de oficiais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso upseerien rivejä kohdasta {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Patch".</column>
       <column name="components"></column>
       <column name="examples">
@@ -1786,6 +1973,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
 ▶ {SIQwI' lu'oy'moHmeH juppu'Daj 'oy'naQmey lo' chaH. SuvwI' qa' patlh veb chavlaHmeH tlhIngan lo'chu' chaH. toDujDaj toblu'.:sen:nolink} "Посох боли употребляется друзьями посвящаемого, которые используют устройство, чтобы причинить боль способом, который позволит Клингону достигнуть более высокого духовного состояния, как воин, доказывая его храбрость."[5]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1793,6 +1981,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT:src}, [3] {BoP:src}, [4] {SkyBox 9:src}, [5] {SkyBox 32:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -1806,6 +1995,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="definition_ru">быть оцененным, иметь статус, быть оцененным; быть отсортированным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被評定、有地位、被評分;被分類 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser classificado, ter status, ser graduado (ter um rank)</column>
+      <column name="definition_fi">olla arvo tai asema, olla arvotettu, olla luokiteltu, olla sijoitettu; olla järjestetty</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{patlh:n}, {patlhmoH:v}, {tetlh:n}</column>
@@ -1816,6 +2006,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">要按字母順序對英語單詞列表進行排序，請使用諸如{wa'DIch a, HochDIch z:sen:nolink}（或{wa'DIch z, HochDIch a:sen:nolink}為相反順序）之類的構造。對於克林崗語，請使用{wa'DIch bay, HochDIch qaghwI':sen:nolink}或{wa'DIch qaghwI', HochDIch bay:sen:nolink}。要反轉列表，請使用{DopmoH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Voit lajitella luettelon englanninkielisistä sanoista aakkosjärjestyksessä käyttämällä rakennetta kuten {wa'DIch a, HochDIch z:sen:nolink} (tai {wa'DIch z, HochDIch a:sen:nolink} päinvastaisessa järjestyksessä). Käytä Klingon-sanoja varten {wa'DIch bay, HochDIch qaghwI':sen:nolink} tai {wa'DIch qaghwI', HochDIch bay:sen:nolink}. Voit kääntää luettelon kääntämällä {DopmoH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1825,6 +2016,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1832,6 +2024,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.06:src}, [2] {KLI mailing list 2018.02.10:src}</column>
     </table>
     <table name="mem">
@@ -1845,6 +2038,7 @@ Observe que o termo Klingon para um sistema estelar é {Hovtay':n}. [AUTOTRANSLA
       <column name="definition_ru">ранг, присвоить статус, сортировать; сравнить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">評價分類</column>
       <column name="definition_pt">classificar, atribuir status, comparar</column>
+      <column name="definition_fi">sijoittaa, määrittää asema, järjestää, lajitella; vertailla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{num:v}, {DopmoH:v}</column>
@@ -1867,6 +2061,9 @@ När verbet används med "jämför" -beteckningen, måste verbens objekt vara pl
       <column name="notes_pt">Quando o objeto é singular, isso significa "classificação" no sentido de "grau" .[2]
 
 Quando usado com o significado de "comparar", o objeto do verbo deve estar no plural. A implicação é que as coisas são classificadas em comparação umas às outras.[1] Quando usado para significar "classificar", o objeto não é uma lista (como um todo), mas as coisas na lista, as coisas a serem classificadas ou classificadas.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun kohde on yksikkö, se tarkoittaa "sijoitus" merkityksessä "arvosana" .[2]
+
+Verbi-merkinnän kanssa käytettynä verbiobjektin on oltava monikko. Tarkoituksena on, että asiat luokitellaan toisiinsa nähden.[1][3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example sentence was suggested to Okrand in Klingon, who provided the English translation.</column>
       <column name="components">{patlh:v}, {-moH:v}</column>
       <column name="examples">
@@ -1877,6 +2074,7 @@ Quando usado com o significado de "comparar", o objeto do verbo deve estar no pl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1884,6 +2082,7 @@ Quando usado com o significado de "comparar", o objeto do verbo deve estar no pl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.06:src}, [2] {KLI mailing list 2018.02.07:src}, [3] {KLI mailing list 2018.02.10:src}</column>
     </table>
     <table name="mem">
@@ -1897,6 +2096,7 @@ Quando usado com o significado de "comparar", o objeto do verbo deve estar no pl
       <column name="definition_ru">Быть срочным, быть безотлагательным, быть экстренным, быть крайне необходимым</column>
       <column name="definition_zh_HK">緊急 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser urgente</column>
+      <column name="definition_fi">olla kiireellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{potlh:v}, {ram:v}, {chach:n}, {nom:adv}
@@ -1910,6 +2110,7 @@ Quando usado com o significado de "comparar", o objeto do verbo deve estar no pl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1920,6 +2121,7 @@ Quando usado com o significado de "comparar", o objeto do verbo deve estar no pl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1927,6 +2129,7 @@ Quando usado com o significado de "comparar", o objeto do verbo deve estar no pl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1940,6 +2143,7 @@ Quando usado com o significado de "comparar", o objeto do verbo deve estar no pl
       <column name="definition_ru">приехать, приезжать, прибывать, прилетать</column>
       <column name="definition_zh_HK">到達 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chegar</column>
+      <column name="definition_fi">saapua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mej:v}, {tlheD:v}</column>
       <column name="see_also"></column>
@@ -1964,6 +2168,9 @@ Förväxla inte detta med {paw':v:1}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">{paw:v:nolink} funciona de maneira semelhante a {jaH:v}.[2]
 
 Não confunda isso com {paw':v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{paw:v:nolink} toimii samalla tavalla kuin {jaH:v}.[2]
+
+Älä sekoita tätä {paw':v:1}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1977,6 +2184,7 @@ Não confunda isso com {paw':v:1}. [AUTOTRANSLATED]</column>
 ▶ {DujDaq jIpaw.:sen:nolink} "Я прибываю на корабле."  Это, "Я прибываю с помощью корабля."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1984,6 +2192,7 @@ Não confunda isso com {paw':v:1}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -1997,6 +2206,7 @@ Não confunda isso com {paw':v:1}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">сталкиваться, вступать в противоречие</column>
       <column name="definition_zh_HK">衝撞</column>
       <column name="definition_pt">colidir</column>
+      <column name="definition_fi">törmätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2019,6 +2229,9 @@ Förväxla inte detta med {paw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">O verbo {paw':v:nolink} sempre leva um sujeito no plural, a saber, as coisas em movimento que colidem. Quando o assunto é pessoas, o verbo é geralmente interpretado com o significado da gíria de "cabeçadas" (ver {paw':v:2,slang}). Para descrever a colisão de algo se movendo com algo parado, use {ngeQ:v} em vez disso.[2; 3]
 
 Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbi {paw':v:nolink} ottaa aina monikkomuodon, nimittäin törmäävät liikkeessä olevat asiat. Kun aihe on ihminen, verbi tulkitaan yleensä slang-merkityksellä "puskupäät" (katso {paw':v:2,slang}). Käytä sen sijaan {ngeQ:v}: n kuvaamista törmäyksestä, joka liikkuu jonkin paikallaan olevan kanssa.
+
+Älä sekoita tätä {paw:v}: een.[2; 3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's what it sounds like.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2029,6 +2242,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2036,6 +2250,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.2-12, Dec. 1998:src}, [3] {KGT p.157:src}</column>
     </table>
     <table name="mem">
@@ -2049,6 +2264,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">стыковые головы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">對接頭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cabeças de bunda</column>
+      <column name="definition_fi">iskeä päät yhteen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qIp'egh nachDu'chaj, tlhIngan SuvwI'pu'.:sen}</column>
@@ -2059,6 +2275,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">與該動詞的字面用法（請參閱{paw':v:1}）一樣，當以其lang語含義使用時，它也包含多個主語，在這種情況下，是撞頭的人。要說兩個人發生碰撞而並不意味著他們在撞頭，可以將{ngeQ:v}與{-chuq:v:suff}.[1]一起使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kuten tämän verbin kirjaimellisessa käytössä (ks. Jos sanotaan, että kaksi ihmistä törmää toisiinsa tarkoittamatta, että he ovat takapäätä, {ngeQ:v}: ta voidaan käyttää yhdessä {-chuq:v:suff}: n kanssa.{paw':v:1}[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's what it sounds like.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2068,6 +2285,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">headbutting</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2075,6 +2293,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.157:src}</column>
     </table>
     <table name="mem">
@@ -2088,6 +2307,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">вена [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">靜脈 [AUTOTRANSLATED]</column>
       <column name="definition_pt">veia</column>
+      <column name="definition_fi">laskimo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mej'aD:n}, {'aD:n}</column>
@@ -2098,6 +2318,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это было сокращено со временем от {pawmeH 'aD:n@@paw:v, -meH:v, 'aD:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">隨著時間的推移，從{pawmeH 'aD:n@@paw:v, -meH:v, 'aD:n}開始縮短了時間。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso foi reduzido com o tempo do {pawmeH 'aD:n@@paw:v, -meH:v, 'aD:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä lyhennettiin ajan myötä {pawmeH 'aD:n@@paw:v, -meH:v, 'aD:n}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2107,6 +2328,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2114,6 +2336,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2127,6 +2350,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">сожалеть, раскаиваться, горевать</column>
       <column name="definition_zh_HK">後悔 [AUTOTRANSLATED]</column>
       <column name="definition_pt">arrepender</column>
+      <column name="definition_fi">katua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeH:v}, {QoS:v}</column>
@@ -2137,6 +2361,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Another way of saying "You'll regret this!" is "You'll pay for this!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2146,6 +2371,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2153,6 +2379,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2166,6 +2393,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">вдруг, скоропостижно, внезапно</column>
       <column name="definition_zh_HK">突然 [AUTOTRANSLATED]</column>
       <column name="definition_pt">de repente</column>
+      <column name="definition_fi">yhtäkkiä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pay'Ha':adv}</column>
       <column name="see_also">{mer:v}, {DaH:adv}, {SIbI':adv}</column>
@@ -2176,6 +2404,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2185,6 +2414,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2192,6 +2422,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2205,6 +2436,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">частица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">粒子</column>
       <column name="definition_pt">partícula</column>
+      <column name="definition_fi">hiukkanen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeySel:n}, {'o'rIS:n}, {ngIng:v}, {ruS:v}, {ngochjuH:n}</column>
@@ -2215,6 +2447,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The name of the consonant "p" in Klingon is {pay:sen:nolink}, and "an" is an article in English, so "p-article".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2224,6 +2457,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2231,6 +2465,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2244,6 +2479,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">археологический памятник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">考古遺址 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sítio arqueológico</column>
+      <column name="definition_fi">arkeologinen kaivaus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIgh:n}</column>
@@ -2254,6 +2490,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Suddenly ({pay':adv}) finished ({rIn:v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2263,6 +2500,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2270,6 +2508,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2283,6 +2522,7 @@ Não confunda isso com {paw:v}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">комната, помещение, пространство, закрытое помещение, камера, палата</column>
       <column name="definition_zh_HK">房間、封閉區域、房間 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sala, área fechada, câmara</column>
+      <column name="definition_fi">huone, kammio, suljettu alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qach:n}</column>
@@ -2307,6 +2547,9 @@ Das {bIS'ub:n} eines {pa':n:1h,nolink} ist sein {rav:n:1}, und sein {'aqroS:n:1}
       <column name="notes_pt">Esta palavra é homófona com {pa':n:2}. No entanto, {pa'Daq:n:nolink} significa inequivocamente "na sala".
 
 O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o seu {rav'eq:n}. Se o {pa':n:1h,nolink} está na história principal de um {qach:n}, então seu {rav'eq:n} é chamado de {pa' beb:n}. As paredes de um {pa':n:1h,nolink} são {tlhoy':n}; se o outro lado de uma parede for {Hur:n}, então a parede também é chamada de {pa' reD:n}. A palavra {tlhoy':n} pode se referir a qualquer lado de uma sala; um teto / piso entre andares é denominado {tlhoy' SaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on homofoninen sanalle {pa':n:2}. {pa'Daq:n:nolink} tarkoittaa kuitenkin yksiselitteisesti "huoneessa".
+
+{pa':n:1h,nolink}: n {bIS'ub:n} on sen {rav:n:1}, ja sen {'aqroS:n:1} on sen {rav'eq:n}. Jos {pa':n:1h,nolink} on {qach:n}: n ylimmässä tarinassa, niin sen {rav'eq:n}: tä kutsutaan sen {pa' beb:n}: ksi. {pa':n:1h,nolink}: n seinät ovat {tlhoy':n}; jos seinän toinen puoli on {Hur:n}, seinää kutsutaan myös {pa' reD:n}: ksi. Sana {tlhoy':n} voi viitata huoneen mihin tahansa puoleen; tarinoiden välistä kattoa / lattiaa kutsutaan {tlhoy' SaS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word is defined as "room" in {TKD:src}, as "enclosed area" in {KGT:src}, and as "chamber" in {BoP:src} (see {cha'puj pa':n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2316,6 +2559,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2323,6 +2567,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {BoP:src}, [4] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -2336,6 +2581,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">здесь, там, вон там, около этого, поблизости, неподалёку, тут</column>
       <column name="definition_zh_HK">那裡、那邊</column>
       <column name="definition_pt">lá, ali, por aí</column>
+      <column name="definition_fi">siellä, sielläpäin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naDev:n}, {Dat:n}, {vogh:n}</column>
@@ -2346,6 +2592,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="notes_ru">Это слово является омофонным с {pa':n:1}. В качестве указания места, {pa':n:2,nolink} никогда не принимает суффикс {-Daq:n:suff}, и может только означать "здесь" ({TKD 3.3.5:src}). В противоположность к {pa'Daq:n:nolink} может означать "в комнате".</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta palavra é homofônica com {pa':n:1}. Como locativo, {pa':n:2,nolink} nunca usa o sufixo {-Daq:n:suff} e pode apenas significar "lá" ({TKD 3.3.5:src}). Por outro lado, {pa'Daq:n:nolink} só pode significar "na sala". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on homofoninen sanalle {pa':n:1}. Paikannusaineena {pa':n:2,nolink} ei koskaan ota liitettä {-Daq:n:suff}, ja se voi tarkoittaa vain "siellä" ({TKD 3.3.5:src}). Sitä vastoin {pa'Daq:n:nolink} voi tarkoittaa vain "huoneessa". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2355,6 +2602,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2362,6 +2610,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2375,6 +2624,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">потолок верхнего этажа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頂樓故事室的天花板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">teto da sala do andar superior</column>
+      <column name="definition_fi">ylimmän kerroksen huoneen katto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{beb:n}, {rav:n:1}, {tlhoy' SaS:n}, {yor:n}</column>
@@ -2385,6 +2635,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="notes_ru">Это относится к потолку ({'aqroS:n:1}) комнаты, которая находится на верхнем (или единственном) этаже здания. Если над ним есть комнаты, то это {rav'eq:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指位於建築物頂層（或僅頂層）的房間的天花板（{'aqroS:n:1}）。如果上方有房間，則為{rav'eq:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao teto ({'aqroS:n:1}) de uma sala que está no topo (ou apenas) de um andar de uma estrutura. Se houver salas acima dela, então é uma {rav'eq:n}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa huoneen kattoon ({'aqroS:n:1}), joka on rakennuksen yläosassa (tai vain). Jos sen yläpuolella on huoneita, se on {rav'eq:n}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2394,6 +2645,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ceiling of a top storey room</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2401,6 +2653,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -2414,6 +2667,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">Я не был здесь</column>
       <column name="definition_zh_HK">我不在那裡。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu não estava lá</column>
+      <column name="definition_fi">En ollut siellä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2424,6 +2678,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2433,6 +2688,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2440,6 +2696,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -2454,6 +2711,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">внутренняя поверхность наружной стены [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">外牆的內部面 [AUTOTRANSLATED]</column>
       <column name="definition_pt">face interior da parede externa</column>
+      <column name="definition_fi">ulkoseinän sisäpinta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reD:n:1}, {tlhoy':n}</column>
@@ -2464,6 +2722,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In Spanish, "pared" means "wall".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2473,6 +2732,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2480,6 +2740,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -2493,6 +2754,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">рифма [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">韻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rima</column>
+      <column name="definition_fi">riimi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sa:v}, {ghuQ:n}</column>
@@ -2503,6 +2765,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2512,6 +2775,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2519,6 +2783,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2532,6 +2797,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">прошлое (в целом) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">過去（整體而言） [AUTOTRANSLATED]</column>
       <column name="definition_pt">o passado (como um todo)</column>
+      <column name="definition_fi">menneisyys (kokonaisuutena)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tuch:n}</column>
       <column name="see_also">{ret:n}</column>
@@ -2542,6 +2808,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="notes_ru">Для сравнения, {'op ret:n@@'op:n, ret:n} означает «в какой-то момент в прошлом». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">相比之下，{'op ret:n@@'op:n, ret:n}的意思是“過去的某個時候”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em comparação, {'op ret:n@@'op:n, ret:n} significa "em algum momento no passado". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vertailun vuoksi {'op ret:n@@'op:n, ret:n} tarkoittaa "jossain vaiheessa menneisyydessä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In German, the word for "in the past" is "damals", which can be pulled apart as "da" ("there", {pa':n:2}) and "mal(s)" ("times", {-logh:n:num,suff}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2551,6 +2818,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2558,6 +2826,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2571,6 +2840,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">Пахво [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Pahvo [AUTOTRANSLATED]</column>
       <column name="definition_pt">Pahvo</column>
+      <column name="definition_fi">Pahvo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa'vongan:n}</column>
@@ -2581,6 +2851,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2590,6 +2861,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2597,6 +2869,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Si Vis Pacem, Para Bellum:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2610,6 +2883,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">Пахван [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Pahvan [AUTOTRANSLATED]</column>
       <column name="definition_pt">Pahvan</column>
+      <column name="definition_fi">pahvolainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa'vo:n}</column>
@@ -2620,6 +2894,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pa'vo:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -2629,6 +2904,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2636,6 +2912,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Si Vis Pacem, Para Bellum:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2649,6 +2926,7 @@ O {bIS'ub:n} de um {pa':n:1h,nolink} é o seu {rav:n:1} e o {'aqroS:n:1} é o se
       <column name="definition_ru">повелительное наклонение: вы(множественное число)(действие)</column>
       <column name="definition_zh_HK">（命令）你們：無</column>
       <column name="definition_pt">imperativo: vocês-nenhum</column>
+      <column name="definition_fi">imperatiivi: te-ei mikään</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Su-:v:pref}</column>
@@ -2663,6 +2941,9 @@ Generally, when a verb describing a state of being is used as an imperative, the
 В целом, когда глагол описывает состояние пребывания, и используется в форме повелительного наклонения, то используются суффиксы {-'egh:v} и {-moH:v} вместе с ним.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{tlhIH:n}: {pagh:n:1h} = {pe-:v:pref,nolink} (imp.)
+
+Yleensä kun olotilaa kuvaavaa verbiä käytetään välttämättömänä, sen kanssa käytetään päätteitä {-'egh:v} ja {-moH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2672,6 +2953,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">you-none</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2679,6 +2961,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.117:src}</column>
     </table>
     <table name="mem">
@@ -2692,6 +2975,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">вид фруктов [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">水果類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de fruta</column>
+      <column name="definition_fi">eräs torpedon muotoinen hedelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaH:v:2}, {Hurgh:n}, {tera' peb'ot:n}</column>
@@ -2702,6 +2986,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru">Это пропитано в {chanDoq:n} и съедено. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">將其浸泡在{chanDoq:n}中並食用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É embebido em {chanDoq:n} e comido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä liotetaan {chanDoq:n}: ssä ja syödään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2711,6 +2996,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cucumber</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2718,6 +3004,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2731,6 +3018,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">заносить снегом, припорошить</column>
       <column name="definition_zh_HK">落雪、慢慢地飄落來（像雪一樣）</column>
       <column name="definition_pt">nevar, cair lentamente (como neve)</column>
+      <column name="definition_fi">sataa lunta, leijailla alas (kuin lumi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chal chuch:n}, {chuch:n}, {Heq:v}, {SIS:v}, {muD Dotlh:n}, {pum:v:2}, {ghomHa':v}</column>
@@ -2753,6 +3041,9 @@ Detta verb kan också användas för andra saker vars fallande rörelse liknar s
       <column name="notes_pt">Não há substantivo ou verbo conhecido para nevasca, mas pode-se dizer {peDqu':sen@@peD:v, -qu':v}, {pe'vIl peD:sen@@pe'vIl:adv, peD:v} ou mesmo {pe'vIl peDqu':sen@@pe'vIl:adv, peD:v, -qu':v}.[2]
 
 Esse verbo também pode ser usado para outras coisas cujo movimento de queda se assemelha a neve, por exemplo migalhas de pão, confete ou cinzas. A coisa que está caindo é o assunto.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Blizzardille ei ole tunnettua substantiivia tai verbiä, mutta voidaan sanoa {peDqu':sen@@peD:v, -qu':v}, {pe'vIl peD:sen@@pe'vIl:adv, peD:v} tai edes {pe'vIl peDqu':sen@@pe'vIl:adv, peD:v, -qu':v}.[2]
+
+Tätä verbiä voidaan käyttää myös muihin asioihin, joiden putoava liike muistuttaa lumisateita, esimerkiksi leivänmuruja, konfettia tai tuhkaa. Kaatuva asia on aihe[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example line appeared in the Kate Bush album "50 Words for Snow".</column>
       <column name="components"></column>
       <column name="examples">
@@ -2764,6 +3055,7 @@ Esse verbo também pode ser usado para outras coisas cujo movimento de queda se 
 ▶ {peDtaH 'ej chIS qo':sen@@peD:v, -taH:v, 'ej:conj, chIS:v, qo':n} "Идёт снег и мир побелел."[4]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2771,6 +3063,7 @@ Esse verbo também pode ser usado para outras coisas cujo movimento de queda se 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}, [3] {Saarbrücken qepHom'a' 2017:src}, [4] {KLI mailing list 2018.02.22:src}</column>
     </table>
     <!-- Maybe {pegh:v} should be "v:ambi", but its definitions don't fit. -->
@@ -2785,6 +3078,7 @@ Esse verbo também pode ser usado para outras coisas cujo movimento de queda se 
       <column name="definition_ru">хранить что-то в секрете, хранить тайну</column>
       <column name="definition_zh_HK">保守秘密 [AUTOTRANSLATED]</column>
       <column name="definition_pt">manter algo em segredo</column>
+      <column name="definition_fi">pitää jokin salassa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tey':v}, {pegh:n}, {'ot:v}, {So':v:2}</column>
@@ -2795,6 +3089,7 @@ Esse verbo também pode ser usado para outras coisas cujo movimento de queda se 
       <column name="notes_ru">Этот глагол также может использоваться без объекта. Смотрите {pegh:v:2}.</column>
       <column name="notes_zh_HK">該動詞也可以不帶賓語使用。參見{pegh:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também pode ser usado sem um objeto. Consulte {pegh:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä voidaan käyttää myös ilman esinettä. Katso {pegh:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TKD:src}, this is defined in the K-E side as "keep something secret", and in the E-K side as "secret, keep something secret".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2804,6 +3099,7 @@ Esse verbo também pode ser usado para outras coisas cujo movimento de queda se 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2811,6 +3107,7 @@ Esse verbo também pode ser usado para outras coisas cujo movimento de queda se 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2824,6 +3121,7 @@ Esse verbo também pode ser usado para outras coisas cujo movimento de queda se 
       <column name="definition_ru">быть секретным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">保密 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser secreto</column>
+      <column name="definition_fi">olla salainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pegh:n}</column>
@@ -2848,6 +3146,9 @@ Detta verb kan också användas med ett objekt. Se {pegh:v:1}. [AUTOTRANSLATED]<
       <column name="notes_pt">Consulte {rav:n:2} para obter um exemplo de como falar sobre informações classificadas.
 
 Este verbo também pode ser usado com um objeto. Consulte {pegh:v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {rav:n:2}-esimerkki siitä, miten puhutaan turvaluokitellusta tiedosta.
+
+Tätä verbiä voidaan käyttää myös kohteen kanssa. Katso {pegh:v:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2859,6 +3160,7 @@ Este verbo também pode ser usado com um objeto. Consulte {pegh:v:1}. [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2866,6 +3168,7 @@ Este verbo também pode ser usado com um objeto. Consulte {pegh:v:1}. [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2879,6 +3182,7 @@ Este verbo também pode ser usado com um objeto. Consulte {pegh:v:1}. [AUTOTRANS
       <column name="definition_ru">тайна, секрет</column>
       <column name="definition_zh_HK">秘密 [AUTOTRANSLATED]</column>
       <column name="definition_pt">segredo</column>
+      <column name="definition_fi">salaisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngoq:n}, {Hung:n}, {pegh:v:1}, {pegh:v:2}, {luH:v:2}, {chaw' ngoq:n}</column>
@@ -2889,6 +3193,7 @@ Este verbo também pode ser usado com um objeto. Consulte {pegh:v:1}. [AUTOTRANS
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2898,6 +3203,7 @@ Este verbo também pode ser usado com um objeto. Consulte {pegh:v:1}. [AUTOTRANS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2905,6 +3211,7 @@ Este verbo também pode ser usado com um objeto. Consulte {pegh:v:1}. [AUTOTRANS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2918,6 +3225,7 @@ Este verbo também pode ser usado com um objeto. Consulte {pegh:v:1}. [AUTOTRANS
       <column name="definition_ru">пословица о секретности [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">保密諺語</column>
       <column name="definition_pt">provérbio secreto</column>
+      <column name="definition_fi">salaisuussanonta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qogh tuQmoHHa':sen}</column>
@@ -2938,6 +3246,9 @@ Detta förkortas också sällan till {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLAT
       <column name="notes_pt">Trata-se de um conjunto de provérbios usados ​​com mais frequência em situações em que o falante deseja mostrar que pode guardar um segredo sob qualquer condição.[2]
 
 Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nämä ovat sananlaskuja, joita käytetään useimmiten tilanteissa, joissa puhuja haluaa osoittaa voivansa pitää salaisuuden missään olosuhteissa.
+
+Tämä lyhennetään harvoin myös muotoon {pegh vIttlhegh:n:nolink}.[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pegh:n}, {-mey:n}, {vIttlhegh:n}</column>
       <column name="examples"></column>
@@ -2947,6 +3258,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2954,6 +3266,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.1, Mar. 1996 p.10:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2968,6 +3281,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">Возраст включения</column>
       <column name="definition_zh_HK">包容時代 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Idade da Inclusão</column>
+      <column name="definition_fi">Age of Inclusion [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nenghep:n}</column>
@@ -2978,6 +3292,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{peH:n:hyp,nolink} or {peH:v:hyp,nolink}, {ghep:n:hyp}</column>
       <column name="examples"></column>
@@ -2987,6 +3302,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2994,6 +3310,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3007,6 +3324,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">сносить, разрушать, уничтожать, разбивать, обрушивать</column>
       <column name="definition_zh_HK">拆除 [AUTOTRANSLATED]</column>
       <column name="definition_pt">demolir</column>
+      <column name="definition_fi">purkaa (rakennus tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qaw':v}</column>
@@ -3017,6 +3335,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3026,6 +3345,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3033,6 +3353,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3046,6 +3367,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">скорлупа (яйца) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蛋殼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">casca (de um ovo)</column>
+      <column name="definition_fi">(munan) kuori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIm:n}, {nagh DIr:n}, {'eb:n}, {pel'aQ:n:2}</column>
@@ -3057,6 +3379,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Существует идиоматическое выражение {pel'aQDaj ghorpa':sen:idiom} «до того, как оно сломает свою оболочку», означающее «пока не поздно» или «пока еще есть время». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個慣用的表達方式{pel'aQDaj ghorpa':sen:idiom}“在它破殼之前”，意思是“在為時已晚之前”或“還有時間”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe uma expressão idiomática {pel'aQDaj ghorpa':sen:idiom} "antes de quebrar sua concha", significando "antes que seja tarde demais" ou "enquanto ainda há tempo". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idiomaattinen ilmaisu {pel'aQDaj ghorpa':sen:idiom} "ennen kuin se rikkoo kuorensa", mikä tarkoittaa "ennen kuin on liian myöhäistä" tai "kun vielä on aikaa". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3066,6 +3389,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3073,6 +3397,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3086,6 +3411,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">гроб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">棺材 [AUTOTRANSLATED]</column>
       <column name="definition_pt">caixão</column>
+      <column name="definition_fi">ruumisarkku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pel'aQ:n:1}, {nev'aQ:n}, {nebeylI':n}, {jItuj'ep:n}</column>
@@ -3096,6 +3422,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3105,6 +3432,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3112,6 +3440,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3125,6 +3454,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">пока не поздно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">在為時已晚之前 [AUTOTRANSLATED]</column>
       <column name="definition_pt">antes que seja tarde</column>
+      <column name="definition_fi">ennen kuin on liian myöhäistä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paS:v}, {'eb:n}</column>
@@ -3135,6 +3465,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Это буквально означает «до того, как оно сломает свою оболочку», и как идиоматическое выражение оно имеет значение «пока не стало слишком поздно» или «пока еще есть время». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“在破殼之前”，作為慣用語，它的意思是“在為時已晚之前”或“在有時間的時候”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "antes de quebrar sua concha" e, como expressão idiomática, tem o significado de "antes que seja tarde demais" ou "enquanto ainda há tempo". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "ennen kuin se rikkoo kuorensa", ja idiomaattisena ilmaisuna sillä on "ennen kuin on liian myöhäistä" tai "kun vielä on aikaa". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3145,6 +3476,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3152,6 +3484,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3165,6 +3498,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">дневное время</column>
       <column name="definition_zh_HK">白天 [AUTOTRANSLATED]</column>
       <column name="definition_pt">diurno</column>
+      <column name="definition_fi">päiväsaika, valoisan aika</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ram:n}</column>
       <column name="see_also">{jaj:n}, {jajlo':n}, {po:n}, {pov:n}, {pemjep:n}</column>
@@ -3175,6 +3509,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Относится к части дня, когда есть свет (в противоположность к {ram:n}).[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Refere-se à parte do dia em que a luz está apagada (em oposição a {ram:n}).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa päivän osaan, jolloin se on valaistu (toisin kuin {ram:n}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3184,6 +3519,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">day, daylight</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3191,6 +3527,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.121:src}</column>
     </table>
     <table name="mem">
@@ -3204,6 +3541,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">полдень</column>
       <column name="definition_zh_HK">正午</column>
       <column name="definition_pt">meio dia</column>
+      <column name="definition_fi">keskipäivä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ramjep:n:1}</column>
       <column name="see_also">{DungluQ:n}, {megh:n}, {pem:n}, {pov:n}</column>
@@ -3214,6 +3552,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pem:n}, {jep:n:hyp}</column>
       <column name="examples"></column>
@@ -3223,6 +3562,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3230,6 +3570,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3243,6 +3584,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">Пентат III(Планета)</column>
       <column name="definition_zh_HK">Pentath III [AUTOTRANSLATED]</column>
       <column name="definition_pt">Pentath III</column>
+      <column name="definition_fi">Pentath III</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3253,6 +3595,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Планета в Кардассианском Союзе. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">Cardassian Union中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta na União Cardassiana. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Cardassian Unionissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3262,6 +3605,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3269,6 +3613,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3282,6 +3627,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">торпеда</column>
       <column name="definition_zh_HK">魚雷（單數）</column>
       <column name="definition_pt">torpedo</column>
+      <column name="definition_fi">torpedo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jorneb:n}, {baH:v}</column>
@@ -3292,6 +3638,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Известные типы Клингонских торпед включают {pach peng:n}, {moratlh ro':n}, и {notqa' pach:n}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Os tipos conhecidos de torpedos Klingon incluem o {pach peng:n}, {moratlh ro':n} e {notqa' pach:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tunnettuja Klingonin torpedotyyppejä ovat {pach peng:n}, {moratlh ro':n} ja {notqa' pach:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Ping" is the sonar sound made by submarines.</column>
       <column name="components">{cha:n:inhpl}</column>
       <column name="examples">
@@ -3302,6 +3649,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">missile</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3309,6 +3657,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru">ракета</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3322,6 +3671,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">теплоотвод для торпедной установки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">魚雷發射器的熱量排放 [AUTOTRANSLATED]</column>
       <column name="definition_pt">exaustão de calor para lançador de torpedos</column>
+      <column name="definition_fi">torpedonheittimen lämmönpoisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3332,6 +3682,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{peng:n}, {baHjan:n}, {tuj ghImwI':n}</column>
       <column name="examples"></column>
@@ -3341,6 +3692,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3348,6 +3700,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3361,6 +3714,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">повышение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">提高</column>
       <column name="definition_pt">levantar</column>
+      <column name="definition_fi">nostaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3371,6 +3725,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "pep" rally raises a team's spirits.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3380,6 +3735,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3387,6 +3743,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3400,6 +3757,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">ток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">當前 [AUTOTRANSLATED]</column>
       <column name="definition_pt">corrente</column>
+      <column name="definition_fi">(sähkö)virta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IrmeD:n}, {marQen:n}</column>
@@ -3410,6 +3768,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Это относится к движению воздуха или воды. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指空氣或水的運動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um movimento do ar ou da água. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ilman tai veden liikkumiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A "currant" is a type of raisin ({pep:v}-{en:sen:nolink}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3419,6 +3778,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3426,6 +3786,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -3439,6 +3800,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">устраивать резню, устраивать бойню, устраивать кровопролитие</column>
       <column name="definition_zh_HK">屠宰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">abate</column>
+      <column name="definition_fi">teurastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wID:v}, {HoH:v}</column>
@@ -3449,6 +3811,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Это слово означает намерение, нацеленное на конкретных жертв.</column>
       <column name="notes_zh_HK">這個詞意指針對特定受害者的意圖。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra conota intenção, visando vítimas específicas.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana merkitsee tarkoitusta, joka kohdistuu tiettyihin uhreihin[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example sentence is a lip-match for {'ej DochmeywIj vItlhapqa'meH}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3460,6 +3823,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
 ▶ {'ej Dojmey wID, vInDa'ma' peq.:sen@@'ej:conj, Dojmey:n, wID:v, vInDa':n, -ma':n, peq:v} "Он убил много наших людей."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3467,6 +3831,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -3480,6 +3845,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">магнетизм, личное обаяние</column>
       <column name="definition_zh_HK">磁性</column>
       <column name="definition_pt">magnetismo</column>
+      <column name="definition_fi">magnetismi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ul:n}</column>
@@ -3490,6 +3856,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3501,6 +3868,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
 ▶ {bISuvtaHvIS qarDaS bIghHa' peQ botjan Daveghchu'.:sen:nolink} "Сражайся самоятоятельно за пределами щитов Кардассианской тюрьмы."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3508,6 +3876,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3521,6 +3890,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">магнитное поле</column>
       <column name="definition_zh_HK">磁場</column>
       <column name="definition_pt">campo magnético</column>
+      <column name="definition_fi">magneettikenttä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoSchem:n}, {pIvchem:n}, {Surchem:n}, {tlhamchem:n}</column>
@@ -3531,6 +3901,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is written as {peQ chem:n:nolink} (with a space) in {TKDA:src}. The space has been removed for consistency with the other terms ending in {chem:n:hyp}.</column>
       <column name="components">{peQ:n}, {chem:n:hyp}</column>
       <column name="examples"></column>
@@ -3540,6 +3911,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">peQ chem</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3547,6 +3919,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3560,6 +3933,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">магнит [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">磁石</column>
       <column name="definition_pt">magneto</column>
+      <column name="definition_fi">magneetti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SInan:n}</column>
@@ -3570,6 +3944,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3579,6 +3954,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3586,6 +3962,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3599,6 +3976,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">ярлык, метка, этикетка, маркировка, бирка, пометка</column>
       <column name="definition_zh_HK">標籤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rótulo</column>
+      <column name="definition_fi">etiketti, nimike</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{per:v}</column>
@@ -3609,6 +3987,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3618,6 +3997,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3625,6 +4005,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3638,6 +4019,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">метить, помечать, наклеивать ярлыки, относить к какой-то категории, устанавливать, выяснять, удостоверяться, уточнять</column>
       <column name="definition_zh_HK">標籤、確定、指定 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rotular, verificar, especificar</column>
+      <column name="definition_fi">nimetä, nimikoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngu':v}, {per:n}</column>
@@ -3648,6 +4030,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Глагол {per:v:nolink} обычно означает "привязать или прикрепить имя к чему-то", но может быть использован для понятия, типа "конкретизировать, указывать". Один из способов спросить "который час" {rep yIper!:sen}, что дословно значит "Отметь час!"[2]</column>
       <column name="notes_zh_HK">動詞{per:v:nolink}通常表示“向其分配名稱”，但也可以用於“確定，指定，固定”這樣的概念。要求時間的一種方法是{rep yIper!:sen}，字面意思是“標註時間！”[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O verbo {per:v:nolink} geralmente significa "atribuir ou anexar um nome", mas também pode ser usado para noções como "verificar, especificar, fixar". Uma maneira de solicitar a hora é {rep yIper!:sen}, literalmente, "Marque a hora!"[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbi {per:v:nolink} tarkoittaa yleensä "nimen nimeämistä tai liittämistä", mutta sitä voidaan käyttää myös sellaisiin käsitteisiin kuten "selvittää, määritellä, kiinnittää". Yksi tapa kysyä aikaa on {rep yIper!:sen}, kirjaimellisesti "Merkitse tunti!" [2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3657,6 +4040,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3664,6 +4048,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1999.02.02:src}</column>
     </table>
         <table name="mem">
@@ -3677,6 +4062,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
           <column name="definition_ru">Кодовое имя</column>
           <column name="definition_zh_HK">代號</column>
           <column name="definition_pt">nome de código (apelido)</column>
+      <column name="definition_fi">koodinimi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Qu':n}, {tuH:n}</column>
@@ -3687,6 +4073,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
           <column name="notes_ru">Кодовое имя обычно заканчивается на {Qu':n}, например, {targh Qu':n:nolink} "Операция Тарг".[1, стр.48]</column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt">Um nome de código geralmente termina em {Qu':n}, por exemplo, {targh Qu':n:nolink} "Operation Targ" .[1, p.48] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Koodinimi päättyy yleensä kohtaan {Qu':n}, esim. {targh Qu':n:nolink} "Operation Targ".[1, p.48] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{per:n}, {yuD:v}</column>
           <column name="examples"></column>
@@ -3696,6 +4083,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">operation, mission</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3703,6 +4091,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
           <column name="search_tags_ru">операция, задание</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
     <table name="mem">
@@ -3716,6 +4105,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">пень [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">樹樁 [AUTOTRANSLATED]</column>
       <column name="definition_pt">toco</column>
+      <column name="definition_fi">kanto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sor:n}</column>
@@ -3726,6 +4116,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Это относится к деревьям и т. Д., А не к частям тела. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這適用於樹木等，不適用於身體部位。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se aplica a árvores, etc., não a partes do corpo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä koskee puita jne., Ei ruumiinosia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3735,6 +4126,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3742,6 +4134,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3755,6 +4148,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">поставка, отделка, обеспечение, выдача [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">供應、提供、提供、分配 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fornecer, prover, dispensar</column>
+      <column name="definition_fi">toimittaa, järjestää, varustaa, hankkia, jakaa jotakin (jollekulle)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nob:v}</column>
@@ -3765,6 +4159,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru">Объект этого глагола - это то, что выдано. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個動詞的賓語是發出的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto deste verbo é o que é dado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde on annettu asia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"PEZ" is a brand of candy dispenser.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3774,6 +4169,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hand out, give out, distribute</column>
       <column name="search_tags_de">ausgeben</column>
       <column name="search_tags_fa"></column>
@@ -3781,6 +4177,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -3794,6 +4191,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">быть сваренным (вместе) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">焊接（一起） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser soldado (juntos)</column>
+      <column name="definition_fi">olla hitsattu (yhteen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3804,6 +4202,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Tape". Possibly related to {petqaD:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3813,6 +4212,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3820,6 +4220,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <!-- Gowron says {petaD!}: http://youtu.be/i48VMmapyks -->
@@ -3834,6 +4235,7 @@ Também raramente é abreviado para {pegh vIttlhegh:n:nolink}.[1] [AUTOTRANSLATE
       <column name="definition_ru">оскорбление, эпитет</column>
       <column name="definition_zh_HK">稱號 [AUTOTRANSLATED]</column>
       <column name="definition_pt">epíteto</column>
+      <column name="definition_fi">eräs haukkumasana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vum:n}</column>
@@ -3858,6 +4260,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/GonhyphPQPU} [AUTOTRAN
       <column name="notes_pt">Este é um dos epítetos Klingon mais comuns.
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/GonhyphPQPU} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksi yleisimmistä klingonin epiteeteistä.
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/GonhyphPQPU} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">There's an explanation of the origin of this word on {paq'batlh p.70:src}.
 
 The sentence {nItlhejbogh petaQmey tInuD:sen:nolink} occurs on {paq'batlh p.143:src}, but it's not clear if the suffix {-mey:n:suff} is always used with this word.</column>
@@ -3869,6 +4274,7 @@ The sentence {nItlhejbogh petaQmey tInuD:sen:nolink} occurs on {paq'batlh p.143:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">p'tahk, pahtk, pahtak, p'tak</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3876,6 +4282,7 @@ The sentence {nItlhejbogh petaQmey tInuD:sen:nolink} occurs on {paq'batlh p.143:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3889,6 +4296,7 @@ The sentence {nItlhejbogh petaQmey tInuD:sen:nolink} occurs on {paq'batlh p.143:
       <column name="definition_ru">костная связка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">骨粘合劑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Dispositivo de cicatrização óssea</column>
+      <column name="definition_fi">luunsitoja?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaqwI':n}, {Hom:n:1}</column>
@@ -3899,6 +4307,7 @@ The sentence {nItlhejbogh petaQmey tInuD:sen:nolink} occurs on {paq'batlh p.143:
       <column name="notes_ru">Это устройство или вещество, используемое {HaqwI':n} для соединения сломанных костей на месте. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{HaqwI':n}用來將折斷的骨頭粘合到位的裝置或物質。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um dispositivo ou substância usada pelo {HaqwI':n} para colar ossos quebrados no lugar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on laite tai aine, jota {HaqwI':n} käyttää rikkoutuneiden luiden kiinnittämiseen paikoilleen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This seems to refer to a device similar to one used by the Federation called a bone-knitting laser (knitter for short), bone regenerator, or osteo-regenerator.
 
 "Duck tape". Possibly related to {pet:v}.</column>
@@ -3910,6 +4319,7 @@ The sentence {nItlhejbogh petaQmey tInuD:sen:nolink} occurs on {paq'batlh p.143:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bone-knitter, bone regenerator, osteo-regenerator</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3917,6 +4327,7 @@ The sentence {nItlhejbogh petaQmey tInuD:sen:nolink} occurs on {paq'batlh p.143:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Haynes BoP Manual p.107:src}, [2] {KLI mailing list 2014.12.17:src}</column>
     </table>
     <table name="mem">
@@ -3930,6 +4341,7 @@ The sentence {nItlhejbogh petaQmey tInuD:sen:nolink} occurs on {paq'batlh p.143:
       <column name="definition_ru">Действовать! Сделай это! Сделай это так! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">採取行動！做吧！這樣做！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Tome uma atitude! Faça isso! Faça assim!</column>
+      <column name="definition_fi">Toimi! Tee se!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3954,6 +4366,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [AUTOTRAN
       <column name="notes_pt">Isso é usado ao se dirigir a várias pessoas. Para se dirigir a uma única pessoa, diga {yIvang!:sen@@yI-:v, vang:v}
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään puhuttaessa useille ihmisille. Jos haluat puhua yksittäiselle henkilölle, sano {yIvang!:sen@@yI-:v, vang:v}
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pe-:v}, {vang:v}</column>
       <column name="examples"></column>
@@ -3963,6 +4378,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3970,6 +4386,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -3984,6 +4401,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">кислота</column>
       <column name="definition_zh_HK">酸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ácido</column>
+      <column name="definition_fi">happo</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'evtlhev:n}</column>
       <column name="see_also">{taS:n}, {ngoS:v}, {pIchSIv:n}</column>
@@ -3994,6 +4412,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is almost how "pH" is pronounced in French.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4003,6 +4422,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4010,6 +4430,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4023,6 +4444,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">резать, отрезать, разрезать</column>
       <column name="definition_zh_HK">切 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cortar</column>
+      <column name="definition_fi">leikata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIj:v:1}, {DuQ:v:1}, {chIp:v}, {taq:v}, {rIv:v}, {vIrgh:v}</column>
@@ -4033,6 +4455,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a private joke.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4042,6 +4465,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4049,6 +4473,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4062,6 +4487,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">нож для резки</column>
       <column name="definition_zh_HK">切刀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">faca de corte</column>
+      <column name="definition_fi">leikkuuveitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4072,6 +4498,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru">Относится к инструменту, а не к оружию.</column>
       <column name="notes_zh_HK">這是指工具刀，而不是武器刀。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma faca de ferramenta, em oposição a uma faca de arma. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa työkaluterään, toisin kuin aseveitsiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pe':v}, {-meH:v}, {taj:n}</column>
       <column name="examples"></column>
@@ -4081,6 +4508,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4088,6 +4516,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4101,6 +4530,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">разделочная доска [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">切菜板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tábua de cortar</column>
+      <column name="definition_fi">leikkuulauta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4111,6 +4541,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pe':v}, {-meH:v}, {'echlet:n}</column>
       <column name="examples"></column>
@@ -4120,6 +4551,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4127,6 +4559,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -4140,6 +4573,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">молния(погодное явление)</column>
       <column name="definition_zh_HK">閃電 [AUTOTRANSLATED]</column>
       <column name="definition_pt">raio</column>
+      <column name="definition_fi">salama</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{raw:v}, {tuD:v}, {jev:v:1}</column>
@@ -4150,6 +4584,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4159,6 +4594,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4166,6 +4602,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4179,6 +4616,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">мощно, насильно, силой</column>
       <column name="definition_zh_HK">強行、武力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">forçosamente, pela força</column>
+      <column name="definition_fi">voimakkaasti, väkisin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pe'vIlHa':adv}</column>
       <column name="see_also">{raD:v}</column>
@@ -4189,6 +4627,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a private joke.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4202,6 +4641,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4209,6 +4649,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -4222,6 +4663,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">осторожно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">平緩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gentilmente</column>
+      <column name="definition_fi">hellävaroen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pe'vIl:adv}</column>
       <column name="see_also">{-Ha':v:suff}</column>
@@ -4232,6 +4674,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4241,6 +4684,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4248,6 +4692,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 19 (2012):src} ({KLI mailing list 2012.08.30:src})</column>
     </table>
     <table name="mem">
@@ -4261,6 +4706,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">сделать что-то сразу, как одно событие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">作為一個單一事件、一次做一些事情 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer algo de uma só vez, como um único evento</column>
+      <column name="definition_fi">tehdä jokin yhdellä kertaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4271,6 +4717,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru">Это идиоматическое выражение буквально означает «насильно смести». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是“強行掃除”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa literalmente "varrer à força". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "voimakkaasti pyyhkimistä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4281,6 +4728,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4288,6 +4736,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.112:src}</column>
     </table>
     <table name="mem">
@@ -4301,6 +4750,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">ругайтесь хорошо!</column>
       <column name="definition_zh_HK">詛咒好！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Insulte bem!</column>
+      <column name="definition_fi">Kiroa hyvin!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4311,6 +4761,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4320,6 +4771,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4327,6 +4779,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.148:src}</column>
     </table>
     <table name="mem">
@@ -4340,6 +4793,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/QAd6OugYyxw} [A
       <column name="definition_ru">сильно использовать третий палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">強有力地使用第三個腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">use o terceiro dedo com força</column>
+      <column name="definition_fi">käyttää kolmatta varvasta voimakkaasti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mor:v}</column>
@@ -4364,6 +4818,9 @@ Verbetet {roS:v:2} betyder "att använda den tredje tån". Det är också homofo
       <column name="notes_pt">Essa expressão idiomática transmite a ideia de que alguém é particularmente ágil, ágil ou ágil.
 
 O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono com o verbo {roS:v:1} que significa "lamber". No entanto, é possível que este verbo seja na verdade um verbo desconhecido ou arcaico {roS:v:3,hyp} que significa "ser ágil". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu välittää ajatuksen siitä, että joku on erityisen ketterä tai ketterä tai spry.
+
+Verbi {roS:v:2} tarkoittaa "kolmannen kärjen käyttämistä". Se on myös homofoninen verbillä {roS:v:1}, joka tarkoittaa "nuolla". On kuitenkin mahdollista, että tämä verbi on itse asiassa muuten tuntematon tai arkaainen verbi {roS:v:3,hyp}, joka tarkoittaa "olla ketterä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4373,6 +4830,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be agile, be nimble, be spry</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4380,6 +4838,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4393,6 +4852,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Добро пожаловать! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">歡迎！</column>
       <column name="definition_pt">Bem-vindo!</column>
+      <column name="definition_fi">Tervetuloa!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4403,6 +4863,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Это клингонское приветствие, используемое для приветствия группы на мероприятии. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是克林崗語的問候，用於歡迎團體參加活動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma saudação Klingon usada para receber um grupo em um evento. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on klingonilainen tervehdys, jota käytetään ryhmän kutsumiseen tapahtumaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pe'vIl:adv}, {Su-:v}, {paw':v:2}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -4412,6 +4873,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4419,6 +4881,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4432,6 +4895,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">вести счет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">保持得分 [AUTOTRANSLATED]</column>
       <column name="definition_pt">manter a pontuação</column>
+      <column name="definition_fi">laskea pisteitä, pitää kirjaa pisteistä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIvwa':n}, {mIvwa'mey poj:n}, {mI' poj:n}, {SubmaH:n}</column>
@@ -4442,6 +4906,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">單詞{mIvwa'mey:n@@mIvwa':n, -mey:n}用於保持提示或得分。要說“出”，請使用類似{loSlogh pe''egh; vaghlogh nID:sen@@loS:n:1,num, -logh:n:num, pe''egh:v, vagh:n:1,num, -logh:n, nID:v}的結構（即5分中的4分）。即使此人在四點之後停下來並且沒有試圖獲得第五分，也將使用此方法.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra {mIvwa'mey:n@@mIvwa':n, -mey:n} é usada para manter um registro ou pontuação. Para dizer "fora de", use uma construção como {loSlogh pe''egh; vaghlogh nID:sen@@loS:n:1,num, -logh:n:num, pe''egh:v, vagh:n:1,num, -logh:n, nID:v} (ou seja, 4 de 5 pontos). Isso é usado mesmo se a pessoa parou após as quatro e não tentou obter o quinto ponto.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sanaa {mIvwa'mey:n@@mIvwa':n, -mey:n} käytetään pitämään laskenta tai pisteet. Jos haluat sanoa "out of", käytä {loSlogh pe''egh; vaghlogh nID:sen@@loS:n:1,num, -logh:n:num, pe''egh:v, vagh:n:1,num, -logh:n, nID:v}: n kaltaista rakennetta (eli 4 pistettä viidestä). Tätä käytetään, vaikka henkilö pysähtyi neljän jälkeen eikä yrittänyt saada viides piste[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Another meaning of "to score" is to cut a notch in something.</column>
       <column name="components">{pe':v}, {-'egh:v}</column>
       <column name="examples">
@@ -4452,6 +4917,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4459,6 +4925,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -4472,6 +4939,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Мы(действие)-тебе,Мы(действие)-вам(единственное число)</column>
       <column name="definition_zh_HK">我們：你</column>
       <column name="definition_pt">nós-você</column>
+      <column name="definition_fi">me-sinua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ju-:v:pref}</column>
       <column name="see_also">{qa-:v:pref}, {re-:v:pref}</column>
@@ -4482,6 +4950,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{maH:n:1h}: {SoH:n} = {pI-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4491,6 +4960,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4498,6 +4968,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4511,6 +4982,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">винить, обвинять, возлагать вину, упрекать</column>
       <column name="definition_zh_HK">怪罪、責備</column>
       <column name="definition_pt">culpa</column>
+      <column name="definition_fi">syyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIch:n}, {ngoy':v}</column>
@@ -4521,6 +4993,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4530,6 +5003,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4537,6 +5011,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4550,6 +5025,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">вина, ответственность, порицание, обвинение, упрек, проступок</column>
       <column name="definition_zh_HK">罪、責</column>
       <column name="definition_pt">falha, culpa</column>
+      <column name="definition_fi">syy, vika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIch:v}</column>
@@ -4560,6 +5036,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Заметьте, что {ghaj:v} используется с этим существительным, чтобы обозначить вину или проступок.</column>
       <column name="notes_zh_HK">請注意，{ghaj:v}與該名詞一起使用來表示過錯或非議。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que {ghaj:v} é usado com este substantivo para indicar falha ou culpa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tätä substantiivia käytetään {ghaj:v}: llä osoittamaan vikaa tai syyllisyyttä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4571,6 +5048,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
 ▶ {pIch vIghajbe'.:sen} "Это не моя вина."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4578,6 +5056,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -4591,6 +5070,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="definition_ru">Это не моя вина.</column>
           <column name="definition_zh_HK">這不是我的錯。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Não é minha culpa.</column>
+      <column name="definition_fi">Se ei ollut minun syytäni.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4601,6 +5081,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{pIch:n}, {vI-:v}, {ghaj:v}, {-be':v}</column>
           <column name="examples"></column>
@@ -4610,6 +5091,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4617,6 +5099,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
     <table name="mem">
@@ -4630,6 +5113,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">уксус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">尖酸刻薄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vinagre</column>
+      <column name="definition_fi">etikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pey:n}, {HIq:n}</column>
@@ -4640,6 +5124,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Vinegar is a common condiment for "fish and chips" ({vIS:sen:nolink} and {chIp:sen:nolink} backwards).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4649,6 +5134,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4656,6 +5142,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4669,6 +5156,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">шуба с травяной смесью(еда)</column>
       <column name="definition_zh_HK">帶有草藥混合物的外套（食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">casaco (comida) com mistura de ervas</column>
+      <column name="definition_fi">päällystää (ruokaa) yrttiseoksella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngat:n:2}, {chanDoq:n}</column>
@@ -4679,6 +5167,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is "dip" backwards.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4688,6 +5177,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4695,6 +5185,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4708,6 +5199,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">{laS:v}</column>
       <column name="definition_zh_HK">{laS:v}</column>
       <column name="definition_pt">{laS:v}</column>
+      <column name="definition_fi">{laS:v}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pID:v:1}</column>
@@ -4718,6 +5210,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4727,6 +5220,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4734,6 +5228,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -4747,6 +5242,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">руины, развалины</column>
       <column name="definition_zh_HK">廢墟 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ruínas</column>
+      <column name="definition_fi">rauniot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pay'rIn:n}</column>
@@ -4757,6 +5253,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4767,6 +5264,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4774,6 +5272,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4787,6 +5286,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">ожидать, рассчитывать, ждать</column>
       <column name="definition_zh_HK">期望 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter expectativa</column>
+      <column name="definition_fi">odottaa, olettaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qIH:v}, {ghom:v}</column>
@@ -4797,6 +5297,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4808,6 +5309,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
 ▶ {pIpIH.:sen@@pI-:v, pIH:v:1} "Мы ожидаем тебя."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4815,6 +5317,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -4828,6 +5331,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">быть подозрительным, быть сомнительным</column>
       <column name="definition_zh_HK">可疑</column>
       <column name="definition_pt">desconfiar, ter suspeita</column>
+      <column name="definition_fi">olla epäilyttävä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nub:v}, {voqHa':v}, {qagh Sopbe'!:sen}</column>
@@ -4838,6 +5342,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4847,6 +5352,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4854,6 +5360,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4867,6 +5374,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">часто, регулярно, зачастую</column>
       <column name="definition_zh_HK">經常、頻繁</column>
       <column name="definition_pt">com frequência, frequentemente</column>
+      <column name="definition_fi">usein</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIjHa':adv}</column>
       <column name="see_also">{reH:adv}, {rut:adv}, {not:adv}, {motlh:adv}, {roD:adv}</column>
@@ -4877,6 +5385,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Другой способ выразить это, если он решителен, это перифрастически: {V 'ej V-qa' ('ej V-qa'...):sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">強調的另一種表達方式是近距表達：{V 'ej V-qa' ('ej V-qa'...):sen:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Outra maneira de expressar isso, se for enfática, é perifricamente: {V 'ej V-qa' ('ej V-qa'...):sen:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toinen tapa ilmaista tämä, jos se on korostettava, on etenevästi: {V 'ej V-qa' ('ej V-qa' ...): sen: nolink}.{V 'ej V-qa' ('ej V-qa'...):sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4887,6 +5396,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4894,6 +5404,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4907,6 +5418,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Не верь тем, кто часто улыбается</column>
       <column name="definition_zh_HK">唔好相信經常微笑嘅人。</column>
       <column name="definition_pt">Não confie naqueles que sorriem com frequência.</column>
+      <column name="definition_fi">Älä luota niihin, jotka hymyilevät usein.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4917,6 +5429,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4926,6 +5439,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4933,6 +5447,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.167:src}</column>
     </table>
     <table name="mem">
@@ -4946,6 +5461,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Бесконечное многообразие в бесконечных комбинациях</column>
       <column name="definition_zh_HK">無限組合中的無限多樣性 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Diversidade Infinita em Combinações Infinitas</column>
+      <column name="definition_fi">Ääretön monimuotoisuus äärettömissä yhdistelmissä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIpoq:n:name}, {yIn nI' yISIQ 'ej yIchep!:sen}</column>
@@ -4956,6 +5472,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Это базовый догмат в Вулканской философии, и идея переводится на Клингонский нескладно. Перевод означает что-то вроде "различные вещи продолжают быть вместе".</column>
       <column name="notes_zh_HK">這是瓦肯哲學的基本宗旨，這個想法笨拙地翻譯成克林崗語。翻譯的意思是“不同的事物始終保持在一起”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse é o princípio básico da filosofia vulcano, e a idéia se traduz de maneira desajeitada em klingon. A tradução significa algo como "coisas diferentes continuam sempre juntas". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vulkaanisen filosofian perusperiaate, ja ajatus kääntyy hankalasti Klingoniksi. Käännös tarkoittaa jotain "erilaiset asiat jatkuvat aina yhdessä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pIj:adv}, {tay':v}, {-taH:v}, {Doch:n}, {pIm:v}</column>
       <column name="examples">
@@ -4967,6 +5484,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
 ▶ {qum DuSaQmeyDaq 'Irghbe'meH ghotpu' nabmey ghojmoH, 'ej pIj tay'taH Doch pIm num.:sen:nolink} "В общих школах, это учит процедурам, чтобы людей не запугивали, и это пропагандирует бесконечное многообразие в бесконечных комбинациях."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4974,6 +5492,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Air &amp; Space Magazine, August 2016:src}, [2] {Pop Culture Hero Coalition announcement:src} ({KLI mailing list 2016.11.30:src})</column>
     </table>
     <table name="mem">
@@ -4987,6 +5506,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">редко, нечасто [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不常、少有、很少</column>
       <column name="definition_pt">raramente, infrequentemente</column>
+      <column name="definition_fi">harvoin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIj:adv}</column>
       <column name="see_also">{qub:v}, {-Ha':v:suff}</column>
@@ -4997,6 +5517,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5006,6 +5527,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rarely</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5013,6 +5535,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5026,6 +5549,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">быть стимулированным, быть вдохновленным, быть мотивированным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">受到激勵、受到啟發、受到激勵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser estimulado, inspirado, motivado</column>
+      <column name="definition_fi">olla innostunut, inspiroitunut, motivoitunut</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIlHa':v}</column>
       <column name="see_also">{Sey:v}</column>
@@ -5036,6 +5560,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Это относится к мотивации со стороны внешнего источника, в отличие от {vaw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與{vaw:v}相比，這是指外部來源的動力。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à motivação de uma fonte externa, em contraste com o {vaw:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ulkoisen lähteen motivaatioon, toisin kuin {vaw:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Someone needs to take a "pill".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5045,6 +5570,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5052,6 +5578,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5065,6 +5592,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">быть немотивированным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沒有動力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desmotivado</column>
+      <column name="definition_fi">olla motivoimaton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIl:v}</column>
       <column name="see_also">{SaHHa':v}</column>
@@ -5075,6 +5603,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is not defined as such, but to translate "apathy" or "apathy creature" for the Klingon Christmas Carol, one of MO's suggestions was {pIlHa'wI':n:nolink} "unmotivated one".[1]</column>
       <column name="components">{pIl:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -5084,6 +5613,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5091,6 +5621,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2010.09.01:src}</column>
     </table>
     <table name="mem">
@@ -5104,6 +5635,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">стимулировать, вдохновлять, мотивировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刺激、激勵、激勵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estimular, inspirar, motivar</column>
+      <column name="definition_fi">innostaa, inspiroida, motivoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5114,6 +5646,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Это может быть применено к музыке. [1, p.71] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以應用於音樂。[1, p.71] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser aplicado à música.[1, p.71] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan soveltaa musiikkiin.[1, p.71] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pIl:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -5123,6 +5656,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5130,6 +5664,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5143,6 +5678,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">мачта, флагшток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">桅杆、旗桿 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mastro, mastro de bandeira</column>
+      <column name="definition_fi">masto, lipputanko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joqwI':n}</column>
@@ -5153,6 +5689,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The book "Two Years Before the Mast" chronicled the 1834 voyage of the sailing brig named the Pilgrim.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5162,6 +5699,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5169,6 +5707,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5182,6 +5721,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">быть различным, быть отличающимся от, быть другим, быть непохожим</column>
       <column name="definition_zh_HK">與眾不同 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser diferente</column>
+      <column name="definition_fi">olla erilainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nIb:v}, {rap:v}</column>
       <column name="see_also">{jaS:adv}, {Sar:v}</column>
@@ -5192,6 +5732,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5201,6 +5742,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5208,6 +5750,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5221,6 +5764,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Босс, Шеф</column>
       <column name="definition_zh_HK">上頭、老闆</column>
       <column name="definition_pt">chefe</column>
+      <column name="definition_fi">pomo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moch:n}, {pIn:n:2}, {jonpIn:n}, {nuHpIn:n}, {QeDpIn:n}, {QumpIn:n}</column>
@@ -5231,6 +5775,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">King"pin".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5240,6 +5785,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5247,6 +5793,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5260,6 +5807,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">эксперт, авторитет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">專家、權威人士</column>
       <column name="definition_pt">especialista, autoridade</column>
+      <column name="definition_fi">asiantuntija, auktoriteetti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIn:n:1}</column>
@@ -5270,6 +5818,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">В этом сленговом смысле {pIn:n:nolink} никогда не используется отдельно, но всегда является вторым существительным в конструкции существительное-существительное. Несленговый термин "эксперт" - {po'wI':n}.[1, p.158] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從這個語的意義上講，{pIn:n:nolink}絕不會單獨使用，而始終是名詞名詞構造中的第二個名詞。 “專家”的非s語術語是{po'wI':n}.[1, p.158] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Nesse sentido de gíria, {pIn:n:nolink} nunca é usado sozinho, mas é sempre o segundo substantivo em uma construção substantivo-substantivo. O termo que não usa gíria para "especialista" é {po'wI':n}.[1, p.158] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tässä slangi-merkityksessä {pIn:n:nolink}-tiedostoa ei koskaan käytetä yksin, vaan se on aina substantiivi-substantiivien toinen substantiivi. "Asiantuntijan" slangiton termi on {po'wI':n}.[1, p.158] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5279,6 +5828,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5286,6 +5836,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
         <table name="mem">
@@ -5299,6 +5850,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="definition_ru">territorial wall (e.g. Berlin Wall) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">領土牆（例如柏林牆） [AUTOTRANSLATED]</column>
           <column name="definition_pt">muro territorial (por exemplo, muro de Berlim)</column>
+      <column name="definition_fi">rajamuuri (esim. Berliinin muuri)</column>
           <column name="synonyms">{chevwI' tlhoy':n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5309,6 +5861,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This is a reference to the Pink Floyd album "The Wall", the songs of which were played at a concert in Berlin eight months after the fall of the Berlin Wall.</column>
           <column name="components">{pIn:n:1}, {tlhoy':n}</column>
           <column name="examples"></column>
@@ -5318,6 +5871,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5325,6 +5879,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src})</column>
         </table>
         <table name="mem">
@@ -5338,6 +5893,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="definition_ru">apron (clothing) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">圍裙（衣服） [AUTOTRANSLATED]</column>
           <column name="definition_pt">avental (vestuário)</column>
+      <column name="definition_fi">esiliina</column>
           <column name="synonyms">{mejnay:n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5348,6 +5904,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="notes_ru">Этот жаргонный термин может использоваться в неформальной обстановке, но никогда в научной лаборатории или в мастерской с высокой нагрузкой. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這個語可以在非正式場合使用，但絕不能在科學實驗室或重型車間使用。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esse termo de gíria pode ser usado em ambientes informais, mas nunca em um laboratório de ciências ou em uma oficina pesada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä slangitermiä voidaan käyttää epävirallisissa olosuhteissa, mutta ei koskaan tiedelaboratoriossa tai raskaassa työpajassa. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -5357,6 +5914,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5364,6 +5922,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
         </table>
         <table name="mem">
@@ -5377,6 +5936,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="definition_ru">Хозяин, Господин</column>
           <column name="definition_zh_HK">主 [AUTOTRANSLATED]</column>
           <column name="definition_pt">mestre</column>
+      <column name="definition_fi">mestari</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5387,6 +5947,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{pIn:n:1}, {-'a':n}</column>
           <column name="examples"></column>
@@ -5396,6 +5957,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5403,6 +5965,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKDA:src}</column>
         </table>
     <table name="mem">
@@ -5416,6 +5979,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Слава тебе и твоему дому</column>
       <column name="definition_zh_HK">榮耀你和你的房子。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Glória a você e sua casa.</column>
+      <column name="definition_fi">Kunnia sinulle ja huoneellesi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngay':n}</column>
@@ -5426,6 +5990,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Ритуальная фраза, произносимая во время {muvtay:n}.</column>
       <column name="notes_zh_HK">這是在{muvtay:n}期間說的一種禮節性用語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma frase ritualizada dita durante {muvtay:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ritualisoitu lause, joka sanottiin {muvtay:n}-ohjelman aikana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5435,6 +6000,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5442,6 +6008,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.182:src}</column>
     </table>
     <table name="mem">
@@ -5455,6 +6022,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">позвоночник, спинной хребет, позвоночный столб</column>
       <column name="definition_zh_HK">椎骨、脊柱、背脊骨</column>
       <column name="definition_pt">espinha, coluna</column>
+      <column name="definition_fi">selkäranka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qal'aq:n}, {Hom:n:1}</column>
@@ -5465,6 +6033,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5474,6 +6043,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">backbone</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5481,6 +6051,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5494,6 +6065,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Пипиус</column>
       <column name="definition_zh_HK">pipius [AUTOTRANSLATED]</column>
       <column name="definition_pt">pipius</column>
+      <column name="definition_fi">eräs eläin, pipius</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIpyuS pach:n}</column>
@@ -5504,6 +6076,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Когти используются в качестве пищи и требуют измельчения</column>
       <column name="notes_zh_HK">它的爪子用作食物，需要打碎。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Suas garras são usadas como alimento e requerem quebra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen kynsiä käytetään ruokana ja ne on murtettava. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5513,6 +6086,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5520,6 +6094,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5533,6 +6108,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Коготь пипия</column>
       <column name="definition_zh_HK">琵琶爪（食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">garra pipius (comida)</column>
+      <column name="definition_fi">eräs ruokalaji, pipiuksen kynsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIpyuS:n}</column>
@@ -5543,6 +6119,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pIpyuS:n}, {pach:n}</column>
       <column name="examples"></column>
@@ -5552,6 +6129,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5559,6 +6137,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5572,6 +6151,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">If you want to eat pipius claw, you'll have to break a few pipiuses. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">如果你想吃琵琶爪，你將不得不打破一些pipiuses。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Se você quiser comer guarra de pipius, você terá que quebrar alguns pipius.</column>
+      <column name="definition_fi">Jos haluaa syödä pipiuksen kynttä, on ensin murrettava pari pipiusta.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5582,6 +6162,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5591,6 +6172,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5598,6 +6180,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.185:src}</column>
     </table>
     <table name="mem">
@@ -5611,6 +6194,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">Сломайте пипия</column>
       <column name="definition_zh_HK">打破p！！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quebre um pipius!</column>
+      <column name="definition_fi">Murra pipius!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5621,6 +6205,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="notes_ru">Это выражение, которое говорит кому-то (часто ребенку) начать что-то или посвятить больше усилий проекту. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種表達，告訴某人（通常是孩子）開始某些事情或為項目投入更多的精力。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma expressão que diz a alguém (geralmente uma criança) para começar algo ou dedicar mais esforço a um projeto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ilmaus, joka käskee jotakuta (usein lasta) aloittamaan jotain tai panostamaan enemmän projektiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5630,6 +6215,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5637,6 +6223,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.185:src}</column>
     </table>
     <table name="mem">
@@ -5650,6 +6237,7 @@ O verbo {roS:v:2} significa "usar o terceiro dedo do pé". Também é homófono 
       <column name="definition_ru">time period from now (future) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">從現在開始的時間段（未來） [AUTOTRANSLATED]</column>
       <column name="definition_pt">período a partir de agora (futuro)</column>
+      <column name="definition_fi">... (ajanjakson) päästä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ret:n}</column>
       <column name="see_also">{'opleS:n}, {tuch:n}</column>
@@ -5665,6 +6253,12 @@ For other units of time, {pIq:n:nolink} is used.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Erikoissanaa käytetään osoittamaan tulevaisuuden aika seuraaville yksiköille:
+▶ {jaj:n} "päivä" - {leS:n} "päivää nyt"
+▶ {jar:n} "kuukausi" - {waQ:n} "kuukausi nyt"
+▶ {DIS:n:2} "vuosi" - {nem:n} "vuosi sitten"
+
+Muita aikayksikköjä käytetään {pIq:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5675,6 +6269,7 @@ For other units of time, {pIq:n:nolink} is used.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">future</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5682,6 +6277,7 @@ For other units of time, {pIq:n:nolink} is used.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.3, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -5695,6 +6291,7 @@ For other units of time, {pIq:n:nolink} is used.</column>
       <column name="definition_ru">Название Клингонской письменности</column>
       <column name="definition_zh_HK">克林崗書寫系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sistema de escrita klingon</column>
+      <column name="definition_fi">klingonin kirjoitusjärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghItlhmeH Ho'DoS:n}, {ngutlh:n}, {Degh:n:1}</column>
@@ -5705,6 +6302,7 @@ For other units of time, {pIq:n:nolink} is used.</column>
       <column name="notes_ru">Мало изветно о том, как {pIqaD:n:nolink} работает, за исключением, что это не алфавит.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Pouco se sabe sobre como {pIqaD:n:nolink} funciona, exceto que não é um alfabeto.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{pIqaD:n:nolink}: n toiminnasta tiedetään vähän, paitsi että se ei ole aakkoset.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">If interpreted as a sentence, {pIqaD:sen@@pI-:v, qaD:v} literally means "we challenge you".
 
 In the promotional posters and videos for {DSC:src}, as well as in the backgrounds of the sets, Klingon is written in {pIqaD:n:nolink} treating the symbols as an alphabet. The mapping between the twenty-six symbols and Okrand's Latin transcription has a one-to-one grapheme-phoneme correspondence (e.g., so that {tlh:sen:nolink} is written as one symbol), and originated from an unknown source at Paramount and was popularised by the Klingon Language Institute.</column>
@@ -5716,6 +6314,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5723,6 +6322,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.10.17:src}</column>
     </table>
     <table name="mem">
@@ -5736,6 +6336,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_ru">{janluq pIqarD:n:name}</column>
       <column name="definition_zh_HK">{janluq pIqarD:n:name}</column>
       <column name="definition_pt">{janluq pIqarD:n:name}</column>
+      <column name="definition_fi">{janluq pIqarD:n:name}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5746,6 +6347,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5755,6 +6357,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5762,6 +6365,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 5.3, Sept. 1996:src}</column>
     </table>
     <table name="mem">
@@ -5775,6 +6379,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_ru">спортсмен [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">運動員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atleta</column>
+      <column name="definition_fi">urheilija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIqcho' qaD:n}, {pIqcho' Quj:n}, {mI':v}</column>
@@ -5785,6 +6390,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="notes_ru">Это может относиться либо к человеку, либо к животному и принимать любой суффикс множественного числа. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以指一個人或一個動物，並可以採用多個後綴。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode se referir a uma pessoa ou a um animal e leva o sufixo plural apropriado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata joko henkilöön tai eläimeen ja käyttää monikkomuodon sopivaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The question of whether an animal can be an athlete came up during the Q &amp; A session.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5794,6 +6400,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5801,6 +6408,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
         <table name="mem">
@@ -5814,6 +6422,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
           <column name="definition_ru">спортивное соревнование [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">體育比賽 [AUTOTRANSLATED]</column>
           <column name="definition_pt">competição atlética</column>
+      <column name="definition_fi">urheilukilpailu</column>
           <column name="synonyms">{pIqcho' Quj:n}</column>
           <column name="antonyms"></column>
           <column name="see_also">{pIqcho':n}</column>
@@ -5824,6 +6433,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{pIqcho':n}, {qaD:n}</column>
           <column name="examples"></column>
@@ -5833,6 +6443,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5840,6 +6451,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -5853,6 +6465,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
           <column name="definition_ru">спортивное соревнование [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">體育比賽 [AUTOTRANSLATED]</column>
           <column name="definition_pt">competição atlética</column>
+      <column name="definition_fi">urheilukilpailu</column>
           <column name="synonyms">{pIqcho' qaD:n}</column>
           <column name="antonyms"></column>
           <column name="see_also">{pIqcho':n}</column>
@@ -5863,6 +6476,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{pIqcho':n}, {Quj:n}</column>
           <column name="examples"></column>
@@ -5872,6 +6486,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5879,6 +6494,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -5892,6 +6508,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_ru">быть прямым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">直接的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser direto</column>
+      <column name="definition_fi">olla suora (välitön, suunnasta poikkeamaton tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIQHa':v}</column>
       <column name="see_also"></column>
@@ -5902,6 +6519,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5911,6 +6529,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5918,6 +6537,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -5931,6 +6551,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_ru">быть косвенным, обходным, хитрым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">是間接的、是迂迴的、是狡猾的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser indireto, ser rotundo, ser desonesto</column>
+      <column name="definition_fi">olla epäsuora, olla ovela, kavala, petollinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIQ:v}</column>
       <column name="see_also">{'ong:v}</column>
@@ -5941,6 +6562,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pIQ:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -5950,6 +6572,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5957,6 +6580,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -5970,6 +6594,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_ru">быть плодородным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肥沃 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser fértil</column>
+      <column name="definition_fi">olla hedelmällinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yatlh:v}</column>
@@ -5980,6 +6605,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="notes_ru">Это может применяться к земле, животным и людям, а также многим другим вещам. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以應用於土地，動物和人以及許多其他事物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser aplicado à terra, animais e pessoas, além de muitas outras coisas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan soveltaa maahan, eläimiin ja ihmisiin sekä moniin muihin asioihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The request was for a word which could be applied "land, animals, people", and it was confirmed during the Q &amp; A session that this word is quite broad in scope.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5989,6 +6615,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5996,6 +6623,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6009,6 +6637,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_ru">Праксис (Клингонская луна)</column>
       <column name="definition_zh_HK">普拉西斯（克林崗衛星）</column>
       <column name="definition_pt">Praxis</column>
+      <column name="definition_fi">Praxis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6019,6 +6648,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="notes_ru">Луна Клингонского родного мира ({Qo'noS:n}), и главный энергетический объект ({HoS waw':n}).</column>
       <column name="notes_zh_HK">克林崗家庭世界的月亮（{Qo'noS:n}）和主要能源設施的所在地（{HoS waw':n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin kotimaailman kuu ({Qo'noS:n}) ja suuren energialaitoksen paikka ({HoS waw':n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It is misspelled {pIraQSIS:n:nolink} in the first edition of {paq'batlh p.118-119:src}. This is corrected in the second edition.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6028,6 +6658,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pIraQSIS</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6035,6 +6666,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -6048,6 +6680,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_ru">низ (при взгляде извне)</column>
       <column name="definition_zh_HK">底部（外）</column>
       <column name="definition_pt">piso, face inferior (exterior)</column>
+      <column name="definition_fi">pohja (ulkopinta)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yor:n}</column>
       <column name="see_also">{bIng:n}, {'aqroS:n:1}, {Hur:n}</column>
@@ -6058,6 +6691,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="notes_ru">Относится к нижней части объекта, а не к нижней части изнутри (для которой смотрите {bIS'ub:n}).</column>
       <column name="notes_zh_HK">這是指對象的底面，而不是其內部底部（即其{bIS'ub:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à parte inferior de um objeto, e não à parte inferior interna (que é o {bIS'ub:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kohteen alaosaan eikä sen sisäpohjaan (joka on sen {bIS'ub:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Pyramus, a character played by Nick Bottom in the play-within-a-play in Shakespeare's "A Midsummer Night's Dream".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6067,6 +6701,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">exterior, outside bottom</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6074,6 +6709,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="search_tags_ru">экстерьер</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -6087,6 +6723,7 @@ In the promotional posters and videos for {DSC:src}, as well as in the backgroun
       <column name="definition_ru">Готово (задача выполнена)</column>
       <column name="definition_zh_HK">完成（在完成任務時發出） [AUTOTRANSLATED]</column>
       <column name="definition_pt">pronto (pronunciado na conclusão de uma tarefa)</column>
+      <column name="definition_fi">Valmista. Tehty.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIn:v}, {Qapla'!:sen}</column>
@@ -6103,6 +6740,9 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
 Смотрите, как Гаурон говорит это: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä muistuttaa sanomista "Se on tehty!", "Olen tehnyt sen!", "Se on valmis!", "Kaikki tehty!" Ja niin edelleen.
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/4gCJJiBXaE4} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6112,6 +6752,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6119,6 +6760,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6132,6 +6774,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">Быть здоровым, быть жизнеспособным, быть полезным</column>
       <column name="definition_zh_HK">健康 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser saudável</column>
+      <column name="definition_fi">olla terve, olla terveellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{rop:v}</column>
       <column name="see_also">{yIpIv!:sen}</column>
@@ -6142,6 +6785,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6151,6 +6795,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6158,6 +6803,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6171,6 +6817,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">Варп-поле</column>
       <column name="definition_zh_HK">經線場 [AUTOTRANSLATED]</column>
       <column name="definition_pt">campo de dobra</column>
+      <column name="definition_fi">poimukenttä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIvghor:n}, {HoSchem:n}, {peQchem:n}, {Surchem:n}, {tlhamchem:n}</column>
@@ -6181,6 +6828,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pIv:n:hyp}, {chem:n:hyp}</column>
       <column name="examples"></column>
@@ -6190,6 +6838,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6197,6 +6846,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6210,6 +6860,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">Массив генератора варп-поля</column>
       <column name="definition_zh_HK">warp字段生成數組 [AUTOTRANSLATED]</column>
       <column name="definition_pt">matriz de geração de campo de distorção</column>
+      <column name="definition_fi">poimukenttägeneraattorisarja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIvghor lIngwI' DaH:n}</column>
@@ -6220,6 +6871,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This actually appears in the plural on the {BoP:src} poster: {pIvchem lIngwI' DaHmey:n:nolink}.[1]</column>
       <column name="components">{pIvchem:n}, {lIngwI':n}, {DaH:n}</column>
       <column name="examples"></column>
@@ -6229,6 +6881,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6236,6 +6889,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6249,6 +6903,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">регулятор варп-поля</column>
       <column name="definition_zh_HK">經線場控制器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">controlador de campo de dobra</column>
+      <column name="definition_fi">poimukentän ohjausyksikkö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6259,6 +6914,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pIvchem:n}, {SeH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -6268,6 +6924,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6275,6 +6932,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6288,6 +6946,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">варп-привод</column>
       <column name="definition_zh_HK">曲速引擎、曲速驅動</column>
       <column name="definition_pt">motor de dobra</column>
+      <column name="definition_fi">poimuajo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIvchem:n}, {Hongghor:n}</column>
@@ -6298,6 +6957,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru">Смотрите, как Гаурон говорит это: {YouTube video:url:http://youtu.be/uf77DXNXSFY}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/uf77DXNXSFY} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/uf77DXNXSFY} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/uf77DXNXSFY} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pIv:n:hyp}, {ghor:n:2,hyp}</column>
       <column name="examples"></column>
@@ -6307,6 +6967,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6314,6 +6975,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6327,6 +6989,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">Варп-генератор</column>
       <column name="definition_zh_HK">扭曲發生器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gerador de dobra</column>
+      <column name="definition_fi">poimugeneraattori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIvghor lIngwI' DaH:n}</column>
@@ -6337,6 +7000,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pIvghor:n}, {lIngwI':n}</column>
       <column name="examples"></column>
@@ -6346,6 +7010,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6353,6 +7018,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6366,6 +7032,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">массив генерации основы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">warp生成數組 [AUTOTRANSLATED]</column>
       <column name="definition_pt">matriz geradora de dobra</column>
+      <column name="definition_fi">poimugeneraattorisarja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIvchem lIngwI' DaH:n}</column>
@@ -6376,6 +7043,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pIvghor lIngwI':n}, {DaH:n}</column>
       <column name="examples"></column>
@@ -6385,6 +7053,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6392,6 +7061,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6405,6 +7075,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">система привода основы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">變形驅動系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sistema motor de dobra</column>
+      <column name="definition_fi">poimuajojärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6415,6 +7086,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pIvghor:n}, {pat:n}</column>
       <column name="examples"></column>
@@ -6424,6 +7096,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6431,6 +7104,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6444,6 +7118,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">Варп-фактор</column>
       <column name="definition_zh_HK">扭曲因子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fator de dobra</column>
+      <column name="definition_fi">poimukerroin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6454,6 +7129,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6463,6 +7139,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6470,6 +7147,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6483,6 +7161,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">пффиоты [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小費 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pffiots</column>
+      <column name="definition_fi">eräs ruokalaji, pffiots</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'o'mat ghIrI', tI'Im, pIvyoch:n}</column>
@@ -6493,6 +7172,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru">Это особый, довольно острый клингонский напиток. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種特殊的辛辣克林崗飲料。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma bebida Klingon especial e bastante picante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on erityinen, melko pistävä Klingon-juoma. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6502,6 +7182,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6509,6 +7190,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {TNG - Heart of Glory:src}</column>
     </table>
     <table name="mem">
@@ -6522,6 +7204,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">запах, аромат, благоухание, душок</column>
       <column name="definition_zh_HK">氣味 [AUTOTRANSLATED]</column>
       <column name="definition_pt">odor</column>
+      <column name="definition_fi">haju, tuoksu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{He':v}, {He'So':v}, {largh:v}</column>
@@ -6532,6 +7215,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Pew.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6541,6 +7225,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">odour, smell, scent</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6548,6 +7233,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -6561,6 +7247,7 @@ Siehe wie Gowron dies sagt: {YouTube video:url:http://youtu.be/4gCJJiBXaE4}</col
       <column name="definition_ru">быть толстым, быть жирным, быть упитанным, быть тучным, быть откормленным</column>
       <column name="definition_zh_HK">發胖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser gordo</column>
+      <column name="definition_fi">olla paksu, tukeva</column>
       <column name="synonyms">{ror:v}</column>
       <column name="antonyms">{lang:v}</column>
       <column name="see_also">{tlhagh:n}, {juch:v}, {vaS:v}</column>
@@ -6585,6 +7272,9 @@ Det kan också användas i typografi för att beskriva ett "fet" teckensnitt. Se
       <column name="notes_pt">Este verbo não carrega uma conotação de volume devido à gordura corporal ou algo semelhante, para o qual consulte {ror:v}.[2]
 
 Também pode ser usado em tipografia para descrever uma fonte "negrito". Consulte {ngutlh tu'qom:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä verbillä ei ole ruumiinrasvasta tai vastaavasta johtuvaa irtotavaraa, josta ks.{ror:v}.[2]
+
+Sitä voidaan käyttää myös typografiassa "lihavoidun" fontin kuvaamiseen. Katso {ngutlh tu'qom:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6594,6 +7284,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be stout</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6601,6 +7292,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru">быть толстым</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6614,6 +7306,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">утро, утренняя заря</column>
       <column name="definition_zh_HK">早上</column>
       <column name="definition_pt">manhã</column>
+      <column name="definition_fi">aamu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jajlo':n}, {nIQ:n}, {pem:n}, {'eSreH:n}</column>
@@ -6624,6 +7317,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6633,6 +7327,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6640,6 +7335,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6653,6 +7349,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">животное, которое шумит на рассвете [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">在黎明時發出噪音的動物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">animal que faz barulho ao amanhecer</column>
+      <column name="definition_fi">eräs eläin, joka pitää melua aamunkoitteessa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6663,6 +7360,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru">Это литературное название для {'uSgheb:n} или {jajlo' Qa':n}. Это обычно используется в операх и пьесах, но редко в повседневной речи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{'uSgheb:n}或{jajlo' Qa':n}的文學名稱。它通常用於歌劇和戲劇中，但很少用於日常演講中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome literário para um {'uSgheb:n} ou um {jajlo' Qa':n}. É comumente usado em óperas e peças de teatro, mas raramente no discurso cotidiano. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjallinen nimi tuotteelle {'uSgheb:n} tai {jajlo' Qa':n}. Sitä käytetään yleisesti oopperoissa ja näytelmissä, mutta harvoin jokapäiväisessä puheessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{po:n}, {Ha'DIbaH:n:1}</column>
       <column name="examples"></column>
@@ -6672,6 +7370,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6679,6 +7378,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -6692,6 +7392,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">волосы на теле</column>
       <column name="definition_zh_HK">體毛</column>
       <column name="definition_pt">cabelo (no corpo)</column>
+      <column name="definition_fi">karvoitus, tukka (muu kuin hiukset)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6702,6 +7403,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru">Относится к волосам ниже шеи. Например, "волосы на руке" будут {DeS pob:n@@DeS:n:1, pob:n}. Также используется, чтобы сказать о волосах в ухе или в носу. Использовать это слово, чтобы упомянуть о волосах на лице (смотрите {rol:n} и {loch:n}) или волосах на голове (смотрите {jIb:n}) является возможным, но будет расцениваться странно.[2]</column>
       <column name="notes_zh_HK">這是指從脖子向下的頭髮。例如，“手臂頭髮”是{DeS pob:n@@DeS:n:1, pob:n}。它也用於談論耳毛或鼻毛。可以使用此詞來指代面部毛髮（請參閱{rol:n}和{loch:n}）或頭毛（請參閱{jIb:n}），但這樣做確實很奇怪。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se aos cabelos do pescoço para baixo. Por exemplo, "cabelo do braço" é {DeS pob:n@@DeS:n:1, pob:n}. Também é usado para falar sobre pêlos da orelha ou pêlos do nariz. Usar esta palavra para se referir a pêlos faciais (consulte {rol:n} e {loch:n}) ou pêlos da cabeça (consulte {jIb:n}) é possível, mas isso seria considerado muito estranho.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa hiuksiin kaulasta alaspäin. Esimerkiksi "käsivarren hiukset" on {DeS pob:n@@DeS:n:1, pob:n}. Sitä käytetään myös puhumaan korvan tai nenän hiuksista. Tämän sanan käyttäminen viittaamaan kasvojen hiuksiin (katso {rol:n} ja {loch:n}) tai pään hiuksiin (katso {jIb:n}) on mahdollista, mutta sitä pidettäisiin hyvin outona tehdä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6711,6 +7413,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6718,6 +7421,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -6731,6 +7435,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">сажать, засаживать, подсаживать, сажать в грунт</column>
       <column name="definition_zh_HK">廠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">plantar</column>
+      <column name="definition_fi">istuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yob:v}, {naH:n}, {wIj:v}, {tI:n}, {tIr:n}</column>
@@ -6741,6 +7446,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru">Относится только к посадке растений и посеву агрокультур</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6750,6 +7456,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6757,6 +7464,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6770,6 +7478,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">быть обрезанным, быть подрезанным</column>
       <column name="definition_zh_HK">被修剪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser cortado</column>
+      <column name="definition_fi">olla leikattu, lyhennetty</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6780,6 +7489,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6789,6 +7499,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6796,6 +7507,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6809,6 +7521,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">обрезать, подрезать</column>
       <column name="definition_zh_HK">夾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">grampo</column>
+      <column name="definition_fi">leikata, lyhentää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6819,6 +7532,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is missing from the K-E side of {TKD:src}.</column>
       <column name="components">{poD:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -6828,6 +7542,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6835,6 +7550,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6848,6 +7564,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">перчатка</column>
       <column name="definition_zh_HK">手套</column>
       <column name="definition_pt">luva</column>
+      <column name="definition_fi">käsine, hansikas, hanska</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghop:n}, {lIghon DuQwI' pogh:n}, {tawleHnu' pogh:n@@tawleHnu':n, pogh:n}</column>
@@ -6858,6 +7575,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru">Смотрите {mIvDaq pogh cha':sen} для идиомы, что включает в себя {pogh:n:nolink}.</column>
       <column name="notes_zh_HK">有關{pogh:n:nolink}的慣用法，請參見{mIvDaq pogh cha':sen}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {mIvDaq pogh cha':sen} para obter um idioma que envolve {pogh:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {mIvDaq pogh cha':sen}-sanasto, joka sisältää {pogh:n:nolink}-sanan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The reverse of this is {ghop:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6867,6 +7585,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6874,6 +7593,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6887,6 +7607,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">период времени</column>
       <column name="definition_zh_HK">一段的時間 [AUTOTRANSLATED]</column>
       <column name="definition_pt">período de tempo</column>
+      <column name="definition_fi">aika, ajanjakso</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bov:n}, {HovpoH:n}, {poH:v}, {qImroq:n}, {tlhey'at:n}</column>
@@ -6897,6 +7618,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru">Чтобы обозначить "период времени некоторое время назад" или "период времени спустя", {ret:n} и {pIq:n} используются там, где используется {poH:n}, соответственно.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Para indicar "período de tempo atrás" ou "período de tempo a partir de agora", {ret:n} e {pIq:n} são usados ​​no lugar de {poH:n}, respectivamente.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"Aika sitten" tai "ajanjakso nyt" osoittamiseksi käytetään {ret:n} ja {pIq:n} vastaavasti {poH:n}: n sijasta.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6910,6 +7632,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6917,6 +7640,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 8.3, p.3, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -6930,6 +7654,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">приурочить, назначить время, удачно выбирать время, показывать время</column>
       <column name="definition_zh_HK">計時</column>
       <column name="definition_pt">tempo</column>
+      <column name="definition_fi">ottaa aikaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{poH:n}</column>
@@ -6940,6 +7665,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6949,6 +7675,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6956,6 +7683,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6969,6 +7697,7 @@ Também pode ser usado em tipografia para descrever uma fonte "negrito". Consult
       <column name="definition_ru">кристалл времени [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">時間水晶 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cristal do tempo</column>
+      <column name="definition_fi">aikakristalli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6993,6 +7722,9 @@ För Klingons utanför {bo'retlh:n} var tidskristaller en myt, en symbol för Ka
       <column name="notes_pt">Este é um recurso raro e perigoso que se encontra no planeta sagrado de {bo'retlh:n}. Tocar induz visões do futuro, e removê-lo requer um grande sacrifício. Ele pode ser usado como fonte de energia na tecnologia de viagem no tempo.
 
 Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um símbolo de Kahless e o homônimo de {Qo'noS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on harvinainen ja vaarallinen resurssi, joka löytyy {bo'retlh:n}: n pyhältä planeetalta. Yhden koskettaminen saa aikaan visioita tulevaisuudesta, ja yhden poistaminen vaatii suurta uhrausta. Sitä voidaan käyttää virtalähteenä aikamatkatekniikassa.
+
+Klingonsille {bo'retlh:n}: n ulkopuolella aikakiteet olivat myytti, Kahlessin symboli ja {Qo'noS:n}: n nimimerkki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In Greek philosophy, "Chronos" is the personification of time. If time crystals are the namesake of {Qo'noS:n:nolink}, then the similarity to the planet's name is not a coincidence.</column>
       <column name="components">{poH:n}, {qut:n}</column>
       <column name="examples"></column>
@@ -7002,6 +7734,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">poHqut</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7009,6 +7742,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Through the Valley of Shadows:src}</column>
     </table>
     <table name="mem">
@@ -7022,6 +7756,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">анализ, проба, разложение, разбор</column>
       <column name="definition_zh_HK">分析</column>
       <column name="definition_pt">análise</column>
+      <column name="definition_fi">analyysi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{poj:v}</column>
@@ -7032,6 +7767,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7041,6 +7777,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7048,6 +7785,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7061,6 +7799,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">анализировать, проводить анализ, проводить исследование, забирать пробу</column>
       <column name="definition_zh_HK">分析、解析</column>
       <column name="definition_pt">analisar</column>
+      <column name="definition_fi">analysoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{waH:v:1}, {nuD:v}, {chov:v}, {tob:v}, {Daj:v:2}, {poj:n}</column>
@@ -7071,6 +7810,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7080,6 +7820,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7087,6 +7828,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7101,6 +7843,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">сохранять, держать, соблюдать, придерживаться, хранить, спасать, беречь, копить</column>
       <column name="definition_zh_HK">收藏、保存</column>
       <column name="definition_pt">manter, salvar</column>
+      <column name="definition_fi">säilyttää, säästää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{polHa':v}</column>
       <column name="see_also">{choq:v}, {toD:v}, {boS:v}</column>
@@ -7111,6 +7854,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7120,6 +7864,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7127,6 +7872,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7140,6 +7886,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">отбрасывать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">丟棄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">descartar</column>
+      <column name="definition_fi">heittää pois</column>
       <column name="synonyms">{woD:v:1}</column>
       <column name="antonyms">{pol:v}</column>
       <column name="see_also"></column>
@@ -7150,6 +7897,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pol:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -7159,6 +7907,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7166,6 +7915,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7179,6 +7929,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">дело неважно, это не имеет значения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">這件事並不重要、它沒有任何區別 [AUTOTRANSLATED]</column>
       <column name="definition_pt">o assunto não é importante, não faz diferença</column>
+      <column name="definition_fi">asia ei ole tärkeä, se on merkityksetön</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ram:v}</column>
@@ -7189,6 +7940,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это идиоматическое выражение буквально означает, что кто-то «может либо сохранить его, либо отказаться от него». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是某人“可以保留它或丟棄它”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática literalmente significa que alguém "pode ​​mantê-la ou descartá-la". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaus tarkoittaa kirjaimellisesti sitä, että joku "voi joko pitää sen tai hylätä sen". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pol:v}, {-laH:v}, {pagh:conj}, {pol:v}, {-Ha':v}, {-laH:v}</column>
       <column name="examples">
@@ -7199,6 +7951,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7206,6 +7959,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.117:src}</column>
     </table>
     <table name="mem">
@@ -7219,6 +7973,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Полоний (персонаж Гамлета)</column>
       <column name="definition_zh_HK">波洛涅斯</column>
       <column name="definition_pt">Polonius</column>
+      <column name="definition_fi">Polonius</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -7229,6 +7984,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7238,6 +7994,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7245,6 +8002,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -7258,6 +8016,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Дизентерия</column>
       <column name="definition_zh_HK">痢疾</column>
       <column name="definition_pt">disenteria</column>
+      <column name="definition_fi">punatauti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{poq:n}</column>
@@ -7268,6 +8027,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7277,6 +8037,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7284,6 +8045,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7297,6 +8059,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">уговаривать, убеждать, склонять, уверять</column>
       <column name="definition_zh_HK">勸說、說服</column>
       <column name="definition_pt">persuadir, convencer</column>
+      <column name="definition_fi">suostutella, taivutella, vakuuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoH:v}, {meq:n}, {meq:v}</column>
@@ -7307,6 +8070,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7328,6 +8092,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
    И тем самым, убить тебя на месте!"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7335,6 +8100,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.144-145:src}</column>
     </table>
     <table name="mem">
@@ -7348,6 +8114,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Имя</column>
       <column name="definition_zh_HK">名稱</column>
       <column name="definition_pt">nome</column>
+      <column name="definition_fi">nimi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{... 'oH pongwIj'e'.:sen}</column>
@@ -7358,6 +8125,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Чтобы выразить идею делать что-то от чьего-либо имени, рассмотрите возможность использования {DoQ:v} с {woQ:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了表達以某人的名義做某事的概念，請考慮將{DoQ:v}與{woQ:n}結合使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para expressar o conceito de fazer algo no nome de alguém, considere usar {DoQ:v} com {woQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Harkitse {DoQ:v}: n käyttämistä {woQ:n}: n kanssa ilmaisemaan käsitteen tekemisestä jonkun nimessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7367,6 +8135,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7374,6 +8143,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7387,6 +8157,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Меня зовут ... .</column>
       <column name="definition_zh_HK">我的名字是……。</column>
       <column name="definition_pt">Meu nome é ... .</column>
+      <column name="definition_fi">Minun nimeni on ... .</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pong:n}, {jIH:n:1,pro}, {SoH 'Iv?:sen}, {nuq 'oH ponglIj'e'?:sen}</column>
@@ -7397,6 +8168,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence does not appear explicitly in {TKD:src}, but can be constructed using nothing but the vocabulary and grammar presented in it.[1] The sentence in {paq'batlh:src} has a typo: it says {pongwI''e':sen:nolink} rather than {pongwIj'e':sen:nolink}.[2]</column>
       <column name="components"></column>
       <column name="examples">
@@ -7407,6 +8179,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7414,6 +8187,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.127:src}</column>
     </table>
     <table name="mem">
@@ -7427,6 +8201,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">называть, нарекать, именовать, давать имя, вызывать</column>
       <column name="definition_zh_HK">姓名、電話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nomear, chamar</column>
+      <column name="definition_fi">kutsua (jotakin/jotakuta) joksikin, nimetä (jokin) joksikin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7437,6 +8212,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7448,6 +8224,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
 ▶ {roD 'oHvaD juHqo' ponglu' neH.:sen:nolink} "[Qo'noS] обычно упоминается, как просто 'Родной мир'."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7455,6 +8232,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 27:src}</column>
     </table>
     <table name="mem">
@@ -7468,6 +8246,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">награда, воздаяние, вознаграждение, почёт, почести, знак уважения</column>
       <column name="definition_zh_HK">獎勵、榮譽、尊重的象徵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">recompensa, honra, prova de estima</column>
+      <column name="definition_fi">palkinto, kunnianosoitus, kunniakirja (saavutuksesta)</column>
       <column name="synonyms">{van'a':n}</column>
       <column name="antonyms">{bIj:n}</column>
       <column name="see_also">{tev:n}</column>
@@ -7478,6 +8257,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Любое официальное признание достижения или достижений. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對一項或多項成就的任何形式上的認可。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Qualquer reconhecimento formal de uma realização ou realizações. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Suorituskyvyn tai saavutusten virallinen tunnustaminen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7487,6 +8267,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7494,6 +8275,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru">чтить</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {HQ 12.3, Sept. 2003:src}</column>
     </table>
         <table name="mem">
@@ -7507,6 +8289,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">Добродетель является наградой!</column>
           <column name="definition_zh_HK">美德是獎勵。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">A virtude é a recompensa.</column>
+      <column name="definition_fi">Hyve on palkinto.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7517,6 +8300,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -7526,6 +8310,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7533,6 +8318,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.47:src}</column>
         </table>
     <table name="mem">
@@ -7546,6 +8332,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">натрий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鈉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sódio</column>
+      <column name="definition_fi">natrium</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{na':v:1}, {tamler:n}</column>
@@ -7556,6 +8343,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это химический элемент с символом Na и атомным номером 11. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是化學元素，符號為Na，原子序數為11。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o elemento químico com o símbolo Na e o número atômico 11. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kemiallinen alkuaine, jolla on symboli Na ja atominumero 11. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7565,6 +8353,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7572,6 +8361,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7585,6 +8375,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">расстройство желудка, несварение, нарушение пищеварения</column>
       <column name="definition_zh_HK">消化不良 [AUTOTRANSLATED]</column>
       <column name="definition_pt">indigestão</column>
+      <column name="definition_fi">ruoansulatushäiriö, vatsavaiva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pom:n}</column>
@@ -7595,6 +8386,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7604,6 +8396,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7611,6 +8404,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7624,6 +8418,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">требовать, затребовать, предъявлять требования</column>
       <column name="definition_zh_HK">需求、要求</column>
       <column name="definition_pt">demandar, exigir</column>
+      <column name="definition_fi">vaatia, tarvita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qap:v}, {tlhob:v}, {qablIj HI'ang!:sen}</column>
@@ -7634,6 +8429,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Этот глагол также используется для описания акта вызова к дуэли (см. {Hay':v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞還用於描述對決進行質詢的行為（請參閱{Hay':v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado para descrever o ato de desafiar um duelo (consulte {Hay':v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös kuvaamaan kaksintaisteluun haastetta (katso {Hay':v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7651,6 +8447,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7658,6 +8455,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {ENT - Affliction:src}, [3] {paq'batlh p.130-131:src}</column>
     </table>
     <table name="mem">
@@ -7671,6 +8469,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">leaf (of a plant) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">葉（植物）</column>
       <column name="definition_pt">folha (de uma planta)</column>
+      <column name="definition_fi">(kasvin) lehti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sor:n}, {bartIq:n}, {Qechjem'a':n}, {San'emDer:n}, {namchIl:n}</column>
@@ -7681,6 +8480,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это слово может также относиться к масти «сердца» в колоде игральных карт (см. {Degh:n:1}) .[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此單詞還可以指一副撲克牌中的“心臟”套裝（請參閱{Degh:n:1}）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra também pode se referir ao naipe "coração" em um baralho de cartas (consulte {Degh:n:1}) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi viitata myös "sydänpukuun" pelikorttipakassa (katso {Degh:n:1}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A leaf has lots of "pore"s.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7690,6 +8490,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7697,6 +8498,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -7710,6 +8512,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">вдыхать лист [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吸氣葉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inalar folha</column>
+      <column name="definition_fi">hengittää lehtien (savua)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7720,6 +8523,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это, вероятно, сокращено от {por tlhIch pur:sen@@por:n, tlhIch:n, pur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能比{por tlhIch pur:sen@@por:n, tlhIch:n, pur:v}縮短了。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Provavelmente, isso é abreviado de {por tlhIch pur:sen@@por:n, tlhIch:n, pur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on todennäköisesti lyhennetty {por tlhIch pur:sen@@por:n, tlhIch:n, pur:v}-sanasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Maltz didn't know what kind of leaf this might be referring to.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7729,6 +8533,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7736,6 +8541,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -7750,6 +8556,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">тело</column>
       <column name="definition_zh_HK">身體 [AUTOTRANSLATED]</column>
       <column name="definition_pt">corpo</column>
+      <column name="definition_fi">keho, vartalo, ruumis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qa':n}, {ro:n}, {chor:n:1}, {Dub:n}, {porghQeD:n}</column>
@@ -7760,6 +8567,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7769,6 +8577,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7776,6 +8585,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7789,6 +8599,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">температура тела [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">體溫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">temperatura corporal</column>
+      <column name="definition_fi">ruumiinlämpö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iw HIq:n}</column>
@@ -7799,6 +8610,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это лучшая температура для подачи кровяного вина. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是食用血的最佳溫度。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a melhor temperatura para servir vinho de sangue. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on paras lämpötila veriviinin tarjoamiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This appears in the body of {KGT:src} but not in the word lists.</column>
       <column name="components">{porgh:n}, {Hat:n}</column>
       <column name="examples"></column>
@@ -7808,6 +8620,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7815,6 +8628,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.95:src}</column>
     </table>
     <table name="mem">
@@ -7828,6 +8642,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">телесная функция [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">身體機能 [AUTOTRANSLATED]</column>
       <column name="definition_pt">função corporal</column>
+      <column name="definition_fi">ruumiintoiminto, elintoiminto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{porghQeD:n}</column>
@@ -7838,6 +8653,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Мальцу было трудно подумать о повседневном предложении, содержащем эту фразу.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">Maltz很難思考包含該短語的日常句子。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Maltz teve dificuldade em pensar em uma frase cotidiana que continha essa frase.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maltzilla oli vaikeuksia ajatella jokapäiväistä virkettä, joka sisälsi tämän lauseen[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{porgh:n}, {mIw:n}</column>
       <column name="examples"></column>
@@ -7847,6 +8663,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7854,6 +8671,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -7867,6 +8685,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">научное исследование функций организма [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">身體機能的科學研究 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estudo científico das funções corporais</column>
+      <column name="definition_fi">ruumiintoimintojen tieteellinen tutkimus, biologia, anatomia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qur:n}, {porgh:n}</column>
@@ -7877,6 +8696,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Клингоны не так много говорят о функциях организма как о группе, но они, безусловно, говорят о конкретных функциях организма (см. {porgh mIw:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">Klingons並沒有過多地討論作為一個整體的身體功能，但是他們確實在談論特定的身體功能（請參閱{porgh mIw:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os klingons não falam muito sobre funções corporais como um grupo, mas certamente falam sobre funções corporais específicas (consulte {porgh mIw:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonit eivät puhu niin paljon ruumiillisista toiminnoista ryhmänä, mutta he puhuvat varmasti erityisistä ruumiillisista toiminnoista (ks.{porgh mIw:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A person who studies this would presumably be a {porghtej:n@@porgh:n, tej:n}, but this word has never appeared in canon.</column>
       <column name="components">{porgh:n}, {QeD:n}</column>
       <column name="examples"></column>
@@ -7886,6 +8706,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7893,6 +8714,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -7906,6 +8728,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть открытым</column>
       <column name="definition_zh_HK">開</column>
       <column name="definition_pt">ser aberto, aberto</column>
+      <column name="definition_fi">olla avoin, avattu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SoQ:v}</column>
       <column name="see_also"></column>
@@ -7916,6 +8739,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7925,6 +8749,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7932,6 +8757,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7945,6 +8771,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">левая сторона</column>
       <column name="definition_zh_HK">左邊</column>
       <column name="definition_pt">esquerdo (lado)</column>
+      <column name="definition_fi">vasen (puoli)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nIH:n}</column>
       <column name="see_also">{tlhop:n:1}, {'em:n}, {'et:n:2h}, {'o':n}</column>
@@ -7955,6 +8782,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">При обращении к левой и правой сторонам используются притяжательные суффиксы.[2] См. Также {lurgh:n} для других слов, связанных с пространственными направлениями. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Ao se referir aos lados esquerdo e direito, são utilizados sufixos possessivos.[2] Consulte também {lurgh:n} para outras palavras relacionadas às direções espaciais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vasemmalle ja oikealle puolelle viitattaessa käytetään omistavia jälkiliitteitä.[2]{lurgh:n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7964,6 +8792,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">port</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7971,6 +8800,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru">проход</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2019.08.05:src}</column>
     </table>
     <table name="mem">
@@ -7984,6 +8814,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">открывать</column>
       <column name="definition_zh_HK">打開</column>
       <column name="definition_pt">abir</column>
+      <column name="definition_fi">avata</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SoQmoH:v}</column>
       <column name="see_also"></column>
@@ -7994,6 +8825,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{poS:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -8003,6 +8835,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8010,6 +8843,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8023,6 +8857,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">обстоятельная вещь, что-то важное</column>
       <column name="definition_zh_HK">重要的事物、重要的事情</column>
       <column name="definition_pt">coisa consequencial, algo importante</column>
+      <column name="definition_fi">merkittävä tai tärkeä asia</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tu'HomI'raH:n}</column>
       <column name="see_also">{ngoD:n}, {Sov:n}, {De':n}, {potlh:v}</column>
@@ -8033,6 +8868,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8043,6 +8879,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8050,6 +8887,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8063,6 +8901,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть важным, быть значительным, быть существенным</column>
       <column name="definition_zh_HK">重要</column>
       <column name="definition_pt">ser importante</column>
+      <column name="definition_fi">olla tärkeä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ram:v}</column>
       <column name="see_also">{pav:v}, {potlh:n}</column>
@@ -8073,6 +8912,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{potlhbe' to'.:sen}</column>
@@ -8082,6 +8922,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8089,6 +8930,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8102,6 +8944,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">приоритетное сообщение</column>
       <column name="definition_zh_HK">優先訊息 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mensagem prioritária</column>
+      <column name="definition_fi">korkean prioriteetin viesti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8112,6 +8955,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{potlh:n}, {De':n}</column>
       <column name="examples">
@@ -8122,6 +8966,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">potlhDe'</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8129,6 +8974,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.11, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -8142,6 +8988,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Если победа неважна, тогда зачем вести счёт?</column>
       <column name="definition_zh_HK">如果獲勝不重要、那麼為什麼要保持得分呢？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Se ganhar não é importante, então por que manter a pontuação?</column>
+      <column name="definition_fi">Jos voittaminen ei ole tärkeää, miksi pitää kirjaa pisteistä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8152,6 +8999,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8161,6 +9009,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8168,6 +9017,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.135:src}</column>
     </table>
     <table name="mem">
@@ -8181,6 +9031,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">послеполуденное время, послеобеденное время</column>
       <column name="definition_zh_HK">下午</column>
       <column name="definition_pt">tarde (parte do dia)</column>
+      <column name="definition_fi">iltapäivä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pemjep:n}, {megh:n}</column>
@@ -8191,6 +9042,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8200,6 +9052,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8207,6 +9060,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8220,6 +9074,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть отличным, быть великолепным, быть превосходным</column>
       <column name="definition_zh_HK">高超、非常好</column>
       <column name="definition_pt">ser excelente</column>
+      <column name="definition_fi">olla erinomainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QaQ:v}, {qu':v:2}, {chong:v:2}, {Doj:v}</column>
@@ -8230,6 +9085,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8239,6 +9095,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8246,6 +9103,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8259,6 +9117,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">вторник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星期二</column>
       <column name="definition_pt">terça-feira</column>
+      <column name="definition_fi">tiistai</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hogh:n}</column>
@@ -8269,6 +9128,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это только совпадение, что это слово гомофонично с {povjaj!:excl} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個單詞與{povjaj!:excl}同音只是一個巧合 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É apenas uma coincidência que esta palavra seja homofônica com {povjaj!:excl} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On vain sattumaa, että tämä sana on homofoninen {povjaj!:excl}: n kanssa [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This refers to a line in "Lady Madonna" by The Beatles: "Tuesday afternoon is never-ending."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8278,6 +9138,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8285,6 +9146,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -8298,6 +9160,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Пусть это будет отлично! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">願它好極了！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Que seja excelente!</column>
+      <column name="definition_fi">Olkoon se erinomainen!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qapla'!:sen}</column>
@@ -8308,6 +9171,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это выражение используется для выражения желания, чтобы что-то получилось хорошо. Это всего лишь совпадение, что оно гомофонично с названием дня недели {povjaj:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該表達用於表達希望事情好轉的願望。它與工作日{povjaj:n}的名稱諧音只是一個巧合。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão é usada para expressar o desejo de que algo dê certo. É apenas uma coincidência que seja homofônico com o nome do dia da semana {povjaj:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä ilmaisua käytetään ilmaisemaan toiveen siitä, että jokin sujuu hyvin. Se on vain sattumaa, että se on homofoninen viikonpäivän {povjaj:n} nimen kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8317,6 +9181,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Good luck!</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8324,6 +9189,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -8337,6 +9203,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">тайна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">神秘 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mistério</column>
+      <column name="definition_fi">mysteeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngajrun:n}, {pan:v:2}</column>
@@ -8347,6 +9214,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это относится к настоящей тайне, то, что смущает людей. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個真正的謎，使人感到困惑。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um verdadeiro mistério, algo que confunde as pessoas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa todelliseen mysteeriin, mikä hämmentää ihmisiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Hercule Poirot and Miss Marple are the names of two detectives in Agatha Christie's mystery novels.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8356,6 +9224,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8363,6 +9232,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8376,6 +9246,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть опытным, быть квалифицированным, быть экспертным</column>
       <column name="definition_zh_HK">要專業、熟練 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser especialista, hábil</column>
+      <column name="definition_fi">olla taitava, etevä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhIb:v}</column>
       <column name="see_also">{'um:v}, {Han:v}, {Doj:v}, {po'wI':n}</column>
@@ -8386,6 +9257,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8403,6 +9275,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
    Имперское Клингонское судно Парг является хищной птицей класса К'Ворт под командованием капитана Каргана. Имеет лучшее оружие и некоторое количество отличных воинов в Клингонском флоте."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">competent</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8410,6 +9283,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru">быть компетентным</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 7:src}</column>
     </table>
     <table name="mem">
@@ -8423,6 +9297,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">эксперт, специалист в каком-то вопросы</column>
       <column name="definition_zh_HK">專家 [AUTOTRANSLATED]</column>
       <column name="definition_pt">experiente</column>
+      <column name="definition_fi">asiantuntija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIn:n:2,slang}</column>
@@ -8433,6 +9308,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{po':v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -8442,6 +9318,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8449,6 +9326,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.159:src}</column>
     </table>
     <table name="mem">
@@ -8462,6 +9340,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">угол улицы, угол листа бумаги [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">街角、一張紙的一角 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esquina da rua, esquina de um pedaço de papel</column>
+      <column name="definition_fi">kadunkulma, paperin kulma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tajvaj:n:2}</column>
@@ -8472,6 +9351,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"The House at Pooh Corner" is a volume of stories about Winnie the Pooh.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8481,6 +9361,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">intersection</column>
       <column name="search_tags_de">Kreuzung</column>
       <column name="search_tags_fa"></column>
@@ -8488,6 +9369,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -8501,6 +9383,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">кипятить, кипеть, кипятить, варить, вариться</column>
       <column name="definition_zh_HK">熬 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ferver</column>
+      <column name="definition_fi">kiehua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuj:v}, {bIQ:n}, {SeS:n}, {tet:v}, {'Im:v}</column>
@@ -8511,6 +9394,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">While the example shows a usage of the verb with no object, and in which the subject is the thing that is boiling, it's possible that {pub:v:nolink} acts like {meQ:v}, and that when it has both a subject and an object then the subject is causing the object to boil. However, there is no evidence that this is the case.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8522,6 +9406,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8529,6 +9414,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8542,6 +9428,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">кипящее червивое вино</column>
       <column name="definition_zh_HK">煮沸的酒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vinho de sangue fervente</column>
+      <column name="definition_fi">eräs juoma, kiehuva matoviini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8552,6 +9439,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Хотя это не влияет на {romuluS HIq:n}, оно все же впечатляет. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">儘管這沒有{romuluS HIq:n}的影響，但仍然令人印象深刻。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Embora isso não tenha o impacto de {romuluS HIq:n}, ainda é impressionante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikka tällä ei ole {romuluS HIq:n}: n vaikutusta, se on silti vaikuttava. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pub:v}, {-taH:v}, {-bogh:v}, {ghargh:n}, {HIq:n}</column>
       <column name="examples"></column>
@@ -8561,6 +9449,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8568,6 +9457,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -8581,6 +9471,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Туалет (помещение)</column>
       <column name="definition_zh_HK">廁所 [AUTOTRANSLATED]</column>
       <column name="definition_pt">banheiro</column>
+      <column name="definition_fi">wc-istuin, vessanpönttö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puchpa':n}, {qeQ:n}, {turmIq:n}, {taQbang:n:2}, {ghIm:v}, {vuj:v}, {'ImSIng:n}</column>
@@ -8591,6 +9482,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Сленговое выражение {qIvon belmoH:sen} также иногда используется для посещения туалета. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">sometimes語{qIvon belmoH:sen}有時也用於上廁所。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A expressão de gíria {qIvon belmoH:sen} também é usada algumas vezes para ir ao banheiro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Slangilauseketta {qIvon belmoH:sen} käytetään joskus myös WC: ssä käymiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A "pooch" is a slang word for "dog", an animal which drinks out of toilets.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8600,6 +9492,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8607,6 +9500,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8620,6 +9514,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">ванная, комната для мытья</column>
       <column name="definition_zh_HK">洗手間、浴室 [AUTOTRANSLATED]</column>
       <column name="definition_pt">banheiro, lavabo</column>
+      <column name="definition_fi">wc, vessa, pesuhuone, kylpyhuone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puch:n}, {DoQmIv:n}, {Say'moHmeH DoQmIv'a':n}</column>
@@ -8630,6 +9525,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The word lists say "washroom". The "bathroom" definition comes from the example sentence on p.170.</column>
       <column name="components">{puch:n}, {pa':n:1}</column>
       <column name="examples">
@@ -8642,6 +9538,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8649,6 +9546,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8662,6 +9560,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">отбросы, подонки</column>
       <column name="definition_zh_HK">渣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">escória</column>
+      <column name="definition_fi">(juoman) sakka, porot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qegh:n}</column>
@@ -8672,6 +9571,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In the episode {TOS - Plato's Stepchildren:src}, Spock is forced to sing a song, "Maiden Wine", whose lyrics contain the phrase "bitter dregs".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8681,6 +9581,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8688,6 +9589,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8701,6 +9603,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">земля, поверхность, почва, земельная собственность</column>
       <column name="definition_zh_HK">土地</column>
       <column name="definition_pt">aterrizagem</column>
+      <column name="definition_fi">(kuiva) maa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yav:n}, {wutlh:n}, {yotlh:n}, {Saq:v}, {'ambay:n}, {yuwey:n}</column>
@@ -8711,6 +9614,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{puH nIl:n}, {puH beQ:n}, {puH yIQ:n}</column>
@@ -8720,6 +9624,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8727,6 +9632,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -8740,6 +9646,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">равнины, равнины [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">平原</column>
           <column name="definition_pt">planícies</column>
+      <column name="definition_fi">tasanko</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -8750,6 +9657,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puH:n}, {beQ:v}</column>
           <column name="examples"></column>
@@ -8759,6 +9667,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8766,6 +9675,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 24 (2017):src}</column>
         </table>
         <table name="mem">
@@ -8779,6 +9689,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">автомобиль, автомашина</column>
           <column name="definition_zh_HK">汽車</column>
           <column name="definition_pt">carro, veículo terrestre</column>
+      <column name="definition_fi">auto, maakulkuneuvo</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{SeD:v}, {Duj:n:1}, {vergh:n}, {vergh:v}</column>
@@ -8789,6 +9700,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puH:n}, {Duj:n:1}</column>
           <column name="examples"></column>
@@ -8798,6 +9710,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">vehicle</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8805,6 +9718,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru">транспорт</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -8818,6 +9732,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">луг, степь [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">草原</column>
           <column name="definition_pt">pastagem, estepe</column>
+      <column name="definition_fi">ruohomaa, aro</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -8828,6 +9743,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puH:n}, {nIl:v}</column>
           <column name="examples"></column>
@@ -8837,6 +9753,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8844,6 +9761,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 24 (2017):src}</column>
         </table>
         <table name="mem">
@@ -8857,6 +9775,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">тундра [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">苔原 [AUTOTRANSLATED]</column>
           <column name="definition_pt">tundra</column>
+      <column name="definition_fi">tundra</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -8867,6 +9786,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puH:n}, {taD:v}</column>
           <column name="examples"></column>
@@ -8876,6 +9796,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8883,6 +9804,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -8896,6 +9818,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">болото, болота [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">沼澤、濕地</column>
           <column name="definition_pt">pântano</column>
+      <column name="definition_fi">suo, kosteikko</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -8906,6 +9829,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puH:n}, {yIQ:v}</column>
           <column name="examples"></column>
@@ -8915,6 +9839,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8922,6 +9847,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 24 (2017):src}</column>
         </table>
     <table name="mem">
@@ -8935,6 +9861,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">мыс, точка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">開普角 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ponto (termo geográfico)</column>
+      <column name="definition_fi">niemi, niemeke</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8945,6 +9872,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это географический термин. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個地理術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo geográfico. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maantieteellinen termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{puH:n}, {ley':n} or a homophonous element</column>
       <column name="examples"></column>
@@ -8954,6 +9882,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8961,6 +9890,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8974,6 +9904,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть слабым, быть немощным, быть ослабленным, быть щуплым</column>
       <column name="definition_zh_HK">要軟弱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser fraco</column>
+      <column name="definition_fi">olla heikko, voimaton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{HoS:v}, {rotlh:v}</column>
       <column name="see_also">{bIQ:n}, {puj:n:1h}</column>
@@ -8984,6 +9915,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Этот глагол также используется для разносторонних треугольников.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞也用於斜角三角形。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado para triângulos escalenos.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös skaalakolmioihin.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It is unclear what this means when applied to polygons and polyhedra.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8993,6 +9925,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9000,6 +9933,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -9013,6 +9947,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">слабость, немощность</column>
       <column name="definition_zh_HK">弱點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fraqueza</column>
+      <column name="definition_fi">heikkous</column>
       <column name="synonyms"></column>
       <column name="antonyms">{HoS:n:1}</column>
       <column name="see_also">{puj:v}</column>
@@ -9023,6 +9958,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9044,6 +9980,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
    Против страха и против слабости!"[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9051,6 +9988,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.118-119:src}</column>
     </table>
     <!-- Note that {puj:n:2} is in the "extra" section. -->
@@ -9065,6 +10003,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">ослаблять, ослабевать, ветшать</column>
       <column name="definition_zh_HK">削弱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">enfraquecer</column>
+      <column name="definition_fi">heikentää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{HoSmoH:v}</column>
       <column name="see_also"></column>
@@ -9075,6 +10014,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Является соединением {puj:v} и {-moH:v}.</column>
       <column name="notes_zh_HK">這只是{puj:v}加上{-moH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on vain {puj:v} plus {-moH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components">{puj:v}, {-moH:v}</column>
       <column name="examples">
@@ -9086,6 +10026,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
 ▶ {jaghpu'ra' bopujmoHtaHvIS, ghur tuqmeyraj quv.:sen@@jagh:n, -pu':n, -ra':n, bo-:v, pujmoH:v, -taH:v, -vIS:v, ghur:v, tuq:n, -mey:n, -raj:n, quv:n} "Чести в ваших домах будет прибавляться также, как вы ставите врагов на колени."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9093,6 +10034,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.11.30:src} (repeated in {s.k 1998.02.23:src}), [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -9106,6 +10048,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">слабовольный человек, хилое существо, слабое существо</column>
       <column name="definition_zh_HK">弱者</column>
       <column name="definition_pt">fraco</column>
+      <column name="definition_fi">rääpäle, heikko henkilö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9116,6 +10059,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components">{puj:v}, {-wI':v}</column>
       <column name="examples">
@@ -9126,6 +10070,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9133,6 +10078,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9146,6 +10092,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Нет чести в том, чтобы нападать на слабых</column>
       <column name="definition_zh_HK">攻擊弱者沒有榮譽。</column>
       <column name="definition_pt">Não há honra em atacar os fracos.</column>
+      <column name="definition_fi">Ei ole kunniallista hyökätä heikkoja vastaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9156,6 +10103,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pujwI':n}, {HIv:v}, {-lu':v}, {-chugh:v}, {quv:v}, {-be':v}, {-lu':v}</column>
       <column name="examples"></column>
@@ -9165,6 +10113,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">There is no honour in attacking the weak.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9172,6 +10121,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru">Нет чести в том, чтобы нападать на слабых</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.24:src}</column>
     </table>
     <table name="mem">
@@ -9185,6 +10135,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть заземленным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被打磨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser moído</column>
+      <column name="definition_fi">olla jauhettu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9195,6 +10146,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Pulverised."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9204,6 +10156,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9211,6 +10164,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -9224,6 +10178,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть низким (в поле) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">低（間距） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser baixo (no tom)</column>
+      <column name="definition_fi">olla matala (äänenkorkeudeltaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Ham:v}</column>
       <column name="see_also">{wab:n}, {ghogh:n}, {QoQ:n}</column>
@@ -9234,6 +10189,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это может означать глубокий голос или низкую ноту в музыке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能表示聲音很深或音樂中的聲音較低。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode se referir a uma voz profunda ou uma nota baixa na música. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata syvään ääniin tai matalaan nuottiin musiikissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A pun often results in a low groan.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9243,6 +10199,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9250,6 +10207,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -9263,6 +10221,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">обвинение, обвинительный акт</column>
       <column name="definition_zh_HK">指控 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acusação</column>
+      <column name="definition_fi">syytös</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pum:v:1}</column>
@@ -9273,6 +10232,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9282,6 +10242,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9289,6 +10250,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9302,6 +10264,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">обвинять</column>
       <column name="definition_zh_HK">告 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acusar</column>
+      <column name="definition_fi">syyttää, tehdä syytös</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pum:n}</column>
@@ -9312,6 +10275,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9321,6 +10285,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9328,6 +10293,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9342,6 +10308,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">пасть, падать, терпеть крах</column>
       <column name="definition_zh_HK">跌</column>
       <column name="definition_pt">cair</column>
+      <column name="definition_fi">pudota</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peD:v}, {chagh:v}, {qaw':v}</column>
@@ -9352,6 +10319,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Для описания символического падения (например потеря статуса), смотрите {lu:v}.</column>
       <column name="notes_zh_HK">如果是像徵性跌倒（即失去身份），請參閱{lu:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para uma queda simbólica (ou seja, perda de status), consulte {lu:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso symbolinen pudotus (ts. Tilan menetys) kohdasta {lu:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The definition in {TKD:src} just says "fall". In {s.k 1999.11.05:src} this is glossed as "fall down or fall off of something".</column>
       <column name="components"></column>
       <column name="examples">
@@ -9362,6 +10330,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9369,6 +10338,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1999.11.05:src} (reprinted in {HQ 8.4, p.9, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -9382,6 +10352,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">к тому времени, к тому времени, когда (что-то) произошло [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">到那個時候、（某事）發生的時候 [AUTOTRANSLATED]</column>
       <column name="definition_pt">naquele momento, no momento em que (algo) ocorreu</column>
+      <column name="definition_fi">sillä hetkellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngugh:adv}</column>
@@ -9392,6 +10363,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Это идиоматическое выражение буквально означает «когда оно падает». Чаще всего его слышат без субъекта, но при указании субъекта наиболее распространенным является {'etlh:n}. Другое слово может быть выбрано в качестве субъекта в качестве формы игры слов, при условии, что оно может упасть (например, {DaS:n}, {'obmaQ:n}, {nagh:n}, {rutlh:n}). При использовании идиоматически {pumDI':sen:nolink} всегда предшествует главному предложению.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是“跌倒時”。在沒有主題的情況下通常會聽到它，但是在指定主題時，最常見的是{'etlh:n}。可以將另一個單詞選作單詞遊戲的形式，只要它可以掉下來（例如{DaS:n}，{'obmaQ:n}，{nagh:n}，{rutlh:n}）。習慣用法時，{pumDI':sen:nolink}始終在主子句之前。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta expressão idiomática significa literalmente "quando cair". É mais freqüentemente ouvido sem um assunto, mas quando um assunto é especificado, o mais comum é {'etlh:n}. Outra palavra pode ser escolhida como o assunto como uma forma de jogo de palavras, desde que seja algo que pode cair (por exemplo, {DaS:n}, {'obmaQ:n}, {nagh:n}, {rutlh:n}). Quando usado de forma idiomática, {pumDI':sen:nolink} sempre precede a cláusula principal.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "kun se putoaa". Sitä kuulee useimmin ilman aihetta, mutta kun aihe määritetään, yleisin on {'etlh:n}. Toinen sana voidaan valita aiheeksi sanapelimuodoksi, kunhan se voi pudota (esim. {DaS:n}, {'obmaQ:n}, {nagh:n}, {rutlh:n}). Kun sitä käytetään idiomaattisesti, {pumDI':sen:nolink} edeltää aina päälauseketta.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pum:v:2}, {-DI':v}</column>
       <column name="examples">
@@ -9402,6 +10374,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">by then</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9409,6 +10382,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.05:src} (reprinted in {HQ 8.4, p.9, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -9422,6 +10396,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">наручники, наручники [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手銬，手銬 [AUTOTRANSLATED]</column>
       <column name="definition_pt">algemas, grilhões</column>
+      <column name="definition_fi">käsiraudat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9432,6 +10407,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9441,6 +10417,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shackles</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9448,6 +10425,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9461,6 +10439,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">жалость, милосердие, сострадание, пощада, помилование</column>
       <column name="definition_zh_HK">憐憫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">misericórdia</column>
+      <column name="definition_fi">armo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vup:v}</column>
@@ -9472,6 +10451,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9482,6 +10462,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9489,6 +10470,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9502,6 +10484,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Милость или власть. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">憐憫或力量。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Misericórdia ou poder.</column>
+      <column name="definition_fi">Armo tai valta.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9512,6 +10495,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Обратите внимание, что соединение {ghap:conj} обычно следует за существительными, к которым оно присоединяется. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，連接詞{ghap:conj}通常跟隨其連接的名詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que a conjunção {ghap:conj} normalmente segue os substantivos aos quais está se unindo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että yhdistelmä {ghap:conj} seuraa tavallisesti substantiiveja, joihin se liittyy. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pung:n}, {ghap:conj}, {HoS:n:1}</column>
       <column name="examples"></column>
@@ -9521,6 +10505,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9528,6 +10513,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.119:src}</column>
     </table>
     <table name="mem">
@@ -9541,6 +10527,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть идеальным, быть совершенным, быть превосходным, быть точным, быть безупречным, быть безукоризненным</column>
       <column name="definition_zh_HK">完美、準確 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser perfeito, exato</column>
+      <column name="definition_fi">olla täydellinen, tarkka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pup:v:2}</column>
@@ -9551,6 +10538,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9560,6 +10548,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">precise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9567,6 +10556,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru">точный</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9580,6 +10570,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть с высоким разрешением [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">高分辨率 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser de alta resolução</column>
+      <column name="definition_fi">olla korkeatarkkuuksinen, korkearesoluutioinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pup:v:1}</column>
@@ -9590,6 +10581,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9600,6 +10592,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9607,6 +10600,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -9620,6 +10614,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">пинать, лягать, брыкнуть, бить ногой</column>
       <column name="definition_zh_HK">踢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chutar</column>
+      <column name="definition_fi">potkaista, potkia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nan:v:3}</column>
@@ -9630,6 +10625,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9639,6 +10635,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9646,6 +10643,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9659,6 +10657,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">ребенок, отпрыск, потомство</column>
       <column name="definition_zh_HK">細路、孩子、後代</column>
       <column name="definition_pt">criança, descendência</column>
+      <column name="definition_fi">lapsi, jälkeläinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vav:n}, {SoS:n}, {Qup:v}, {nortlham:n}, {HojnIy:n}</column>
@@ -9669,6 +10668,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {qup:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9678,6 +10678,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">youth, young</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9685,6 +10686,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru">юность, юный, молодой</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -9698,6 +10700,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">вилка [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">叉</column>
           <column name="definition_pt">garfo</column>
+      <column name="definition_fi">haarukka</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{baghneQ:n}</column>
@@ -9708,6 +10711,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puq:n}, {chonnaQ:n}</column>
           <column name="examples"></column>
@@ -9717,6 +10721,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">utensil</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9724,6 +10729,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {s.k 1998.05.05:src} (reprinted in {HQ 7.2, p.9, Jun. 1998:src}), [2] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -9737,6 +10743,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">детский язык, "baby talk" [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">孩子的語言、「臊蝦語言」</column>
           <column name="definition_pt">linguagem infantil, "conversa de bebê"</column>
+      <column name="definition_fi">lapsenkieli, vauvankieli</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9747,6 +10754,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru">Это используется только при разговоре с маленькими детьми или домашними животными. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">僅在與幼兒或寵物說話時使用。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso é usado apenas ao falar com crianças pequenas ou animais de estimação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään vain puhuttaessa pienille lapsille tai lemmikkeille. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{puq:n}, {Hol:n}</column>
           <column name="examples"></column>
@@ -9756,6 +10764,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9763,6 +10772,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -9776,6 +10786,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">поколение [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">代</column>
           <column name="definition_pt">geração</column>
+      <column name="definition_fi">sukupolvi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9786,6 +10797,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puq:n}, {poH:n}</column>
           <column name="examples"></column>
@@ -9795,6 +10807,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9802,6 +10815,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -9815,6 +10829,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">дочь</column>
           <column name="definition_zh_HK">女兒</column>
           <column name="definition_pt">filha</column>
+      <column name="definition_fi">tytär</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{be'Hom:n}</column>
@@ -9825,6 +10840,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puq:n}, {be':n}</column>
           <column name="examples"></column>
@@ -9834,6 +10850,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9841,6 +10858,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -9854,6 +10872,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">сын</column>
           <column name="definition_zh_HK">男兒</column>
           <column name="definition_pt">filho</column>
+      <column name="definition_fi">poika (miespuolinen jälkeläinen)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{loDHom:n}</column>
@@ -9864,6 +10883,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puq:n}, {loD:n}</column>
           <column name="examples"></column>
@@ -9873,6 +10893,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9880,6 +10901,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -9893,6 +10915,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">внук, внучка</column>
           <column name="definition_zh_HK">孫</column>
           <column name="definition_pt">neto, neta</column>
+      <column name="definition_fi">lapsenlapsi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{puq:n}, {nortlham:n}</column>
@@ -9903,6 +10926,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -9912,6 +10936,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9919,6 +10944,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
         </table>
         <table name="mem">
@@ -9932,6 +10958,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">внучка</column>
           <column name="definition_zh_HK">孫女</column>
           <column name="definition_pt">neta</column>
+      <column name="definition_fi">lapsentytär, pojantytär, tyttärentytär</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9942,6 +10969,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puqnI':n}, {be':n}</column>
           <column name="examples"></column>
@@ -9951,6 +10979,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9958,6 +10987,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
         </table>
         <table name="mem">
@@ -9971,6 +11001,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="definition_ru">внук</column>
           <column name="definition_zh_HK">孫子</column>
           <column name="definition_pt">neto</column>
+      <column name="definition_fi">lapsenpoika, pojanpoika, tyttärenpoika</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9981,6 +11012,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{puqnI':n}, {loD:n}</column>
           <column name="examples"></column>
@@ -9990,6 +11022,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9997,6 +11030,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
         </table>
     <table name="mem">
@@ -10010,6 +11044,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть накормленным, насытиться</column>
       <column name="definition_zh_HK">受夠了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser alimentado</column>
+      <column name="definition_fi">olla saanut tarpeeksi, olla kyllästynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QeH:v}, {Qay':v:1}, {nuQ:v}, {bergh:v}</column>
@@ -10020,6 +11055,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Puke".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10029,6 +11065,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10036,6 +11073,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10049,6 +11087,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">вдох [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吸入 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inalar</column>
+      <column name="definition_fi">hengittää jotakin, vetää henkeensä jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{rech:v}</column>
       <column name="see_also">{jev:v:2}, {tlhov:v}, {tlhuH:v:1}, {tagh:n}, {ghIch:n}, {tlhon:n}, {mIrSam:n}</column>
@@ -10059,6 +11098,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Чтобы сказать «курить» (как при вдыхании никотина от горения {toba'qo:n}), используйте {tlhIch pur:sen@@tlhIch:n, pur:v}.[2] Можно также сказать {por pur:sen} для вдыхания дыма от других видов растений. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">要說“吸煙”（例如從燃燒{toba'qo:n}吸入尼古丁），請使用{tlhIch pur:sen@@tlhIch:n, pur:v}.[2]。也可以說{por pur:sen}從其他種類的植物中吸取煙氣。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para dizer "fumar" (como na inalação de nicotina por queimar {toba'qo:n}), use {tlhIch pur:sen@@tlhIch:n, pur:v}.[2] Também é possível dizer {por pur:sen} por inalar fumaça de outros tipos de plantas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat sanoa "tupakoida" (kuten hengittää nikotiinia {toba'qo:n}: n polttamisesta), käytä {tlhIch pur:sen@@tlhIch:n, pur:v}.[2] Voidaan myös sanoa {por pur:sen} muiden kasvien savun hengittämiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Purr". Also, the words for inhale and exhale together sound like "poor wretch" ({pur rech:sen:nolink}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10068,6 +11108,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10075,6 +11116,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}, [2] {TNK:src}, [3] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -10088,6 +11130,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">быть немногочисленным, быть в некотором количестве, быть горстью, быть пригорошней, быть маленькой кучкой, быть маленькой группкой</column>
       <column name="definition_zh_HK">很少、幾個、少數 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser poucos, ser vários, ser um punhado</column>
+      <column name="definition_fi">olla vähän, olla harva, olla muutama, olla kourallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{law':v}</column>
       <column name="see_also">{yap:v}</column>
@@ -10098,6 +11141,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru">Слово {puS:v:nolink} используется в сравнительных конструкциях. Смотрите {... X law' ... X puS:sen}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Sanaa {puS:v:nolink} käytetään vertailurakenteissa. Katso {... X law' ... X puS:sen}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10107,6 +11151,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10114,6 +11159,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10127,6 +11173,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">{... X law' ... X puS:sen}</column>
       <column name="definition_zh_HK">{... X law' ... X puS:sen}</column>
       <column name="definition_pt">{... X law' ... X puS:sen}</column>
+      <column name="definition_fi">{... X law' ... X puS:sen}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10137,6 +11184,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{puS:v:1}</column>
       <column name="examples"></column>
@@ -10146,6 +11194,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10153,6 +11202,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10166,6 +11216,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">наблюдать, разглядеть, заметить, обнаруживать (с помощью стрелкового прицела)</column>
       <column name="definition_zh_HK">視線（帶瞄準具） [AUTOTRANSLATED]</column>
       <column name="definition_pt">visão (com uma mira de tiro)</column>
+      <column name="definition_fi">tähdätä (tähtäimellä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qeq:v:1}</column>
@@ -10176,6 +11227,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{DoS wIpuStaH.:sen}</column>
@@ -10185,6 +11237,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10192,6 +11245,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10205,6 +11259,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">летать, пролетать, лететь, пролететь</column>
       <column name="definition_zh_HK">飛</column>
       <column name="definition_pt">mosca</column>
+      <column name="definition_fi">lentää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qaj:v}, {'or:v}, {muD Duj:n}, {'al:v:1}</column>
@@ -10215,6 +11270,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10224,6 +11280,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10231,6 +11288,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10244,6 +11302,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">разрушать, сносить, рухнуть</column>
       <column name="definition_zh_HK">破壞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">naufrágio</column>
+      <column name="definition_fi">hajottaa, tuhota ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qaw':v}</column>
@@ -10254,6 +11313,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10263,6 +11323,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10270,6 +11331,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10283,6 +11345,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">новинка</column>
       <column name="definition_zh_HK">新星 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nova</column>
+      <column name="definition_fi">nova</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10293,6 +11356,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10302,6 +11366,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10309,6 +11374,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10322,6 +11388,7 @@ Para os Klingons fora de {bo'retlh:n}, os cristais de tempo eram um mito, um sí
       <column name="definition_ru">Фазер</column>
       <column name="definition_zh_HK">移相器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">faser</column>
+      <column name="definition_fi">eräs ampuma-ase, vaiheinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaSpu':n}</column>
@@ -10346,6 +11413,9 @@ Klingon motsvarande en phaser är en {nISwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é descendente da palavra arcaica para "espiga" ({pu':n:2}).
 
 O equivalente Klingon a um phaser é um {nISwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana polveutuu arkaaisesta sanasta "piikki" ({pu':n:2}).
+
+Phaseria vastaava Klingon on {nISwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10355,6 +11425,7 @@ O equivalente Klingon a um phaser é um {nISwI':n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10362,6 +11433,7 @@ O equivalente Klingon a um phaser é um {nISwI':n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10375,6 +11447,7 @@ O equivalente Klingon a um phaser é um {nISwI':n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">шип, шип ботинка</column>
       <column name="definition_zh_HK">穗、靴子穗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ponta da bota</column>
+      <column name="definition_fi">piikki, saapaspiikki [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaSpu':n}, {DuQwI':n}, {pu':n:1}</column>
@@ -10397,6 +11470,9 @@ Detta ord tar flertalssuffixet {-mey:n}, till skillnad från när {pu':n:3} refe
       <column name="notes_pt">No Klingon moderno, o pico na ponta de uma bota é sempre chamado de {DaSpu':n}, nunca apenas {pu':n:2,nolink} sozinho.[1]
 
 Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} se refere a um chifre (parte do corpo animal) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nykyaikaisessa Klingonissa kengän varren piikkiä kutsutaan aina {DaSpu':n}: ksi, ei koskaan vain {pu':n:2,nolink} yksinään.
+
+Tämä sana vie monikon {-mey:n}, toisin kuin silloin, kun {pu':n:3} viittaa sarviin (eläimen ruumiinosa).[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10406,6 +11482,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10413,6 +11490,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.58:src}, [2] {KLI mailing list 2018.08.31:src}</column>
     </table>
     <table name="mem">
@@ -10426,6 +11504,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="definition_ru">рог (часть тела)</column>
       <column name="definition_zh_HK">角（牛角）</column>
       <column name="definition_pt">chifre</column>
+      <column name="definition_fi">sarvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10436,6 +11515,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="notes_ru">Относится к рогу животного. Когда необходимо выделить шип (например на ботинке, смотрите {pu':n:2}), кто-то может сказать {Ha'DIbaH pu':n@@Ha'DIbaH:n:1, pu':n:3} или {DI'raq loD pu':n@@DI'raq:n, loD:n, pu':n:3} и так далее. Принимает суффикс для обозначения множественного числа для частей тела {-Du':n}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa eläimen sarviin. Kun tämä on tarpeen erottaa piikistä (kuten kengässä, katso {pu':n:2}), voidaan sanoa {Ha'DIbaH pu':n@@Ha'DIbaH:n:1, pu':n:3} tai {DI'raq loD pu':n@@DI'raq:n, loD:n, pu':n:3} ja niin edelleen. Se vie monikon {-Du':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10445,6 +11525,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10452,6 +11533,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -10465,6 +11547,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="definition_ru">фазерная винтовка</column>
       <column name="definition_zh_HK">移相器步槍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rifle faser</column>
+      <column name="definition_fi">eräs ampuma-ase, vaiheiskivääri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10475,6 +11558,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is misspelled {pu'bej:n:nolink} on {KGT p.56:src}.</column>
       <column name="components">{pu':n:1}, {beH:n}</column>
       <column name="examples"></column>
@@ -10484,6 +11568,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pu'bej</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10491,6 +11576,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10504,6 +11590,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="definition_ru">фазерный экипаж</column>
       <column name="definition_zh_HK">相位工作人員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">equipe do faser</column>
+      <column name="definition_fi">vaiheistiimi?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10514,6 +11601,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pu':n:1}, {beq:n}</column>
       <column name="examples"></column>
@@ -10523,6 +11611,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10530,6 +11619,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10543,6 +11633,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="definition_ru">фазерные батареи</column>
       <column name="definition_zh_HK">移相銀行 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bancos de faser</column>
+      <column name="definition_fi">vaiheissarja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10553,6 +11644,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pu':n:1}, {DaH:n}</column>
       <column name="examples"></column>
@@ -10562,6 +11654,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10569,6 +11662,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10582,6 +11676,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="definition_ru">фазерный пистолет</column>
       <column name="definition_zh_HK">移相器手槍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pistola de faser</column>
+      <column name="definition_fi">eräs ampuma-ase, vaiheispistooli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10592,6 +11687,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{pu':n:1}, {HIch:n}</column>
       <column name="examples"></column>
@@ -10601,6 +11697,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10608,6 +11705,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10621,6 +11719,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="definition_ru">карта, план (как в плане здания), план [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地圖、計劃（如在建築計劃中）、藍圖 [AUTOTRANSLATED]</column>
       <column name="definition_pt"> mapa, planta (como em um plano de construção), desenho</column>
+      <column name="definition_fi">kartta, pohjapiirrustus, rakennuspiirrustus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qach:n}, {tlhat:n}</column>
@@ -10631,6 +11730,7 @@ Esta palavra recebe o sufixo plural {-mey:n}, ao contrário de quando {pu':n:3} 
       <column name="notes_ru">Это слово относится к плану физического объекта, а не к процедуре или плану события (которое будет {nab:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞指的是物理對象的計劃，而不是指事件的過程或計劃（可能是{nab:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se ao plano de um objeto físico, e não a um procedimento ou plano de um evento (que seria {nab:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa fyysisen objektin suunnitelmaan, ei menettelyyn tai tapahtumasuunnitelmaan (mikä olisi {nab:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Augustus W. N. Pugin was an English architect who assisted in the design of the Palace of Westminster.
 
 The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq DIvI' De' pu'jInmey... 'ach pu'jInmeylIj bIHbe'.:sen:nolink}</column>
@@ -10642,6 +11742,7 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10649,5 +11750,6 @@ The 2009 {Star Trek:src} movie has a deleted scene with the line: {buqmeylIjDaq 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 14 (2007):src}</column>
     </table>

--- a/mem-11-p.xml
+++ b/mem-11-p.xml
@@ -5385,7 +5385,7 @@ Verbi {roS:v:2} tarkoittaa "kolmannen kärjen käyttämistä". Se on myös homof
       <column name="notes_ru">Другой способ выразить это, если он решителен, это перифрастически: {V 'ej V-qa' ('ej V-qa'...):sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">強調的另一種表達方式是近距表達：{V 'ej V-qa' ('ej V-qa'...):sen:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Outra maneira de expressar isso, se for enfática, é perifricamente: {V 'ej V-qa' ('ej V-qa'...):sen:nolink}. [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Toinen tapa ilmaista tämä, jos se on korostettava, on etenevästi: {V 'ej V-qa' ('ej V-qa' ...): sen: nolink}.{V 'ej V-qa' ('ej V-qa'...):sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toinen tapa ilmaista tämä, jos se on korostettava, on etenevästi: {V 'ej V-qa' ('ej V-qa'...):sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">

--- a/mem-12-q.xml
+++ b/mem-12-q.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {q:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{q:sen:nolink}</column>
       <column name="definition_pt">a consoante {q:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {q:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">Я(действие)-тебе</column>
       <column name="definition_zh_HK">我：你</column>
       <column name="definition_pt">eu-você</column>
+      <column name="definition_fi">minä-sinua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{cho-:v:pref}</column>
       <column name="see_also">{pI-:v:pref}, {Sa-:v:pref}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{jIH:n:1h}: {SoH:n} = {qa-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">быть плохим, быть некачественным, быть дурным, быть нехорошим, быть испорченным</column>
       <column name="definition_zh_HK">壞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser mal, ser ruim</column>
+      <column name="definition_fi">olla paha, olla huono</column>
       <column name="synonyms"></column>
       <column name="antonyms">{QaQ:v}</column>
       <column name="see_also">{'argh:v}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru">Подобно слову {QaQ:v} данный глагол используется в контексте обозначения качества. Не используется для обозначения "не быть добрым"</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">Лицо</column>
       <column name="definition_zh_HK">面部</column>
       <column name="definition_pt">cara, rosto, face</column>
+      <column name="definition_fi">kasvot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rol:n}, {loch:n}, {mIn:n}, {ghIch:n}, {nuj:n}, {qogh:n:2,body}, {qevpob:n}, {woS:n}, {nach:n}, {'alnum:n}</column>
@@ -136,6 +149,7 @@
       <column name="notes_ru">чьё-то лицо показано, как символ идентичности или чести.[2] Различные аспекты дуэли выражаются в терминах показа лица (см. {Hay':v}).[3] Смотрите также {cha' qabDu':n} и {qabDu' law':n} для идиоматических выражений, использующих это слово. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">O rosto de alguém é mostrado como um símbolo de identidade ou honra.[2] Vários aspectos do duelo são expressos em termos de mostrar o rosto (consulte {Hay':v}) .[3] Consulte também {cha' qabDu':n} e {qabDu' law':n} para usos idiomáticos dessa palavra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Henkilön kasvot näytetään identiteetin tai kunnian symbolina.[2]{Hay':v}[3]{cha' qabDu':n}{qabDu' law':n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Spanish word for "head" is "cabeza".</column>
       <column name="components"></column>
       <column name="examples">
@@ -146,6 +160,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">symbol of identity</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -153,6 +168,7 @@
       <column name="search_tags_ru">символ идентичности</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW p.59:src}, [3] {KGT p.68:src}</column>
     </table>
         <table name="mem">
@@ -166,6 +182,7 @@
           <column name="definition_ru">Множество лиц</column>
           <column name="definition_zh_HK">很多面部</column>
           <column name="definition_pt">muitas faces</column>
+      <column name="definition_fi">monet kasvot</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{ghom'a':n}, {cha' qabDu':n}, {Dojmey:n}</column>
@@ -176,6 +193,7 @@
           <column name="notes_ru">Данное идиоматическое выражение относится к группе, принимающей участие в одном мероприятии. Например, уличная драка может быть описана {Suv qabDu' law':sen:nolink} "Множество лиц сражаются".</column>
           <column name="notes_zh_HK">該慣用語是指參加單個活動的組。例如，可以通過說{Suv qabDu' law':sen:nolink}“許多面孔在戰鬥”來描述鬥毆。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Essa expressão idiomática se refere a um grupo que participa de uma única atividade. Por exemplo, uma briga pode ser descrita dizendo {Suv qabDu' law':sen:nolink} "Muitos rostos estão brigando". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu viittaa ryhmään, joka osallistuu yhteen toimintaan. Rähinä voidaan kuvata esimerkiksi sanomalla {Suv qabDu' law':sen:nolink} "Monet kasvot taistelevat". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qab:n}, {-Du':n}, {law':v}</column>
           <column name="examples"></column>
@@ -185,6 +203,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">many people, a lot of people, lots of people, multitude, crowd, brawl</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -192,6 +211,7 @@
           <column name="search_tags_ru">множество людей, толпа, уличная драка</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.124:src}</column>
         </table>
         <table name="mem">
@@ -205,6 +225,7 @@
           <column name="definition_ru">маскировать [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">面具 [AUTOTRANSLATED]</column>
           <column name="definition_pt">máscara</column>
+      <column name="definition_fi">naamio, maski</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -215,6 +236,7 @@
           <column name="notes_ru">Это относится к маске, используемой для маскировки, например, используемой в сценическом спектакле. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是指用於偽裝的面具，例如舞台劇中使用的面具。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso se refere a uma máscara usada para disfarçar, por exemplo, como usada em uma peça de teatro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa naamioon, jota käytetään naamiointiin, esimerkiksi käytettynä näyttämössä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes">While not explicitly stated, it seems likely it is not used for a breathing mask (except if it is used for disguise).</column>
           <column name="components">{qab:n}, {jech:n}</column>
           <column name="examples"></column>
@@ -224,6 +246,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -231,6 +254,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
         </table>
         <table name="mem">
@@ -244,6 +268,7 @@
           <column name="definition_ru">Покажи мне свое лицо! [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">讓我看看你的臉！ [AUTOTRANSLATED]</column>
           <column name="definition_pt">Me mostre seu rosto!</column>
+      <column name="definition_fi">Näytä kasvosi minulle!</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -254,6 +279,7 @@
           <column name="notes_ru">Эта команда используется для вызова кого-либо на дуэль. Это часто сокращается до {HI'ang!:sen:nolink} Смотрите {Hay':v} для более подробной информации. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">此命令用於挑戰某人進行決鬥。通常將其縮短為{HI'ang!:sen:nolink}，有關更多信息，請參閱{Hay':v}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este comando é usado para desafiar alguém a um duelo. Geralmente é encurtado para {HI'ang!:sen:nolink} Consulte {Hay':v} para obter mais detalhes. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä komentoa käytetään haastamaan joku kaksintaisteluun. Se lyhennetään usein muotoon {HI'ang!:sen:nolink}. Katso lisää etaileja kohdasta {Hay':v}. [AUTOTRANSLATED]</column>
   <column name="hidden_notes">The Klingon version of this sentence has no punctuation as printed on {KGT p.68:src}, but the English one has an exclamation mark. The exclamation mark has been added for consistency.</column>
           <column name="components">{qab:n}, {-lIj:n}, {HI-:v}, {'ang:v}</column>
           <column name="examples"></column>
@@ -263,6 +289,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -270,6 +297,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.68:src}</column>
         </table>
         <table name="mem">
@@ -283,6 +311,7 @@
           <column name="definition_ru">Я не прячу свое лицо. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">我不遮臉。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Eu não escondo meu rosto.</column>
+      <column name="definition_fi">En piilota kasvojani.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -293,6 +322,7 @@
           <column name="notes_ru">Говорят, что это согласие на дуэль. Это обычно сокращается до {vISo'be':sen@@vI-:v, So':v:1, -be':v}. Смотрите {Hay':v} для более подробной информации. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">據說這是對決。通常將其縮寫為{vISo'be':sen@@vI-:v, So':v:1, -be':v}。有關更多詳細信息，請參見{Hay':v}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Dizem que concorda em um duelo. É geralmente reduzido para {vISo'be':sen@@vI-:v, So':v:1, -be':v}. Consulte {Hay':v} para mais detalhes. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanotaan sopivan kaksintaisteluun. Se lyhennetään yleisesti muotoon {vISo'be':sen@@vI-:v, So':v:1, -be':v}. Katso lisätietoja kohdasta {Hay':v}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -302,6 +332,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -309,6 +340,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.69:src}</column>
         </table>
     <table name="mem">
@@ -322,6 +354,7 @@
       <column name="definition_ru">Здание, строение, структура, сооружение, конструкция</column>
       <column name="definition_zh_HK">房屋、樓</column>
       <column name="definition_pt">construção, estrutura</column>
+      <column name="definition_fi">rakennus, talo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HuDyar:n}, {chalqach:n}, {jem'IH:n}, {DuHmor:n}, {qappam:n}, {wonmugh:n}, {raywal:n}</column>
@@ -346,6 +379,9 @@ För {qoD:n} delar av en {qach:n}, se {pa':n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {yor:n} de um {qach:n} é o seu {beb:n}, e suas paredes voltadas para o {Hur:n} são chamadas de {reD:n:1}. O outro lado do {beb:n} (isto é, o {'aqroS:n:1} de um {qach:n}) é chamado de {pa' beb:n}; a face {qoD:n} de um {reD:n:1} é conhecida como {pa' reD:n}.
 
 Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{qach:n}: n {yor:n} on sen {beb:n}, ja sen {Hur:n} -puoleisia seiniä kutsutaan {reD:n:1}: ksi. {beb:n}: n (toisin sanoen {qach:n}: n {'aqroS:n:1}) toista puolta kutsutaan {pa' beb:n}: ksi; {reD:n:1}-kasvoihin {qoD:n} viitataan nimellä {pa' reD:n}.
+
+Katso {qach:n}-osat DONOTTRANSLATE14-osasta kohdasta {pa':n:1}.{qoD:n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -355,6 +391,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Haus</column>
       <column name="search_tags_fa"></column>
@@ -362,6 +399,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru">здание, строение</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -375,6 +413,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
           <column name="definition_ru">{choghvat:n:2}</column>
           <column name="definition_zh_HK">{choghvat:n:2}</column>
           <column name="definition_pt">{choghvat:n:2}</column>
+      <column name="definition_fi">{choghvat:n:2}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -385,6 +424,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qach:n}, {choghvat:n:2}</column>
           <column name="examples"></column>
@@ -394,6 +434,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -401,6 +442,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -414,6 +456,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
           <column name="definition_ru">landmark (building) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">地標（建築物）</column>
           <column name="definition_pt">ponto de referência (construção)</column>
+      <column name="definition_fi">maamerkki (rakennus)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Daq noy:n}</column>
@@ -424,6 +467,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qach:n}, {noy:v}</column>
           <column name="examples"></column>
@@ -433,6 +477,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -440,6 +485,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
     <table name="mem">
@@ -453,6 +499,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="definition_ru">состязание, испытание чьих-то способностей, вызов(на поединок)</column>
       <column name="definition_zh_HK">挑戰、考驗一個人的能力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desafio, testar as habilidades de uma pessoa</column>
+      <column name="definition_fi">haaste, kilpa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ov:v}, {chov:v}, {qaD:v}</column>
@@ -463,6 +510,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{bo'DIj qaD:n}, {Do qaD:n}, {nalqaD:n}, {pIqcho' qaD:n}</column>
@@ -472,6 +520,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">contest</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -479,6 +528,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru">поединок, состязание</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -492,6 +542,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="definition_ru">бросать вызов, оспаривать, противостоять, сопротивляться, оказывать сопротивление, противиться, быть против, стоять против, узреть, встретиться лицом к лицу</column>
       <column name="definition_zh_HK">挑戰、抵制、反對、面對、面對 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desafiar, resistir, opor-se, confrontar, enfrentar</column>
+      <column name="definition_fi">haastaa, uhmata, vastustaa, kohdata; haastaa (kilpailuun)?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIch:v}, {'om:v}, {chov:v}, {qaD:n}</column>
@@ -502,6 +553,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Есть идиома, {ngup qaD:sen:nolink}, дословно означающая "бросить вызов мысу", которая описывает кого-то неудовлетворённого текущим положением дел и бросить вызов ответственному за это. Смотрите {ngup:n:0}.[2, стр.157]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">On olemassa idiooma {ngup qaD:sen:nolink}, joka kirjaimellisesti "haastaa viitta", joka kuvaa henkilöä, joka ei ole tyytyväinen status quoon ja haluaa haastaa vastuuhenkilöt. Katso {ngup:n:0}.[2, p.157] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -511,6 +563,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -518,6 +571,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -531,6 +585,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="definition_ru">турнир</column>
       <column name="definition_zh_HK">比賽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">torneio</column>
+      <column name="definition_fi">turnaus, ottelu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -541,6 +596,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Дословно переводится, как "цепочка состязаний".</column>
       <column name="notes_zh_HK">這實際上是一個“挑戰鏈”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é literalmente uma "cadeia de desafios". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjaimellisesti "haaste ketju". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qaD:n}, {mIr:n:1}</column>
       <column name="examples"></column>
@@ -550,6 +606,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -557,6 +614,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -570,6 +628,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="definition_ru">площадка для состязаний</column>
       <column name="definition_zh_HK">挑戰地板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">plataforma de desafio</column>
+      <column name="definition_fi">haastelava?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -580,6 +639,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Согласно {A Burning House:src}, это возвышенная, огороженная платформа на площади, находящейся за пределами штаб-квартиры {tlhIngan Hubbeq:n}.</column>
       <column name="notes_zh_HK">根據{A Burning House:src}的說法，這是{tlhIngan Hubbeq:n}總部外部廣場中的高架圍欄平台。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com {A Burning House:src}, esta é uma plataforma elevada e cercada na praça fora da sede da {tlhIngan Hubbeq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{A Burning House:src}: n mukaan tämä on kohotettu, aidattu alusta aukioilla {tlhIngan Hubbeq:n}: n pääkonttorin ulkopuolella. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qaD:n}, {rav:n:1}</column>
       <column name="examples"></column>
@@ -589,6 +649,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -596,6 +657,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -609,6 +671,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="definition_ru">прерывать, препятствовать</column>
       <column name="definition_zh_HK">打斷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">interruptor</column>
+      <column name="definition_fi">keskeyttää, häiritä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suj:v}</column>
@@ -619,6 +682,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -628,6 +692,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -635,6 +700,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -648,6 +714,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="definition_ru">гортанная смычка</column>
       <column name="definition_zh_HK">聲門停止 [AUTOTRANSLATED]</column>
       <column name="definition_pt">parada glótica</column>
+      <column name="definition_fi">glottaaliklusiili, {':sen:nolink}-äänne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wab:n}</column>
@@ -658,6 +725,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Названия согласных состоят из звука, который следует за {ay:sen:nolink}, а названия гласных состоят из звука, который предшествует {':sen:nolink} и следует за {t:sen:nolink}. Гортанная смычка является исключением.</column>
       <column name="notes_zh_HK">輔音的名稱由{ay:sen:nolink}後面的聲音組成，元音的名稱由{':sen:nolink}之前的聲音和{t:sen:nolink}之後的聲音組成。聲門停止是一個例外。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os nomes das consoantes consistem no som seguido por {ay:sen:nolink}, e os nomes das vogais consistem no som precedido por {':sen:nolink} e seguido por {t:sen:nolink}. A parada glótica é uma exceção. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Konsonanttien nimet koostuvat äänestä, jota seuraa {ay:sen:nolink}, ja vokaalien nimet koostuvat äänestä, jota edeltää {':sen:nolink} ja jota seuraa {t:sen:nolink}. Glotal stop on poikkeus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qagh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -667,6 +735,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -674,6 +743,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -687,6 +757,7 @@ Para as partes {qoD:n} de um {qach:n}, consulte {pa':n:1}. [AUTOTRANSLATED]</col
       <column name="definition_ru">змеевидный червь (еда)</column>
       <column name="definition_zh_HK">蛇蟲（作為食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">minhoca serpente (alimento)</column>
+      <column name="definition_fi">eräs ruokalaji, käärmemato</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghargh:n}, {ghevI':n}, {'Iw puj:n}, {qagh tlhIq:n}, {raHta':n}, {ghIS:v}, {nogh:v}</column>
@@ -711,6 +782,9 @@ Det finns ett formspråk, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSL
       <column name="notes_pt">Esta palavra é frequentemente escrita em inglês como "gagh".
 
 Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana kirjoitetaan usein englanniksi nimellä "gagh".
+
+On idioomi {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -722,6 +796,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gagh</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -729,6 +804,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru">гагх</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -742,6 +818,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">делать что-либо контрпродуктивно</column>
       <column name="definition_zh_HK">做一些適得其反的事 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer algo contraproducente</column>
+      <column name="definition_fi">tehdä jotain haitallista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -752,6 +829,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru">Дословно означает "убить гагх", который должен быть съеден живым. Это идиоматическое выражение применяется к кому-то, кто делает что-то непродуктивно</column>
       <column name="notes_zh_HK">這字面意思是“殺死gagh（蛇蠕蟲）”，應立即食用。這種慣用語適用於正在適得其反的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "matar gagh (serpentes vermes)", que deve ser consumido vivo. Essa expressão idiomática é aplicada a alguém que está fazendo algo contraproducente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "tappaa gagh (käärmematot)", joka tulisi syödä elävinä. Tätä idiomaattista ilmaisua sovelletaan henkilöön, joka tekee jotain haitallista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qagh:n}, {HoH:v}</column>
       <column name="examples">
@@ -763,6 +841,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
 ▶ {SuyDuj DaQaw'chugh qagh DaHoH.:sen@@SuyDuj:n, Da-:v, Qaw':v, -chugh:v, qagh:n, Da-:v, HoH:v} Это указывает, что уничтожение торгового корабля идет вразрез с текущей миссией.</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">counterproductivity</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -770,6 +849,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru">контрпродуктивно</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.118:src}</column>
     </table>
     <table name="mem">
@@ -783,6 +863,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">Он не ест Гагх!</column>
       <column name="definition_zh_HK">他不吃飯！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ele não come gagh!</column>
+      <column name="definition_fi">Hän ei syö gaghia!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'maH cha' joQDu':n}</column>
@@ -793,6 +874,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru">Мягко пренебрежительная ремарка, использованная для подразумевания, того, что с кем-то что-то не так. Или кто-то действует подозрительно. Также используется, чтобы упомянуть о ком-то как о трусе.</column>
       <column name="notes_zh_HK">這是一個輕描淡寫的言論，用來表示某人有問題或某人行為可疑。它也被用來​​指某人為ward夫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma observação levemente desdenhosa, usada para significar que há algo errado com alguém ou que alguém está agindo de forma suspeita. Também é usado para se referir a alguém como um covarde. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lievästi hylkäävä huomautus, jota käytetään tarkoittamaan, että joku on vialla tai että joku toimii epäilyttävästi. Sitä käytetään myös viittaamaan jonkun pelkuriksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qagh:n}, {Sop:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -802,6 +884,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -809,6 +892,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.137:src}</column>
     </table>
     <table name="mem">
@@ -822,6 +906,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">тушеный кляп, кляп служил остатками [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">咳嗽、咳嗽作為剩菜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">guisado de gagh, gagh servido como sobras</column>
+      <column name="definition_fi">eräs ruokalaji, gagh-muhennos, gaghin jämät</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -832,6 +917,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qagh:n}, {tlhIq:n}</column>
       <column name="examples"></column>
@@ -841,6 +927,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -848,6 +935,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.87:src}</column>
     </table>
     <table name="mem">
@@ -861,6 +949,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">соус для гагха</column>
       <column name="definition_zh_HK">醬汁為gagh [AUTOTRANSLATED]</column>
       <column name="definition_pt">molho para gagh</column>
+      <column name="definition_fi">eräs kastike gaghille</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghevI':n}, {Se'tu':n}</column>
@@ -871,6 +960,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qagh:n}, {vIychorgh:n}</column>
       <column name="examples"></column>
@@ -880,6 +970,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -887,6 +978,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -900,6 +992,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">Сэр</column>
       <column name="definition_zh_HK">長官、尊者</column>
       <column name="definition_pt">Senhor</column>
+      <column name="definition_fi">sir, herra</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{joH:n}</column>
@@ -910,6 +1003,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru">Слово используется для прямого обращения.[2]</column>
       <column name="notes_zh_HK">除了直接地址外，從未聽說過這個詞。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra nunca é ouvida, exceto no endereço direto.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa ei koskaan kuule, paitsi suorassa osoitteessa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -920,6 +1014,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ma'am, madam</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -927,6 +1022,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru">мэм, мадам</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.198:src}</column>
     </table>
     <table name="mem">
@@ -940,6 +1036,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">парить, витать, летать высоко, вспархивать</column>
       <column name="definition_zh_HK">翱翔 [AUTOTRANSLATED]</column>
       <column name="definition_pt">planar</column>
+      <column name="definition_fi">liidellä, leijailla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puv:v}</column>
@@ -950,6 +1047,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -959,6 +1057,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">gleiten, segeln</column>
       <column name="search_tags_fa"></column>
@@ -966,6 +1065,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -979,6 +1079,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">смелость, смелость [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勇氣、大膽</column>
       <column name="definition_pt">coragem, audácia</column>
+      <column name="definition_fi">(uhka)rohkeus, uskaliaisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toDuj:n}, {vaHbo':n}, {Daqturaq:n}</column>
@@ -989,6 +1090,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru">Это слово буквально означает «огненная лава» на Криосе. Это подразумевает смелость неожиданного или неожиданного характера, возможно, даже безрассудства (в отличие от {toDuj:n}, который более нейтрален) .[1, p.10] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta palavra significa literalmente "lava ardente" em Krios. Implica coragem de um tipo surpreendente ou inesperado, talvez até imprudência (ao contrário de {toDuj:n}, que é mais neutro).[1, p.10] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana tarkoittaa kirjaimellisesti "tulista laavaa" Kriosissa. Se merkitsee yllättävän tai odottamattoman rohkeutta, ehkä jopa huolimattomuutta (toisin kuin neutraali {toDuj:n}).[1, p.10] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -998,6 +1100,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">recklessness</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1005,6 +1108,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1018,6 +1122,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">быть продажным, быть коррумпированным, быть развращённым, быть нравственно испорченным</column>
       <column name="definition_zh_HK">腐敗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser corrupto</column>
+      <column name="definition_fi">olla turmeltunut, korruptoitunut</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nIt:v}, {watlh:v}</column>
       <column name="see_also"></column>
@@ -1028,6 +1133,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1037,6 +1143,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1044,6 +1151,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1057,6 +1165,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">развращать, разлагать, искажать, подкупать</column>
       <column name="definition_zh_HK">腐敗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">corromper</column>
+      <column name="definition_fi">turmella, korruptoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1067,6 +1176,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qal:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -1076,6 +1186,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1083,6 +1194,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1096,6 +1208,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="definition_ru">цвет (красочность) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">顏色（色彩） [AUTOTRANSLATED]</column>
       <column name="definition_pt">color (cheio de cor)</column>
+      <column name="definition_fi">väri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rItlh:n}, {nguv:v}</column>
@@ -1106,6 +1219,7 @@ Existe um idioma, {ghung; qagh rur@@ghung:v, qagh:n, rur:v}. [AUTOTRANSLATED]</c
       <column name="notes_ru">У клингона нет слова «цвет» в смысле «что это за цвет?» или "красный - это хороший цвет". Это слово используется для различения, например, цветной фотографии и черно-белой фотографии.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗語中的“顏色”一詞毫無意義。或“紅色是一種不錯的顏色”。此詞用於區分彩色照片和黑白照片。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Klingon não tem uma palavra para "cor" no sentido de "que cor é essa?" ou "vermelho é uma cor bonita". Essa palavra é usada para distinguir entre, por exemplo, uma fotografia colorida e uma fotografia em preto e branco.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonilla ei ole sanaa "väri" merkityksessä "mikä väri se on?" tai "punainen on mukava väri". Tätä sanaa käytetään erottamaan esimerkiksi värivalokuva ja mustavalkoinen valokuva.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Herbert Kalmus was the co-founder and President of the Technicolor Motion Picture Corporation, and Natalie Kalmus was the color supervisor for many of its films.
 
 On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this is in the sense of a specific color.</column>
@@ -1117,6 +1231,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">colour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1124,6 +1239,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {KLI mailing list 2019.08.30:src}</column>
     </table>
     <table name="mem">
@@ -1138,6 +1254,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="definition_ru">рама, каркас, опорная конструкция, каркас [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">框架、框架、支撐結構、骨架 [AUTOTRANSLATED]</column>
       <column name="definition_pt">quadro, estrutura, estrutura de suporte, esqueleto</column>
+      <column name="definition_fi">kehys, tukirakenne, tukiranka, luuranko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hom:n:1}, {pIp:n}, {lIvqa'nan:n}</column>
@@ -1148,6 +1265,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="notes_ru">Для анатомического скелета, см. {nobmeD:n}, хотя {Hom qal'aq:n@@Hom:n:1, qal'aq:n} и {porgh qal'aq:n@@porgh:n, qal'aq:n} также хороши. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於解剖骨架，請參見{nobmeD:n}，儘管{Hom qal'aq:n@@Hom:n:1, qal'aq:n}和{porgh qal'aq:n@@porgh:n, qal'aq:n}也可以。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para um esqueleto anatômico, consulte {nobmeD:n}, embora {Hom qal'aq:n@@Hom:n:1, qal'aq:n} e {porgh qal'aq:n@@porgh:n, qal'aq:n} também estejam bem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso anatominen luuranko kohdasta {nobmeD:n}, vaikka myös {Hom qal'aq:n@@Hom:n:1, qal'aq:n} ja {porgh qal'aq:n@@porgh:n, qal'aq:n} ovat hienoja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{toSwI' qal'aq:n}</column>
@@ -1157,6 +1275,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1164,6 +1283,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1177,6 +1297,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="definition_ru">стопа</column>
       <column name="definition_zh_HK">腳</column>
       <column name="definition_pt">pé</column>
+      <column name="definition_fi">jalka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gho':v}, {lem:n}, {waq:n}, {paSlogh:n}, {ghop:n}, {namwech:n}</column>
@@ -1187,6 +1308,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="notes_ru">Части стопы включают в себя {bem:n} "подошву", {va'nuch:n} "пятку", {mov:n} "верх (стопы)", и {yaD:n:1} "большого пальца(цев)". Стопа прикреплена к {'uS:n} "ноге" через {ngIb:n:1} "лодыжку".</column>
       <column name="notes_zh_HK">腳的部分包括其“ {bem:n}”（鞋底），“ {va'nuch:n}”“鞋跟”，“ {mov:n}”“（腳頂）”和{yaD:n:1}“腳趾”。腳通過{ngIb:n:1}“腳踝”連接到{'uS:n}“腿”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">As partes de um pé incluem seus "{bem:n}" solado ", {va'nuch:n}" calcanhar ", {mov:n}" topo (do pé) "e {yaD:n:1}" dedo (s) ". O pé é preso à "perna" do {'uS:n} através do "tornozelo" do {ngIb:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jalan osiin kuuluu sen {bem:n} "pohja", {va'nuch:n} "kantapää", {mov:n} "yläosan (jalka)" ja {yaD:n:1} "varvas (t)". Jalka on kiinnitetty {'uS:n} "jalkaan" {ngIb:n:1} "nilkan" kautta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1196,6 +1318,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1203,6 +1326,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1216,6 +1340,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="definition_ru">велосипед</column>
       <column name="definition_zh_HK">單車</column>
       <column name="definition_pt">bicicleta</column>
+      <column name="definition_fi">polkupyörä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wa' rutlh qam Do Duj:n}</column>
@@ -1226,6 +1351,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="notes_ru">Это то, что Клингоны назовут земным велосипедом.</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族自行車。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que os klingons chamariam de bicicleta terráquea. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-polkupyöräksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qam:n}, {Do:n}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -1235,6 +1361,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bike</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1242,6 +1369,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="search_tags_ru">велосипед, байк</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -1255,6 +1383,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="definition_ru">заключенный</column>
       <column name="definition_zh_HK">犯人、囚犯</column>
       <column name="definition_pt">prisioneiro</column>
+      <column name="definition_fi">vanki</column>
       <column name="synonyms">{jav:n:3,slang}</column>
       <column name="antonyms"></column>
       <column name="see_also">{bIghHa':n}, {'avwI':n}</column>
@@ -1265,6 +1394,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">MO accommodated the filmmakers by changing {qama':sen@@qa-:v, ma':v} to mean "prisoner" while {Star Trek III:src} was being filmed. See {qama'pu' jonta' neH.:sen}</column>
       <column name="components"></column>
       <column name="examples">{qama'pu' jonta' neH.:sen}</column>
@@ -1274,6 +1404,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1281,6 +1412,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1294,6 +1426,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="definition_ru">Кам-Чи</column>
       <column name="definition_zh_HK">QAM的慈 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Qam-Chee</column>
+      <column name="definition_fi">Qam-Chee</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qanra':n:name}</column>
@@ -1304,6 +1437,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="notes_ru">Согласно легенде, это название древней деревни на {Qo'noS:n} где {qeylIS'e' lIjlaHbe'bogh vay':n:name} и {luqara':n:name} сражались в великой битве против сотен врагов, что является основным компонентом их процесса ухаживания.</column>
       <column name="notes_zh_HK">根據傳說，這是{Qo'noS:n}上一個古老村莊的名稱，其中{qeylIS'e' lIjlaHbe'bogh vay':n:name}和{luqara':n:name}與數百名敵人（他們求偶的主要組成部分）進行了激烈的戰鬥。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Segundo a lenda, este é o nome de uma antiga vila em {Qo'noS:n}, onde {qeylIS'e' lIjlaHbe'bogh vay':n:name} e {luqara':n:name} travaram uma grande batalha contra centenas de inimigos, um componente importante de seu namoro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Legendan mukaan tämä on {Qo'noS:n}: n muinaisen kylän nimi, jossa {qeylIS'e' lIjlaHbe'bogh vay':n:name} ja {luqara':n:name} taistelivat suuren taistelun satoja vihollisia vastaan, mikä on tärkeä osa heidän seurusteluaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1313,6 +1447,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1320,6 +1455,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}, [2] {'u':src}, [3] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -1333,6 +1469,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="definition_ru">Камор</column>
       <column name="definition_zh_HK">Kahmor [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kahmor</column>
+      <column name="definition_fi">Kahmor</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1343,6 +1480,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1352,6 +1490,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1359,6 +1498,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.198:src}</column>
     </table>
     <table name="mem">
@@ -1372,6 +1512,7 @@ On {KGT p.81:src}, it is claimed that there is no noun meaning "color", but this
       <column name="definition_ru">быть старым (не молодым)</column>
       <column name="definition_zh_HK">老（不年輕）</column>
       <column name="definition_pt">ser velho (não jovem)</column>
+      <column name="definition_fi">olla vanha (ei nuori)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qup:v}</column>
       <column name="see_also">{qup:n}, {ngo':v}, {tIQ:v}, {QI'tu':n}</column>
@@ -1390,6 +1531,9 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
 Слово применяется к людям и животным.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Huomaa, että Klingonissa on erilainen sana "olla vanha (ei uusi)" ({ngo':v}) kuin "olla vanha (ei nuori)" ({qan:v:1,nolink}). Myös "vanha" "entisen" merkityksessä on {Deq:v}.
+
+Tätä sanaa käytetään ihmisiin ja eläimiin[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1403,6 +1547,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
 ▶ {cha' DISmo' jIH qan law' SoH qan puS:sen:nolink} "Я на два года старше чем ты."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1410,6 +1555,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.130:src}, [3] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -1423,6 +1569,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">используйте мизинец, мизинец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用小指、小指 [AUTOTRANSLATED]</column>
       <column name="definition_pt">usar o dedinho</column>
+      <column name="definition_fi">käyttää pikkusormea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh:n}</column>
@@ -1433,6 +1580,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Идиоматический жест (из-за гомофонии с {qan:v:1}): указывать кому-то свой мизинец - значит комментировать, что вы считаете его старым. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">慣用的手勢（由於與{qan:v:1}的諧音）：將小指指向某人，就是說您認為他們已經老了。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um gesto idiomático (devido à homofonia com {qan:v:1}): apontar seu dedo mindinho para alguém é comentar que você acredita que ele é velho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Idioomainen ele (johtuen homofoniasta DONOR TRANSLATE1: n kanssa): Jos osoitat vaaleanpunaisellesi jotakuta, on kommentoitava, että uskot hänen olevan vanha.{qan:v:1} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Canandaigua Lake.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1443,6 +1591,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">use the pinky</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1450,6 +1599,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
         <table name="mem">
@@ -1463,6 +1613,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
           <column name="definition_ru">Дураки умирают молодыми</column>
           <column name="definition_zh_HK">傻瓜未老就已經死了。</column>
           <column name="definition_pt">Os tolos morrem jovens.</column>
+      <column name="definition_fi">Tyhmät kuolevat nuorina.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1473,6 +1624,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qan:v:1}, {-choH:v}, {-pa':v}, {qoH:n}, {Hegh:v}, {qoH:n}</column>
           <column name="examples"></column>
@@ -1482,6 +1634,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1489,6 +1642,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.117:src}</column>
         </table>
         <table name="mem">
@@ -1502,6 +1656,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
           <column name="definition_ru">мизинец, мизинец [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">小指</column>
           <column name="definition_pt">mindinho, dedo mindinho</column>
+      <column name="definition_fi">pikkusormi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nItlh:n}</column>
@@ -1512,6 +1667,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
           <column name="notes_ru">Обратите внимание, что {qanwI':n:nolink} также может означать «старый человек». Идиоматический жест: указывать на кого-то своим мизинцем - значит комментировать, что вы считаете его старым. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">請注意，{qanwI':n:nolink}也可以表示“老人”。慣用的手勢：將小指點指向某人，就是說您認為他們已經老了。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Observe que {qanwI':n:nolink} também pode significar "pessoa idosa". Um gesto idiomático: apontar seu dedo mindinho para alguém é comentar que você acredita que ele é velho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että {qanwI':n:nolink} voi tarkoittaa myös "vanhaa ihmistä". Idioomainen ele: osoittaa pinkieesi jollekulle on kommentoida, että uskot heidän olevan vanhoja. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qan:v:2}, {-wI':v}</column>
           <column name="examples"></column>
@@ -1521,6 +1677,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">pinky</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1528,6 +1685,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
         </table>
     <table name="mem">
@@ -1541,6 +1699,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Канджит</column>
       <column name="definition_zh_HK">Kanjit [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kanjit</column>
+      <column name="definition_fi">Kanjit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1551,6 +1710,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Он является отцом {qeylIS'e' lIjlaHbe'bogh vay':n:name} и {moratlh:n:name}.</column>
       <column name="notes_zh_HK">他是{qeylIS'e' lIjlaHbe'bogh vay':n:name}和{moratlh:n:name}的父親。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ele é o pai de {qeylIS'e' lIjlaHbe'bogh vay':n:name} e {moratlh:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on {qeylIS'e' lIjlaHbe'bogh vay':n:name}- ja {moratlh:n:name}-isä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1560,6 +1720,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1567,6 +1728,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -1580,6 +1742,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Cancri [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">巨蟹座 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Cancri</column>
+      <column name="definition_fi">Cancri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1590,6 +1753,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это название разумного вида, родом из {qanQIy loS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{qanQIy loS:n}原生的有感覺物種的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma espécie sensível nativa de {qanQIy loS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tuntevan lajin nimi, joka on kotoisin {qanQIy loS:n}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1599,6 +1763,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1606,6 +1771,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Lethe:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1619,6 +1785,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Cancri IV [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Cancri IV [AUTOTRANSLATED]</column>
       <column name="definition_pt">Cancri IV</column>
+      <column name="definition_fi">Cancri IV</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qanQIy:n}</column>
@@ -1629,6 +1796,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1638,6 +1806,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1645,6 +1814,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Lethe:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1658,6 +1828,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Канрад. Птица известная своим пением</column>
       <column name="definition_zh_HK">以歌曲而聞名的鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro conhecido por sua música</column>
+      <column name="definition_fi">eräs laulustaan tunnettu lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1668,6 +1839,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to Conrad Birdie, the lead character in the musical Bye Bye Birdie.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1677,6 +1849,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1684,6 +1857,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1697,6 +1871,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Канрах</column>
       <column name="definition_zh_HK">Kahnrah [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kahnrah</column>
+      <column name="definition_fi">Kahnrah</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1707,6 +1882,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Согласно {paq'batlh:src}, он был патриархом ({qup'a':n}) деревни {qamchIy:n:name} во времена {qeylIS'e' lIjlaHbe'bogh vay':n:name}.</column>
       <column name="notes_zh_HK">根據{paq'batlh:src}的說法，他是{qeylIS'e' lIjlaHbe'bogh vay':n:name}時期的{qamchIy:n:name}的族長（{qup'a':n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o {paq'batlh:src}, ele era o Patriarca ({qup'a':n}) de {qamchIy:n:name} na época de {qeylIS'e' lIjlaHbe'bogh vay':n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{paq'batlh:src}: n mukaan hän oli {qamchIy:n:name}: n patriarkka ({qup'a':n}) {qeylIS'e' lIjlaHbe'bogh vay':n:name}: n aikaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1716,6 +1892,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1723,6 +1900,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.126-129,132-133:src}</column>
     </table>
     <table name="mem">
@@ -1736,6 +1914,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">лить, подливать, переливать (из одной емкости в другую)</column>
       <column name="definition_zh_HK">斟、倒（於一個容器斟入另一個）</column>
       <column name="definition_pt">verter (de um recipiente para outro)</column>
+      <column name="definition_fi">kaataa (astiasta toiseen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIch:v}, {Qoy':v}, {qang:v:2}</column>
@@ -1746,6 +1925,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1756,6 +1936,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1763,6 +1944,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1776,6 +1958,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">всегда согласен с, всегда сотрудничаю с [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">永遠同意、永遠配合 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sempre concordar com, sempre cooperar com</column>
+      <column name="definition_fi">olla aina samaa mieltä, tehdä aina tai rutiininomaisesti yhteistyötä jonkun kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qoch:v}, {jIj:v}, {yeq:v}, {-qang:v}, {qang:v:1}</column>
@@ -1786,6 +1969,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1796,6 +1980,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1803,6 +1988,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1816,6 +2002,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">убеждения, принципы, стандарты, этика, идеология [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">信仰、原則、標準、道德、意識形態 [AUTOTRANSLATED]</column>
       <column name="definition_pt">confiança, princípios, normas, ética, ideologia</column>
+      <column name="definition_fi">uskomukset, periaatteet, arvot, etiikka, ideologia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wontoy:n}</column>
@@ -1826,6 +2013,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1836,6 +2024,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1843,6 +2032,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Pop Culture Hero Coalition announcement:src} ({KLI mailing list 2016.11.30:src}), [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1856,6 +2046,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">настаивать на чём-то</column>
       <column name="definition_zh_HK">咬定 [AUTOTRANSLATED]</column>
       <column name="definition_pt">insistir</column>
+      <column name="definition_fi">vaatia itsepintaisesti jotain, vaatimalla vaatia, ehdottomasti haluta jotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{poQ:v}</column>
@@ -1866,6 +2057,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1881,6 +2073,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1888,6 +2081,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.130-131:src}</column>
     </table>
     <table name="mem">
@@ -1901,6 +2095,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">фундамент (структура) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">基礎（結構） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fundação (estrutura)</column>
+      <column name="definition_fi">perustus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qach:n}, {Qutlh:v}</column>
@@ -1911,6 +2106,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к несущей конструкции здания. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指建築物的支撐基礎結構。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à subestrutura de suporte de um edifício. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa rakennuksen tukirakenteeseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "foundation". The word "structure" was added to distinguish this from {ghanroq:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1920,6 +2116,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1927,6 +2124,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1940,6 +2138,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть предпочтительным</column>
       <column name="definition_zh_HK">更好 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser preferível</column>
+      <column name="definition_fi">olla parempi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maS:v}</column>
@@ -1950,6 +2149,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1959,6 +2159,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1966,6 +2167,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1979,6 +2181,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть точным, быть метким, быть тщательным</column>
       <column name="definition_zh_HK">準確 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser exato</column>
+      <column name="definition_fi">olla tarkka, virheetön, paikkansapitävä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lugh:v}, {teH:v}</column>
@@ -1989,6 +2192,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Этот глагол используется в формировании подтверждающих вопросов с суффиксом {-'a':v:suff}. В таком случае вопрос, {qar'a':sen:nolink} либо следует за глаголом, или следует в самом конце предложения. ({TKDA 6.4:src})</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este verbo é usado na formação de perguntas de marca com o sufixo {-'a':v:suff}. Em tal pergunta, {qar'a':sen:nolink} segue o verbo ou vem no final da frase. ({TKDA 6.4:src}) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään muodostettaessa tunnistekysymyksiä loppuliitteellä {-'a':v:suff}. Tällaisessa kysymyksessä {qar'a':sen:nolink} joko seuraa verbiä tai tulee lauseen loppuun. ({TKDA 6.4:src}) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1998,6 +2202,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2005,6 +2210,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2018,6 +2224,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Огонь торпедами по моей команде!</column>
       <column name="definition_zh_HK">按照我的命令射擊魚雷！</column>
       <column name="definition_pt">Dispare os torpedos ao meu comando!</column>
+      <column name="definition_fi">Ammu torpedot käskystäni!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha yIghuS!:sen}</column>
@@ -2028,6 +2235,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2037,6 +2245,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2044,6 +2253,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.62:src}</column>
     </table>
     <table name="mem">
@@ -2057,6 +2267,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Кардассия</column>
       <column name="definition_zh_HK">「卡達西」星</column>
       <column name="definition_pt">Cardassia</column>
+      <column name="definition_fi">Cardassia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qarDaSngan:n}</column>
@@ -2067,6 +2278,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Родной мир Кардассии, главная планета Кардассианского союза. Также зовется {qarDaSya':n:nolink}[1, p.141-142] и {qarDaS wa':n:nolink} (Кардассия Прайм)[2].</column>
       <column name="notes_zh_HK">Cardassian Homeworld，Cardassian Union的主要星球。也稱為{qarDaSya':n:nolink}[1, p.141-142]和{qarDaS wa':n:nolink}（Cardassia Prime）[2]。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Cardassian Homeworld, Cardassian Unionin pääplaneetta. Kutsutaan myös nimellä {qarDaSya':n:nolink}[1, p.141-142] ja {qarDaS wa':n:nolink} (Cardassia Prime) [2]. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2076,6 +2288,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2083,6 +2296,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2096,6 +2310,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Кардассианец</column>
       <column name="definition_zh_HK">「卡達西」人</column>
       <column name="definition_pt">Cardassiano (pessoa)</column>
+      <column name="definition_fi">cardassi, cardassialainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qarDaS:n}</column>
@@ -2106,6 +2321,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qarDaS:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -2115,6 +2331,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2122,6 +2339,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2135,6 +2353,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Кардассианский союз</column>
       <column name="definition_zh_HK">卡達西聯盟 [AUTOTRANSLATED]</column>
       <column name="definition_pt">União Cardassiana</column>
+      <column name="definition_fi">Cardassian unioni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2145,6 +2364,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qarDaS:n}, {Qa':n:2,hyp}</column>
       <column name="examples">
@@ -2156,6 +2376,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
 ▶ {qarDaSQa'Daq ruDelya' rop'a' Hergh qengbogh yo' Dabot.:sen:nolink} "Перехватите конвой с Руделлианской чумой, который следует до Кардассианского союза."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2163,6 +2384,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2176,6 +2398,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть громоздким, толстым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">笨重</column>
       <column name="definition_pt">ser volumoso, grosso</column>
+      <column name="definition_fi">olla kookas, paksu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2186,6 +2409,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2196,6 +2420,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2203,6 +2428,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2216,6 +2442,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Карган [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Kargan [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kargan</column>
+      <column name="definition_fi">Kargan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2226,6 +2453,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2235,6 +2463,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2242,6 +2471,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 4.3, Sept. 1995:src}</column>
     </table>
     <table name="mem">
@@ -2255,6 +2485,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">трапеция [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">梯形 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trapezoide</column>
+      <column name="definition_fi">puolisuunnikas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loS reD mey':n}</column>
@@ -2265,6 +2496,7 @@ Detta ord används på människor och djur.[2] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к выпуклому четырехугольнику с по меньшей мере одной парой параллельных сторон. Четырехугольник без параллельных сторон является {moHbey:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指具有至少一對平行邊的凸四邊形。沒有平行邊的四邊形是{moHbey:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um quadrilátero convexo com pelo menos um par de lados paralelos. Um quadrilátero sem lados paralelos é um {moHbey:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kuperaan nelikulmioon, jossa on vähintään yksi pari yhdensuuntaista sivua. Nelikulmio, jossa ei ole yhdensuuntaisia ​​sivuja, on {moHbey:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">One of the carpal bones in the wrist is called the trapezoid.
 
 In British English, this word refers to what would be called a "trapezium".</column>
@@ -2276,6 +2508,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2283,6 +2516,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2296,6 +2530,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">птица способна имитировать речь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">能夠模仿言語的鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pássaro capaz de imitar a fala</column>
+      <column name="definition_fi">eräs lintu (joka kykenee matkimaan puhetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qaryoq'a':n}, {vIlInHoD:n}</column>
@@ -2306,6 +2541,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru">Некоторые люди используют это слово как {-pu':n:suff}, но большинство используют {-mey:n:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Algumas pessoas pluralizam essa palavra com {-pu':n:suff}, mas a maioria usa {-mey:n:suff}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jotkut ihmiset moninkertaistavat tämän sanan sanalla {-pu':n:suff}, mutta useimmat käyttävät sanaa {-mey:n:suff}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Karaoke, or José Carioca.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2315,6 +2551,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2322,6 +2559,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2335,6 +2573,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">птица, способная имитировать речь, больше чем {qaryoq:n} [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">能夠模仿語音的鳥、大於{qaryoq:n} [AUTOTRANSLATED]</column>
       <column name="definition_pt">pássaro capaz de imitar a fala, maior que um {qaryoq:n}</column>
+      <column name="definition_fi">eräs lintu (joka kykenee jäljittelemään puhetta ja on isompi kuin {qaryoq:n})</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qaryoq:n}, {vIlInHoD:n}</column>
@@ -2345,6 +2584,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Algumas pessoas pluralizam essa palavra com {-pu':n:suff}, mas a maioria usa {-mey:n:suff}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jotkut ihmiset moninkertaistavat tämän sanan sanalla {-pu':n:suff}, mutta useimmat käyttävät sanaa {-mey:n:suff}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Karaoke, or José Carioca.</column>
       <column name="components">{qaryoq:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -2354,6 +2594,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2361,6 +2602,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2374,6 +2616,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">происходить, случаться, иметь место, бывать</column>
       <column name="definition_zh_HK">發生</column>
       <column name="definition_pt">ocorrer, acontecer</column>
+      <column name="definition_fi">tapahtua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2384,6 +2627,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2395,6 +2639,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2402,6 +2647,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2415,6 +2661,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">Четыре тысячи глоток могут быть перерезаны однажды ночью, бегущим человеком</column>
       <column name="definition_zh_HK">一個跑步者可能會在一夜之間切開四千個喉嚨。</column>
       <column name="definition_pt">Quatro mil gargantas podem ser cortadas em uma noite por um homem correndo.</column>
+      <column name="definition_fi">Juokseva mies voi leikata neljä tuhatta kurkkua yhdessä yössä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2425,6 +2672,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qaS:v}, {-taH:v}, {-vIS:v}, {wa':n}, {ram:n}, {loS:n:1}, {SaD:n:num}, {Hugh:n}, {SIj:v:1}, {-laH:v}, {qet:v}, {-bogh:v}, {loD:n}</column>
       <column name="examples"></column>
@@ -2434,6 +2682,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2441,6 +2690,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.127:src}</column>
     </table>
     <table name="mem">
@@ -2454,6 +2704,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">Бесчестие отца бесчестит его сыновей и их сыновей в течении трёх поколений</column>
       <column name="definition_zh_HK">父親的羞辱使他的兒子和兒子們遭受了三代人的羞辱。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A desonra do pai desonra seus filhos e os filhos deles por três gerações.</column>
+      <column name="definition_fi">Isän häpeä häpäisee hänen poikansa ja heidän poikansa kolmen sukupolven ajan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2464,6 +2715,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qaS:v}, {-taH:v}, {-vIS:v}, {wej:n}, {puq poH:n}, {-mey:n}, {vav:n}, {puqloD:n}, {-pu':n}, {puqloD:n}, {-pu':n}, {-chaj:n}, {je:conj}, {quvHa':v}, {-moH:v}, {vav:n}, {quvHa':v}, {-ghach:v}</column>
       <column name="examples"></column>
@@ -2473,6 +2725,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">The dishonour of the father dishonours his sons and their sons for three generations.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2480,6 +2733,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru">Бесчестие отца бесчестит его сыновей и их сыновей в течении трёх поколений</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.155:src}</column>
     </table>
     <table name="mem">
@@ -2493,6 +2747,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">Я тебя беспокою?</column>
       <column name="definition_zh_HK">我打擾你嗎？</column>
       <column name="definition_pt">Estou incomodando você?</column>
+      <column name="definition_fi">Häiritsenkö?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2503,6 +2758,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{qaSuj'a '?: sen: nolink} on tapa, jolla esität kysymyksen, jos puhut vain yhdelle henkilölle. Jos haluat kysyä ihmisryhmältä, häiritsetkö heitä, sano {SaSuj'a '?: Sen: nolink} "Häiritsenko sinua (monikko)?"{qaSuj'a'?:sen:nolink}{SaSuj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2512,6 +2768,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2519,6 +2776,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -2532,6 +2790,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">обертывать, заворачивать, оборачивать, упаковывать, обрамлять</column>
       <column name="definition_zh_HK">包裹、包套</column>
       <column name="definition_pt">embrulho, invólucro</column>
+      <column name="definition_fi">kääriä, kietoa, paketoida, koteloida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2542,6 +2801,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Cats were mummified in ancient Egypt.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2551,6 +2811,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2558,6 +2819,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2572,6 +2834,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">Аккомпанимировать(петь) инструментальной музыке</column>
       <column name="definition_zh_HK">伴奏（唱歌）伴奏樂器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acompanhar (cantar) com música instrumental</column>
+      <column name="definition_fi">säestää (laulua soittimilla)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2582,6 +2845,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2591,6 +2855,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2598,6 +2863,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2611,6 +2877,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">Катра (вулканская душа)</column>
       <column name="definition_zh_HK">卡特拉（火神靈魂） [AUTOTRANSLATED]</column>
       <column name="definition_pt">katra (alma vulcano)</column>
+      <column name="definition_fi">katra (vulkanuslaisten sielu)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qa':n}</column>
@@ -2621,6 +2888,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru">Это просто Клингонское произношение вулканского слова.</column>
       <column name="notes_zh_HK">這只是沃爾肯單詞的克林崗語發音。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é apenas a pronúncia klingon de uma palavra vulcano. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain vulkaanisen sanan Klingon-ääntäminen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2630,6 +2898,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2637,6 +2906,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Lethe:src}</column>
     </table>
     <table name="mem">
@@ -2650,6 +2920,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">умник, ботан</column>
       <column name="definition_zh_HK">書呆子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nerd</column>
+      <column name="definition_fi">nörtti</column>
       <column name="synonyms">{venwI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{ven:v}</column>
@@ -2660,6 +2931,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru">Наиболее общий термин для {venwI':n:nolink}.</column>
       <column name="notes_zh_HK">對於{venwI':n:nolink}，這是一個更常見的術語（也是更普通的術語）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo mais comum (e mais nerd) para {venwI':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleisempi termi {venwI':n:nolink}: lle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the Dr. Seuss book "If I Ran the Zoo", the word "nerd" is used as the name of an imaginary animal:
 "And then, just to show them, I'll sail to Katroo
  And bring back an It-Kutch, a Preep and a Proo,
@@ -2672,6 +2944,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2679,6 +2952,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Festival of the Spoken Nerd DVD:src}</column>
     </table>
     <table name="mem">
@@ -2692,6 +2966,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">Почему?</column>
       <column name="definition_zh_HK">為什麼？</column>
       <column name="definition_pt">por que?</column>
+      <column name="definition_fi">miksi?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2702,6 +2977,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2711,6 +2987,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2718,6 +2995,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.4:src}</column>
     </table>
     <table name="mem">
@@ -2731,6 +3009,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">водопровод, воздуховод [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">水管、風管 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tubulação de água, duto</column>
+      <column name="definition_fi">vesiputki tai -johto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'och:n}, {ghImwI':n}</column>
@@ -2741,6 +3020,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to the "Why a Duck?" ("viaduct") routine from the Marx Brothers movie "The Cocoanuts". {Da'nal:n} and {Da'vI':n} are types of Klingon ducks. Also, "duck tape" or "duct tape" is a type of adhesive tape sometimes used in ductwork.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2750,6 +3030,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pipe, conduit, tube</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2757,6 +3038,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.09:src}</column>
     </table>
     <table name="mem">
@@ -2770,6 +3052,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="definition_ru">плата, гонорар, взнос, арендная плата</column>
       <column name="definition_zh_HK">租金、費用 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aluguel, taxa</column>
+      <column name="definition_fi">vuokra, käyttömaksu, hinta, tulli?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIl:v}, {voHDajbo' qav'ap:n}, {ghogh'ot:n}</column>
@@ -2780,6 +3063,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru">Слово использовано в {Klingon Monopoly:src} чтобы указать, за сколько {QaS:n:1h} игроку прийдется заплатить за посадку на планету, которая принадлежит другому игроку.</column>
       <column name="notes_zh_HK">在{Klingon Monopoly:src}中使用此詞表示一個玩家降落在另一個玩家擁有的星球上時必須支付多少{QaS:n:1h}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada em {Klingon Monopoly:src} para indicar quantos {QaS:n:1h} um jogador deve pagar ao pousar em um planeta pertencente a outro jogador. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään {Klingon Monopoly:src}: ssä merkitsemään kuinka monta {QaS:n:1h} pelaajaa on maksettava laskeutuessaan toisen pelaajan omistamalle planeetalle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Cough (it) up".
 
 No English definition has been given for this word. The meaning has been derived from usage. The {KLI:src} New Klingon Words list gives the definition "rent, cost, price, value".</column>
@@ -2791,6 +3075,7 @@ No English definition has been given for this word. The meaning has been derived
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fees, payment, cost, value</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2798,6 +3083,7 @@ No English definition has been given for this word. The meaning has been derived
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2811,6 +3097,7 @@ No English definition has been given for this word. The meaning has been derived
       <column name="definition_ru">помнить, запоминать, вспоминать</column>
       <column name="definition_zh_HK">記得 [AUTOTRANSLATED]</column>
       <column name="definition_pt">relembrar</column>
+      <column name="definition_fi">muistaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lIj:v}, {qawHa':v}</column>
       <column name="see_also">{qaw:n}, {wov'on:n}, {ngonDer:n}</column>
@@ -2821,6 +3108,7 @@ No English definition has been given for this word. The meaning has been derived
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2832,6 +3120,7 @@ No English definition has been given for this word. The meaning has been derived
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2839,6 +3128,7 @@ No English definition has been given for this word. The meaning has been derived
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2852,6 +3142,7 @@ No English definition has been given for this word. The meaning has been derived
       <column name="definition_ru">память (способность)</column>
       <column name="definition_zh_HK">記憶（能力） [AUTOTRANSLATED]</column>
       <column name="definition_pt">memória (habilidade)</column>
+      <column name="definition_fi">muisti, muistamiskyky</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qaw:v}</column>
@@ -2866,6 +3157,9 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
 Кто-то, у кого есть великолепная память, может иметь {qaw pov:n@@qaw:n, pov:v}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa "muistiin" kyvyssä muistaa tai muistamisen voimaan. Se ei tarkoita erityisiä muistoja tai muistelmia, joista ks. {wov'on:n}.
+
+Joku, jolla on erinomainen muisti, voidaan sanoa olevan {qaw pov:n@@qaw:n, pov:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2875,6 +3169,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2882,6 +3177,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.06:src}</column>
     </table>
         <table name="mem">
@@ -2895,6 +3191,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="definition_ru">банки памяти, банки данных</column>
           <column name="definition_zh_HK">存儲庫、數據庫 [AUTOTRANSLATED]</column>
           <column name="definition_pt">bancos de memória, bancos de dados</column>
+      <column name="definition_fi">muistipankki, tietopankki</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{De':n}, {mem:n}, {wa'chaw:n}</column>
@@ -2905,6 +3202,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="notes_ru">Это слово в единственном числе. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這個詞是單數。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esta palavra é singular. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on yksikkö. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -2914,6 +3212,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">database</column>
           <column name="search_tags_de">Datenspeicher</column>
           <column name="search_tags_fa"></column>
@@ -2921,6 +3220,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="search_tags_ru">база данных</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}, [2] {TKDA:src}</column>
         </table>
         <table name="mem">
@@ -2934,6 +3234,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="definition_ru">подзабывать,помнить некорректно</column>
           <column name="definition_zh_HK">misremember、記錯了 [AUTOTRANSLATED]</column>
           <column name="definition_pt">lembre-se mal, lembre-se incorretamente</column>
+      <column name="definition_fi">muistaa väärin</column>
           <column name="synonyms"></column>
           <column name="antonyms">{qaw:v}</column>
           <column name="see_also"></column>
@@ -2944,6 +3245,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qaw:v}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -2953,6 +3255,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2960,6 +3263,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.102:src}</column>
         </table>
         <table name="mem">
@@ -2973,6 +3277,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="definition_ru">Напоминать</column>
           <column name="definition_zh_HK">提醒 [AUTOTRANSLATED]</column>
           <column name="definition_pt">lembrar</column>
+      <column name="definition_fi">muistuttaa jostakin</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2997,6 +3302,9 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="notes_pt">Com base no exemplo, o sujeito faz a lembrança, o objeto é a coisa lembrada e a pessoa lembrada é marcada com {-vaD:n}.
 
     Mais genericamente, parece que quando {-moH:v} é adicionado a um verbo {X:sen:nolink} que leva um objeto, o verbo bivalente resultante {XmoH:sen:nolink} leva o mesmo objeto, enquanto o sujeito original de {X:sen:nolink} torna-se o beneficiário de {XmoH:sen:nolink} e é marcado com {-vaD:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Esimerkin perusteella aihe tekee muistutuksen, esine on muistettava asia ja muistutettava henkilö merkitään tekstillä {-vaD:n}.
+
+    Yleisemmin näyttää siltä, ​​että kun {-moH:v} lisätään objektin ottavaan verbiin {X:sen:nolink}, tuloksena oleva kaksiarvoinen verbi {XmoH:sen:nolink} vie saman objektin, kun taas {X:sen:nolink}: n alkuperäinen aihe tulee {XmoH:sen:nolink}: n edunsaajaksi ja on merkitty {-vaD:n}: llä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qaw:v}, {-moH:v}</column>
           <column name="examples">
@@ -3008,6 +3316,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
 ▶ {qorDu'Daj tuq 'oS Ha'quj'e' tuQbogh wo'rIv. tuQtaHvIS Hem. ghaHvaD quHDaj qawmoH.:sen:nolink} "Перевязь, которую носит Ворф, является символом его семьи. Он носит её гордо, как напоминание о его наследии."[2]</column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3015,6 +3324,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}, [2] {SkyBox 20:src} (reprinted in {HQ 5.2, p.14, Jun. 1996:src})</column>
         </table>
     <table name="mem">
@@ -3028,6 +3338,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
       <column name="definition_ru">опрокидывать, переворачивать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">翻倒，翻過來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tombar, virar</column>
+      <column name="definition_fi">kaatua kumoon</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pum:v:2}</column>
@@ -3038,6 +3349,7 @@ Someone who has an excellent memory may be said to have a {qaw pov:n@@qaw:n, pov
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">如果某些東西是自己主動或看似自己主動提出的，則將使用此方法（即使有已知原因）。例如，如果一個人失去了平衡，將使用此方法。有關“完全翻轉”的信息，請參閱{yoymoH:v}和{tach:v}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä käytettäisiin, jos jokin kaatui omasta aloitteestaan ​​tai näennäisesti omasta aloitteestaan ​​(vaikka syy olisi tiedossa). Esimerkiksi tätä käytettäisiin, jos joku menettää tasapainonsa. Katso "käännä (kokonaan) yli", katso {yoymoH:v} ja {tach:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Cow tipping" is an urban legend about the activity of pushing over a cow for entertainment.
 
 This was first defined as "flip over", but it was revealed in answer to a question about cars being overturned in the street, a chair or big box being kicked over, or a drinking glass or anything else falling over from a vertical into a horizontal position.[1] It was later clarified that "tip over" is a better definition.[2]
@@ -3051,6 +3363,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fall down, fall over</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3058,6 +3371,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}, [2] {KLI mailing list 2020.06.09:src}</column>
     </table>
         <table name="mem">
@@ -3071,6 +3385,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
           <column name="definition_ru">опрокидываться, опрокидываться, опрокидываться [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">翻倒撞倒 [AUTOTRANSLATED]</column>
           <column name="definition_pt">tombar, derrubar</column>
+      <column name="definition_fi">kaataa kumoon</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -3081,6 +3396,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qaw':v}, {-moH:v}</column>
           <column name="examples"></column>
@@ -3090,6 +3406,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3097,6 +3414,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.06.09:src}</column>
         </table>
     <table name="mem">
@@ -3110,6 +3428,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="definition_ru">Используйте средний палец</column>
       <column name="definition_zh_HK">使用第二個（中間）手指 [AUTOTRANSLATED]</column>
       <column name="definition_pt">usar o segundo dedo (do meio)</column>
+      <column name="definition_fi">käyttää keskisormea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh:n}</column>
@@ -3120,6 +3439,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Cayuga Lake.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3129,6 +3449,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3136,6 +3457,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
         <table name="mem">
@@ -3149,6 +3471,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
           <column name="definition_ru">средний палец, безымянный палец</column>
           <column name="definition_zh_HK">中指、第二根手指 [AUTOTRANSLATED]</column>
           <column name="definition_pt">dedo médio, segundo dedo</column>
+      <column name="definition_fi">keskisormi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nItlh:n}</column>
@@ -3159,6 +3482,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">If someone is a {qay'wI'}, then you give them a {qaywI':n:nolink}.</column>
           <column name="components">{qay:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -3168,6 +3492,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3175,6 +3500,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
         </table>
     <table name="mem">
@@ -3188,6 +3514,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="definition_ru">{yulyuS qaySar:n:name}</column>
       <column name="definition_zh_HK">{yulyuS qaySar:n:name}</column>
       <column name="definition_pt">{yulyuS qaySar:n:name}</column>
+      <column name="definition_fi">{yulyuS qaySar:n:name}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3198,6 +3525,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3207,6 +3535,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3214,6 +3543,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -3227,6 +3557,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="definition_ru">родитель (гендерно-нейтральный термин) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">父母（不分性別） [AUTOTRANSLATED]</column>
       <column name="definition_pt">pai (termo neutro em termos de gênero)</column>
+      <column name="definition_fi">(lapsen) vanhempi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoS:n}, {vav:n}</column>
@@ -3237,6 +3568,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3246,6 +3578,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3253,6 +3586,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3266,6 +3600,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="definition_ru">быть трудностью, быть проблемой, быть надоедливым, быть докучающим</column>
       <column name="definition_zh_HK">是一個問題、麻煩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser um problema, ser um incômodo</column>
+      <column name="definition_fi">olla ongelma, olla hankaluus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3276,6 +3611,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{qay'be':sen}</column>
@@ -3285,6 +3621,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3292,6 +3629,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3305,6 +3643,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="definition_ru">Нет проблем</column>
       <column name="definition_zh_HK">沒問題。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sem problemas.</column>
+      <column name="definition_fi">Ei ongelmaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3315,6 +3654,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">According to the {The Star Trek Encyclopedia:src}, MO devised this phrase to honour Star Trek III visual-effects supervisor Ken Ralston and his ILM crew, who responded to every request with "No problem!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3324,6 +3664,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3331,6 +3672,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -3344,6 +3686,7 @@ This is confirmed as intransitive since {qaw'moH:v} was also glossed as "make so
       <column name="definition_ru">замещать, заменять</column>
       <column name="definition_zh_HK">更換 [AUTOTRANSLATED]</column>
       <column name="definition_pt">substituir, trocar</column>
+      <column name="definition_fi">korvata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tam:v:2}, {mech:v}, {'e' qa':sen}</column>
@@ -3368,6 +3711,9 @@ Detta verb verkar ha härledts från {qa'meH:n}, eventuellt genom felaktig tolkn
       <column name="notes_pt">O sujeito faz a substituição e o objeto é substituído.
 
 Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretação do que era originalmente o sufixo {-qa':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Subjekti korvaa ja objekti on korjattu.
+
+Tämä verbi näyttäisi olevan johdettu {qa'meH:n}:sta, mahdollisesti tulkitsemalla väärin jotain, mikä oli alun perin verbipääte {-qa':v}.</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3383,6 +3729,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
 ▶ {Quj wa'DIch juH qachmey mebpa'mey je qa' raQmey chu' monmey chu' je:sen:nolink} "Обычные аванпосты и столицы заменяют оригинальными домами и отелями"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3390,6 +3737,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3403,6 +3751,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="definition_ru">дух [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">精神 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espírito</column>
+      <column name="definition_fi">henki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIyma':n}, {Qun:n}, {porgh:n}, {qatra':n}</column>
@@ -3413,6 +3762,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="notes_ru">Это относится к некой жизненной силе внутри человека, которая убегает, когда тот умирает.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指一個人內的一種生命力，該生命力在該人死亡時會逃脫。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um tipo de força vital dentro de uma pessoa que escapa quando ela morre.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa eräänlaiseen ihmishenkeen, joka pakenee, kun henkilö kuolee[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is an acceptable word to use for "ghost", but there may be another (and better) unknown word for that concept.[2]</column>
       <column name="components"></column>
       <column name="examples">
@@ -3424,6 +3774,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ghost</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3431,6 +3782,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KLI mailing list 2008.11.23:src}</column>
     </table>
     <table name="mem">
@@ -3444,6 +3796,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="definition_ru">Мы сражаемся, чтобы обогатить наш дух</column>
       <column name="definition_zh_HK">我們努力豐富精神。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Lutamos para enriquecer o espírito.</column>
+      <column name="definition_fi">Taistelemme rikastuttaaksemme henkeä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3454,6 +3807,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qa':n}, {wI-:v}, {je':v:2}, {-meH:v}, {ma-:v}, {Suv:v}</column>
       <column name="examples"></column>
@@ -3463,6 +3817,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3470,6 +3825,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.7:src}</column>
     </table>
     <table name="mem">
@@ -3483,6 +3839,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="definition_ru">замена (постоянная)</column>
       <column name="definition_zh_HK">更換（永久） [AUTOTRANSLATED]</column>
       <column name="definition_pt">substituição (permanente)</column>
+      <column name="definition_fi">korvaaja (pysyvä, ei sijainen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qa':v}, {lIw:n}, {velqa':n}, {qa'meH vIttlhegh:n}</column>
@@ -3493,6 +3850,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="notes_ru">Слово является укороченной формой {quvqa'meH:sen:nolink} (смотрите {qa'meH vIttlhegh:n}), но принято другими в качестве полноправного существительного. Относится к чему-то, что берет что-то на себя или использовано вместо чего-то, что ушло, или что было потеряно. Чтобы указать на временную замену или на дублёра, используйте {lIw:n}.[2]</column>
       <column name="notes_zh_HK">這個詞最初是{quvqa'meH:sen:nolink}的縮寫形式（請參閱{qa'meH vIttlhegh:n}），但是自此以後就被接受為名詞。它指代接替或使用的東西，而不是已消失或丟失的東西。要表示臨時替代品或替代品，請使用{lIw:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra era originalmente uma forma abreviada de {quvqa'meH:sen:nolink} (consulte {qa'meH vIttlhegh:n}), mas desde então foi aceita como um substantivo por si só. Refere-se a algo que assume ou é usado em vez de algo que se foi ou que foi perdido. Para denotar um substituto temporário ou substituto, use {lIw:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana oli alun perin lyhennetty {quvqa'meH:sen:nolink}-muoto (ks. {qa'meH vIttlhegh:n}), mutta siitä lähtien siitä on tullut hyväksytty substantiiviksi itsessään. Se viittaa johonkin, joka ottaa haltuunsa tai jota käytetään menneen tai kadonneen sijasta. Jos haluat merkitä väliaikaisen korvaavan tai valmiustilan, käytä {lIw:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3502,6 +3860,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3509,6 +3868,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 5.1, Mar. 1996 p.10:src}</column>
     </table>
         <table name="mem">
@@ -3522,6 +3882,7 @@ Este verbo parece ter derivado de {qa'meH:n}, possivelmente por má interpretaç
           <column name="definition_ru">заменяющая пословица</column>
           <column name="definition_zh_HK">替代諺語</column>
           <column name="definition_pt">provérbio de substituição</column>
+      <column name="definition_fi">korvaussanonta</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -3542,6 +3903,9 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
 В прошлом, это было {quvqa'meH vIttlhegh:n:nolink}.[1]</column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi">Nämä ovat joukko sananlaskuja, joita käytetään kunnioituksen tai uskottavuuden palauttamiseen sen jälkeen, kun jotakin on nolostettu julkisessa ympäristössä.
+
+Aikaisemmin tämä oli {quvqa'meH vIttlhegh:n:nolink}.[1][2] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qa'meH:n}, {vIttlhegh:n}</column>
           <column name="examples"></column>
@@ -3551,6 +3915,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3558,6 +3923,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 5.1, Mar. 1996 p.10:src}, [2] {PK:src}</column>
         </table>
         <table name="mem">
@@ -3571,6 +3937,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
           <column name="definition_ru">номер версии (младший) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">版本號（次要） [AUTOTRANSLATED]</column>
           <column name="definition_pt">número da versão (menor)</column>
+      <column name="definition_fi">sivuversionumero</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nIqHom mI':n}</column>
@@ -3581,6 +3948,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
           <column name="notes_ru">Это используется для незначительного обновления программного обеспечения (например, от 2.0 до 2.1). [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這用於次要軟件更新（例如2.0到2.1）。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso é usado para uma pequena atualização de software (por exemplo, 2.0 a 2.1). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään pieneen ohjelmistopäivitykseen (esim. 2.0 - 2.1). [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qa'meH:n}, {mI':n}</column>
           <column name="examples"></column>
@@ -3590,6 +3958,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3597,6 +3966,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
         </table>
     <table name="mem">
@@ -3610,6 +3980,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="definition_ru">Каминар [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">卡米納爾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kaminar</column>
+      <column name="definition_fi">Kaminar</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qelpIngan:n}</column>
@@ -3620,6 +3991,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3629,6 +4001,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3636,6 +4009,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -3649,6 +4023,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="definition_ru">обезьяноподобное существо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">猴子般的生物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">criatura parecida com um macaco</column>
+      <column name="definition_fi">eräs apinan kaltainen olento</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3659,6 +4034,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Capuchin monkey.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3668,6 +4044,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3675,6 +4052,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3688,6 +4066,7 @@ Tidigare brukade detta vara {quvqa'meH vIttlhegh:n:nolink}.[1] [AUTOTRANSLATED]<
       <column name="definition_ru">вид животного, ка'радж [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、ka'raj [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, ka'raj</column>
+      <column name="definition_fi">eräs eläin, ka'raj</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3712,6 +4091,9 @@ Förväxla inte detta med liknande namn {Qaj:n}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Sua garra foi comida. Esta palavra também pode ser escrita {Qa'raj:n:nolink}.
 
 Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen kynsi on syönyt. Tämä sana voidaan myös kirjoittaa {Qa'raj:n:nolink}.
+
+Älä sekoita tätä vastaavasti nimettyyn {Qaj:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">On {KGT p.94:src}, this word is spelled {qa'raj:n:nolink}. However, it is spelled {Qa'raj:n:nolink} in both the E-K and K-E word lists.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3721,6 +4103,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3728,6 +4111,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3741,6 +4125,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="definition_ru">конец (коридора, туннеля, водовода, трубы Джеффриса, канализации, дороги, моста, длинного поля и т. д.) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結束（走廊，隧道，管道、杰弗里斯管、下水道、道路、橋樑、長場等） [AUTOTRANSLATED]</column>
       <column name="definition_pt">final (de corredor, túnel, conduto, tubo Jeffries, esgoto, estrada, ponte, campo longo, etc.)</column>
+      <column name="definition_fi">(käytävän, tunnelin, putken, tien, sillan tms.) pää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'och:n}, {QI:n}, {megh'an:n}, {'er'In:n}, {'ImSIng:n}</column>
@@ -3751,6 +4136,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к обоим (или всем) концам любого длинного замкнутого пространства, внутри которого обычно находится человек, или изнутри, или ограниченного пространства, которое рассматривается как имеющее длину, даже если оно не замкнуто. {qa'rI':n:nolink}, на котором можно войти или выйти, - {DIn:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Refere-se a ambas as extremidades (ou todas) de qualquer espaço fechado longo que normalmente se encontra dentro ou experimenta por dentro, ou um espaço delimitado que é visto como tendo comprimento mesmo que não esteja fechado. Um {qa'rI':n:nolink} no qual é possível entrar ou sair é um {DIn:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa minkä tahansa pitkään suljetun tilan molempiin (tai kaikkiin) päihin, jotka tyypillisesti ovat sisällä tai joita se kokee sisältä, tai rajoitettuun tilaan, jonka katsotaan olevan pitkiä, vaikka sitä ei olisikaan suljettu. {qa'rI':n:nolink}, josta voi tulla sisään tai sieltä, on {DIn:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a private joke referring to a specific person.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3760,6 +4146,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3767,6 +4154,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}, [2] {KLI mailing list 2019.04.11:src}</column>
     </table>
     <table name="mem">
@@ -3780,6 +4168,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Очень большая птица</column>
       <column name="definition_zh_HK">一隻非常大的鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro realmente grande</column>
+      <column name="definition_fi">eräs todella iso musta lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3790,6 +4179,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Она гораздо больше, чем {notqa':n}.</column>
       <column name="notes_zh_HK">它比{notqa':n}大得多。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É muito maior que um {notqa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Se on paljon suurempi kuin {notqa':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The character of Big Bird on the children's show Sesame Street was played by Caroll Edwin Spinney.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3811,6 +4201,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
    Чтобы он потерял свою гордость и объявил претензии на трон."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3818,6 +4209,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}, [2] {paq'batlh p.62-63:src}</column>
     </table>
     <table name="mem">
@@ -3832,6 +4224,7 @@ Não confunda isso com o {Qaj:n} de nome semelhante. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Генезис, "Большой взрыв"</column>
       <column name="definition_zh_HK">創世、「大爆炸」</column>
       <column name="definition_pt">Gênesis, "Big Bang"</column>
+      <column name="definition_fi">maailman synty, alkuräjähdys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bI'reS:n}</column>
@@ -3852,6 +4245,9 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
 Слово само по себе означает "источник всего" или "начало начал" или что-то подобное, и относится к началу вселенной.[3]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on federaation Genesis-aseiden tutkimushankkeen Klingon-koodinimi.[2]
+
+Sana itsessään tarkoittaa "kaiken alkuperää" tai "kaiken alkua" tai vastaavaa ja viittaa maailmankaikkeuden alkuun. Toisin kuin englanninkielinen käännös, Klingon-termi ei sisällä räjähdyksen käsitettä.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Maltz said that it's possible to say {qa'vam nger:sen:nolink} "Big Bang Theory", but it sounded weird to him, since {qa'vam:n:nolink} is not a theory.[3]</column>
       <column name="components"></column>
       <column name="examples">
@@ -3862,6 +4258,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Big Bang</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3869,6 +4266,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek III:src}, [3] {KLI mailing list 2015.03.16:src}</column>
     </table>
     <table name="mem">
@@ -3882,6 +4280,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">Ка'вак (традиционная игра) с обручем и палкой</column>
       <column name="definition_zh_HK">qa'vak（傳統遊戲）、玩箍和棍子的遊戲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">qa'vak (jogo tradicional), jogo jogado com aro e bastão</column>
+      <column name="definition_fi">eräs kepillä ja renkaalla pelattava perinteinen peli, qa'vak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gho:n}, {naQ:n:1}</column>
@@ -3892,6 +4291,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru">Идиома {vIHtaH gho:sen} происходит от этого занятия.</column>
       <column name="notes_zh_HK">成語{vIHtaH gho:sen}來自此活動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O idioma {vIHtaH gho:sen} vem dessa atividade. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Idioomi {vIHtaH gho:sen} tulee tästä toiminnasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It may just be a coincidence, but this sounds like {qa' vaQ:n:nolink} "aggressive spirit". See {qa':n} and {vaQ:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3901,6 +4301,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3908,6 +4309,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -3921,6 +4323,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">кофе</column>
       <column name="definition_zh_HK">咖啡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">café</column>
+      <column name="definition_fi">kahvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ra'taj:n}</column>
@@ -3931,6 +4334,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3940,6 +4344,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">caffeine</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3947,6 +4352,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru">кофеин</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 4.2, p.7, Jun. 1995:src}</column>
     </table>
     <table name="mem">
@@ -3960,6 +4366,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">сожмите [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擠壓（風袋樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">squeeze (instrumento de sopro)</column>
+      <column name="definition_fi">puristaa (säkkipilliä tms. soitinta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chu':v:3}, {rey:v}, {ngaH:v}</column>
@@ -3970,6 +4377,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru">Это относится к действию сдавливания части сумки {DIron:n}, обычно с локтем. [1, p.76] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指通常用肘部擠壓{DIron:n}的袋子部分的動作。[1, p.76] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa {DIron:n}-laukun pussin puristamiseen tavallisesti kyynärpäällä.[1, p.76] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3979,6 +4387,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3986,6 +4395,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3999,6 +4409,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">идея</column>
       <column name="definition_zh_HK">理念 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ideia</column>
+      <column name="definition_fi">idea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nger:n}, {ngoD:n}, {vuD:n}</column>
@@ -4009,6 +4420,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4018,6 +4430,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4025,6 +4438,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4038,6 +4452,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">упразднять, освобождать(покидать ранее занимаемое место), оставлять</column>
       <column name="definition_zh_HK">空出 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desocupar</column>
+      <column name="definition_fi">tyhjentää, lähteä, evakuoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIm:v}, {choS:v}</column>
@@ -4048,6 +4463,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4057,6 +4473,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4064,6 +4481,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4077,6 +4495,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">чан, бочка (для хранения ликёра)</column>
       <column name="definition_zh_HK">桶、桶（用於儲存酒） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tonel, barril (para armazenamento de bebidas alcoólicas)</column>
+      <column name="definition_fi">sammio, tynnyri (viinin tms. varastointiin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIq:n}, {pugh:n}, {HaySIn:n}</column>
@@ -4087,6 +4506,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Keg".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4096,6 +4516,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4103,6 +4524,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4116,6 +4538,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">возмущаться, обижаться, негодовать</column>
       <column name="definition_zh_HK">憤恨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ressentir</column>
+      <column name="definition_fi">paheksua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pay:v}, {qeHHa':v}</column>
@@ -4126,6 +4549,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4135,6 +4559,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4142,6 +4567,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4155,6 +4581,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">прощать</column>
       <column name="definition_zh_HK">原諒、不同意 [AUTOTRANSLATED]</column>
       <column name="definition_pt">perdoar, não ressentir</column>
+      <column name="definition_fi">antaa anteeksi, lopettaa paheksuminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeH:v}</column>
@@ -4165,6 +4592,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru">В {paq'raD:n:nolink} "Книга силы", являющаяся частью {paq'batlh:n}, вторая секция озаглавлена {qeHHa' loDnI':sen:nolink}, что переводится, как "Братское прощение". Сноска объясняет, что концепция прощения не относится к Клингонской культуре, и что дословное значение заголовка "Брат не негодует". Заголовок соответствующей песни в опере {'u':n:name,nolink} будет {loDnI'Daj quvqa'moH:sen:nolink}, что дословно значит, "он побуждает своего брата получить честь снова".</column>
       <column name="notes_zh_HK">在{paq'batlh:n}的{paq'raD:n:nolink}“強製書”中，第二部分的標題為{qeHHa' loDnI':sen:nolink}，該部分的英文譯本有點“兄弟的寬恕”。一個腳註解釋說，寬恕的概念與克林崗文化並不完全對應，標題的字面意思是“不折磨的兄弟”。歌劇《 {'u':src}》中相應頌歌的標題是{loDnI'Daj quvqa'moH:sen:nolink}，字面意思是“他使兄弟再次獲得榮譽”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No {paq'raD:n:nolink} "Force Book" do {paq'batlh:n}, a segunda seção é intitulada {qeHHa' loDnI':sen:nolink}, que recebe a tradução em inglês um tanto vaga de "Perdão de um irmão". Uma nota de rodapé explica que o conceito de perdão não é mapeado exatamente para a cultura klingon e que o significado literal do título é "Um irmão não ressentido". O título do canto correspondente na ópera {'u':src} é {loDnI'Daj quvqa'moH:sen:nolink}, literalmente, "ele faz com que o irmão tenha honra novamente". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{paq'raD:n:nolink}: n "Force Book" -kirjassa DONOTTRANSLATE1 on toinen osa otsikolla {qeHHa' loDnI':sen:nolink}, jolle on annettu hieman löysä englanninkielinen käännös "A Brother's Forgiveness". Alaviitteessä selitetään, että anteeksiannon käsite ei sovi tarkalleen Klingonin kulttuuriin ja että otsikon kirjaimellinen merkitys on "Veli ei läsnä". Vastaavan laulun nimi oopperassa {'u':src} on {loDnI'Daj quvqa'moH:sen:nolink}, kirjaimellisesti "hän saa veljen jälleen kunnioittamaan".{paq'batlh:n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qeH:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -4174,6 +4602,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4181,6 +4610,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.100-101:src}</column>
     </table>
     <table name="mem">
@@ -4194,6 +4624,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">быть ворчливым, быть брюзгливым, быть недоброжелательным, быть дрянным, быть придирчивым</column>
       <column name="definition_zh_HK">不高興、意思是 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ranzinza, mau</column>
+      <column name="definition_fi">olla pahansisuinen, olla ilkeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Doch:v}, {veqlargh:n}, {'I'SeghIm:n}</column>
@@ -4204,6 +4635,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4213,6 +4645,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">grumpy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4220,6 +4653,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4233,6 +4667,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">рассматривать, учитывать, считаться с чем-то, принимать во внимание</column>
       <column name="definition_zh_HK">考慮、考慮到 [AUTOTRANSLATED]</column>
       <column name="definition_pt">considerar, levar em consideração</column>
+      <column name="definition_fi">ottaa huomioon</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4243,6 +4678,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4252,6 +4688,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4259,6 +4696,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -4272,6 +4710,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">кивать головой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">點頭</column>
       <column name="definition_pt">aceno com a cabeça</column>
+      <column name="definition_fi">nyökätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4282,6 +4721,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru">Это означает, что голова немного опущена, независимо от того, поднята голова или нет. Так что, между прочим, это может означать кивание в такт музыке или сонливость (засыпание). Субъектом может быть, например, «голова» {nach:n} (даже если это может считаться избыточным) или кивок. Это не берет объект. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著無論是否再次抬起頭部，都要稍微降低頭部。因此，除其他外，它可以指點拍音樂節拍或點頭睡著（入睡）。例如，主題可能是{nach:n}“頭”（即使這可能被認為是多餘的）或點頭。它不帶對象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa abaixar a cabeça levemente, independentemente de a cabeça ser novamente levantada. Portanto, entre outras coisas, pode se referir a citar a batida da música ou a adormecer (adormecer). O sujeito pode ser, por exemplo, {nach:n} "head" (mesmo que isso possa ser considerado redundante) ou o nodder. Não é necessário um objeto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa, että päätä lasketaan hiukan riippumatta siitä, nostetaanko pää uudelleen. Joten se voi muun muassa viitata nyökkäykseen musiikin tahtiin tai nyökkäykseen (nukahtaminen). Kohde voi olla esimerkiksi {nach:n} "pää" (vaikka tätä voidaan pitää tarpeettomana) tai nyökkääjä. Se ei vie kohdetta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This refers to the motion, not any particular meaning (such as nodding to indicate "yes" in some cultures). This was clarified during the Q &amp; A session.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4291,6 +4731,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4298,6 +4739,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4311,6 +4753,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">Kal'Hyah [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">卡爾海亞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kal'Hyah</column>
+      <column name="definition_fi">Kal'Hyah, "klingonien polttarit"</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tawI'yan:n}, {lop:n}, {tlhogh:n}</column>
@@ -4321,6 +4764,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru">Это «умственное и духовное путешествие», которое клингонский жених совершает со своими ближайшими друзьями-мужчинами. Это длится четыре дня, и участники поста должны выдержать шесть испытаний: лишение, кровь, боль, жертва, боль и смерть. Он был неточно назван «клингонской холостяцкой вечеринкой». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是克林崗新郎與他最親密的男性朋友一起進行的“精神和精神之旅”。它持續四天，而禁食的參與者必須經受六項考驗：剝奪，鮮血，痛苦，犧牲，痛苦和死亡。它被不正確地稱為“克林崗單身派對”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma "jornada mental e espiritual" que um noivo Klingon realiza com seus amigos mais próximos. Dura quatro dias e os participantes do jejum são obrigados a suportar seis provações: privação, sangue, dor, sacrifício, angústia e morte. Foi referido incorretamente como uma "parte Klingon bacheler". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on "henkinen ja hengellinen matka", jonka klingonilainen sulhanen tekee lähimpien miesystäviensä kanssa. Se kestää neljä päivää, ja paasto-osallistujat joutuvat kestämään kuusi koetta: puute, veri, kipu, uhraus, ahdistus ja kuolema. Sitä kutsutaan virheellisesti "Klingon bacheler -puolueeksi". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4330,6 +4774,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bachelor party</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4337,6 +4782,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {DS9 - You Are Cordially Invited:src}</column>
     </table>
     <table name="mem">
@@ -4350,6 +4796,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="definition_ru">келликам</column>
       <column name="definition_zh_HK">《kellicam》（太空公里）</column>
       <column name="definition_pt">kellicam</column>
+      <column name="definition_fi">eräs pituuden yksikkö, kellikam (n. 2 kilometriä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuq:n}, {loghqam:n}</column>
@@ -4360,6 +4807,7 @@ Ordet i sig betyder "alltingens ursprung" eller "början på allt" eller liknand
       <column name="notes_ru">Единица измерения расстояний, приблизительно равная двум километрам.</column>
       <column name="notes_zh_HK">這是一個大約兩公里的度量單位。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma unidade de medida semelhante a dois quilômetros. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on mittayksikkö, joka muistuttaa suunnilleen kahta kilometriä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Kilo-foot".
 
 The information about the length comes from {The Star Trek Encyclopedia, 4th ed., vol.1, p.409:src}.</column>
@@ -4371,6 +4819,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4378,6 +4827,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4391,6 +4841,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="definition_ru">Келпиен [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Kelpian [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kelpien</column>
+      <column name="definition_fi">kelpiläinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngan:n}</column>
@@ -4401,6 +4852,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="notes_ru">Это гуманоидный вид от {qa'mInar:n}. Они делят планету с другим разумным видом, баулом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是來自{qa'mInar:n}的類人動物物種。他們與另一個有意識的物種Ba'ul共享地球。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma espécie humanóide da {qa'mInar:n}. Eles compartilham o planeta com outra espécie sensível, os Ba'ul. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {qa'mInar:n}: n humanoidilaji. He jakavat planeetan toisen tuntevan lajin, Ba'ulin kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The spelling {qelpIya'ngan:n} was used in the Klingon-language subtitles for {DSC:src} on Netflix before Okrand gave this spelling. Both are acceptable.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4410,6 +4862,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4417,6 +4870,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Si Vis Pacem, Para Bellum:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -4430,6 +4884,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="definition_ru">{qelpIngan:n}</column>
       <column name="definition_zh_HK">{qelpIngan:n}</column>
       <column name="definition_pt">{qelpIngan:n}</column>
+      <column name="definition_fi">{qelpIngan:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4440,6 +4895,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4449,6 +4905,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4456,6 +4913,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Si Vis Pacem, Para Bellum:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -4469,6 +4927,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="definition_ru">приносить, привозить, нести, занести</column>
       <column name="definition_zh_HK">帶來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trazer</column>
+      <column name="definition_fi">tuoda</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4479,6 +4938,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4489,6 +4949,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4496,6 +4957,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4509,6 +4971,7 @@ The information about the length comes from {The Star Trek Encyclopedia, 4th ed.
       <column name="definition_ru">предок</column>
       <column name="definition_zh_HK">祖先</column>
       <column name="definition_pt">antepassado</column>
+      <column name="definition_fi">esivanhempi, esi-isä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ISyar:n}</column>
@@ -4533,6 +4996,9 @@ I {paq'batlh:src} är {qempa'QeH:n:nolink} de förargade spritarna (se {QeH:v}) 
       <column name="notes_pt">Refere-se a um ancestral ou antepassado cultural ou social (que não está necessariamente relacionado ao sangue). Para um ancestral direto, consulte {'emrIgh:n}.
 
 No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfurecidos (consulte {QeH:v}) que povoam {ghe'tor:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kulttuuriseen tai yhteiskunnalliseen esi-isään tai esivanhempaan (joka ei välttämättä ole verisukulainen). Katso suoraa esi-isää kohdasta {'emrIgh:n}.
+
+{paq'batlh:src}-ohjelmassa {qempa'QeH:n:nolink} ovat raivostuneita (katso {QeH:v}) esi-isiä, jotka asuttavat {ghe'tor:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{no':n:inhpl}</column>
       <column name="examples"></column>
@@ -4542,6 +5008,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">qempa'QeH</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4549,6 +5016,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.108-109:src}</column>
     </table>
     <table name="mem">
@@ -4562,6 +5030,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="definition_ru">Недавно</column>
       <column name="definition_zh_HK">近來、不久前</column>
       <column name="definition_pt">recentemente, há pouco tempo</column>
+      <column name="definition_fi">äskettäin, vähän aikaa sitten, jonkin aikaa sitten</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qenHa':adv:hyp}</column>
       <column name="see_also">{tugh:adv}</column>
@@ -4572,6 +5041,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4581,6 +5051,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4588,6 +5059,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.02.02:src}</column>
     </table>
     <table name="mem">
@@ -4601,6 +5073,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="definition_ru">нести, содержать, везти, транспортировать, перевозить, переправлять</column>
       <column name="definition_zh_HK">攜帶、傳達 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transportar, conduzir</column>
+      <column name="definition_fi">kantaa, kuljettaa, välittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIj:v}, {Qay:v}</column>
@@ -4611,6 +5084,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="notes_ru">Беременной женщине сказано {qeng:v:nolink} об {puq:n}.[2] Смотрите {yatlh:v}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Raskaana olevan naisen sanotaan {qeng:v:nolink} a {puq:n}. [2] Katso {yatlh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4624,6 +5098,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
 ▶ {qarDaSQa'Daq ruDelya' rop'a' Hergh qengbogh yo' Dabot.:sen:nolink} "Перехватите конвой с Руделлианской чумой, который следует до Кардассианского союза."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">burden</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4631,6 +5106,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.184-185:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -4644,6 +5120,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="definition_ru">Канг</column>
       <column name="definition_zh_HK">炕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kang</column>
+      <column name="definition_fi">Kang</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mara:n:name}</column>
@@ -4654,6 +5131,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="notes_ru">Сыгран {mayqel 'anSara':n:name}.</column>
       <column name="notes_zh_HK">由{mayqel 'anSara':n:name}演奏。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Jogado por {mayqel 'anSara':n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toistanut {mayqel 'anSara':n:name}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4663,6 +5141,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4670,6 +5149,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4683,6 +5163,7 @@ No {paq'batlh:src}, os {qempa'QeH:n:nolink} são os espíritos ancestrais enfure
       <column name="definition_ru">сокровище, добыча, трофеи, награбленное добро, грабеж, хищение, разграбление, добыча грабителя</column>
       <column name="definition_zh_HK">寶藏、戰利品、掠奪、贓物、戰利品 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tesouro, saque, pilhagem</column>
+      <column name="definition_fi">aarre, ryöstö- tai sotasaalis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DerlIq:n}</column>
@@ -4707,6 +5188,9 @@ Likheten med "Captain Kang" ({qeng HoD:n@@qeng:n, HoD:n}) är sammanfallande, me
       <column name="notes_pt">A melhor tradução é determinada pelo contexto. Se houver muitas coisas, a forma plural {qengHoDmey:n@@qengHoD:n, -mey:n} é freqüentemente (mas não necessariamente) usada.
 
 A semelhança com o "Capitão Kang" ({qeng HoD:n@@qeng:n, HoD:n}) é coincidência, mas mesmo assim, a tripulação de Kang teve o cuidado de nunca dizer {qengHoDmey:n:nolink} quando ele estava por perto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Paras käännös määräytyy kontekstin mukaan. Jos tavaraa on paljon, käytetään usein (mutta ei välttämättä) monikkomuotoa {qengHoDmey:n@@qengHoD:n, -mey:n}.
+
+Samankaltaisuus "Kapteeni Kangin" ({qeng HoD:n@@qeng:n, HoD:n}) kanssa on sattumaa, mutta silti Kangin miehistö oli varovainen, ettei koskaan sanonut {qengHoDmey:n:nolink} ollessaan lähellä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Captain Kangaroo" was a children's TV series based around life in the "Treasure House".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4716,6 +5200,7 @@ A semelhança com o "Capitão Kang" ({qeng HoD:n@@qeng:n, HoD:n}) é coincidênc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4723,6 +5208,7 @@ A semelhança com o "Capitão Kang" ({qeng HoD:n@@qeng:n, HoD:n}) é coincidênc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4736,6 +5222,7 @@ A semelhança com o "Capitão Kang" ({qeng HoD:n@@qeng:n, HoD:n}) é coincidênc
       <column name="definition_ru">встреча, собрание</column>
       <column name="definition_zh_HK">會議 [AUTOTRANSLATED]</column>
       <column name="definition_pt">reunião</column>
+      <column name="definition_fi">kokous, tapaaminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rojmab qep:n}</column>
@@ -4746,6 +5233,7 @@ A semelhança com o "Capitão Kang" ({qeng HoD:n@@qeng:n, HoD:n}) é coincidênc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4757,6 +5245,7 @@ A semelhança com o "Capitão Kang" ({qeng HoD:n@@qeng:n, HoD:n}) é coincidênc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">summit, conference</column>
       <column name="search_tags_de">Tagung, Konferenz</column>
       <column name="search_tags_fa"></column>
@@ -4764,6 +5253,7 @@ A semelhança com o "Capitão Kang" ({qeng HoD:n@@qeng:n, HoD:n}) é coincidênc
       <column name="search_tags_ru">саммит, конференция</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4778,6 +5268,7 @@ A semelhança com o "Capitão Kang" ({qeng HoD:n@@qeng:n, HoD:n}) é coincidênc
       <column name="definition_ru">ежегодная встреча спикеров клингонов в Германии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">德國克林崗語者年會</column>
       <column name="definition_pt">reunião anual de oradores klingons na Alemanha</column>
+      <column name="definition_fi">vuotuinen klingonin puhujien kokoontuminen Saksassa Saarbrückenissä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quvar:n:name}</column>
@@ -4792,6 +5283,9 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{qepHom'a':n:nolink} on vuotuinen klingon-kielen kokous Saarbrückenissä ({Sarbruqen:n}) Saksassa. Käy heidän verkkosivuillaan osoitteessa {www.qepHom.de:url:http://www.qepHom.de/} saadaksesi lisätietoja.
+
+Klingonin kieli-instituutin virallinen vuosikonferenssi tunnetaan nimellä {qep'a':n}, kun taas muut klingonistien kokoukset tunnetaan nimellä {qepHommey:n:nolink}. Saarbrückenissä, Saksassa, pidettävä kokous on suurin {qepHom:n:nolink} (ja siinä on joskus jopa enemmän osallistujia kuin {qep'a':n:nolink}). Tästä syystä sitä kutsutaan {qepHom'a':n:nolink}. Sen nimi sisältää tarkoituksellisen kielioppimattomuuden: kaksi tyypin 1 substantiiviliitettä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This intentional use of improper grammar was approved by MO.</column>
       <column name="components">{qep:n}, {-Hom:n:suff}, {-'a':n:suff}</column>
       <column name="examples"></column>
@@ -4801,6 +5295,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4808,6 +5303,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -4821,6 +5317,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="definition_ru">Ежегодная конференция KLI [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗語言學院年會</column>
       <column name="definition_pt">Conferência anual KLI</column>
+      <column name="definition_fi">KLI:n vuotuinen konferenssi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qepHom'a':n}</column>
@@ -4831,6 +5328,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="notes_ru">{qep'a':n:nolink} является официальной ежегодной конференцией Клингонского языкового института ({tlhIngan Hol yejHaD:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{qep'a':n:nolink}是克林崗語言學院（{tlhIngan Hol yejHaD:n}）的官方年度會議。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {qep'a':n:nolink} é a conferência anual oficial do Klingon Language Institute ({tlhIngan Hol yejHaD:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{qep'a':n:nolink} on Klingon Language Institutein ({tlhIngan Hol yejHaD:n}) virallinen vuosittainen konferenssi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qep:n}, {-'a':n:suff}</column>
       <column name="examples"></column>
@@ -4840,6 +5338,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4847,6 +5346,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -4860,6 +5360,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="definition_ru">военные учения, боевые тренировки</column>
       <column name="definition_zh_HK">演習（軍事） [AUTOTRANSLATED]</column>
       <column name="definition_pt">exercício militar, exercício</column>
+      <column name="definition_fi">sulkeisharjoitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeq:v}, {tuH:n}</column>
@@ -4870,6 +5371,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4879,6 +5381,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">exercise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4886,6 +5389,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="search_tags_ru">упражнение</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4899,6 +5403,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="definition_ru">практиковать, практиковаться, заниматься, тренироваться, тренировать, готовить (речь не о еде), подготавливать</column>
       <column name="definition_zh_HK">練習、訓練、準備 [AUTOTRANSLATED]</column>
       <column name="definition_pt">praticar, treinar, preparar</column>
+      <column name="definition_fi">harjoitella, treenata, valmistautua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeq:n}, {ghuH:v}, {ghuS:v:1}</column>
@@ -4909,6 +5414,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="notes_ru">Есть связанные суффиксы {-rup:v} и {-beH:v}.</column>
       <column name="notes_zh_HK">後綴{-rup:v}和{-beH:v}也相關。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Também estão relacionados os sufixos {-rup:v} e {-beH:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Liittyvät myös pääte {-rup:v} ja {-beH:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4918,6 +5424,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4925,6 +5432,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4938,6 +5446,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="definition_ru">фекалии</column>
       <column name="definition_zh_HK">屎、糞便</column>
       <column name="definition_pt">matéria fecal</column>
+      <column name="definition_fi">uloste</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taQbang:n:2}, {ghIm:v}, {vuj:v}, {puch:n}</column>
@@ -4948,6 +5457,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4957,6 +5467,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">poo, shit, feces</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4964,6 +5475,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="search_tags_ru">дерьмо</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4977,6 +5489,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="definition_ru">место для разжигания огня</column>
       <column name="definition_zh_HK">壁爐 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lareira</column>
+      <column name="definition_fi">tulisija, takka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qul:n}, {vut:v}</column>
@@ -4987,6 +5500,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="notes_ru">Относится к специфичному месту в доме для разжигания огня или приготовления еды.</column>
       <column name="notes_zh_HK">這是指房屋中用於取暖或準備食物的特定位置。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um local específico da casa para aquecimento ou preparação de alimentos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tiettyyn paikkaan talossa lämmitykseen tai ruoanvalmistukseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4996,6 +5510,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">oven</column>
       <column name="search_tags_de">Kamin</column>
       <column name="search_tags_fa"></column>
@@ -5003,6 +5518,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5016,6 +5532,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="definition_ru">совет, консультация</column>
       <column name="definition_zh_HK">忠告 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conselho, recomendação</column>
+      <column name="definition_fi">neuvo, ohje</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeS:v}, {chup:v}</column>
@@ -5026,6 +5543,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5035,6 +5553,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5042,6 +5561,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5055,6 +5575,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="definition_ru">советовать, рекомендовать</column>
       <column name="definition_zh_HK">勸告 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aconselhar</column>
+      <column name="definition_fi">neuvoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chup:v}, {qeS:n}</column>
@@ -5065,6 +5586,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5074,6 +5596,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">beraten, raten</column>
       <column name="search_tags_fa"></column>
@@ -5081,6 +5604,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5094,6 +5618,7 @@ Die Hauptversammlung des Klingon Language Institute ist bekannt als {qep'a':n}, 
       <column name="definition_ru">Клингонское искусство войны</column>
       <column name="definition_zh_HK">克林崗戰爭藝術 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A Arte da Guerra Klingon</column>
+      <column name="definition_fi">eräs kirja, Klingonien Sodankäynnin taito</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5118,6 +5643,9 @@ Den berömda författaren {Qa'taq:n:name} skrev en kommentar till detta arbete. 
       <column name="notes_pt">Este é o nome de um livro.
 
 O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjan nimi.
+
+Kuuluisa kirjailija {Qa'taq:n:name} kirjoitti kommentin tähän teokseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qeS:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -5127,6 +5655,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5134,6 +5663,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {The Klingon Art of War:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -5147,6 +5677,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">лис</column>
       <column name="definition_zh_HK">狐狸</column>
       <column name="definition_pt">Raposa</column>
+      <column name="definition_fi">eräs ketun kaltainen eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{targh:n}</column>
@@ -5157,6 +5688,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru">Это Клингонское животное, которое ест овощи, а также маленьких животных и птиц. Клингоны могут есть их, но в большинстве своём рассматривают их, как вредителей.</column>
       <column name="notes_zh_HK">這是一種克林崗（Klingon）動物，它以植物為食，還有小動物和鳥類。克林崗人可能會吃掉它們，但大多認為它們是害蟲。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um animal klingon que come vegetação e também pequenos animais e pássaros. Os klingons podem comê-los, mas principalmente os consideram pragas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on klingonilainen eläin, joka syö kasvillisuutta sekä pieniä eläimiä ja lintuja. Klingonit saattavat syödä niitä, mutta pitävät niitä enimmäkseen tuholaisina. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In Aesop's fables, the fox is known to give misleading advice.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5166,6 +5698,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5173,6 +5706,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -5186,6 +5720,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">бежать, бегать трусцой, бежать трусцой</column>
       <column name="definition_zh_HK">跑步</column>
       <column name="definition_pt">correr</column>
+      <column name="definition_fi">juosta, hölkätä, lenkkeillä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIt:v}, {lID:v}</column>
@@ -5196,6 +5731,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5206,6 +5742,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5213,6 +5750,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5226,6 +5764,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">Тип соуса (кетчуп)</column>
       <column name="definition_zh_HK">茄汁</column>
       <column name="definition_pt">tipo de molho</column>
+      <column name="definition_fi">eräs sakeutetusta marinadista valmistettu kastike</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Se'tu':n}</column>
@@ -5236,6 +5775,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru">Этот соус приготовлен путём сгущения {chanDoq:n}.</column>
       <column name="notes_zh_HK">這是通過將{chanDoq:n}增稠而製備的調味料。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o molho preparado pelo espessante {chanDoq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kastike, joka on valmistettu sakeuttamalla {chanDoq:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is "ketchup".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5245,6 +5785,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5252,6 +5793,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5265,6 +5807,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">быть унылым, быть неинтересным, быть вялым, быть безрадостным</column>
       <column name="definition_zh_HK">變得遲鈍、無趣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser chato, desinteressante</column>
+      <column name="definition_fi">olla tylsä, mielenkiinnoton, ikävystyttävä</column>
       <column name="synonyms">{Dal:v}</column>
       <column name="antonyms">{Daj:v:1}</column>
       <column name="see_also"></column>
@@ -5275,6 +5818,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5284,6 +5828,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5291,6 +5836,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5304,6 +5850,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">толпиться, теснить, вытеcнять, напирать, собираться толпой</column>
       <column name="definition_zh_HK">人群 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agrupar (multidão)</column>
+      <column name="definition_fi">tunkea, ahtaa ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qev:n}, {ghom'a':n}, {boq:n:1}, {DIvI':n}, {tlhach:n}</column>
@@ -5314,6 +5861,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5323,6 +5871,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5330,6 +5879,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5343,6 +5893,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">толпа, людская масса, толкотня</column>
       <column name="definition_zh_HK">人群、大眾</column>
       <column name="definition_pt">multidão</column>
+      <column name="definition_fi">väkijoukko, väentungos</column>
       <column name="synonyms">{ghom'a':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{qev:v}, {boq:n:1}, {DIvI':n}, {tlhach:n}, {Dojmey:n}</column>
@@ -5353,6 +5904,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In its first appearance as a noun, in {HQ 4.4, Dec. 1995:src}, {qev:n:nolink} was listed as "[a]mong those words already well-known for different types of groups" and indicated to be a synonym for {ghom'a':n}. The noun {tlhach:n} was explicitly introduced as being a new word in the same article. This suggests that the verb {qev:v} was misread as a noun by Marc Okrand when he was preparing the article.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5362,6 +5914,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5369,6 +5922,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 4.4, p.11:src}</column>
     </table>
     <table name="mem">
@@ -5382,6 +5936,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">Кевас (товар)</column>
       <column name="definition_zh_HK">kevas（交易商品） [AUTOTRANSLATED]</column>
       <column name="definition_pt">kevas (uma mercadoria comercializada)</column>
+      <column name="definition_fi">eräs kauppatavara, kevas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naghboch:n}</column>
@@ -5392,6 +5947,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru">Является торгуемым товаром, наподобие {DIlyum:n}.</column>
       <column name="notes_zh_HK">這是一種交易商品，例如{DIlyum:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma mercadoria comercializada, como {DIlyum:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kauppatavara, kuten {DIlyum:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is described in {The Star Trek Encyclopedia:src} as a type of gemstone.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5401,6 +5957,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5408,6 +5965,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5421,6 +5979,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">щека</column>
       <column name="definition_zh_HK">臉頰</column>
       <column name="definition_pt">bochecha</column>
+      <column name="definition_fi">poski</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qab:n}, {nuj:n}</column>
@@ -5431,6 +5990,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5440,6 +6000,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5447,6 +6008,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5460,6 +6022,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">используйте безымянный палец</column>
       <column name="definition_zh_HK">使用戒指（第三）手指 [AUTOTRANSLATED]</column>
       <column name="definition_pt">usar o anel (terceiro) dedo</column>
+      <column name="definition_fi">käyttää nimetöntä (sormea)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh:n}</column>
@@ -5470,6 +6033,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Keuka Lake.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5479,6 +6043,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5486,6 +6051,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -5499,6 +6065,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">безымянный палец</column>
       <column name="definition_zh_HK">無名指、第三指 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dedo anelar, terceiro dedo</column>
+      <column name="definition_fi">nimetön (sormi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh:n}</column>
@@ -5509,6 +6076,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qew:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5518,6 +6086,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5525,6 +6094,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -5538,6 +6108,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">напрасно, бесполезно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">徒勞無功 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser em vão, fútil</column>
+      <column name="definition_fi">olla turha, hyödytön, tulokseton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lo'laHbe':v}</column>
@@ -5548,6 +6119,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5557,6 +6129,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5564,6 +6137,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <!-- {qeylIn:n:name,fic} is used by MO in a message {msn 1997.09.01:src}, but was not invented by MO and does not appear in Star Trek canon. -->
@@ -5578,6 +6152,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">влагалище [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陰道 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vagina</column>
+      <column name="definition_fi">emätin, vagina</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'InSep:n}, {chI'ID:n}, {ngagh:v}, {nga'chuq:v}</column>
@@ -5588,6 +6163,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru">Это относится ко всей системе, включая вульву. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指整個系統，包括外陰。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a todo o sistema, incluindo a vulva. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa koko järjestelmään, mukaan lukien häpy. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5598,6 +6174,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_zh_HK"></column>
       <!-- Note: Vulgar search terms have been deliberately left out. -->
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5605,6 +6182,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5618,6 +6196,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">К'Элейр [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">凱利 [AUTOTRANSLATED]</column>
       <column name="definition_pt">K'Ehleyr</column>
+      <column name="definition_fi">K'Ehleyr</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wo'rIv:n:name}</column>
@@ -5628,6 +6207,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5637,6 +6217,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5644,6 +6225,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5658,6 +6240,7 @@ O famoso autor {Qa'taq:n:name} escreveu um comentário sobre esta obra. [AUTOTRA
       <column name="definition_ru">Кейлесс Незабываемый</column>
       <column name="definition_zh_HK">令人難忘的「凱勒斯」</column>
       <column name="definition_pt">Kahless, o inesquecível</column>
+      <column name="definition_fi">Kahless Unohtumaton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{luqara':n:name}, {moratlh:n:name}, {qanjIt:n:name}, {qeylIS bov:n}, {qeylIS bov nubwI':n}, {meQboghnom:n}, {bo'retlh:n}</column>
@@ -5689,6 +6272,10 @@ Hans återkomst profeteras i berättelsens berättelse, som säger att:
 
 Seu retorno é profetizado na História da Promessa, que afirma que:
 ▶ {ghIq chalDaq HovDaq SIq qeylIS 'ej jatlh pa' DaqHomvetlh wovDaq HInej.:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kahless on legendaarinen ensimmäinen Klingonin keisari, joka yhdisti klingonilaiset.
+
+Hänen paluunsa ennustetaan Lupauksen tarinassa, jossa todetaan seuraavaa:
+▶ {ghIq chalDaq HovDaq SIq qeylIS 'ej jatlh pa' DaqHomvetlh wovDaq HInej.:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This has also been translated as {qeylIS lIjlaHbogh pagh:sen:nolink} in the {paq'batlh:src}.</column>
       <column name="components">{qeylIS:n:name}, {-'e':n}, {lIj:v}, {-laH:v}, {-be':v}, {-bogh:v}, {vay':n}</column>
       <column name="examples"></column>
@@ -5698,6 +6285,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">qeylIS lIjlaHbogh pagh</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5705,6 +6293,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 8:src}</column>
     </table>
     <table name="mem">
@@ -5718,6 +6307,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">{qeylIS'e' lIjlaHbe'bogh vay':n:name}</column>
       <column name="definition_zh_HK">{qeylIS'e' lIjlaHbe'bogh vay':n:name}</column>
       <column name="definition_pt">{qeylIS'e' lIjlaHbe'bogh vay':n:name}</column>
+      <column name="definition_fi">{qeylIS'e' lIjlaHbe'bogh vay':n:name}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5728,6 +6318,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5737,6 +6328,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5744,6 +6336,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5757,6 +6350,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">Меч Кейлеса</column>
       <column name="definition_zh_HK">「凱勒斯」的光榮聖劍</column>
       <column name="definition_pt">Espada de Kahless</column>
+      <column name="definition_fi">eräs artefakti, Kahlessin miekka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIStaq:n}</column>
@@ -5767,6 +6361,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qeylIS:n}, {betleH:n}</column>
       <column name="examples"></column>
@@ -5776,6 +6371,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5783,6 +6379,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5796,6 +6393,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">Эра Кейлеса</column>
       <column name="definition_zh_HK">「凱勒斯」時代</column>
       <column name="definition_pt">a era de Kahless</column>
+      <column name="definition_fi">Kahlessin aikakausi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeylIS bov nubwI':n}</column>
@@ -5806,6 +6404,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru">В {paq'batlh:src} это сокращено до QB</column>
       <column name="notes_zh_HK">這是{paq'batlh:src}中的QB的縮寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é QB abreviado no {paq'batlh:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä lyhennetään QB-muodossa {paq'batlh:src}-tiedostossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qeylIS:n}, {bov:n}</column>
       <column name="examples"></column>
@@ -5815,6 +6414,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5822,6 +6422,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -5835,6 +6436,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">До эры Кейлеса</column>
       <column name="definition_zh_HK">「凱勒斯」時代前</column>
       <column name="definition_pt">antes da era de Kahless</column>
+      <column name="definition_fi">ennen Kahlessin aikakautta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeylIS bov:n}</column>
@@ -5845,6 +6447,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru">В {paq'batlh:src} это сокращено до QBV</column>
       <column name="notes_zh_HK">這是{paq'batlh:src}中的QBV的縮寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é QBV abreviado no {paq'batlh:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä lyhennetään QBV-muodossa {paq'batlh:src}-tiedostossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's not explained what the V stands for. This could be a typo for QBN.</column>
       <column name="components">{qeylIS bov:n}, {nubwI':n}</column>
       <column name="examples"></column>
@@ -5854,6 +6457,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5861,6 +6465,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -5874,6 +6479,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">Глаза Кейлеса, игра в которую играют с помощью игральных костей</column>
       <column name="definition_zh_HK">「凱勒斯」的眼睛（色子遊戲）</column>
       <column name="definition_pt">Olhos de Kahless, um jogo jogado com dados</column>
+      <column name="definition_fi">eräs noppapeli, Kahlessin silmät</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI' nagh:n}, {loy:v}, {qIp:v}</column>
@@ -5884,6 +6490,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru">Это угадайка, в которой победитель получает удар кулаком</column>
       <column name="notes_zh_HK">這是一款帶有骰子的猜謎遊戲，獲勝者將獲得一拳。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um jogo de adivinhação com dados em que o vencedor recebe um soco. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on arvaava noppapeli, jossa voittaja saa lyönnin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qeylIS:n}, {mIn:n}, {-Du':n}</column>
       <column name="examples"></column>
@@ -5893,6 +6500,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5900,6 +6508,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <!-- {qeylor:n:name,fic} is used by MO in a message {msn 1997.09.01:src}, but was not invented by MO and does not appear in Star Trek canon. -->
@@ -5914,6 +6523,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">Кайвак</column>
       <column name="definition_zh_HK">Kayvak [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kayvak</column>
+      <column name="definition_fi">Kayvak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5924,6 +6534,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5933,6 +6544,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5940,6 +6552,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.91:src}</column>
     </table>
     <table name="mem">
@@ -5953,6 +6566,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">Пища Кайвака</column>
       <column name="definition_zh_HK">Kayvak的食物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Comida de Kayvak</column>
+      <column name="definition_fi">Kayvakin liha, hapan/käynyt liha?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{roghmoH:v}</column>
@@ -5963,6 +6577,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru">Перебродившее мясо известно, как {qeyvaq Ha'DIbaH:n:nolink}. При необходимости, замените слово {Ha'DIbaH:n:1} на слово, которое уточняет название мяса.</column>
       <column name="notes_zh_HK">所有發酵的肉都被稱為{qeyvaq Ha'DIbaH:n:nolink}，其中特定肉類的單詞代替了{Ha'DIbaH:n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Toda carne fermentada é conhecida como {qeyvaq Ha'DIbaH:n:nolink}, com a palavra para carne específica substituindo a palavra {Ha'DIbaH:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kaikki fermentoitu liha tunnetaan nimellä {qeyvaq Ha'DIbaH:n:nolink}, jossa sana erityiselle lihalle korvaa sanan {Ha'DIbaH:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Kiviak" is an Inuit food made of auks fermented in the body of a seal.</column>
       <column name="components">{qeyvaq:n:name}, {Ha'DIbaH:n:1}</column>
       <column name="examples"></column>
@@ -5972,6 +6587,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5979,6 +6595,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.91:src}</column>
     </table>
     <table name="mem">
@@ -5992,6 +6609,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">морковь</column>
       <column name="definition_zh_HK">胡蘿蔔 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cenoura</column>
+      <column name="definition_fi">porkkana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oQqar:n}</column>
@@ -6002,6 +6620,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru">Это то, что Клингоны называют земным овощем</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族蔬菜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que os klingons chamariam de vegetal terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-vihannekseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6011,6 +6630,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6018,6 +6638,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6031,6 +6652,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">Галактика</column>
       <column name="definition_zh_HK">星系 [AUTOTRANSLATED]</column>
       <column name="definition_pt">galáxia</column>
+      <column name="definition_fi">galaksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh:n}, {jogh:n}</column>
@@ -6041,6 +6663,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6050,6 +6673,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6057,6 +6681,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6070,6 +6695,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">Галактический рубеж</column>
       <column name="definition_zh_HK">銀河邊緣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">borda galáctica</column>
+      <column name="definition_fi">galaksin reuna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6080,6 +6706,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was apparently intended to be {qIb:n} plus {HeH:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6089,6 +6716,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6096,6 +6724,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6109,6 +6738,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">осуждать, приговорить, обречь, выносить приговор</column>
       <column name="definition_zh_HK">譴責 [AUTOTRANSLATED]</column>
       <column name="definition_pt">condenar</column>
+      <column name="definition_fi">tuomita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naDHa':v}, {mIl:v}</column>
@@ -6119,6 +6749,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6128,6 +6759,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6135,6 +6767,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6148,6 +6781,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">шутка</column>
       <column name="definition_zh_HK">玩笑、笑話</column>
       <column name="definition_pt">piada</column>
+      <column name="definition_fi">vitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qID:v}, {tlhaQ:v}</column>
@@ -6158,6 +6792,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In English slang, to "kid" is to joke.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6167,6 +6802,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6174,6 +6810,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6187,6 +6824,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">шутить, пошутить, рассказать шутку, подшучивать, балагурить</column>
       <column name="definition_zh_HK">講笑、開玩笑</column>
       <column name="definition_pt">fazer uma piada, contar uma piada</column>
+      <column name="definition_fi">vitsailla, kertoa vitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sagh:v}, {tlhaQ:v}, {chem:v}, {qID:n}</column>
@@ -6197,6 +6835,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru">Этот глагол обычно не берет предмет (если только он не играет в игры в слова или что-то в этом роде).[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個動詞通常不會帶任何賓語（除非有人在玩文字遊戲或其他東西）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse verbo normalmente não aceita um objeto (a menos que alguém esteja jogando jogos de palavras ou algo assim).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi ei yleensä ota esinettä (ellei joku pelaa sanapelejä tai jotain muuta) .[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In English slang, to "kid" is to joke.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6208,6 +6847,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6215,6 +6855,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6228,6 +6869,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">кратчайший путь, кратчайшее расстояние</column>
       <column name="definition_zh_HK">捷徑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atalho</column>
+      <column name="definition_fi">oikotie, oikopolku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6238,6 +6880,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Quick".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6247,6 +6890,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6254,6 +6898,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6267,6 +6912,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">встретиться впервые</column>
       <column name="definition_zh_HK">見面（第一次） [AUTOTRANSLATED]</column>
       <column name="definition_pt">encontra (pela primeira vez)</column>
+      <column name="definition_fi">tavata joku (ensimmäistä kertaa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIH:v:1}, {ghom:v}, {pIH:v:1}</column>
@@ -6277,6 +6923,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru">Этот глагол всегда принимает объект или суффикс {-chuq:v} при обычном использовании.[2]</column>
       <column name="notes_zh_HK">該動詞通常會使用正常使用的對像或{-chuq:v}。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä verbi vie aina objektin tai {-chuq:v} normaalikäytössä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6286,6 +6933,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6293,6 +6941,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.11, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -6306,6 +6955,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">быть чёрным</column>
       <column name="definition_zh_HK">黑色</column>
       <column name="definition_pt">ser preto</column>
+      <column name="definition_fi">olla musta</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chIS:v}</column>
       <column name="see_also">{Hurgh:v}</column>
@@ -6316,6 +6966,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6325,6 +6976,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6332,6 +6984,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -6345,6 +6998,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
           <column name="definition_ru">серый [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">灰色 [AUTOTRANSLATED]</column>
           <column name="definition_pt">cinza (cor)</column>
+      <column name="definition_fi">olla harmaa</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -6355,6 +7009,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qIj:v}, {'ej:conj}, {wov:v}</column>
           <column name="examples"></column>
@@ -6364,6 +7019,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">grey</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6371,6 +7027,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -6384,6 +7041,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
           <column name="definition_ru">{qIj 'ej wov:sen}</column>
           <column name="definition_zh_HK">{qIj 'ej wov:sen}</column>
           <column name="definition_pt">{qIj 'ej wov:sen}</column>
+      <column name="definition_fi">{qIj 'ej wov:sen}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -6394,6 +7052,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qIj:v}, {'ach:conj}, {wov:v}</column>
           <column name="examples"></column>
@@ -6403,6 +7062,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6410,6 +7070,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
     <table name="mem">
@@ -6423,6 +7084,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="definition_ru">отменять, прерывать (компьютерную программу)</column>
       <column name="definition_zh_HK">取消;中止（計算機程序） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cancelar; abortar (um programa de computador)</column>
+      <column name="definition_fi">peruuttaa; keskeyttää (tietokoneohjelma)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bup:v}</column>
@@ -6433,6 +7095,7 @@ Seu retorno é profetizado na História da Promessa, que afirma que:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Kill". This is defined in {TKD:src} only as "cancel". The "abort" meaning was given at {Saarbrücken qepHom'a' 2011:src}.[2]
 
 This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly.[3]</column>
@@ -6444,6 +7107,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6451,6 +7115,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2011:src}, [3] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <table name="mem">
@@ -6464,6 +7129,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">уделять внимание, концентрироваться, сосредотачиваться</column>
       <column name="definition_zh_HK">注意、集中註意力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prestar atenção, concentre-se</column>
+      <column name="definition_fi">kiinnittää huomiota johonkin, keskittyä johonkin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qImHa':v}</column>
       <column name="see_also">{buS:v}, {paQ:v}</column>
@@ -6474,6 +7140,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6483,6 +7150,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6490,6 +7158,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -6503,6 +7172,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
           <column name="definition_ru">игнорировать, пренебрегать, не уважать</column>
           <column name="definition_zh_HK">漠視 [AUTOTRANSLATED]</column>
           <column name="definition_pt">desprezar</column>
+      <column name="definition_fi">jättää huomiotta</column>
           <column name="synonyms"></column>
           <column name="antonyms">{qIm:v}</column>
           <column name="see_also"></column>
@@ -6513,6 +7183,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qIm:v}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -6522,6 +7193,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -6529,6 +7201,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
     <table name="mem">
@@ -6542,6 +7215,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">Ким'лак</column>
       <column name="definition_zh_HK">K'mlak [AUTOTRANSLATED]</column>
       <column name="definition_pt">K'mlak</column>
+      <column name="definition_fi">K'mlak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6552,6 +7226,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6561,6 +7236,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6568,6 +7244,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6581,6 +7258,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">Сезон</column>
       <column name="definition_zh_HK">季節 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estação (temporada)</column>
+      <column name="definition_fi">vuodenaika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{poH:n}</column>
@@ -6591,6 +7269,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru">Является общим словом дляи обозначения сезона. Например, {qImroq tuj:n@@qImroq:n, tuj:v} будет означать что-то вроде "лето" для планеты Земля.</column>
       <column name="notes_zh_HK">這是一個季節的通用詞。例如，{qImroq tuj:n@@qImroq:n, tuj:v}在地球上將類似於“夏天”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a palavra geral para uma temporada. Por exemplo, {qImroq tuj:n@@qImroq:n, tuj:v} seria algo como "verão" na Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kauden yleinen sana. Esimerkiksi {qImroq tuj:n@@qImroq:n, tuj:v} olisi jotain "kesää" maan päällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"McCormick" is a brand of food seasoning.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6600,6 +7279,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6607,6 +7287,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -6620,6 +7301,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">Кин'лат</column>
       <column name="definition_zh_HK">Quin'lat [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quin'lat</column>
+      <column name="definition_fi">Quin'lat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qoH vuvbe' SuS.:sen}</column>
@@ -6630,6 +7312,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru">Это название города, где {qeylIS'e' lIjlaHbe'bogh vay':n:name} однажды увидел глупца, стоявшего снаружи стен, во время жестокого шторма, в попытке заставить ветер себя уважать.</column>
       <column name="notes_zh_HK">這就是一座城市的名字，{qeylIS'e' lIjlaHbe'bogh vay':n:name}曾經目睹一個愚蠢的人在猛烈的暴風雨中站在牆外，試圖使風尊重他。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma cidade, onde {qeylIS'e' lIjlaHbe'bogh vay':n:name} testemunhou um homem tolo parado do lado de fora dos muros durante uma tempestade feroz, na tentativa de fazer o vento o respeitar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kaupungin nimi, jossa {qeylIS'e' lIjlaHbe'bogh vay':n:name} on kerran nähnyt tyhmän miehen seisovan kovan myrskyn aikana seinien ulkopuolella yrittäen saada tuuli kunnioittamaan häntä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6639,6 +7322,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6646,6 +7330,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNG - Rightful Heir:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -6659,6 +7344,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">коса, серп, фалькс [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鐮刀，鐮刀，鐮刀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">foice, falx</column>
+      <column name="definition_fi">viikate, sirppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Satlh:n}, {Du':n}, {wIj:v}. {yob:v}</column>
@@ -6669,6 +7355,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru">Это инструмент, напоминающий серп. Это для сельского хозяйства, но, конечно, его можно использовать как оружие. Если у него длинная ручка, «коса» может быть лучшим переводом, хотя это не совсем один из них. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個類似於鐮刀的工具。它用於農業，但是當然可以用作武器。如果處理時間較長，則“鐮刀”翻譯可能會更好，儘管兩者都不盡相同。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma ferramenta semelhante a uma foice. É para a agricultura, mas, é claro, poderia ser usado como arma. Se tiver uma alça longa, "foice" pode ser uma tradução melhor, embora não seja uma delas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sirppiä muistuttava työkalu. Se on tarkoitettu maatalouteen, mutta tietysti sitä voidaan käyttää aseena. Jos sillä on pitkä kahva, "viikat" voi olla parempi käännös, vaikka se ei ole kumpikaan niistä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Knuts and sickles are both names of coins used by wizards in the Harry Potter universe.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6678,6 +7365,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">halberd</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6685,6 +7373,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6698,6 +7387,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">наносить удар (с помощью руки, кулака, орудия)</column>
       <column name="definition_zh_HK">打（用手、拳頭、工具） [AUTOTRANSLATED]</column>
       <column name="definition_pt">golpe (com mão, punho, implemento)</column>
+      <column name="definition_fi">lyödä (kädellä tai esineellä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moq:v}, {tlhaw':v}, {weq:v}</column>
@@ -6708,6 +7398,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6718,6 +7409,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">punch</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6725,6 +7417,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6738,6 +7431,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">бунтовать, поднимать мятеж, поднимать восстание</column>
       <column name="definition_zh_HK">兵變 [AUTOTRANSLATED]</column>
       <column name="definition_pt">motim</column>
+      <column name="definition_fi">kapinoida (aluksella)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daw':v}</column>
@@ -6748,6 +7442,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{qIQ:v:nolink} is similar to "Kirk", who named his stolen Bird of Prey "HMS Bounty", in reference to the historical event of the mutiny on the Bounty.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6757,6 +7452,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6764,6 +7460,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6777,6 +7474,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">{jemS tIy qIrq:n:name}</column>
       <column name="definition_zh_HK">{jemS tIy qIrq:n:name}</column>
       <column name="definition_pt">{jemS tIy qIrq:n:name}</column>
+      <column name="definition_fi">{jemS tIy qIrq:n:name}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6787,6 +7485,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6796,6 +7495,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6803,6 +7503,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -6816,6 +7517,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">континуум [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">連續體 [AUTOTRANSLATED]</column>
       <column name="definition_pt">continuum</column>
+      <column name="definition_fi">jatkumo, kontinuumi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhey'at:n}, {roDSer:n}, {yutlhegh:n}</column>
@@ -6826,6 +7528,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Kiera Cameron is the main character of the Canadian science fiction series "Continuum".</column>
       <column name="components"></column>
       <column name="examples">{tlhey'at qIr'a':n}</column>
@@ -6835,6 +7538,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6842,6 +7546,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -6856,6 +7561,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="definition_ru">Раптор (класс судна)</column>
       <column name="definition_zh_HK">猛禽（船隻） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Raptor (nave)</column>
+      <column name="definition_fi">eräs alustyyppi, petolintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}, {toQDuj:n}</column>
@@ -6866,6 +7572,7 @@ This was used for "Cancel" (while {ruch:v} was used for "Ok") in Klingon Blockly
       <column name="notes_ru">Пока это слово известно только, как название класса корабля. Похоже, что оно также относится к птице или классу птиц (cf. {toQ:n}).</column>
       <column name="notes_zh_HK">雖然此詞僅被稱為船級的名稱，但它似乎也可能指的是鳥類或掠食性鳥類的類別（請參閱{toQ:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Embora essa palavra seja conhecida apenas como o nome de uma classe de navio, parece provável que também se refira a um pássaro ou a uma classe de aves predadoras (cf. {toQ:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikka tämä sana tunnetaan vain alusluokan nimenä, näyttää todennäköiseltä, että se viittaa myös lintuun tai saalistajien lintuluokkaan (vrt. {toQ:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is "Jurassic" spelled backwards.
 
 In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:nolink} in Klingon, but this is likely a placeholder which was overlooked by mistake.</column>
@@ -6877,6 +7584,7 @@ In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6884,6 +7592,7 @@ In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6897,6 +7606,7 @@ In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:noli
       <column name="definition_ru">быть возможным, быть вероятным</column>
       <column name="definition_zh_HK">有可能</column>
       <column name="definition_pt">ser possível</column>
+      <column name="definition_fi">olla mahdollinen</column>
       <column name="synonyms">{DuH:v}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6907,6 +7617,7 @@ In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:noli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6916,6 +7627,7 @@ In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:noli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6923,6 +7635,7 @@ In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:noli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {msn 1996.12.12:src}</column>
     </table>
     <table name="mem">
@@ -6937,6 +7650,7 @@ In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:noli
       <column name="definition_ru">Вид птицы</column>
       <column name="definition_zh_HK">一種鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma espécie de pássaro</column>
+      <column name="definition_fi">eräs lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6947,6 +7661,7 @@ In the {Haynes BoP Manual:src}, this ship class is referred to as {raptor:n:noli
       <column name="notes_ru">Является большой, толстой птицей, являющейся коренным обитателем Кроноса, умеющей летать,но непродолжительное время. Самок этих птиц называют {qItbe':n:nolink}, в то время, как самцов {qItloD:n:nolink}.[2] Похожа на земную цесарку.[1]</column>
       <column name="notes_zh_HK">這是克羅諾斯（Kronos）原生的大胖鳥，能夠飛翔，但時間不長。其中一個雌性是{qItbe':n:nolink}，而一個雄性是{qItloD:n:nolink}.[2]，它類似於人種的guineafowl。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um pássaro grande e gordo, nativo de Cronos, que consegue voar, mas não por muito tempo. Uma fêmea dessas é uma {qItbe':n:nolink}, enquanto um macho é uma {qItloD:n:nolink}.[2] Ela se assemelha a uma guineafowl terráquea.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on iso, lihava Kronosista kotoisin oleva lintu, joka pystyy lentämään, mutta ei pitkään aikaan. Nainen näistä on {qItbe':n:nolink}, kun taas uros on {qItloD:n:nolink}.[2] Se muistuttaa Terran-helmikanaa.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The source is Andrew Miller. This word was revealed for a Smithsonian Klingon Shakespeare skit that he and Marc Okrand were involved in. It was confirmed at the {Saarbrücken qepHom'a' 2016:src}.
 
 Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
@@ -6958,6 +7673,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">qItbe', qItloD</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6965,6 +7681,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Facebook "tlhIngan Hol jatlhwI'pu'" group 2014.12.26:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6978,6 +7695,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="definition_ru">К'Тинга (класс судна)</column>
       <column name="definition_zh_HK">K'Tinga類（船） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Classe K'Tinga (embarcação)</column>
+      <column name="definition_fi">eräs alustyyppi, K'Tinga-luokka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}</column>
@@ -6988,6 +7706,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The sentence from {SkyBox 15:src} has the {wa'DIch:n} in the wrong place. Also, the second occurrence of {vatlh DIS poH:n} is missing a space.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7005,6 +7724,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
    По конфигурации похож, на первые встреченные Клингонские суда, Класс К'Тинга продолжал использоваться большую часть 23-го столетия. Спящий корабль данного класса, Т'Онг, был встречен в 24-м веке кораблем Федерации Энтерпрайз."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7012,6 +7732,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 15:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -7025,6 +7746,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="definition_ru">девушка легкого поведения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">妓女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prostituta</column>
+      <column name="definition_fi">prostituoitu</column>
       <column name="synonyms">{'opuHwI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7035,6 +7757,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">On the American radio and TV Western drama "Gunsmoke", the profession of the character of Miss Kitty was hinted at, but not made explicit.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7044,6 +7767,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7051,6 +7775,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7064,6 +7789,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="definition_ru">Колено</column>
       <column name="definition_zh_HK">膝頭蓋</column>
       <column name="definition_pt">joelho</column>
+      <column name="definition_fi">polvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tor:v:1}, {'eD:v:1}, {'uS:n}, {DeSqIv:n}, {wIlle':n}, {cha'neH:n}, {nev'ob:n}, {reStav:n}</column>
@@ -7074,6 +7800,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Arrows come from "quiv"ers, and you can take an arrow to the knee.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7083,6 +7810,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7090,6 +7818,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7103,6 +7832,7 @@ Note that {qItbe'@@qIt:v, -be':v} means "impossible".</column>
       <column name="definition_ru">Часть тела (не идентифицирована)</column>
       <column name="definition_zh_HK">身體部位（未進一步確定） [AUTOTRANSLATED]</column>
       <column name="definition_pt">parte do corpo (não mais identificada)</column>
+      <column name="definition_fi">ruumiinosa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7119,6 +7849,9 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
 Мальц неохотно разговаривает о том, что в точности это такое.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{qor:n:name}: n vasen {qIvon:n:nolink} sattuisi aina, kun hänen aluksensa loimi loimi kahdeksan.
+
+Maltz näytti haluttomalta puhua mitä tämä oikein on[3][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">According to {The Star Trek Encyclopedia:src}, the writers of {DS9 - Blood Oath:src} intended this to be the word for "knee". It seems that they changed it slightly because they didn't like the sound of {qIv:n}. Perhaps it refers to a part of the knee, or is a dialectical or outmoded word for the knee.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7130,6 +7863,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7137,6 +7871,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.06.29:src}, [3] {DS9 - Blood Oath:src}</column>
     </table>
     <table name="mem">
@@ -7150,6 +7885,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">пойти в ванную [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">去洗手間 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ir ao banheiro</column>
+      <column name="definition_fi">käydä vessassa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puch:n}</column>
@@ -7160,6 +7896,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru">У клингонов нет эвфемизмов для посещения ванной комнаты, и они просто использовали бы {ghIm:v} с {turmIq:n}, {qeQ:n} или {taQbang:n:2}. Тем не менее, это сленговое выражение или идиома время от времени используется, хотя в основном (но вряд ли всегда) детьми. Можно спросить у нервного ребенка {belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n} Большинство людей говорят {qIvon:n}, но некоторые говорят {qIvonDu':n@@qIvon:n, -Du':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗人沒有上廁所的委婉說法，只會將{ghIm:v}與{turmIq:n}，{qeQ:n}或{taQbang:n:2}結合使用。但是，這種mostly語表達或習語有時會被孩子使用，儘管大多數（但並非總是如此）使用。有人可能會問一個緊張的孩子，{belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n}大多數人都說{qIvon:n}，但有些人則說{qIvonDu':n@@qIvon:n, -Du':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os klingons não têm eufemismos para ir ao banheiro e usariam {ghIm:v} com {turmIq:n}, {qeQ:n} ou {taQbang:n:2}. No entanto, essa expressão ou expressão de gíria é usada de tempos em tempos, embora principalmente (mas quase sempre) por ou para crianças. Pode-se perguntar a uma criança nervosa: {belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n} A maioria das pessoas diz {qIvon:n}, mas algumas dizem {qIvonDu':n@@qIvon:n, -Du':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingoneilla ei ole eufemismejä käymällä vessassa, ja he käyttävät vain {ghIm:v}: tä {turmIq:n}: n, {qeQ:n}: n tai {taQbang:n:2}: n kanssa. Tätä slangilauseketta tai idiomia käytetään kuitenkin ajoittain, vaikkakin enimmäkseen (mutta tuskin aina) lapset tai lapsille. Voisi kysyä jittery-lapselta, {belHa''a 'qIvonlIj?: Sen @@ belHa': v, -'a ': v, qIvon: n, -lIj: n} Useimmat ihmiset sanovat {qIvon:n}, mutta jotkut sanovat {qIvonDu':n@@qIvon:n, -Du':n}.[2]{belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qIvon:n}, {bel:v}, {-moH:v}</column>
       <column name="examples">
@@ -7170,6 +7907,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7177,6 +7915,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Kauderwelsch Klingonisch:src}, [2] {KLI mailing list 2019.09.20:src}</column>
     </table>
     <table name="mem">
@@ -7190,6 +7929,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">К'Ворт (класс судна)</column>
       <column name="definition_zh_HK">K'Vort類（船） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Classe K'Vort (navio)</column>
+      <column name="definition_fi">eräs alustyyppi, K'Vort-luokka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toQDuj:n}</column>
@@ -7200,6 +7940,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7217,6 +7958,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
    Имперское клингонкое судно Пар является хищной птицей класса К'Ворт под командованием капитана Каргана. Имеет лучшее оружие и некоторое количество отличнейших воинов в Клингонском флоте."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7224,6 +7966,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 7:src}</column>
     </table>
     <table name="mem">
@@ -7237,6 +7980,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">подписывать договор, ставить подпись под договором</column>
       <column name="definition_zh_HK">簽署（條約） [AUTOTRANSLATED]</column>
       <column name="definition_pt">assinar (um tratado)</column>
+      <column name="definition_fi">allekirjoittaa (sopimus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mab:n:1}, {rom:n}, {Sutlh:v}</column>
@@ -7247,6 +7991,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru">Также подходит для обозначения процесса регистрации учётной записи {mab qI':sen@@mab:n:2, qI':v:2}.</column>
       <column name="notes_zh_HK">此動詞還用於註冊帳戶以使用服務。參見{qI':v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado para se inscrever em uma conta para usar um serviço. Consulte {qI':v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös tilin luomiseen palvelua varten. Katso {qI':v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7256,6 +8001,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7263,6 +8009,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7276,6 +8023,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">зарегистрироваться, зарегистрироваться (аккаунт) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">註冊，註冊（帳戶） [AUTOTRANSLATED]</column>
       <column name="definition_pt">registrar-se, inscrever-se em (uma conta)</column>
+      <column name="definition_fi">rekisteröityä, luoda tunnus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaQHa'moH:v:1}</column>
@@ -7286,6 +8034,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru">Это расширение {qI':v:1}, означающее регистрацию учетной записи для использования службы. Типичный объект этого глагола - {mab:n:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{qI':v:1}的擴展，意味著註冊一個帳戶即可使用服務。該動詞的典型對像是{mab:n:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma extensão do {qI':v:1}, para significar a inscrição em uma conta para usar um serviço. O objeto típico desse verbo é {mab:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {qI':v:1}: n laajennus, joka tarkoittaa tilin rekisteröitymistä palvelua varten. Tämän verbin tyypillinen kohde on {mab:n:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7297,6 +8046,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
 ▶ {mab qI'lu'ta':sen:nolink} "Учётная запись уже существует"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7304,6 +8054,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -7317,6 +8068,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">Кимпек</column>
       <column name="definition_zh_HK">K'mpec [AUTOTRANSLATED]</column>
       <column name="definition_pt">K'mpec</column>
+      <column name="definition_fi">K'mpec</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7327,6 +8079,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7337,6 +8090,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7344,6 +8098,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -7357,6 +8112,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">партнёр, напарник, компаньон, соучастник</column>
       <column name="definition_zh_HK">夥伴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">parceiro</column>
+      <column name="definition_fi">kumppani</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7367,6 +8123,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru">Это относится к человеку, а не к слову, используемому при обращении к другой половине пары носков или перчаток или тому подобного, о которой см. {nelwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指一個人，不是指襪子或手套之類的另一半時要使用的詞，有關此信息，請參見{nelwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa e não é a palavra a ser usada quando se refere à outra metade de um par de meias ou luvas ou similares, para as quais consulte {nelwI':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, eikä sitä ole käytettävä sana viitattaessa sukkien tai käsineiden tai vastaavien parin toiseen puoliskoon, josta ks. {nelwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Coach". See also {maqoch:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7376,6 +8133,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7383,6 +8141,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2019.01.22:src}</column>
     </table>
     <table name="mem">
@@ -7396,6 +8155,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">выжимать, впихивать, втискивать, вдавливать (в пространство)</column>
       <column name="definition_zh_HK">擠壓（進入一個空間） [AUTOTRANSLATED]</column>
       <column name="definition_pt">espremer (em um espaço)</column>
+      <column name="definition_fi">puristaa (tilaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaH:v}, {'olQan:n}</column>
@@ -7406,6 +8166,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru">Объектом для данного глагола является пространство, в которое происходит втискивание, такое как маленькая машина или забитый людьми лифт, или одежда, или обувь, которые также малы.</column>
       <column name="notes_zh_HK">該動詞的對像是被擠壓到的空間，例如小型汽車或擁擠的電梯，或者衣服或鞋子太小。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objetivo desse verbo é o espaço que está sendo espremido, como um carro pequeno ou elevador lotado, ou roupas ou sapatos muito pequenos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin tarkoituksena on puristettu tila, kuten pieni auto tai tungosta hissi, tai liian pienet vaatteet tai kengät. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Coach" is the lowest (and most cramped) seating class in air travel.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7415,6 +8176,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7422,6 +8184,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -7435,6 +8198,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">резинка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">橡膠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">borracha</column>
+      <column name="definition_fi">kumi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7445,6 +8209,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru">Это относится к клейкому материалу. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指膠粘材料。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao material gomoso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kumimaiseen materiaaliin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Caoutchouc" is natural rubber that has not been vulcanised (hardened).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7454,6 +8219,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7461,6 +8227,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7474,6 +8241,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">внутри, интерьер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">裡面、入便</column>
       <column name="definition_pt">interior, parte de dentro</column>
+      <column name="definition_fi">sisällä, sisäpuoli</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hur:n}</column>
       <column name="see_also">{ngaS:v}, {joj:n}, {botlh:n:1}</column>
@@ -7484,6 +8252,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7493,6 +8262,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7500,6 +8270,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7513,6 +8284,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">стабилизатор внутренней опоры [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">內支撐穩定劑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estabilizador de suporte interno</column>
+      <column name="definition_fi">sisäinen tukivakain?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7523,6 +8295,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qoD:n}, {Qutlh:v}, {-wI':v}, {ngaDmoHwI':n}</column>
       <column name="examples"></column>
@@ -7532,6 +8305,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7539,6 +8313,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7552,6 +8327,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">пояс, ремень, портупея</column>
       <column name="definition_zh_HK">腰帶</column>
       <column name="definition_pt">cinto</column>
+      <column name="definition_fi">vyö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'alnIl:n}</column>
@@ -7572,6 +8348,9 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
 {qoghmey:n:nolink} в общем означает "пояса", но также может означать "уши, разбросанные повсюду", из-за того, что слово является омофоном к {qogh:n:2}. Данный омофон также является основой для сленгового выражения, {qogh tuQmoHHa':sen}.[3]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä pitää molemmat yllä {yopwaH:n}: tä ja sitä käytetään ripustamaan aseita
+
+{qoghmey:n:nolink} tarkoittaa yleensä "vyöt", mutta se voi tarkoittaa myös "korvat, jotka ovat hajallaan", johtuen homofoniasta {qogh:n:2}: n kanssa. Tämä homofonia on myös slangilausekkeen {qogh tuQmoHHa':sen}.[3] perusta.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7581,6 +8360,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7588,6 +8368,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.58:src}, [3] {HQ 2.4, p.17, Dec. 1993:src}, [4] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7601,6 +8382,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">Ухо</column>
       <column name="definition_zh_HK">耳朵（外部、軟骨皮瓣） [AUTOTRANSLATED]</column>
       <column name="definition_pt">orelha (retalho externo cartilaginoso)</column>
+      <column name="definition_fi">korvalehti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{teS:n}, {Serrum:n}</column>
@@ -7625,6 +8407,9 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="notes_pt">Isso se refere ao retalho externo de pele, cartilagem ou qualquer outra coisa. O órgão interno da audição é denominado {teS:n}.
 
 {qoghDu':n:nolink} só pode significar "orelhas", enquanto {qoghmey:n:nolink} é geralmente o plural de {qogh:n:1} e significa "cintos". A homofonia entre essas duas palavras é a base de uma expressão de gíria, {qogh tuQmoHHa':sen}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ihon, ruston tai muun ulkoiseen läppään. Sisäisen kuuloelimen nimi on {teS:n}.
+
+{qoghDu':n:nolink} voi tarkoittaa vain "korvia", kun taas {qoghmey:n:nolink} on yleensä monikko {qogh:n:1} ja tarkoittaa "vöitä". Näiden kahden sanan välinen homofonia on slangilausekkeen {qogh tuQmoHHa':sen}.[2] perusta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the painter Vincent van Gogh, who cut off his ear.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7634,6 +8419,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7641,6 +8427,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
     </table>
     <table name="mem">
@@ -7654,6 +8441,7 @@ Maltz verkade ovillig att prata om vad detta är exakt. [2] [AUTOTRANSLATED]</co
       <column name="definition_ru">не слышать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聽不到 [AUTOTRANSLATED]</column>
       <column name="definition_pt">não ouvir</column>
+      <column name="definition_fi">ei kuulla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuQmoH:v}, {Qoy:v}, {peghmey vIttlhegh:n}</column>
@@ -7678,6 +8466,9 @@ Det är oklart varför uttrycket använder {tuQmoHHa':v:nolink} och inte {tuQHa'
       <column name="notes_pt">Esta expressão significa literalmente "tirar o cinto". Seu significado de gíria deriva da homofonia entre {qogh:n:1} e {qogh:n:2}.
 
 Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH:v}. Uma possibilidade é que {tuQmoH:v} seja tão comum que alguns Klingons o tratam como um verbo por si só, em vez do verbo {tuQ:v} mais o sufixo {-moH:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ilmaisu tarkoittaa kirjaimellisesti "riisua vyö". Se saa slangin merkityksensä {qogh:n:1}: n ja {qogh:n:2}: n välisestä homofoniasta.
+
+On epäselvää, miksi lauseke käyttää {tuQmoHHa':v:nolink} eikä {tuQHa'moH:v}. Yksi mahdollisuus on, että {tuQmoH:v} on niin yleinen, että jotkut klingonit käsittelevät sitä omana verbinä eikä verbinä {tuQ:v} plus pääte {-moH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The {msn:src} source does not explicitly discuss {tuQmoHHa':v:nolink}. The example given is {quvmoH'egh:sen@@quvmoH:v, -'egh:v}, where the suffixes are switched for rhetorical effect.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7688,6 +8479,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7695,6 +8487,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 2.4, p.17, Dec. 1993:src}, [2] {msn 1997.11.30:src} (repeated in {s.k 1998.02.23:src})</column>
     </table>
     <table name="mem">
@@ -7708,6 +8501,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">дурак, глупец</column>
       <column name="definition_zh_HK">傻瓜</column>
       <column name="definition_pt">idiota</column>
+      <column name="definition_fi">tyhmä, typerys, hölmö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dogh:v}, {chul:v}</column>
@@ -7718,6 +8512,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru">Смотрите, как это говорит Гаурон: {YouTube video:url:http://youtu.be/FJ7HlgaTt44}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/FJ7HlgaTt44} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/FJ7HlgaTt44} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/FJ7HlgaTt44} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7727,6 +8522,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7734,6 +8530,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7747,6 +8544,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">Ветер не уважает глупца</column>
       <column name="definition_zh_HK">風不尊重傻瓜。</column>
       <column name="definition_pt">O vento não respeita um tolo.</column>
+      <column name="definition_fi">Tuuli ei kunnioita typeryksiä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghaH vuv SuS neH:sen}, {qInlat:n}</column>
@@ -7757,6 +8555,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qoH:n}, {vuv:v}, {-be':v}, {SuS:n}</column>
       <column name="examples"></column>
@@ -7766,6 +8565,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7773,6 +8573,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.107:src}, [2] {KGT p.122:src}</column>
     </table>
     <table name="mem">
@@ -7786,6 +8587,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">утёс, крутой обрыв</column>
       <column name="definition_zh_HK">懸崖、山崖</column>
       <column name="definition_pt">penhasco</column>
+      <column name="definition_fi">kallio, kallionjyrkänne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HuD:n:1}</column>
@@ -7796,6 +8598,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7805,6 +8608,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7812,6 +8616,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7825,6 +8630,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">или, и/или (объединяет предложения)</column>
       <column name="definition_zh_HK">或者、和/或（加入句子） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ou, e / ou (juntando frases)</column>
+      <column name="definition_fi">tai, ja/tai (inklusiivinen tai) (yhdistää lauseita, verbejä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ej:conj}, {pagh:conj}, {joq:conj}</column>
@@ -7835,6 +8641,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru">Смотрите пример использования.</column>
       <column name="notes_zh_HK">連接多個句子時，僅需要最後一個連詞。參見示例。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ao conectar várias frases, apenas a conjunção final é necessária. Veja o exemplo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun yhdistetään useita lauseita, tarvitaan vain viimeinen yhdistelmä. Katso esimerkki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7845,6 +8652,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7852,6 +8660,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7865,6 +8674,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">произносят [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發音</column>
       <column name="definition_pt">pronunciar</column>
+      <column name="definition_fi">ääntää, lausua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIch wab Ho'DoS:n}</column>
@@ -7875,6 +8685,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru">Это используется для обозначения артикуляции и не имеет смысла «объявлять, объявлять, указывать». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是用於表達，沒有“宣布，宣告，判令”的意思。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para se referir à articulação e não tem o sentido de "proclamar, declarar, decretar". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään viittaamaan artikulaatioon, eikä sillä ole merkitystä "julistaa, julistaa, säätää". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Hebrew word for "voice" is קוֹל.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7885,6 +8696,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7892,6 +8704,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.01.16:src}</column>
     </table>
     <table name="mem">
@@ -7905,6 +8718,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">Кол</column>
       <column name="definition_zh_HK">科爾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kol</column>
+      <column name="definition_fi">Kol</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7915,6 +8729,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru">Является членом дома Кора ({qor tuq:n:name}).</column>
       <column name="notes_zh_HK">他是Kor之家（{qor tuq:n:name}）的成員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ele é membro da Casa de Kor ({qor tuq:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on Korin talon ({qor tuq:n:name}) jäsen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7924,6 +8739,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7931,6 +8747,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Battle at the Binary Stars:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -7944,6 +8761,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">{qo'leq:n:name}</column>
       <column name="definition_zh_HK">{qo'leq:n:name}</column>
       <column name="definition_pt">{qo'leq:n:name}</column>
+      <column name="definition_fi">{qo'leq:n:name}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7954,6 +8772,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru">Это имя не переведено в {KGT:src} и, возможно, является ошибочным написанием для {qo'leq:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該名稱在{KGT:src}中未翻譯，可能是{qo'leq:n:name}的拼寫錯誤。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este nome não está traduzido em {KGT:src} e é possivelmente um erro ortográfico para {qo'leq:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä nimeä ei ole käännetty kielellä {KGT:src}, ja se on mahdollisesti kirjoitusvirhe {qo'leq:n:name}: lle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7963,6 +8782,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7970,6 +8790,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7983,6 +8804,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">Колот</column>
       <column name="definition_zh_HK">Koloth [AUTOTRANSLATED]</column>
       <column name="definition_pt">Koloth</column>
+      <column name="definition_fi">Koloth</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7993,6 +8815,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8002,6 +8825,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8009,6 +8833,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8022,6 +8847,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">ядро, сердечник, сердцевина, сущность, эссенция</column>
       <column name="definition_zh_HK">核心、本質 [AUTOTRANSLATED]</column>
       <column name="definition_pt">núcleo, essência</column>
+      <column name="definition_fi">perusolemus, ydin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuqSIv:n}, {ghanroq:n}</column>
@@ -8032,6 +8858,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Kor". See {jan qalI'qoS:n:name}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8041,6 +8868,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8048,6 +8876,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 14 (2007):src}</column>
     </table>
     <table name="mem">
@@ -8061,6 +8890,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">золото</column>
       <column name="definition_zh_HK">金</column>
       <column name="definition_pt">ouro</column>
+      <column name="definition_fi">kulta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}</column>
@@ -8072,6 +8902,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to Coloma, the originating site of the California Gold Rush.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8081,6 +8912,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8088,6 +8920,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -8101,6 +8934,7 @@ Não está claro por que a expressão usa {tuQmoHHa':v:nolink} e não {tuQHa'moH
       <column name="definition_ru">Котар</column>
       <column name="definition_zh_HK">塔爾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kotar</column>
+      <column name="definition_fi">Kotar</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8125,6 +8959,9 @@ Detta namn skrivs ibland som Kortar ({qortar:n:name,nolink}). [AUTOTRANSLATED]</
       <column name="notes_pt">De acordo com a lenda Klingon, Kotar foi o primeiro Klingon. Ele e sua companheira mataram os deuses, e agora ele transporta as almas dos desonrados para Gre'thor ({ghe'tor:n}) na Barcaça dos Mortos ({Hegh Duj:n}).
 
 Esse nome às vezes é escrito como Kortar ({qortar:n:name,nolink}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin legendan mukaan Kotar oli ensimmäinen Klingon. Hän ja hänen puolisonsa tappoivat jumalat, ja nyt hän kuljettaa häpeällisten sielut Gre'thorille ({ghe'tor:n}) kuolleiden proomulla ({Hegh Duj:n}).
+
+Tämä nimi kirjoitetaan joskus nimellä Kortar ({qortar:n:name,nolink}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8134,6 +8971,7 @@ Esse nome às vezes é escrito como Kortar ({qortar:n:name,nolink}). [AUTOTRANSL
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Kortar, qortar</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8141,6 +8979,7 @@ Esse nome às vezes é escrito como Kortar ({qortar:n:name,nolink}). [AUTOTRANSL
       <column name="search_tags_ru">Кортар</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -8154,6 +8993,7 @@ Esse nome às vezes é escrito como Kortar ({qortar:n:name,nolink}). [AUTOTRANSL
       <column name="definition_ru">тип еды [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物種類 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de comida</column>
+      <column name="definition_fi">eräs ruokalaji</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8164,6 +9004,7 @@ Esse nome às vezes é escrito como Kortar ({qortar:n:name,nolink}). [AUTOTRANSL
       <column name="notes_ru">Чтобы подготовить это, {tap:v} смесь {naH:n} и животного вещества, и позвольте {rogh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Para preparar isso, {tap:v} uma mistura de {naH:n} e matéria animal e deixe {rogh:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän valmistamiseksi {tap:v} on {naH:n}: n ja eläinaineen seos ja anna {rogh:v}: n. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Compost" or "compote" (both from Latin "compositum").</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8173,6 +9014,7 @@ Esse nome às vezes é escrito como Kortar ({qortar:n:name,nolink}). [AUTOTRANSL
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8180,6 +9022,7 @@ Esse nome às vezes é escrito como Kortar ({qortar:n:name,nolink}). [AUTOTRANSL
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8193,6 +9036,7 @@ Esse nome às vezes é escrito como Kortar ({qortar:n:name,nolink}). [AUTOTRANSL
       <column name="definition_ru">записывать, сочинять, составлять</column>
       <column name="definition_zh_HK">記錄、撰寫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gravar, compor</column>
+      <column name="definition_fi">kirjoittaa ylös, tallentaa, säveltää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghItlh:v}, {laD:v}</column>
@@ -8215,6 +9059,9 @@ Det finns ett annat verb, {gher:v}, som används för att sammanställa listor o
       <column name="notes_pt">Esta palavra é usada para o ato de compor canções, histórias, etc.[2, p.71] Os klingons consideram as canções como coisas que simplesmente existem, e o ato de composição é visto como caçá-las, capturá-las e registrá-las.[3]
 
 Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que, ao contrário de {qon:v:nolink}, sugere que a informação é meramente repassada.[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään kappaleiden, tarinoiden yms. Säveltämiseen.
+
+On toinenkin verbi, {gher:v}, jota käytetään luetteloiden ja vastaavien kokoamiseen, ja joka toisin kuin {qon:v:nolink} viittaa siihen, että tietoa pelkästään välitetään.[2, p.71][3][4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined as "record" in {TKD:src}, and as "compose" in {KGT:src}.[1; 2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8224,6 +9071,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8231,6 +9079,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {HQ 2.4, p.17, Dec. 1993:src}, [4] {s.k 1998.07.09:src} (reprinted in {HQ 8.1, p.8, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -8244,6 +9093,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="definition_ru">Композитор</column>
       <column name="definition_zh_HK">作曲家</column>
       <column name="definition_pt">compositor de música</column>
+      <column name="definition_fi">lauluntekijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8254,6 +9104,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="notes_ru">Заметьте, что {qonwI':n:nolink} может также означать "записывающее устройство", как в {mIllogh qonwI':n}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Observe que {qonwI':n:nolink} também pode significar um dispositivo de gravação, como em {mIllogh qonwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että {qonwI':n:nolink} voi tarkoittaa myös tallennuslaitetta, kuten {mIllogh qonwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qon:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -8263,6 +9114,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8270,6 +9122,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.71:src}</column>
     </table>
     <table name="mem">
@@ -8283,6 +9136,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="definition_ru">Арестовывать, прозводить арест</column>
       <column name="definition_zh_HK">逮捕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prender</column>
+      <column name="definition_fi">pidättää joku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeS:v}, {HeSwI':n}, {Hung:n}, {ghan'Iq:n}, {chut:n}</column>
@@ -8293,6 +9147,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In English, "cop" is a slang term for a police officer.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8302,6 +9157,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8309,6 +9165,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8322,6 +9179,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="definition_ru">робот</column>
       <column name="definition_zh_HK">機械人</column>
       <column name="definition_pt">robô</column>
+      <column name="definition_fi">robotti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8332,6 +9190,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8341,6 +9200,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8348,6 +9208,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8361,6 +9222,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="definition_ru">ботнет (компьютерный жаргон)</column>
       <column name="definition_zh_HK">殭屍網絡（計算機行話） [AUTOTRANSLATED]</column>
       <column name="definition_pt">botnet (jargão do computador)</column>
+      <column name="definition_fi">bottiverkko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8371,6 +9233,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qoq:n}, {De'wI':n}, {Dojmey:n}</column>
       <column name="examples"></column>
@@ -8380,6 +9243,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8387,6 +9251,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -8400,6 +9265,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="definition_ru">убирать мусор, продувать, копаться в отбросах</column>
       <column name="definition_zh_HK">清除 [AUTOTRANSLATED]</column>
       <column name="definition_pt">limpar</column>
+      <column name="definition_fi">kaivella, tonkia, haalia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8410,6 +9276,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8419,6 +9286,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8426,6 +9294,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8439,6 +9308,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="definition_ru">Кор</column>
       <column name="definition_zh_HK">「寇爾」</column>
       <column name="definition_pt">Kor</column>
+      <column name="definition_fi">Kor</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Da'ar:n}</column>
@@ -8449,6 +9319,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="notes_ru">Сыгран актёром {jan qalI'qoS:n:name}.</column>
       <column name="notes_zh_HK">由{jan qalI'qoS:n:name}演奏。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Jogado por {jan qalI'qoS:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toistanut {jan qalI'qoS:n:name}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8458,6 +9329,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8465,6 +9337,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8478,6 +9351,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="definition_ru">Дом Кора</column>
       <column name="definition_zh_HK">Kor之家 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Casa de Kor</column>
+      <column name="definition_fi">Korin huone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuq:n}</column>
@@ -8488,6 +9362,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="notes_ru">Это дом {qol:n:name} и конечно же {qor:n:name}.</column>
       <column name="notes_zh_HK">這是{qol:n:name}，當然是{qor:n:name}的房屋。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on {qol:n:name}: n ja tietysti {qor:n:name}: n talo. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8497,6 +9372,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8504,6 +9380,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - The Butcher's Knife Cares Not for the Lamb's Cry:src}</column>
     </table>
     <table name="mem">
@@ -8517,6 +9394,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="definition_ru">семья</column>
       <column name="definition_zh_HK">家庭</column>
       <column name="definition_pt">família</column>
+      <column name="definition_fi">perhe</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuq:n}, {tuqnIgh:n}</column>
@@ -8527,6 +9405,7 @@ Há outro verbo, {gher:v}, que é usado para compilar listas e semelhantes e que
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Klingon sentence on {SkyBox 13:src} seems to have dropped some words, since it is ungrammatical.
 
 This word refers to something which is not capable of language (even though its individual members might be). In the first edition of the {paq'batlh:src}, the suffixes {-lI':n} and {-wI':n} were incorrectly used on {qorDu':n:nolink}. The correct suffixes are {-lIj:n} and {-wIj:n}.[4]</column>
@@ -8548,6 +9427,7 @@ This word refers to something which is not capable of language (even though its 
 ▶ {qorDu'Daj tuq 'oS Ha'quj'e' tuQbogh wo'rIv. tuQtaHvIS Hem. ghaHvaD quHDaj qawmoH.:sen:nolink} "Перевязь, которую носит Ворф, является символом  дома его семьи. Он носит её гордо, как напоминание о своём наследии."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8555,6 +9435,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 13:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src}), [3] {SkyBox 20:src} (reprinted in {HQ 5.2, p.14, Jun. 1996:src}), [4] {KLI mailing list 2020.08.17:src}</column>
     </table>
     <table name="mem">
@@ -8568,6 +9449,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="definition_ru">Коракс</column>
       <column name="definition_zh_HK">Korax [AUTOTRANSLATED]</column>
       <column name="definition_pt">Korax</column>
+      <column name="definition_fi">Korax</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8578,6 +9460,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8587,6 +9470,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8594,6 +9478,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 5.6:src}</column>
     </table>
     <table name="mem">
@@ -8607,6 +9492,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="definition_ru">заткнись, заполните дыру [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">停下來、填一個洞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pare, encha um buraco</column>
+      <column name="definition_fi">tukkia, täyttää (reikä tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoD:v}, {teb:v}, {qung:n}</column>
@@ -8617,6 +9503,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="notes_ru">В отличие от {teb:v}, это указывает на закрытие отверстия, но не на заполнение внутренней части. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與{teb:v}不同，這表示停止了開口，但未填滿內部。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ao contrário de {teb:v}, isso indica interromper uma abertura, mas não encher a parte interna. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toisin kuin {teb:v}, tämä tarkoittaa aukon pysäyttämistä, mutta sisäosan täyttämättä jättämistä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Cork".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8626,6 +9513,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8633,6 +9521,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -8646,6 +9535,7 @@ This word refers to something which is not capable of language (even though its 
       <column name="definition_ru">пробка, соска [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">軟木塞、安撫奶嘴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cortiça, chupeta</column>
+      <column name="definition_fi">korkki, tutti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuvtlhe':n}, {bal:n}</column>
@@ -8662,6 +9552,9 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sana viittaa pullon, kuten viinipullon, korkkiin tai tulpaan
+
+Sitä voidaan käyttää myös laitteeseen, jota jotkut ihmiset käyttävät vauvojensa hiljentämiseen (mikä ei ole klingonilaista tapaa).[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Cork".</column>
       <column name="components">{qorgh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -8671,6 +9564,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">stopper</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8678,6 +9572,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -8691,6 +9586,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">Корнелий</column>
       <column name="definition_zh_HK">科尼利厄斯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Cornelius</column>
+      <column name="definition_fi">Cornelius</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -8701,6 +9597,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8710,6 +9607,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8717,6 +9615,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -8730,6 +9629,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">Корвак</column>
       <column name="definition_zh_HK">Qorvaqk [AUTOTRANSLATED]</column>
       <column name="definition_pt">Qorvaqk</column>
+      <column name="definition_fi">Qorvaqk</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuch:n}</column>
@@ -8740,6 +9640,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Согласно легенде, это имя Клингона, кто совершил убийство, пока его жертва спала. Его имя является синонимом трусости.[1]</column>
       <column name="notes_zh_HK">據傳說，這是一個克林崗人的名字，他在受害者睡覺時犯了謀殺罪。他的名字是怯ward的代名詞。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Segundo a lenda, este é o nome de um Klingon que cometeu assassinato enquanto sua vítima estava dormindo. Seu nome é sinônimo de covardia.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Legendan mukaan tämä on Klingonin nimi, joka teki murhan uhrinsa nukkuessa. Hänen nimensä on synonyymi pelkuruudelle.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8749,6 +9650,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8756,6 +9658,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {The Klingon Art of War:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -8769,6 +9672,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">Корвит (тип грызуна)</column>
       <column name="definition_zh_HK">korvit、囓齒動物的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">korvit, tipo de roedor</column>
+      <column name="definition_fi">eräs jyrsijän kaltainen eläin, korvit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuSwI':n}</column>
@@ -8779,6 +9683,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Согласно глоссарию {A Burning House:src}, это грызун, который считается вредителем на Клингонских фермах, где фермеры вынуждены устанавливать ловушки, чтобы поймать его.</column>
       <column name="notes_zh_HK">根據{A Burning House:src}的詞彙表，這是一種囓齒動物，被認為是克林崗農場的破壞性害蟲，農民必須為他們設陷阱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o glossário do {A Burning House:src}, este é um roedor considerado uma praga destrutiva nas fazendas de Klingon, onde os agricultores precisam armar armadilhas para eles. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{A Burning House:src}-sanaston mukaan tämä on jyrsijä, jota pidetään tuhoisana tuholaisena Klingonin tiloilla, joissa viljelijöiden on asetettava heille ansoja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Corvids are members of Corvidae, a family of birds containing crows, ravens, jays, magpies, and so on.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8788,6 +9693,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rabbit</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8795,6 +9701,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru">кролик</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -8808,6 +9715,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">день рождения</column>
       <column name="definition_zh_HK">生日 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aniversário</column>
+      <column name="definition_fi">syntymäpäivä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'echletHom:n}, {bogh:v}, {DISjaj:n}</column>
@@ -8818,6 +9726,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8827,6 +9736,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8834,6 +9744,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8847,6 +9758,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">Кос'Карий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">科斯卡里 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kos'Karii</column>
+      <column name="definition_fi">eräs käärmeen kaltainen eläin, Kos'Karii</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8857,6 +9769,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Это бледные змееподобные существа, обитающие в водах, пересекаемых баржой мертвых ({Hegh Duj:n}) на пути к Гретору ({ghe'tor:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這些蒼白的蛇狀生物棲息在死船（{Hegh Duj:n}）通往格羅索（{ghe'tor:n}）的途中，棲息在死海中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Estas são criaturas pálidas, semelhantes a serpentes, que habitam as águas atravessadas pela Barcaça dos Mortos ({Hegh Duj:n}) a caminho de Gre'thor ({ghe'tor:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nämä ovat kalpea, käärmeen kaltaisia ​​olentoja, jotka asuvat kuolleiden proomun ({Hegh Duj:n}) ylittämillä vesillä matkalla Gre'thoriin ({ghe'tor:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'angwIl:n:inhps}</column>
       <column name="examples"></column>
@@ -8866,6 +9779,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8873,6 +9787,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8887,6 +9802,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">лента, лента [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">絲帶、膠帶 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fita, banda</column>
+      <column name="definition_fi">nauha, suikale, kaistale</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIrgh:n}</column>
@@ -8897,6 +9813,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Это слово относится к форме, а не функции.[2] Его можно рассматривать как плоскую версию {SIrgh:n}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞是指形式而不是功能。[2]可以認為是{SIrgh:n}的平面版本。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se refere à forma, e não à função.[2] Pode ser considerada uma versão simples de {SIrgh:n}.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa muotoon eikä funktioon.[2]{SIrgh:n}[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The clarifications were made because the only uses of this word in canon had been for ribbon-like recording media.[2; 3].</column>
       <column name="components"></column>
       <column name="examples">
@@ -8908,6 +9825,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8915,6 +9833,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}, [2] {KLI mailing list 2013.07.29:src}, [3] {Facebook "Learn Klingon" group 2013.08.10:src}</column>
     </table>
     <table name="mem">
@@ -8928,6 +9847,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">щекотать, пощекотать, доставлять удовольствие</column>
       <column name="definition_zh_HK">擳（痕）</column>
       <column name="definition_pt">cócegas</column>
+      <column name="definition_fi">kutittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hagh:v}</column>
@@ -8938,6 +9858,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8948,6 +9869,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8955,6 +9877,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8968,6 +9891,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">заслуживать, быть достойным, гарантировать, выступать гарантом, ручаться</column>
       <column name="definition_zh_HK">值得的、保證 [AUTOTRANSLATED]</column>
       <column name="definition_pt">merecer, garantir</column>
+      <column name="definition_fi">ansaita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIb:n}</column>
@@ -8978,6 +9902,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8988,6 +9913,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">worthy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8995,6 +9921,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru">быть достойным</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -9008,6 +9935,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">маленькое собачье существо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小犬似的生物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pequena criatura canina</column>
+      <column name="definition_fi">eräs pieni koiran kaltainen eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{targh:n}, {ngavyaw':n}</column>
@@ -9018,6 +9946,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Это существо, подобное домашнему животному Крюге (см. {Qugh:n:2,name}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個像克魯格的寵物一樣的生物（見{Qugh:n:2,name}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma criatura como o animal de estimação de Kruge (veja {Qugh:n:2,name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Krugen lemmikin kaltainen olento (katso {Qugh:n:2,name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Backwards, this is {jIvoq:sen@@jI-:v, voq:v} "I have faith", which is the Latin meaning of the name "Fido" (a common name for a dog).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9027,6 +9956,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dog, poodle, puppy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9034,6 +9964,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9047,6 +9978,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">умолять, просить, ходатайствовать, выпрашивать, упрашивать</column>
       <column name="definition_zh_HK">懇求、求求 [AUTOTRANSLATED]</column>
       <column name="definition_pt">suplicar, implorar</column>
+      <column name="definition_fi">anoa, kerjätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhob:v}</column>
@@ -9057,6 +9989,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9066,6 +9999,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9073,6 +10007,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9086,6 +10021,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">мир, царство</column>
       <column name="definition_zh_HK">世界、境界</column>
       <column name="definition_pt">mundo, reino</column>
+      <column name="definition_fi">maailma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'umber:n}</column>
@@ -9096,6 +10032,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9108,6 +10045,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9115,6 +10053,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {paq'batlh p.56-57:src}</column>
     </table>
     <table name="mem">
@@ -9128,6 +10067,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">Кола (напиток)</column>
       <column name="definition_zh_HK">可樂（汽水）</column>
       <column name="definition_pt">Cola (de refrigerante)</column>
+      <column name="definition_fi">cola (virvoitusjuoma)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'awje':n}</column>
@@ -9138,6 +10078,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Первая часть - это просто транслитерация английского слова «кола». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">第一部分只是英文單詞“ cola”的音譯。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A primeira parte é apenas a transliteração da palavra em inglês "cola". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ensimmäinen osa on vain englanninkielisen sanan "cola" translitterointi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{qo'qa' qo'la':n}</column>
@@ -9147,6 +10088,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pop, soft drink</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9154,6 +10096,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -9167,6 +10110,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">Ко'лек</column>
       <column name="definition_zh_HK">Ko'lek [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ko'lek</column>
+      <column name="definition_fi">Ko'lek</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9177,6 +10121,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9186,6 +10131,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9193,6 +10139,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.41:src}</column>
     </table>
     <table name="mem">
@@ -9206,6 +10153,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">мокрота, слизь, флегма</column>
       <column name="definition_zh_HK">痰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">catarro</column>
+      <column name="definition_fi">lima</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hugh:n}, {ghup:v}, {tuy':v}, {'IqnaH:n}</column>
@@ -9216,6 +10164,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9225,6 +10174,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9232,6 +10182,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -9245,6 +10196,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">Коридан</column>
       <column name="definition_zh_HK">Coridan [AUTOTRANSLATED]</column>
       <column name="definition_pt">Coridan</column>
+      <column name="definition_fi">Coridan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9255,6 +10207,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Планета в составе объединённой федерации планет</column>
       <column name="notes_zh_HK">聯邦中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta na Federação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta federaatiossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9264,6 +10217,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9271,6 +10225,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -9284,6 +10239,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">соли хрома [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鉻鹽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sais de cromo</column>
+      <column name="definition_fi">kromisuola</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qo'rIn DIr:n}</column>
@@ -9294,6 +10250,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Это относится к солям хрома, таким как соли, используемые при дублении кожи, тогда как {velSo':n} - это элементарный хром. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指鉻鹽，如皮革鞣製中所用的鉻鹽，而{velSo':n}是元素鉻。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a sais de cromo, como os usados ​​no curtimento de couro, enquanto o {velSo':n} é o cromo elementar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kromisuoloihin, kuten niitä, joita käytetään nahan parkituksessa, kun taas {velSo':n} on alkukromi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">See under {qo'rIn DIr:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9303,6 +10260,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9310,6 +10268,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9323,6 +10282,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="definition_ru">натуральная кожа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">皮革 [AUTOTRANSLATED]</column>
       <column name="definition_pt">couro</column>
+      <column name="definition_fi">nahka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIr:n}</column>
@@ -9333,6 +10293,7 @@ Det kan också användas för den enhet som vissa människor använder för att 
       <column name="notes_ru">Это считается материалом, а не частью тела.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這被認為是材料，而不是身體部位。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é considerado um material, não uma parte do corpo.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä pidetään materiaalina, ei ruumiinosana[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Corinthian leather.
 
 Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commercials extolling the virtues of the cars' rich Corinthian leather.</column>
@@ -9345,6 +10306,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9352,6 +10314,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9365,6 +10328,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="definition_ru">политическая марионетка</column>
       <column name="definition_zh_HK">木偶（政治） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fantoche (política)</column>
+      <column name="definition_fi">nukke (-hallitsija, -valtio tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{woQ:n}</column>
@@ -9375,6 +10339,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="notes_ru">Используется для обозначения, к примеру, "марионеточного государства" или "марионеточного правительства".</column>
       <column name="notes_zh_HK">例如，這用於表示“偽國家”或“偽政府”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado, por exemplo, para denotar um "estado fantoche" ou "governo fantoche". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään esimerkiksi merkitsemään "nukketilaa" tai "nukketaloushallitusta". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "puppet". The word "politics" was added to distinguish this from {SIrgh raghghan:n}.
 
 "Korob" is the name of one of the antagonists in {TOS - Catspaw:src}, whose true form was portrayed using a puppet. A "cat's paw" is an English expression referring to a person used to serve the purposes of another.</column>
@@ -9386,6 +10351,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9393,6 +10359,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -9406,6 +10373,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="definition_ru">Великое древо мира</column>
       <column name="definition_zh_HK">世界大樹</column>
       <column name="definition_pt">a grande árvore do mundo</column>
+      <column name="definition_fi">Suuri maailmanpuu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9416,6 +10384,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="notes_ru">Согласно {The Klingon Art of War:src}, древние Клингонские боги жили на нём.[1]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{The Klingon Art of War:src}: n mukaan muinaiset klingonijumalat asuivat täällä.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qo':n}, {Sor:n}</column>
       <column name="examples"></column>
@@ -9425,6 +10394,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9432,6 +10402,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {The Klingon Art of War:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -9445,6 +10416,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="definition_ru">быть редким</column>
       <column name="definition_zh_HK">很少見 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser raro</column>
+      <column name="definition_fi">olla harvinainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{motlh:v}</column>
       <column name="see_also">{Soj qub:n}, {pIjHa':adv}</column>
@@ -9455,6 +10427,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9464,6 +10437,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9471,6 +10445,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9484,6 +10459,7 @@ Ricardo Montalbán (Khan Noonien Singh) appeared in a series of Chrysler commerc
       <column name="definition_ru">размах, бег, растяжение (между) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">跨度，奔跑，伸展 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estender-se, correr, esticar-se (entre)</column>
+      <column name="definition_fi">väli (aikaväli, välimatka tms. väli kahden pisteen välillä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIch:v}, {joj:n}</column>
@@ -9508,6 +10484,9 @@ Använd {rav ... 'aqroS ...:sen} för att uttrycka idén om någon punkt (kanske
       <column name="notes_pt">Isso se refere ao período total de tempo ou distância ou o que quer que seja entre as duas extremidades de um intervalo.
 
 Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extremidades de um intervalo, use {rav ... 'aqroS ...:sen}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa koko ajanjaksoa tai etäisyyttä tai mitä tahansa alueen kahden pään välillä.
+
+Voit ilmaista ajatuksen jostakin alueen pään välisestä pisteestä (ehkä tuntemattomasta) käyttämällä {rav ... 'aqroS ...:sen}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9520,6 +10499,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">between, range</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9527,6 +10507,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9540,6 +10521,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">похищать детей</column>
       <column name="definition_zh_HK">綁架 [AUTOTRANSLATED]</column>
       <column name="definition_pt">raptar</column>
+      <column name="definition_fi">kidnapata, siepata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{voHDajbo':n}, {vub:n}</column>
@@ -9550,6 +10532,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9559,6 +10542,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9566,6 +10550,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9579,6 +10564,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">Тип соуса</column>
       <column name="definition_zh_HK">《qud》（醬汁的類型）</column>
       <column name="definition_pt">tipo de molho</column>
+      <column name="definition_fi">eräs kastike</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{burgh quD:n}, {'un quD:n}</column>
@@ -9589,6 +10575,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru">Сделано из переваренного {Su'lop:n}.</column>
       <column name="notes_zh_HK">這是從消化的{Su'lop:n}製成的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é feito do {Su'lop:n} digerido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on valmistettu pilkotusta {Su'lop:n}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Cud".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9598,6 +10585,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9605,6 +10593,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9618,6 +10607,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">совершать рейс</column>
       <column name="definition_zh_HK">巡航 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cruzeiro</column>
+      <column name="definition_fi">ajaa, matkata (tasaisella nopeudella, vakio- tai matkanopeudella)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leng:v}, {ngIv:v}</column>
@@ -9628,6 +10618,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9637,6 +10628,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9644,6 +10636,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9657,6 +10650,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">крейсерская скорость</column>
       <column name="definition_zh_HK">巡航速度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">velocidade de cruzeiro</column>
+      <column name="definition_fi">matkanopeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9667,6 +10661,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru">Согласно {BoP:src} постеру, {qughDo motlh:n:nolink} означает "нормальная крейсерская скорость".</column>
       <column name="notes_zh_HK">從{BoP:src}海報上看，{qughDo motlh:n:nolink}是“正常巡航速度”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No pôster {BoP:src}, {qughDo motlh:n:nolink} é "velocidade de cruzeiro normal". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{BoP:src}-julisteesta {qughDo motlh:n:nolink} on "normaali matkanopeus". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qugh:v} or {qugh:n:hyp,nolink}, {Do:n}</column>
       <column name="examples"></column>
@@ -9676,6 +10671,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9683,6 +10679,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -9696,6 +10693,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">крейсер</column>
       <column name="definition_zh_HK">巡洋艦</column>
       <column name="definition_pt">cruzador</column>
+      <column name="definition_fi">risteilijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9706,6 +10704,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qugh:v} or {qugh:n:hyp,nolink}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -9715,6 +10714,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9722,6 +10722,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -9735,6 +10736,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">наследие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">遺產 [AUTOTRANSLATED]</column>
       <column name="definition_pt">herança</column>
+      <column name="definition_fi">perintö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIgh:n}, {lurDech:n}, {'ISyar:n}</column>
@@ -9745,6 +10747,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9755,6 +10758,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9762,6 +10766,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 20:src} (reprinted in {HQ 5.2, p.14, Jun. 1996:src})</column>
     </table>
     <table name="mem">
@@ -9775,6 +10780,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">нарезать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">切片、刻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fatiar, esculpir</column>
+      <column name="definition_fi">viipaloida, suikaloida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baylaD:n}</column>
@@ -9785,6 +10791,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9794,6 +10801,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9801,6 +10809,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -9814,6 +10823,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">перхоть</column>
       <column name="definition_zh_HK">頭皮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">caspa (nos cabelos)</column>
+      <column name="definition_fi">hilse</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIr:n}, {nach:n}, {jIb:n}</column>
@@ -9824,6 +10834,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9833,6 +10844,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9840,6 +10852,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9853,6 +10866,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">огонь, пламя</column>
       <column name="definition_zh_HK">火</column>
       <column name="definition_pt">fogo</column>
+      <column name="definition_fi">tuli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIch:n}, {meQ:v}, {qerjIq:n}, {tIpqan:n}</column>
@@ -9863,6 +10877,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Cool" or "coal".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9872,6 +10887,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9879,6 +10895,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -9892,6 +10909,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">искра</column>
           <column name="definition_zh_HK">火花 [AUTOTRANSLATED]</column>
           <column name="definition_pt">faísca</column>
+      <column name="definition_fi">kipinä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{pan:v:1}</column>
@@ -9902,6 +10920,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qul:n}, {-Hom:n}</column>
           <column name="examples">
@@ -9913,6 +10932,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
 ▶ {jIbDaj lumeQmoH qul bIQtIq qulHommey:sen:nolink} "Искры от огненной реки опалили его волосы"[1]</column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9920,6 +10940,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {paq'batlh p.86-87:src}</column>
         </table>
         <table name="mem">
@@ -9933,6 +10954,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">вулкан</column>
           <column name="definition_zh_HK">火山</column>
           <column name="definition_pt">vulcão</column>
+      <column name="definition_fi">tulivuori</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{qul ngeng:n}, {vaHbo':n}, {QIStaq:n}</column>
@@ -9943,6 +10965,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qul:n}, {HuD:n:1}</column>
           <column name="examples"></column>
@@ -9952,6 +10975,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9959,6 +10983,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2018.02.01:src}</column>
         </table>
         <table name="mem">
@@ -9972,6 +10997,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">огненная шкура (еда)</column>
           <column name="definition_zh_HK">火皮（食物）</column>
           <column name="definition_pt">pele de fogo (comida)</column>
+      <column name="definition_fi">eräs ruokalaji, tuli-iho</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{qul DIr yISop!:sen}</column>
@@ -9982,6 +11008,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru">Относится к шкурам животного, вымоченных в ликёре и подожжённых, которые надо очень быстро съесть.</column>
           <column name="notes_zh_HK">這是指浸泡在酒中並著火的動物皮膚碎片，必須迅速食用。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Refere-se a pedaços de pele de animal embebidos em licor e incendiados, que devem ser consumidos rapidamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa nesteeseen kastettuihin ja sytytettyihin eläinnahan paloihin, jotka on syötävä nopeasti. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qul:n}, {DIr:n}</column>
           <column name="examples"></column>
@@ -9991,6 +11018,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9998,6 +11026,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.93:src}</column>
         </table>
         <table name="mem">
@@ -10011,6 +11040,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">скорее!поторопись!</column>
           <column name="definition_zh_HK">趕快！動作快點！ [AUTOTRANSLATED]</column>
           <column name="definition_pt">Se apresse! Mova-se rapidamente!</column>
+      <column name="definition_fi">Kiirehdi! Liiku nopeasti!</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{pav:v}, {nom:adv}
@@ -10023,6 +11053,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru">Данная идиома дословно означает "Ешь огненную шкуру!"</column>
           <column name="notes_zh_HK">這個慣用語的字面意思是“吃火的皮膚！” [AUTOTRANSLATED]</column>
           <column name="notes_pt">Essa expressão idiomática significa literalmente "Coma a pele do fogo!" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "syö tulipalon ihoa!" [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qul DIr:n}, {yI-:v}, {Sop:v}</column>
           <column name="examples"></column>
@@ -10032,6 +11063,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10039,6 +11071,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.110:src}</column>
         </table>
         <table name="mem">
@@ -10052,6 +11085,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">танцор с огнём</column>
           <column name="definition_zh_HK">火舞者 [AUTOTRANSLATED]</column>
           <column name="definition_pt">dançarina de fogo</column>
+      <column name="definition_fi">tulitanssija</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -10062,6 +11096,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qul:n}, {mI'wI':n}</column>
           <column name="examples"></column>
@@ -10071,6 +11106,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10078,6 +11114,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -10091,6 +11128,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">Мечта огня!</column>
           <column name="definition_zh_HK">火之夢 [AUTOTRANSLATED]</column>
           <column name="definition_pt">O sonho do fogo</column>
+      <column name="definition_fi">eräs romaani, Tulen uni</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -10101,6 +11139,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru">Это название известной новеллы, написанной {Qa'taq:n:name}.</column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt">Este é o nome de um romance famoso escrito por {Qa'taq:n:name}. Observe que o Klingon é uma frase completa, pois {naj:v} é um verbo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {Qa'taq:n:name}: n kirjoittaman kuuluisan romaanin nimi. Huomaa, että Klingon on täydellinen lause, koska {naj:v} on verbi. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qul:n}, {naj:v}</column>
           <column name="examples"></column>
@@ -10110,6 +11149,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10117,6 +11157,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNG - The Measure of a Man:src}, [2] {The Klingon Art of War:src}, [3] {Saarbrücken qepHom'a' 2014:src}</column>
         </table>
         <table name="mem">
@@ -10130,6 +11171,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">матч, поединок</column>
           <column name="definition_zh_HK">比賽 [AUTOTRANSLATED]</column>
           <column name="definition_pt">partida</column>
+      <column name="definition_fi">tulitikku</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -10140,6 +11182,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru">Дословно значит огненная палка.</column>
           <column name="notes_zh_HK">這字面意思是“火棍”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso literalmente significa "vara de fogo". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "tulipaloa". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{qul:n}, {naQ:n:1}</column>
           <column name="examples"></column>
@@ -10149,6 +11192,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10156,6 +11200,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -10169,6 +11214,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">Территория, заполненная лавой, внутри вулкана</column>
           <column name="definition_zh_HK">火山內的火湖</column>
           <column name="definition_pt">área cheia de lava dentro de um vulcão</column>
+      <column name="definition_fi">laavan täyttämä alue tulivuoren sisällä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{qulHuD:n}, {QIStaq:n}, {vaHbo':n}, {ngeng HeH:n}</column>
@@ -10179,6 +11225,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru">Дословно значит "озеро огня"</column>
           <column name="notes_zh_HK">這個詞的字面意思是“火湖”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este termo significa literalmente "lago do fogo". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä termi tarkoittaa kirjaimellisesti "tulijärveä". [AUTOTRANSLATED]</column>
           <column name="hidden_notes">This term isn't actually explicitly defined in the {paq'bath:src}, but is just used this way.</column>
           <column name="components">{qul:n}, {ngeng:n}</column>
           <column name="examples"></column>
@@ -10188,6 +11235,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10195,6 +11243,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {paq'batlh p.78-79:src}</column>
         </table>
         <table name="mem">
@@ -10208,6 +11257,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">Дом огня (название оперы)</column>
           <column name="definition_zh_HK">火之家、歌劇的名字 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Casa do Fogo, nome de uma ópera</column>
+      <column name="definition_fi">eräs ooppera, Tulen huone</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{qul:n}, {tuq:n}</column>
@@ -10218,6 +11268,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qul:n}, {tuq:n}</column>
           <column name="examples"></column>
@@ -10227,6 +11278,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10234,6 +11286,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KCD:src}</column>
         </table>
     <table name="mem">
@@ -10247,6 +11300,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">пломбир [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">奶油 [AUTOTRANSLATED]</column>
       <column name="definition_pt">creme</column>
+      <column name="definition_fi">kerma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIm:n}, {'Ir:v:2}</column>
@@ -10257,6 +11311,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Some creams are prepared by souring with a bacterial "culture".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10266,6 +11321,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10273,6 +11329,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -10286,6 +11343,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">править, управлять </column>
       <column name="definition_zh_HK">治理 [AUTOTRANSLATED]</column>
       <column name="definition_pt">governar</column>
+      <column name="definition_fi">hallita (maata, kaupunkia tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loH:v}, {teblaw':n}, {qum:n}</column>
@@ -10296,6 +11354,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10305,6 +11364,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10312,6 +11372,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10325,6 +11386,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">правительство</column>
       <column name="definition_zh_HK">政府</column>
       <column name="definition_pt">governo</column>
+      <column name="definition_fi">hallitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loH:n}, {teblaw':n}, {qum:v}</column>
@@ -10335,6 +11397,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10344,6 +11407,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10351,6 +11415,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10364,6 +11429,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">правитель,губернатор</column>
       <column name="definition_zh_HK">州長 [AUTOTRANSLATED]</column>
       <column name="definition_pt">governador</column>
+      <column name="definition_fi">kuvernööri, hallitsija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10374,6 +11440,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qum:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -10383,6 +11450,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10390,6 +11458,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -10403,6 +11472,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">Средняя школа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">公立學校</column>
       <column name="definition_pt">escola pública</column>
+      <column name="definition_fi">julkinen koulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10413,6 +11483,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qum:n}, {DuSaQ:n}</column>
       <column name="examples">
@@ -10423,6 +11494,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10430,6 +11502,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Pop Culture Hero Coalition announcement:src} ({KLI mailing list 2016.11.30:src})</column>
     </table>
     <table name="mem">
@@ -10443,6 +11516,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">история</column>
       <column name="definition_zh_HK">歷史</column>
       <column name="definition_pt">história</column>
+      <column name="definition_fi">historia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10453,6 +11527,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10463,6 +11538,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10470,6 +11546,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10483,6 +11560,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">ругать, бранить, распекать, выговаривать, брюжзать</column>
       <column name="definition_zh_HK">罵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">repreender</column>
+      <column name="definition_fi">torua, nuhdella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10493,6 +11571,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10502,6 +11581,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10509,6 +11589,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -10522,6 +11603,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">Историю пишут победители</column>
           <column name="definition_zh_HK">歷史是勝利者寫的。</column>
           <column name="definition_pt">A história é escrita pelos vencedores.</column>
+      <column name="definition_fi">Voittajat kirjoittavat historian.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -10532,6 +11614,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">The prefix {lu-:v} is missing from {qon:v}.</column>
           <column name="components">{qun:n}, {qon:v}, {charghwI':n}, {-pu':n}, {-'e':n}</column>
           <column name="examples"></column>
@@ -10541,6 +11624,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10548,6 +11632,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.179:src}</column>
         </table>
         <table name="mem">
@@ -10561,6 +11646,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">История (наука)</column>
           <column name="definition_zh_HK">歷史學</column>
           <column name="definition_pt">ciência da história</column>
+      <column name="definition_fi">historia (tiede)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{qun:n}, {QeD:n}, {quntej:n}</column>
@@ -10571,6 +11657,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qun:n}, {QeD:n}</column>
           <column name="examples"></column>
@@ -10580,6 +11667,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10587,6 +11675,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
         </table>
         <table name="mem">
@@ -10600,6 +11689,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="definition_ru">историк</column>
           <column name="definition_zh_HK">歷史學家</column>
           <column name="definition_pt">historiador</column>
+      <column name="definition_fi">historioitsija, historiantutkija</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{qunQeD:n}, {tej:n}</column>
@@ -10610,6 +11700,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{qun:n}, {tej:n}</column>
           <column name="examples"></column>
@@ -10619,6 +11710,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -10626,6 +11718,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
         </table>
     <table name="mem">
@@ -10639,6 +11732,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">Наречие (МВЛ) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">副詞、狀語</column>
       <column name="definition_pt">advérbio</column>
+      <column name="definition_fi">adverbi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuvmey:n}</column>
@@ -10649,6 +11743,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10658,6 +11753,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">adverbial</column>
       <column name="search_tags_de">Nebenwort, Umstandswort</column>
       <column name="search_tags_fa"></column>
@@ -10665,6 +11761,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -10678,6 +11775,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">Кунивас</column>
       <column name="definition_zh_HK">Kunivas [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kunivas</column>
+      <column name="definition_fi">Kunivas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10688,6 +11786,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10697,6 +11796,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10704,6 +11804,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -10717,6 +11818,7 @@ Para expressar a ideia de algum ponto (talvez desconhecido) entre as duas extrem
       <column name="definition_ru">дыра (как дыра в музыкальном инструменте) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">窿、孔</column>
       <column name="definition_pt">buraco (como um buraco em um instrumento musical)</column>
+      <column name="definition_fi">reikä (puhallinsoittimessa tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Heng:v}, {QemjIq:n}, {'och:n}, {qorgh:v}</column>
@@ -10737,6 +11839,9 @@ Detta ord kan inte användas för ett hål i marken (för vilket se {QemjIq:n}),
       <column name="notes_pt">Com base na explicação em {HQ 10.2:src}, isso parece se referir a um buraco usado para alterar a afinação em um instrumento de sopro e, aparentemente, não a uma boca de som para um instrumento de cordas. No entanto, isso não é declarado explicitamente.[1]
 
 Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {QemjIq:n}), mas pode ser usada para um buraco de bala, um buraco em uma camisa (incluindo casas de botão, buracos de traça, rasgos acidentais, etc.), ou um buraco no telhado. A diferença entre um {QemjIq:n} e um {qung:n:nolink} é que o primeiro pode ser preenchido ({teb:v}) .[2] (em outras palavras, um {qung:n:nolink} é uma punção ou perfuração, enquanto um {QemjIq:n:nolink} é uma cavidade ou depressão.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{HQ 10.2:src}: n selityksen perusteella tämä näyttää viittaavan reikään, jota käytetään puhallinsoittimen sävelkorkeuden muuttamiseen, eikä ilmeisesti kielisoittimen kielekkeeseen. Tätä ei kuitenkaan nimenomaisesti mainita.[1]
+
+Tätä sanaa ei voida käyttää maassa olevaan reikään (josta katso {QemjIq:n}), mutta sitä voidaan käyttää luodinreikään, aukkoon paidassa (mukaan lukien napinlävet, koireikät, vahingossa repeytymät jne.) Tai reikä katossa. Ero {QemjIq:n}: n ja {qung:n:nolink}: n välillä on, että edellinen voidaan täyttää ({teb:v}) .[2] (Toisin sanoen {qung:n:nolink} on puhkaisu tai perforaatio, kun taas {QemjIq:n:nolink} on ontelo tai syvennys.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Possibly based on the Chinese "kǒng" (孔), also meaning hole.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10746,6 +11851,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">puncture, perforation</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10753,6 +11859,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}, [2] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -10766,6 +11873,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">старший, старец</column>
       <column name="definition_zh_HK">長老</column>
       <column name="definition_pt">ancião</column>
+      <column name="definition_fi">vanhin, vanhus, vanhempi ihminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qan:v:1}</column>
@@ -10776,6 +11884,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {puq:n}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -10793,6 +11902,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
    Забрав его у своего спящего отца."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10800,6 +11910,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.64-65:src}</column>
     </table>
     <table name="mem">
@@ -10813,6 +11924,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">патриарх, матриарх</column>
       <column name="definition_zh_HK">族長、女家長 [AUTOTRANSLATED]</column>
       <column name="definition_pt">patriarca, matriarca</column>
+      <column name="definition_fi">patriarkka, matriarkka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10823,6 +11935,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">В {paq'batlh:src}, {qanra':n:name} относится к {qup'a':n:nolink} из {qamchIy:n:name}.</column>
       <column name="notes_zh_HK">在{paq'batlh:src}中，{qanra':n:name}被稱為{qamchIy:n:name}的{qup'a':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No {paq'batlh:src}, {qanra':n:name} é referido como {qup'a':n:nolink} de {qamchIy:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohdassa {paq'batlh:src} {qanra':n:name} kutsutaan nimellä {qamchIy:n:name} {qup'a':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In referring to {qanra':n:name,nolink}, the translation of {qup'a':n:nolink} says "patriarch". The definition "matriarch" was added since the word itself is gender-neutral.</column>
       <column name="components">{qup:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -10832,6 +11945,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10839,6 +11953,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.126-127:src}</column>
     </table>
     <table name="mem">
@@ -10852,6 +11967,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">Совет старейшин</column>
       <column name="definition_zh_HK">長老會</column>
       <column name="definition_pt">Conselho dos Anciãos</column>
+      <column name="definition_fi">Vanhinten neuvosto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10862,6 +11978,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qup:n}, {rIp:n}</column>
       <column name="examples"></column>
@@ -10871,6 +11988,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10878,6 +11996,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10891,6 +12010,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">случилось одновременно</column>
       <column name="definition_zh_HK">同時發生</column>
       <column name="definition_pt">acontecer simultaneamente</column>
+      <column name="definition_fi">tapahtua samanaikaisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIbI':adv}, {ngugh:adv}, {wanI':n}, {nItebHa':adv}</column>
@@ -10901,6 +12021,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">Субъектами являются события, случившиеся одновременно</column>
       <column name="notes_zh_HK">主題是同時發生的事件。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os assuntos são os eventos que acontecem simultaneamente.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Aiheet ovat samanaikaisesti tapahtuvia tapahtumia.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10935,6 +12056,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
    Котар и Кемпа'кех прибывают в лагерь."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10942,6 +12064,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.12, Dec. 1998:src}, [3] {paq'batlh p.140-141:src}</column>
     </table>
     <table name="mem">
@@ -10955,6 +12078,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">быть жадным, быть алчным</column>
       <column name="definition_zh_HK">貪得無厭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser ganancioso</column>
+      <column name="definition_fi">olla ahne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mut:v}, {var:v}, {verengan:n}</column>
@@ -10965,6 +12089,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Greedy cur".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10974,6 +12099,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10981,6 +12107,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10994,6 +12121,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">архитектор (Моршканский диалект)</column>
       <column name="definition_zh_HK">建築師（Morskan） [AUTOTRANSLATED]</column>
       <column name="definition_pt">arquiteto (Morskan)</column>
+      <column name="definition_fi">arkkitehti (Morskan murteessa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mo'rISqa':n}</column>
@@ -11004,6 +12132,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">Является определением слова архитектор, якобы с Моршканского диалекта. Для {ta' Hol:n} архитектор будет {renwI':n}.</column>
       <column name="notes_zh_HK">據稱這是Morskan一詞，指的是建築師。 {ta' Hol:n}術語是{renwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é alegadamente o termo morskan para um arquiteto. O termo {ta' Hol:n} é {renwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän väitetään olevan Morskan-termi arkkitehdille. {ta' Hol:n}-termi on {renwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word was suggested by Quvar to MO as a new word for the {Saarbrücken qepHom'a' 2011:src}. It's based on the name of the Swiss-born French architect Le Corbusier.</column>
       <column name="components">{qurbuS:v:hyp,nolink} (possibly from {Qur:n} and {buS:v}), {-wI':v}</column>
       <column name="examples"></column>
@@ -11013,6 +12142,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11020,6 +12150,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2011:src}</column>
     </table>
     <table name="mem">
@@ -11033,6 +12164,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">фасоль, бобы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">豆</column>
       <column name="definition_pt">feijão</column>
+      <column name="definition_fi">papu, pavut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIno'va' qurgh:n}, {naH:n}, {'oQqar:n}</column>
@@ -11043,6 +12175,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11052,6 +12185,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11059,6 +12193,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -11072,6 +12207,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">ингредиент [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">成分 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ingrediente</column>
+      <column name="definition_fi">ainesosa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIw:n}, {HIl'aD:n}</column>
@@ -11082,6 +12218,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">«Формула», которая является списком ингредиентов чего-либо, будет {qurme'mey:n@@qurme':n, -mey:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">作為某物成分列表的“公式”將是{qurme'mey:n@@qurme':n, -mey:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma "fórmula" que é a lista de ingredientes de algo seria {qurme'mey:n@@qurme':n, -mey:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"Kaava", joka on jonkin aineosan luettelo, olisi {qurme'mey:n@@qurme':n, -mey:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{qur:v} "greedy" + {me':n} "aunt" = "(in)gredient"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11091,6 +12228,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">formula</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11098,6 +12236,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -11111,6 +12250,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">парик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">假髮</column>
       <column name="definition_pt">peruca</column>
+      <column name="definition_fi">peruukki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIb:n}, {jech:n}</column>
@@ -11121,6 +12261,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Peruke".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11130,6 +12271,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11137,6 +12279,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -11150,6 +12293,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">стул, кресло</column>
       <column name="definition_zh_HK">櫈</column>
       <column name="definition_pt">cadeira</column>
+      <column name="definition_fi">tuoli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ba':v}, {raS:n}, {quSlab:n}</column>
@@ -11160,6 +12304,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Cush"ion.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11169,6 +12314,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11176,6 +12322,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -11189,6 +12336,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">это же очевидно!</column>
       <column name="definition_zh_HK">這很明顯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Isso é óbvio</column>
+      <column name="definition_fi">se on ilmeistä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11199,6 +12347,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">Это идиоматическое выражение дословно значит "сесть на стул". Основано на омофонии между {ba':v} и {-ba':v:suff}. Используется в качестве снисхождения в ответ на заявление слишком очевидных вещей!</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是“坐在椅子上”。它基於{ba':v}和{-ba':v:suff}之間的諧音。僅在回應發言者認為過於明顯而無需說明的陳述時，才將其壓縮使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa literalmente "sentar em uma cadeira". É baseado na homofonia entre {ba':v} e {-ba':v:suff}. Ele é usado apenas de maneira condensada em resposta a uma afirmação que o orador considera óbvia demais para ser necessária. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "istua tuolissa". Se perustuu {ba':v}: n ja {-ba':v:suff}: n väliseen homofoniaan. Sitä käytetään vain tiivistyvästi vastauksena lausuntoon, joka puhujan mielestä on liian ilmeinen vaatiakseen lausumista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -11210,6 +12359,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
 ▶ {quSDaq bIba'.:sen:nolink} "То, что ты сказал, это очевидно."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11217,6 +12367,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.124:src}</column>
     </table>
     <table name="mem">
@@ -11230,6 +12381,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">Это место занято?</column>
       <column name="definition_zh_HK">這個座位有人嗎？</column>
       <column name="definition_pt">Este assento está ocupado?</column>
+      <column name="definition_fi">Onko tämä paikka varattu?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11240,6 +12392,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">There is a typo in this sentence in {TKD:src}, an extraneous space after {ba':sen:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11249,6 +12402,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11256,6 +12410,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -11269,6 +12424,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">диван, скамейка, кресло для нескольких человек [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沙發、長凳、多位的椅子</column>
       <column name="definition_pt">sofá, banco, cadeira para várias pessoas</column>
+      <column name="definition_fi">sohva, penkki, usean ihmisen tuoli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quS:n}</column>
@@ -11279,6 +12435,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11288,6 +12445,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sofa</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11295,6 +12453,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -11308,6 +12467,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">кристалл (геологическое формирование)</column>
       <column name="definition_zh_HK">水晶</column>
       <column name="definition_pt">cristal (formação geológica)</column>
+      <column name="definition_fi">kide (geologinen muodostelma)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naghboch:n}</column>
@@ -11318,6 +12478,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Cut", e.g., glass or diamond.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11327,6 +12488,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11334,6 +12496,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -11347,6 +12510,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">соль (кулинарная, галит) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鹽（煮食，鹽石） [AUTOTRANSLATED]</column>
       <column name="definition_pt">sal (culinária, halita)</column>
+      <column name="definition_fi">suola (ruoanlaitossa, vuorisuola)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11357,6 +12521,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">Это также иногда {Do'ol na':n@@Do'ol:n, na':v:1}, по-видимому, в зависимости от точной формы вещества. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有時也可能是{Do'ol na':n@@Do'ol:n, na':v:1}，大概取決於物質的確切形式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Às vezes, isso também é {Do'ol na':n@@Do'ol:n, na':v:1}, presumivelmente dependendo da forma exata da substância. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on myös joskus {Do'ol na':n@@Do'ol:n, na':v:1}, oletettavasti riippuen aineen tarkasta muodosta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qut:n}, {na':v:1}</column>
       <column name="examples"></column>
@@ -11366,6 +12531,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Do'ol na'</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11373,6 +12539,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -11386,6 +12553,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">предсказывать, прогнозировать</column>
       <column name="definition_zh_HK">預卜</column>
       <column name="definition_pt">prever</column>
+      <column name="definition_fi">ennustaa (viihteellisesti, taikauskoisesti)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'aq:v}, {ghut:v}</column>
@@ -11396,6 +12564,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">Относится к совершению предсказания, являющегося мошенническим или которое может таким быть, или если это карнавальное действо или что-то подобное этому (см. {ghIchDep:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指做出欺詐性或懷疑欺詐性的預測，或者是否為狂歡節之類的預測（請參閱{ghIchDep:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a fazer uma previsão que é fraudulenta ou suspeita de ser fraudulenta, ou se é um ato de carnaval ou algo semelhante (consulte {ghIchDep:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ennusteen tekemiseen, joka on petollinen tai epäillään petokseksi, tai jos se on karnevaaliteko tai vastaava (katso {ghIchDep:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">That is, this is a prediction made based on a crystal ({qut:n}) ball.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11405,6 +12574,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11412,6 +12582,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -11425,6 +12596,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">Катлютч (тип оружия)</column>
       <column name="definition_zh_HK">kut'luch、手持武器的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">kut'luch, tipo de arma de mão</column>
+      <column name="definition_fi">eräs teräase, kut'luch</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11435,6 +12607,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">Это оружие ассоциируется с наемными убийцами.</column>
       <column name="notes_zh_HK">該武器象徵性地與刺客聯繫在一起。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta arma está associada simbolicamente a assassinos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ase liittyy symbolisesti salamurhaajiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11444,6 +12617,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11451,6 +12625,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT:src}, [3] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -11464,6 +12639,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">иерархическая структура</column>
       <column name="definition_zh_HK">層次結構 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estrutura hierárquica</column>
+      <column name="definition_fi">hierarkinen rakenne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlham:n:2,slang}, {nugh:n}</column>
@@ -11474,6 +12650,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qutluch:n}, {patlh:n}</column>
       <column name="examples"></column>
@@ -11483,6 +12660,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11490,6 +12668,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.110:src}</column>
     </table>
     <table name="mem">
@@ -11503,6 +12682,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">Церемония катлютч</column>
       <column name="definition_zh_HK">Kut'luch儀式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Cerimônia de Kut'luch</column>
+      <column name="definition_fi">Kut'luch-seremonia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qutluch:n}, {tay:n:2}</column>
@@ -11513,6 +12693,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru">Церемония, в которой молодой Клингон в первый раз проливает кровь.[1, p.62]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta é uma cerimônia em que um jovem Klingon tira sangue pela primeira vez.[1, p.62] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on seremonia, jossa nuori klingon imee verta ensimmäistä kertaa.[1, p.62] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qutluch:n}, {tay:n:2}</column>
       <column name="examples"></column>
@@ -11522,6 +12703,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11529,6 +12711,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -11542,6 +12725,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">быть дешевым, быть недорогим</column>
       <column name="definition_zh_HK">便宜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser barato</column>
+      <column name="definition_fi">olla halpa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wagh:v}</column>
       <column name="see_also"></column>
@@ -11552,6 +12736,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11561,6 +12746,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11568,6 +12754,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -11581,6 +12768,7 @@ Esta palavra não pode ser usada para um buraco no chão (para o qual consulte {
       <column name="definition_ru">честь</column>
       <column name="definition_zh_HK">榮譽</column>
       <column name="definition_pt">honra</column>
+      <column name="definition_fi">(henkilökohtainen) kunnia</column>
       <column name="synonyms"></column>
       <column name="antonyms">{DavHam:n}, {chIvo':n}</column>
       <column name="see_also">{quv:v}</column>
@@ -11605,6 +12793,9 @@ Observera att {ghaj:v} och {Hutlh:v} kan användas med detta substantiv för att
       <column name="notes_pt">Esta palavra se refere à honra pessoal, que é conquistada pelo comportamento de alguém e pode ser concedida, em contraste com {batlh:n}.[2]
 
 Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo para indicar que alguém possui ou não honra, respectivamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa henkilökohtaiseen kunniaan, joka ansaitaan käyttäytymisellä ja joka voidaan antaa, toisin kuin {batlh:n}.[2]
+
+Huomaa, että {ghaj:v}: ta ja {Hutlh:v}: ää voidaan käyttää tämän substantiivin kanssa osoittamaan, että jollakin on kunnia tai häneltä puuttuu kunnia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -11616,6 +12807,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">honour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11623,6 +12815,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {HQ 12.3, p.9, Sept. 2003:src}, [3] {ENT - The Augments:src}, [4] {TKW p.59:src}</column>
     </table>
     <table name="mem">
@@ -11636,6 +12829,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="definition_ru">быть почтенным, быть почитаемым</column>
       <column name="definition_zh_HK">榮幸、可敬</column>
       <column name="definition_pt">ser honrado, ser honrável</column>
+      <column name="definition_fi">olla kunnioitettu, kunnioitettava, kunniallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{quvHa':v}</column>
       <column name="see_also">{batlh:adv}, {mIl:v}, {HoQ:v}, {Qaq:v}, {quv:n}</column>
@@ -11646,6 +12840,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="notes_ru">Было определено как "быть почтенным" в {TKDA:src}. Значение было расширенно в {HQ 12.3:src}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -11656,6 +12851,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be honoured, be honourable, be revered</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11663,6 +12859,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {HQ 12.3, p.8, Sept. 2003:src}</column>
     </table>
         <table name="mem">
@@ -11676,6 +12873,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="definition_ru">быть обесчещенным</column>
           <column name="definition_zh_HK">丟面子、被羞辱</column>
           <column name="definition_pt">ser desonrado</column>
+      <column name="definition_fi">olla häpäisty, häpeällinen, kunniaton</column>
           <column name="synonyms"></column>
           <column name="antonyms">{quv:v}</column>
           <column name="see_also">{ghe'tor:n}, {HoQ:v}, {mIl:v}, {Qaq:v}</column>
@@ -11686,6 +12884,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="notes_ru">Клингонский язык имеет много специфичных слов, чтобы описать бесчестие, которое зависит от обстоятельств. Если оказанная честь является незаслуженной, используйте {HoQ:v}. Если бесчестие включает в себя обман о чьем-то социальном статусе, используйте {Qaq:v}. Если бесчестие включает в себя грешение, используйте {mIl:v}.</column>
           <column name="notes_zh_HK">克林崗語有更多具體的詞來描述不誠實，這取決於不誠實的情況。如果支付給某人的榮譽是不值得或不應得到的，請考慮{HoQ:v}。如果不誠實涉及欺騙某人的社會地位，請考慮{Qaq:v}。如果涉及從恩典中墮落，請考慮{mIl:v}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Klingon tem palavras mais específicas para descrever desonra, que dependem das circunstâncias da desonra. Se a honra prestada a alguém não for merecida ou merecida, considere {HoQ:v}. Se a desonra envolver enganos sobre o status social de alguém, considere {Qaq:v}. Se envolver uma queda da graça, considere {mIl:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonilla on tarkempia sanoja kuvaamaan häpeää, jotka riippuvat häpeän olosuhteista. Jos jollekin maksettu kunnia on ansaitsematon tai ansaitsematon, harkitse {HoQ:v}. Jos häpeään liittyy petos henkilön sosiaalisesta asemasta, ota huomioon {Qaq:v}. Jos siihen liittyy lankeaminen armosta, harkitse {mIl:v}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{quv:v}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -11695,6 +12894,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">be dishonoured</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -11702,6 +12902,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}, [2] {HQ 12.3, Sept. 2003:src}</column>
         </table>
         <table name="mem">
@@ -11715,6 +12916,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="definition_ru">бесчестие</column>
           <column name="definition_zh_HK">羞辱 [AUTOTRANSLATED]</column>
           <column name="definition_pt">desonra</column>
+      <column name="definition_fi">häpeä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -11725,6 +12927,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{quv:v}, {-Ha':v}, {-ghach:v}</column>
           <column name="examples"></column>
@@ -11734,6 +12937,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">dishonour</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -11741,6 +12945,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -11754,6 +12959,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="definition_ru">полоса неудач</column>
           <column name="definition_zh_HK">接二連三地失敗 [AUTOTRANSLATED]</column>
           <column name="definition_pt">série de derrotas</column>
+      <column name="definition_fi">tappioputki</column>
           <column name="synonyms">{lujwI' mIr:n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -11764,6 +12970,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{quvHa'ghach:n}, {mIr:n:2}</column>
           <column name="examples"></column>
@@ -11773,6 +12980,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -11780,6 +12988,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
         <table name="mem">
@@ -11793,6 +13002,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="definition_ru">чтить, почитать</column>
           <column name="definition_zh_HK">榮譽 [AUTOTRANSLATED]</column>
           <column name="definition_pt">honrar</column>
+      <column name="definition_fi">kunnioittaa</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{vuv:v}</column>
@@ -11803,6 +13013,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="notes_ru">Это просто {quv:v} плюс суффикс {-moH:v}, поэтому суффиксы глаголов типов 1–3 должны идти перед {-moH:v}, тип 4. Но это правило иногда нарушается для риторического эффекта.[2] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這只是{quv:v}加上後綴{-moH:v}，因此類型1到3的動詞後綴需要放在{-moH:v}（即類型4）之前。但是，出於修辭效果，有時會打破此規則。[2] [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso é simplesmente {quv:v} mais o sufixo {-moH:v}; portanto, os sufixos verbais dos tipos 1 a 3 precisam passar antes de {-moH:v}, que é do tipo 4. No entanto, às vezes, essa regra é quebrada para efeito retórico.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksinkertaisesti {quv:v} plus loppuliite {-moH:v}, joten tyyppien 1–3 verbiliitteiden on mentävä ennen {-moH:v}-tyyppiä, joka on tyyppi 4. Tämä sääntö kuitenkin joskus rikkoutuu retorisen vaikutuksen vuoksi.[2] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{quv:n}, {-moH:v}</column>
           <column name="examples"></column>
@@ -11812,6 +13023,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">honour, revere</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -11819,6 +13031,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKDA:src}, [2] {msn 1997.11.30:src} (repeated in {s.k 1998.02.23:src})</column>
         </table>
         <table name="mem">
@@ -11832,6 +13045,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="definition_ru">показ чести [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">榮譽展示 [AUTOTRANSLATED]</column>
           <column name="definition_pt">exibição de honra</column>
+      <column name="definition_fi">kunnianäyttely?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{betleH bey':n}, {nuH bey':n}</column>
@@ -11842,6 +13056,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="notes_ru">{quv bey':n:nolink} имеет два {betleH:n} и два {Daqtagh:n}. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">{quv bey':n:nolink}具有兩個{betleH:n}和兩個{Daqtagh:n}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Um {quv bey':n:nolink} possui dois {betleH:n} e dois {Daqtagh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{quv bey':n:nolink}: llä on kaksi {betleH:n} ja kaksi {Daqtagh:n}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{quv:n}, {bey':n}</column>
           <column name="examples"></column>
@@ -11851,6 +13066,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">honour display</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -11858,6 +13074,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KCD:src}</column>
         </table>
         <table name="mem">
@@ -11871,6 +13088,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="definition_ru">Клингон, убивающий не открывая своего лица, не имеет чести</column>
           <column name="definition_zh_HK">沒有露臉的克林崗人沒有榮譽。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">O klingon que mata sem mostrar o rosto não tem honra.</column>
+      <column name="definition_fi">Klingonilla, joka tappaa näyttämättä kasvojaan, ei ole kunniaa.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -11881,6 +13099,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{quv:n}, {Hutlh:v}, {HoH:v}, {-bogh:v}, {tlhIngan:n}, {'ach:conj}, {qab:n}, {-Daj:n}, {'ang:v}, {-be':v}, {-bogh:v}</column>
           <column name="examples"></column>
@@ -11890,6 +13109,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">The Klingon who kills without showing his face has no honour.</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -11897,6 +13117,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.59:src}</column>
         </table>
     <table name="mem">
@@ -11910,6 +13131,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="definition_ru">Кувамаг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">庫瓦瑪格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kuvah'magh</column>
+      <column name="definition_fi">Kuvah'magh</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11920,6 +13142,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta é uma figura salvadora que é venerada por uma minoria religiosa de Klingons que viajaram para o Quadrante Delta.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on pelastushahmo, jota kunnioittaa Delta-kvadranttiin matkustanut klingonilaisten uskonnollinen vähemmistö.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11929,6 +13152,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11936,6 +13160,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}, [2] {VOY - Prophecy:src}</column>
     </table>
     <table name="mem">
@@ -11949,6 +13174,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="definition_ru">привычка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">習慣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">hábito</column>
+      <column name="definition_fi">tapa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{roD:adv}</column>
@@ -11959,6 +13185,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11968,6 +13195,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11975,6 +13203,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -11988,6 +13217,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="definition_ru">Кварк</column>
       <column name="definition_zh_HK">夸克 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quark</column>
+      <column name="definition_fi">Quark</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{verengan:n}, {chom:n}, {logh Hop Hut tengchaH:n}</column>
@@ -11998,6 +13228,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="notes_ru">Имя бармена-ференги на космической станции Федерации Глубокий космос 9.</column>
       <column name="notes_zh_HK">這是聯邦空間站“深空九號”中的Ferengi調酒師的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome do barman Ferengi na estação espacial da Federação Deep Space Nine. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Ferengi-baarimikon nimi Federaation avaruusasemalla Deep Space Nine. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -12009,6 +13240,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
 ▶ {quwargh tach Qe' je qoDDaq Hov leng Soj DatIv.:sen@@quwargh:n, tach:n, Qe':n, je:conj, qoD:n, -Daq:n, Hov leng:n, Soj:n:1, Da-:v, tIv:v} "Наслаждайся Стар Трековской тематической едой и напиткамив баре у Кварка и ресторане."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -12016,6 +13248,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek The Experience:src}</column>
     </table>
     <table name="mem">
@@ -12029,6 +13262,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="definition_ru">рвотное [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嘔吐 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vômito</column>
+      <column name="definition_fi">oksentaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'em:v}, {HuH:n}</column>
@@ -12039,6 +13273,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Note that the reverse, {pI'yuq:sen:nolink}, is phonetically "puke".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -12048,6 +13283,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -12055,6 +13291,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -12068,6 +13305,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="definition_ru">быть свирепым, быть лютым, быть неистовым</column>
       <column name="definition_zh_HK">很兇 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser feroz</column>
+      <column name="definition_fi">olla raivokas, hurja, raju, kiihkeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -12078,6 +13316,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="notes_ru">Глагол применяется только к людям или животным. Когда его применяют к чему-то другому, это больше похоже на сленг (см {qu':v:2}).[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esse verbo normalmente é aplicado apenas a pessoas ou animais. Quando aplicado a algo que não seja uma pessoa ou um animal, é provável que seu significado de gíria (consulte {qu':v:2}) seja intencional.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään tyypillisesti vain ihmisiin tai eläimiin. Kun sitä käytetään mihinkään muuhun kuin henkilöön tai eläimeen, on todennäköistä, että sen slangi-merkitys (ks.{qu':v:2}) on tarkoitettu.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -12087,6 +13326,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -12094,6 +13334,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.159:src}</column>
     </table>
     <table name="mem">
@@ -12107,6 +13348,7 @@ Observe que {ghaj:v} e {Hutlh:v} podem ser usados ​​com este substantivo par
       <column name="definition_ru">будь великим, будь прекрасным, будь отличным, будь великолепным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勁、精彩、屈機</column>
       <column name="definition_pt">ser ótimo, ser maravilhoso, ser excelente, ser esplêndido</column>
+      <column name="definition_fi">olla hieno, olla ihana, olla erinomainen, olla upea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dun:v}, {pov:v}, {chong:v:2}, {vIl:v:2}</column>
@@ -12123,6 +13365,9 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kun tätä verbiä sovelletaan henkilöön tai eläimeen, ei ole aina selvää, onko slangi vai kirjaimellinen merkitys (katso {qu':v:1}) tarkoitettu. Slangin merkitys on kuitenkin todennäköisempi, kun sitä käytetään johonkin muuhun kuin henkilöön tai eläimeen.
+
+Kaksi muodin ulkopuolista slangisanaa, joilla on sama merkitys, ovat {Huv:v:2,slang} ja {nong:v:2,slang}, joista jälkimmäinen saattaa palata takaisin.[1, p.159][1, p.161] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -12132,6 +13377,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -12139,6 +13385,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -12152,6 +13399,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="definition_ru">Курилл прайм</column>
       <column name="definition_zh_HK">Kurill Prime [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kurill Prime</column>
+      <column name="definition_fi">Kurill I</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -12162,6 +13410,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="notes_ru">Планета в гамма-квадранте</column>
       <column name="notes_zh_HK">伽瑪象限中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta no quadrante gama. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Gamma-kvadrantissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -12171,6 +13420,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -12178,6 +13428,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -12191,6 +13442,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="definition_ru">тетраэдр</column>
       <column name="definition_zh_HK">四面體 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tetraedro</column>
+      <column name="definition_fi">tetraedri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -12201,6 +13453,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="notes_ru">Геометрическая пирамида ({'Impey':n}) с трехсторонним основанием ({ra'Duch:n}).</column>
       <column name="notes_zh_HK">這是一個具有三面底面（{ra'Duch:n}）的幾何金字塔（{'Impey':n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on geometrinen pyramidi ({'Impey':n}), jossa on kolmepuolinen pohja ({ra'Duch:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Khufu", also known as Cheops, is the Egyptian pharaoh generally thought to have built the Great Pyramid of Giza.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -12210,6 +13463,7 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pyramid</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -12217,5 +13471,6 @@ Två moderna slangord med samma betydelse är {Huv:v:2,slang} och {nong:v:2,slan
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>

--- a/mem-12-q.xml
+++ b/mem-12-q.xml
@@ -2758,7 +2758,7 @@ In British English, this word refers to what would be called a "trapezium".</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
-      <column name="notes_fi">{qaSuj'a '?: sen: nolink} on tapa, jolla esität kysymyksen, jos puhut vain yhdelle henkilölle. Jos haluat kysyä ihmisryhmältä, häiritsetkö heitä, sano {SaSuj'a '?: Sen: nolink} "Häiritsenko sinua (monikko)?"{qaSuj'a'?:sen:nolink}{SaSuj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{qaSuj'a'?:sen:nolink} on tapa, jolla esität kysymyksen, jos puhut vain yhdelle henkilölle. Jos haluat kysyä ihmisryhmältä, häiritsetkö heitä, sano {SaSuj'a'?:sen:nolink} "Häiritsenko sinua (monikko)?" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7896,7 +7896,7 @@ Maltz näytti haluttomalta puhua mitä tämä oikein on[3][2] [AUTOTRANSLATED]</
       <column name="notes_ru">У клингонов нет эвфемизмов для посещения ванной комнаты, и они просто использовали бы {ghIm:v} с {turmIq:n}, {qeQ:n} или {taQbang:n:2}. Тем не менее, это сленговое выражение или идиома время от времени используется, хотя в основном (но вряд ли всегда) детьми. Можно спросить у нервного ребенка {belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n} Большинство людей говорят {qIvon:n}, но некоторые говорят {qIvonDu':n@@qIvon:n, -Du':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗人沒有上廁所的委婉說法，只會將{ghIm:v}與{turmIq:n}，{qeQ:n}或{taQbang:n:2}結合使用。但是，這種mostly語表達或習語有時會被孩子使用，儘管大多數（但並非總是如此）使用。有人可能會問一個緊張的孩子，{belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n}大多數人都說{qIvon:n}，但有些人則說{qIvonDu':n@@qIvon:n, -Du':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os klingons não têm eufemismos para ir ao banheiro e usariam {ghIm:v} com {turmIq:n}, {qeQ:n} ou {taQbang:n:2}. No entanto, essa expressão ou expressão de gíria é usada de tempos em tempos, embora principalmente (mas quase sempre) por ou para crianças. Pode-se perguntar a uma criança nervosa: {belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n} A maioria das pessoas diz {qIvon:n}, mas algumas dizem {qIvonDu':n@@qIvon:n, -Du':n}.[2] [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Klingoneilla ei ole eufemismejä käymällä vessassa, ja he käyttävät vain {ghIm:v}: tä {turmIq:n}: n, {qeQ:n}: n tai {taQbang:n:2}: n kanssa. Tätä slangilauseketta tai idiomia käytetään kuitenkin ajoittain, vaikkakin enimmäkseen (mutta tuskin aina) lapset tai lapsille. Voisi kysyä jittery-lapselta, {belHa''a 'qIvonlIj?: Sen @@ belHa': v, -'a ': v, qIvon: n, -lIj: n} Useimmat ihmiset sanovat {qIvon:n}, mutta jotkut sanovat {qIvonDu':n@@qIvon:n, -Du':n}.[2]{belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingoneilla ei ole eufemismejä käymällä vessassa, ja he käyttävät vain {ghIm:v}: tä {turmIq:n}: n, {qeQ:n}: n tai {taQbang:n:2}: n kanssa. Tätä slangilauseketta tai idiomia käytetään kuitenkin ajoittain, vaikkakin enimmäkseen (mutta tuskin aina) lapset tai lapsille. Voisi kysyä jittery-lapselta, {belHa''a' qIvonlIj?:sen@@belHa':v, -'a':v, qIvon:n, -lIj:n} Useimmat ihmiset sanovat {qIvon:n}, mutta jotkut sanovat {qIvonDu':n@@qIvon:n, -Du':n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qIvon:n}, {bel:v}, {-moH:v}</column>
       <column name="examples">

--- a/mem-13-Q.xml
+++ b/mem-13-Q.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {Q:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{Q:sen:nolink}</column>
       <column name="definition_pt">a consoante {Q:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {Q:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">Тераген</column>
       <column name="definition_zh_HK">theragen [AUTOTRANSLATED]</column>
       <column name="definition_pt">theragen</column>
+      <column name="definition_fi">terageeni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">владеть или качаться (оружие) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">使用或揮動（武器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">empunhar ou balançar (uma arma)</column>
+      <column name="definition_fi">kantaa tai heiluttaa (asetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chaQ:v}</column>
       <column name="see_also">{'obmaQ:n}, {'aqleH:n}, {jeqqIj:n}, {Henjun:n}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">此動詞用於揮舞或揮動斧頭，棍棒等。[1, p.64]也可以應用於{betleH:n}[2]或whip[3]。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo é usado para empunhar ou balançar um machado, uma clava ou algo semelhante.[1, p.64] Também pode ser aplicado a um {betleH:n}[2] ou whip[3]. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään kirvesen, keppiä tai vastaavien heiluttamiseen tai heiluttamiseen.[1, p.64] Sitä voidaan käyttää myös {betleH:n}[2]- tai whip[3]-piikkeihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Crutch".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {paq'batlh p.158-159:src}, [3] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">быть сухим, быть высушенным, быть высохшим</column>
       <column name="definition_zh_HK">乾燥</column>
       <column name="definition_pt">ser seco, secar</column>
+      <column name="definition_fi">olla kuiva, olla kuivunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{char:v}, {yIQ:v}, {DeH:v}, {QaD:v:2}</column>
@@ -136,6 +149,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined as "be dry" in {TKD:src}, while {KGT:src} extends this with "be dried out".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -145,6 +159,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -152,6 +167,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -165,6 +181,7 @@
       <column name="definition_ru">быть в безопасности, быть защищенным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">安全、受到保護 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser seguro, ser protegido</column>
+      <column name="definition_fi">olla turvallinen, olla suojattu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wun:v}</column>
       <column name="see_also">{QaD:v:1}, {lulIgh:n}</column>
@@ -175,6 +192,7 @@
       <column name="notes_ru">Это чувство {QaD:v:2,nolink} происходит от его сходства с {Qan:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{QaD:v:2,nolink}的這種感覺來自與{Qan:v}的相似之處。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este sentido de {QaD:v:2,nolink} vem de sua semelhança com {Qan:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tunne {QaD:v:2,nolink} tulee sen samankaltaisuudesta {Qan:v}: n kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -184,6 +202,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -191,6 +210,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -204,6 +224,7 @@
       <column name="definition_ru">полотенце</column>
       <column name="definition_zh_HK">毛巾</column>
       <column name="definition_pt">toalha</column>
+      <column name="definition_fi">pyyhe</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -214,6 +235,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{QaD:v:1}, {-moH:v}, {-wI':v}, {DIr:n}</column>
       <column name="examples"></column>
@@ -223,6 +245,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -230,6 +253,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -243,6 +267,7 @@
       <column name="definition_ru">ошибка, отклонение, огрех, недоразумение, заблуждение</column>
       <column name="definition_zh_HK">錯誤</column>
       <column name="definition_pt">erro, falha</column>
+      <column name="definition_fi">virhe, erehdys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qagh:v}</column>
@@ -253,6 +278,7 @@
       <column name="notes_ru">Это также может использоваться, чтобы упомянуть о баге(ошибке в программе)[2]</column>
       <column name="notes_zh_HK">這也可以用來指代軟件“錯誤”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser usado para se referir a um "bug" do software.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää myös viittaamaan ohjelmistovirheeseen .[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -262,6 +288,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bug</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -269,6 +296,7 @@
       <column name="search_tags_ru">баг</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -282,6 +310,7 @@
       <column name="definition_ru">ошибаться, заблуждаться, совершать ошибку, совершить ошибку</column>
       <column name="definition_zh_HK">做錯、錯誤、弄錯</column>
       <column name="definition_pt">errar, estar enganado, cometer um erro</column>
+      <column name="definition_fi">erehtyä, tehdä virhe</column>
       <column name="synonyms">{bachHa':v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{Qagh:n}, {muj:v}, {bIQ ngaS HIvje'.:sen}</column>
@@ -292,6 +321,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -301,6 +331,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -308,6 +339,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -321,6 +353,7 @@
       <column name="definition_ru">Имей мужество признать свои ошибки</column>
       <column name="definition_zh_HK">有勇氣承認自己的錯誤。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Tenha a coragem de admitir seus erros.</column>
+      <column name="definition_fi">Ole rohkea ja myönnä virheesi!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -331,6 +364,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -340,6 +374,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -347,6 +382,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.212:src}</column>
     </table>
     <table name="mem">
@@ -360,6 +396,7 @@
       <column name="definition_ru">помогать, способствовать, оказывать помощь, подсобить, оказывать поддержку</column>
       <column name="definition_zh_HK">幫助</column>
       <column name="definition_pt">ajudar, auxiliar, socorrer</column>
+      <column name="definition_fi">auttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sot:v}, {QaH:n}, {vuy:v}</column>
@@ -370,6 +407,7 @@
       <column name="notes_ru">Используется в ситуациях, где персона нуждается в помощи, не будучи в состоянии сделать что-либо, что должно быть сделано, без оказания помощи, в отличии от {boQ:v}. Объект {QaH:v:nolink} не может завершить задачу в одиночку, так что ответственность падает на субъект (или делится поровну). Нет ничего предосудительного в просьбе о {QaH:v:nolink} когда она гарантирована, но предложение о {QaH:v:nolink} когда ожидается {boQ:v:nolink} может иногда быть мягким оскорблением.[2]</column>
       <column name="notes_zh_HK">與{boQ:v}相反，這種方法將用於需要幫助的人在沒有幫助的情況下無法做任何事情的情況下。 {QaH:v:nolink}的對象無法單獨執行任務，因此責任落在主題上（或由它承擔）。在有擔保的情況下索要{QaH:v:nolink}並沒有什麼弱點，但在預期{boQ:v:nolink}出現時向{QaH:v:nolink}提出的報價有時可能會有點侮辱。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso seria usado em situações em que a pessoa que precisa de ajuda não pode fazer o que for necessário sem assistência, em contraste com o {boQ:v}. O objeto {QaH:v:nolink} não pode executar a tarefa sozinho, portanto a responsabilidade recai sobre o assunto (ou é compartilhado). Não há nada fraco em pedir {QaH:v:nolink} quando justificado, mas uma oferta para {QaH:v:nolink} quando {boQ:v:nolink} é esperado às vezes pode ser um pouco ofensiva.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytettäisiin tilanteissa, joissa apua tarvitseva henkilö ei voi tehdä mitä tarvitsee tehdä ilman apua, toisin kuin {boQ:v}. {QaH:v:nolink}-objekti ei voi suorittaa tehtävää yksin, joten vastuu kuuluu aiheeseen (tai se on jaettu). {QaH:v:nolink}: n pyytämisessä ei ole mitään heikkoa, kun se on perusteltua, mutta tarjous {QaH:v:nolink}: lle, kun {boQ:v:nolink}: ää odotetaan, voi joskus olla lievästi loukkaavaa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -379,6 +417,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -386,6 +425,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2017.10.10:src}</column>
     </table>
     <table name="mem">
@@ -399,6 +439,7 @@
       <column name="definition_ru">помощь, содействие, подсказка, подмога</column>
       <column name="definition_zh_HK">幫幫我 [AUTOTRANSLATED]</column>
       <column name="definition_pt">socorro, ajuda</column>
+      <column name="definition_fi">apu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boQ:n:2}, {QaH:v}</column>
@@ -409,6 +450,7 @@
       <column name="notes_ru">Для помощи в использовании этой программы смотрите {boQwI':n}.</column>
       <column name="notes_zh_HK">有關使用該程序的幫助，請參閱{boQwI':n}下的內容。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para obter ajuda sobre o uso deste programa, consulte {boQwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Lisätietoja tämän ohjelman käytöstä on kohdassa {boQwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -418,6 +460,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -425,6 +468,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -438,6 +482,7 @@
       <column name="definition_ru">Крадж(тип животного)</column>
       <column name="definition_zh_HK">動物的類型、kradge [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, kradge</column>
+      <column name="definition_fi">eräs eläin, kradge</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -460,6 +505,9 @@ Förväxla inte detta med liknande namn {qa'raj:n}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um kradge tem lábios castanhos. A expressão {Doq 'ej Qaj wuS rur:sen} é usada para descrever um objeto que é um tom particular de marrom (ver {Doq 'ej wovbe':sen}) .[2]
 
 Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kradge on ruskeat huulet. Ilmaisua {Doq 'ej Qaj wuS rur:sen} käytetään kuvaamaan kohdetta, joka on tietty ruskea sävy (katso {Doq 'ej wovbe':sen}).
+
+Älä sekoita tätä vastaavasti nimettyyn {qa'raj:n}: ään.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -469,6 +517,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">brown, brown-colour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -476,6 +525,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru">коричневый</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {s.k 1998.02.21:src} (reprinted in {HQ 8.1, p.7, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -489,6 +539,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">хвост краджа</column>
       <column name="definition_zh_HK">食物類型、kradge尾巴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de alimento, rabo de kradge</column>
+      <column name="definition_fi">eräs ruokalaji, kradgen häntä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -499,6 +550,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -508,6 +560,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -515,6 +568,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -528,6 +582,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">плавать, плыть, проплывать, переплывать</column>
       <column name="definition_zh_HK">游泳 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nadar</column>
+      <column name="definition_fi">uida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaH:v:1}, {yIQ:v}, {'oq:v}, {luS:v}</column>
@@ -538,6 +593,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Crawl".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -547,6 +603,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -554,6 +611,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -567,6 +625,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">плавательный бассеин</column>
       <column name="definition_zh_HK">游泳池</column>
       <column name="definition_pt">piscina</column>
+      <column name="definition_fi">uima-allas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Say'moHmeH DoQmIv'a':n}</column>
@@ -577,6 +636,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qal:v}, {-meH:v}, {DoQmIv'a':n}</column>
       <column name="examples"></column>
@@ -586,6 +646,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -593,6 +654,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -606,6 +668,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">стоять [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">企</column>
       <column name="definition_pt">ficar de pé</column>
+      <column name="definition_fi">seistä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ba':v}, {Hu':v}, {Qot:v}, {tor:v:1}, {'uS:n}, {qam:n}</column>
@@ -616,6 +679,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru">стоять, устоять, вынести, держаться, простаивать</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -625,6 +689,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -632,6 +697,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -645,6 +711,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">Лучше умереть стоя, чем жить на коленях</column>
       <column name="definition_zh_HK">就算是死也比委曲求全要好。</column>
       <column name="definition_pt">Melhor morrer de pé do que viver de joelhos.</column>
+      <column name="definition_fi">On parempi kuolla seisten kuin elää polvillaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -655,6 +722,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qam:v}, {-vIS:v}, {Hegh:n}, {qaq:v}, {... law':sen}, {tor:v:1}, {-vIS:v}, {yIn:n}, {qaq:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -664,6 +732,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -671,6 +740,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.95:src}, [2] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -684,6 +754,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">защищать, охранять, беречь, оберегать, покровительствовать, предохранять</column>
       <column name="definition_zh_HK">保護</column>
       <column name="definition_pt">proteger</column>
+      <column name="definition_fi">suojella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hub:v}, {QaD:v:2}, {wun:v}, {lulIgh:n}</column>
@@ -694,6 +765,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{Qang yIQan!:sen}</column>
@@ -703,6 +775,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -710,6 +783,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -723,6 +797,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">канцлер</column>
       <column name="definition_zh_HK">總理</column>
       <column name="definition_pt">chanceler</column>
+      <column name="definition_fi">kansleri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yan 'ISletlh:n}, {ta':n:2}, {voDleH:n}, {la'quv:n}</column>
@@ -733,6 +808,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru">Титул правителя Клингонской империи, когда ей перестал править Император.</column>
       <column name="notes_zh_HK">這是克林崗帝國領導人的頭銜，當時它不是由皇帝統治的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o título do líder do Império Klingon, quando não é governado por um imperador. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Klingonin imperiumin johtajan titteli, kun sitä ei hallitse keisari. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{Qang yIQan!:sen}</column>
@@ -742,6 +818,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">president</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -749,6 +826,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru">президент</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -762,6 +840,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">работать, трудиться, функционировать, выполнять функции, преуспеть, победить, добиться успеха</column>
       <column name="definition_zh_HK">工作、功能、成功、勝利</column>
       <column name="definition_pt">trabalhar, funcionar, ter sucesso, ganhar</column>
+      <column name="definition_fi">toimia (laitteesta tms.); onnistua, menestyä, voittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{luj:v}</column>
       <column name="see_also">{vum:v}, {baj:v}, {yay:n:2}, {'ov:v}, {Qapla':n}, {Qap:v:2}</column>
@@ -772,6 +851,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru">"Чтобы победить" в соревновании, подойдет {Qap:v:nolink}. Если победа решительна или частично удовлетворительна, то используется выражение {Qapchu':v:nolink}, даже если оно немного избыточное.[4]</column>
       <column name="notes_zh_HK">“取勝”競賽是{Qap:v:nolink}。如果勝利是決定性的或特別令人滿意的，則使用{Qapchu':v:nolink}表達式，即使它有點多餘。[4] [AUTOTRANSLATED]</column>
       <column name="notes_pt">"Ganhar" uma competição é {Qap:v:nolink}. Se a vitória for decisiva ou particularmente gratificante, a expressão {Qapchu':v:nolink} será usada, mesmo que seja um pouco redundante.[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kilpailun "voittaminen" on {Qap:v:nolink}. Jos voitto on ratkaiseva tai erityisen ilahduttava, käytetään ilmaisua {Qapchu':v:nolink}, vaikka se olisikin hieman tarpeeton.[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined in {TKD:src} as "work, function, succeed", and in {KGT:src} as "win" and "operate, be in operation" (two separate entries). The "succeed" and "win" meanings are elaborated upon in {TKW:src}. In {HQ 2.4:src}, it is explained that to Klingons, to win is to function perfectly.</column>
       <column name="components"></column>
       <column name="examples">
@@ -785,6 +865,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
 ▶ {qeylIS 'etlh Datlhapqa' 'e' DaQapbe'.:sen:nolink} "Потерпел неудачу при попытке возврата Меча Кейлесса."[5]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -792,6 +873,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {TKW:src}, [4] {HQ 2.4, p.18, Dec. 1993:src}, [5] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -805,6 +887,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">работать, быть в эксплуатации [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">操作、運作 [AUTOTRANSLATED]</column>
       <column name="definition_pt">operar, estar em operação</column>
+      <column name="definition_fi">olla toiminnassa, olla käytössä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qap:v:1}</column>
@@ -815,6 +898,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -824,6 +908,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -831,6 +916,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
         <table name="mem">
@@ -844,6 +930,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="definition_ru">Гравитация работает. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">重力工作。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Gravidade funciona.</column>
+      <column name="definition_fi">Painovoima toimii.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -854,6 +941,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="notes_ru">Это означает, что гравитация делает свою работу, независимо от того, что гравитация должна делать. То есть оно выражает что-то вроде «что должно было случиться». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這意味著萬有引力正在做自己的工作，無論萬有引力應該做。也就是說，它表示類似“應該發生”的內容。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso significa que a gravidade está fazendo seu trabalho, seja o que for que a gravidade deva fazer. Ou seja, expressa algo como "isso deveria acontecer". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa sitä, että painovoima tekee työnsä, mitä tahansa painovoiman pitäisi tehdä. Toisin sanoen se ilmaisee jotain sellaista kuin "sen piti tapahtua". [AUTOTRANSLATED]</column>
           <column name="hidden_notes">This was the winning replacement proverb entry, submitted by Alan Anderson ({ghunchu'wI':n:name,nolink}), in the proverbs competition at {qep'a' 25 (2018):src}.</column>
           <column name="components">{Qap:v:1}, {tlham:n:1}</column>
           <column name="examples"></column>
@@ -863,6 +951,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">replacement proverb</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -870,6 +959,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
         <table name="mem">
@@ -883,6 +973,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="definition_ru">рабочий диапазон [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">（射擊）有效範圍</column>
           <column name="definition_pt">alcance efetivo</column>
+      <column name="definition_fi">toimintasäde</column>
           <column name="synonyms">{bachlu'meH chuq:n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -893,6 +984,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Qap:v:2}, {-chu':v}, {-meH:v}, {chuq:n}</column>
           <column name="examples">
@@ -903,6 +995,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -910,6 +1003,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -923,6 +1017,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="definition_ru">череда побед [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">連勝 [AUTOTRANSLATED]</column>
           <column name="definition_pt">série de vitórias</column>
+      <column name="definition_fi">voittoputki</column>
           <column name="synonyms">{yay mIr:n}</column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -933,6 +1028,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="notes_ru">Это менее распространенный способ сказать это. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是不太常見的說法。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esta é a maneira menos comum de dizer isso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on harvinaisempi tapa sanoa tämä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Qap:v:1}, {-wI':v}, {mIr:n:2}</column>
           <column name="examples"></column>
@@ -942,6 +1038,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -949,6 +1046,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
     <table name="mem">
@@ -962,6 +1060,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">Успех</column>
       <column name="definition_zh_HK">成功、勝利</column>
       <column name="definition_pt">sucesso</column>
+      <column name="definition_fi">menestys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qap:v:1}</column>
@@ -972,6 +1071,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="notes_ru">Это слово используется как восклицательный знак, означающий добрые пожелания, когда кто-то отправляется на миссию. Смотрите {Qapla'!:sen}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞用作感嘆號，表示有人去執行任務時的良好祝愿。參見{Qapla'!:sen}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada como uma exclamação indicando bons desejos quando alguém está partindo para uma missão. Consulte {Qapla'!:sen}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään onnentoivotuksena jollekulle, joka on lähdössä suorittamaan tehtävää. Katso {Qapla'!:sen}.</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -981,6 +1081,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -988,6 +1089,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1002,6 +1104,7 @@ Não confunda isso com o {qa'raj:n} de nome semelhante. [AUTOTRANSLATED]</column
       <column name="definition_ru">Успех!</column>
       <column name="definition_zh_HK">成功！</column>
       <column name="definition_pt">Sucesso!</column>
+      <column name="definition_fi">Menestystä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qapla':n}, {pItlh:excl}, {povjaj!:excl}</column>
@@ -1040,6 +1143,11 @@ Se en lektion om detta ord: {YouTube video:url:http://youtu.be/auqS6FR_RDE} [AUT
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/ZdNqwDxEyiU}
 
 Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auqS6FR_RDE} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksi Klingonin yleisimmin käytettyjä huutomerkkejä, jonka tunnistaa myös monet ei-puhuvat. Ole varovainen oikeinkirjoituksen suhteen, koska muut kuin klingonit sekoittavat sen usein.
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/ZdNqwDxEyiU}
+
+Katso oppitunti tästä sanasta: {YouTube video:url:http://youtu.be/auqS6FR_RDE} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Klingon version of this sentence has no exclamation mark as printed on {TKD p.171:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1049,6 +1157,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1056,6 +1165,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -1069,6 +1179,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="definition_ru">шпуля, катушка, шпиндель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">線軸，捲盤，主軸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">carretel, bobina, eixo</column>
+      <column name="definition_fi">rulla, kerä, käämi, kehrä, puola</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIrmoH:v:2}</column>
@@ -1079,6 +1190,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="notes_ru">Это относится к устройству, вокруг которого наматывается нить или провод. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指在其上纏繞線或線的設備。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um dispositivo em torno do qual fio ou fio é enrolado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa laitetta, jonka ympärille kierre tai lanka kierretään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1088,6 +1200,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1095,6 +1208,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1108,6 +1222,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="definition_ru">вести себя ложно честно, вести себя ложно честно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">表現得非常光榮、表現得非常光榮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comportar-se de forma falsamente honrosa</column>
+      <column name="definition_fi">käyttäytyä väärin kunniallisesti, teeskennellä kunniallista käytöstä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoQ:v}, {DavHam:n}, {quv:v}, {batlh:n}, {toj:v}, {quvHa':v}</column>
@@ -1118,6 +1233,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="notes_ru">Обман подразумевается использованием этого глагола. Однако он отличается от {toj:v} тем, что обман каким-то образом связан с честью или социальным статусом. Например, этот глагол может использоваться для кого-то, кто утверждал, что имел ранг, которого он не достиг, или был членом дома или семьи, к которой он не принадлежал. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">使用此動詞暗含欺騙。但是，它與{toj:v}的不同之處在於，欺騙在某種程度上涉及榮譽或社會地位。例如，該動詞可以用於聲稱自己沒有達到的等級的人，或者是他不屬於的房屋或家庭的成員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Decepção está implícita no uso deste verbo. No entanto, difere de {toj:v}, pois o engano envolve honra ou status social de alguma maneira. Por exemplo, esse verbo pode ser usado para alguém que afirma ter uma classificação que ele não havia atingido ou ser membro de uma casa ou família à qual não pertencia. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin käyttö merkitsee petosta. Se eroaa kuitenkin {toj:v}: stä siinä, että petokseen liittyy jollain tavalla kunnia tai sosiaalinen asema. Esimerkiksi tätä verbiä voidaan käyttää sellaisen henkilön kohdalla, joka väitti olevansa arvoltaan, jota hän ei ollut saavuttanut, tai olevan sellaisen talon tai perheen jäsen, johon hän ei kuulunut. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Crock".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1127,6 +1243,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">behave falsely honourably, behave in a falsely honourable manner</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1134,6 +1251,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, Sept. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1147,6 +1265,7 @@ Assista a uma lição sobre esta palavra: {YouTube video:url:http://youtu.be/auq
       <column name="definition_ru">быть хорошим, быть благим, быть доброкачественным, быть полезным, быть годным</column>
       <column name="definition_zh_HK">好</column>
       <column name="definition_pt">ser bom</column>
+      <column name="definition_fi">olla hyvä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qab:v}</column>
       <column name="see_also">{pov:v}</column>
@@ -1185,6 +1304,11 @@ För beskrivning av trevlig mat eller musik, se {'ey:v} och {DuQ:v:2}. [AUTOTRAN
 Para "bom" como uma exclamação que expressa satisfação, consulte {maj:excl}.
 
 Para descrever comida ou música agradável, consulte {'ey:v} e {DuQ:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on verbi (tai adjektiivi), joka tarkoittaa "olla hyvä". Esimerkkien perusteella se on mieluummin toivottavan laadun kuin siinä mielessä, ettei ole paha (ks.{mIgh:v}).
+
+Katso "hyvä" tyydytystä osoittavana huutomerkkinä artikkelista {maj:excl}.
+
+Jos haluat kuvailla nautittavaa ruokaa tai musiikkia, katso {'ey:v} ja {DuQ:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1198,6 +1322,7 @@ Para descrever comida ou música agradável, consulte {'ey:v} e {DuQ:v:2}. [AUTO
 ▶ {nuqDaq 'oH Qe' QaQ'e'?:sen} "Где хороший ресторан?"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1205,6 +1330,7 @@ Para descrever comida ou música agradável, consulte {'ey:v} e {DuQ:v:2}. [AUTO
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1218,6 +1344,7 @@ Para descrever comida ou música agradável, consulte {'ey:v} e {DuQ:v:2}. [AUTO
       <column name="definition_ru">трещина, щель, расщелина, борозда, излом, надлом</column>
       <column name="definition_zh_HK">裂縫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fissura</column>
+      <column name="definition_fi">halkeama</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Seq:n}, {Qom:v:1}</column>
@@ -1228,6 +1355,7 @@ Para descrever comida ou música agradável, consulte {'ey:v} e {DuQ:v:2}. [AUTO
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Crack".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1237,6 +1365,7 @@ Para descrever comida ou música agradável, consulte {'ey:v} e {DuQ:v:2}. [AUTO
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1244,6 +1373,7 @@ Para descrever comida ou música agradável, consulte {'ey:v} e {DuQ:v:2}. [AUTO
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1257,6 +1387,7 @@ Para descrever comida ou música agradável, consulte {'ey:v} e {DuQ:v:2}. [AUTO
       <column name="definition_ru">Войска</column>
       <column name="definition_zh_HK">軍隊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tropas</column>
+      <column name="definition_fi">(sota)joukot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{negh:n}, {yaS:n}</column>
@@ -1303,6 +1434,13 @@ I {Klingon Monopoly:src} är {tlhIngan QaS:n:nolink} den valutaenhet som använd
 É possível que esta palavra possa ser usada para se referir a um único membro da tropa.[2, p.51]
 
 Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada no jogo. Deste jogo, temos os exemplos {"GO" DajuSDI' cha'vatlh QaS yItlhap:sen:nolink} e {wa'vatlh QaS yItlhap:sen:nolink}. Observe que o prefixo singular {yI-:v} é usado mesmo que {QaS:n:1h,nolink} seja um substantivo inerentemente plural cujos membros estão sendo contados.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan merkitys on kuin {negh:n}, mutta se sulkee pois upseerit ({yaS:n}). {QaS:n:1h,nolink}: n korkeimmat rivit ovat:
+▶ {bu':n} "kersantti"
+▶ {Da':n} "korpraali"
+
+On mahdollista, että tätä sanaa voidaan käyttää viittaamaan yhteen joukkojen jäseneen.[2, p.51]
+
+Kohdassa {Klingon Monopoly:src} {tlhIngan QaS:n:nolink} on pelissä käytetty rahayksikkö. Tästä pelistä meillä on esimerkkejä {"GO" DajuSDI' cha'vatlh QaS yItlhap:sen:nolink} ja {wa'vatlh QaS yItlhap:sen:nolink}. Huomaa, että yksikön etuliitettä {yI-:v} käytetään, vaikka {QaS:n:1h,nolink} on luonnostaan ​​monikko-substantiivi, jonka jäseniä lasketaan.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mang:n}</column>
       <column name="examples"></column>
@@ -1312,6 +1450,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1319,6 +1458,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1332,6 +1472,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">Крас</column>
       <column name="definition_zh_HK">「嘉仕」</column>
       <column name="definition_pt">Kras</column>
+      <column name="definition_fi">Kras</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1342,6 +1483,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">Он появился в эпизоде {TOS - Friday's Child:src}.</column>
       <column name="notes_zh_HK">他出現在{TOS - Friday's Child:src}中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ele apareceu no episódio {TOS - Friday's Child:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän esiintyi jaksossa {TOS - Friday's Child:src}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1351,6 +1493,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1358,6 +1501,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 5.6:src}</column>
     </table>
     <table name="mem">
@@ -1371,6 +1515,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">быть популярным, быть широко известным, быть общедоступным</column>
       <column name="definition_zh_HK">流行、受歡迎</column>
       <column name="definition_pt">ser popular</column>
+      <column name="definition_fi">olla suosittu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1381,6 +1526,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1390,6 +1536,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1397,6 +1544,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1410,6 +1558,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">быть сложным, быть трудным, быть тяжелым, быть нелегким, быть затруднительным, быть комплексным, быть составным, быть запутанным</column>
       <column name="definition_zh_HK">很難、很複雜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser difícil, ser complexo</column>
+      <column name="definition_fi">olla vaikea, olla monimutkainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngeD:v}, {nap:v}</column>
       <column name="see_also"></column>
@@ -1420,6 +1569,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">Для слова "твердый" смотрите {let:v}. Смотрите также {ngem Sarghmey tlha':sen:idiom} для идиомы, которая отнесена к сложности или запутанности.</column>
       <column name="notes_zh_HK">有關“硬（非軟）”的信息，請參閱{let:v}。另請參閱{ngem Sarghmey tlha':sen:idiom}了解與難度或複雜性有關的成語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Katso "kova (ei pehmeä)" kohdasta {let:v}. Katso myös {ngem Sarghmey tlha':sen:idiom} vaikeuksiin tai monimutkaisuuteen liittyvästä idiomasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1435,6 +1585,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
   "В отличие от большинства судов Звездного флота, главный экран на Клингонском корабле обычно покрыт сложной прицельной сеткой."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1442,6 +1593,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {SkyBox 3:src}</column>
     </table>
     <table name="mem">
@@ -1455,6 +1607,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">быть последним, быть конечным, быть заключительным, быть окончательным, быть прошлым, быть крайним</column>
       <column name="definition_zh_HK">最後</column>
       <column name="definition_pt">ser final, último</column>
+      <column name="definition_fi">olla lopullinen, viimeinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wa'DIch:n}</column>
       <column name="see_also">{tagha':adv}, {HochDIch:n}, {natlIS:n}</column>
@@ -1465,6 +1618,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">В отличие от английского слова «последний», это означает «последний» и не означает «предыдущий» (который является {vorgh:v}) или «самый последний» (который является {ret:v}) .[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Diferente da palavra em inglês "last", significa "final" e não significa "previous" (que é {vorgh:v}) ou "mais recente" (que é {ret:v}) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toisin kuin englanninkielinen sana "last", tämä tarkoittaa "lopullista" eikä tarkoita "edellistä" (joka on {vorgh:v}) tai "viimeisintä" (joka on {ret:v}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1474,6 +1628,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1481,6 +1636,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1494,6 +1650,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">уничтожать, разрушать, губить, подрывать, истреблять, прикончить</column>
       <column name="definition_zh_HK">破壞</column>
       <column name="definition_pt">destruir</column>
+      <column name="definition_fi">tuhota</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pej:v}, {QIH:v:1}, {puy:v}, {Sang:v}</column>
@@ -1504,6 +1661,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is listed erroneously as a noun in {TKD:src} in both word lists, but is described as a verb on p.49. It is also used in {TKW:src} on p.211 as a verb.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1516,6 +1674,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1523,6 +1682,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1536,6 +1696,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">передавать, переводить, переносить, перемещать, транспортировать</column>
       <column name="definition_zh_HK">轉讓 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transferir</column>
+      <column name="definition_fi">siirtää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeng:v}, {lup:v}, {HIj:v}</column>
@@ -1546,6 +1707,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1558,6 +1720,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1565,6 +1728,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1578,6 +1742,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">потерять самообладание [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吹一個人的頂部、失去一個人的脾氣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">explodir, perder a paciência</column>
+      <column name="definition_fi">menettää malttinsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QeH:v}, {puQ:v}</column>
@@ -1588,6 +1753,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">Смотрите {Qay':v:2} для связанного идиоматического выражения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關相關的慣用語，請參閱{Qay':v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {Qay':v:2} para obter uma expressão idiomática relacionada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso aiheeseen liittyvä idiomaattinen ilme kohdasta {Qay':v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TKD:src} this is defined as "blow one's top".[1] In {HQ 10.2:src}, the additional definition "lose one's temper" was added for clarification.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1597,6 +1763,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1604,6 +1771,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 10.2, p.11, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1617,6 +1785,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">использовать маленький палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用小腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">usar o dedo mindinho do pé</column>
+      <column name="definition_fi">käyttää pikkuvarvasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qay':v:1}, {yaD:n:1}</column>
@@ -1627,6 +1796,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">Есть идиоматическое выражение {'oy'qu' Qay'wI'wIj.:sen}. Это буквально означает «у меня болит маленький палец», но в нем есть идиоматическое значение «Я очень зол». Выражение, несомненно, возникло из-за гомофонии между {Qay':v:2,nolink} «использовать маленький палец» и {Qay':v:1} «взорвать свою верхушку». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個慣用語表達{'oy'qu' Qay'wI'wIj.:sen}，字面意思是“我的小腳趾很疼”，但帶有慣用語“我非常生氣”。毫無疑問，這種表達是由於{Qay':v:2,nolink}“用小腳趾”和{Qay':v:1}“吹頂”之間的諧音而產生的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">On olemassa idiomaattinen ilmaus {'oy'qu' Qay'wI'wIj.:sen} Tämä tarkoittaa kirjaimellisesti "pieni varpaani kipeästi paljon", mutta sillä on idiomaattinen merkitys "olen erittäin vihainen". Ilmaisu syntyi epäilemättä {Qay':v:2,nolink}: n "käytä pientä varvasta" ja "{Qay':v:1}" "puhaltaa huipun" välillä olevan homofonian vuoksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">And this little piggy cried "wee wee wee" all the way home.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1636,6 +1806,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1643,6 +1814,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1656,6 +1828,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">маленький палец, пятый палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小腳趾、第五個腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dedinho do pé, quinto dedo do pé</column>
+      <column name="definition_fi">pikkuvarvas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaD:n:1}</column>
@@ -1666,6 +1839,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">And this little piggy cried wee wee wee all the way home.</column>
       <column name="components">{Qay':v:2}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1675,6 +1849,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1682,6 +1857,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1695,6 +1871,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">головоломка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">難題 [AUTOTRANSLATED]</column>
       <column name="definition_pt">enigma</column>
+      <column name="definition_fi">palapeli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngajrun:n}, {Qay'mol teSra':n}, {pan:v:2}</column>
@@ -1705,6 +1882,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">Это относится к физической головоломке, такой как мозаика или металлические обручи, которые необходимо распутать. То есть такая головоломка должна включать физический объект или объекты, которыми нужно манипулировать. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指物理拼圖，例如需要解開的拼圖遊戲或金屬箍。即，這種難題必須涉及必須操縱的一個或多個物理對象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um quebra-cabeça físico, como quebra-cabeças ou aros de metal que precisam ser desembaraçados. Ou seja, esse quebra-cabeça deve envolver um objeto físico ou objetos que devem ser manipulados. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa fyysiseen palapeliin, kuten palapeliin tai metallivanteisiin, jotka on purettava. Toisin sanoen tällaisessa palapelissä on oltava fyysinen esine tai esineitä, joita on käsiteltävä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1714,6 +1892,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1721,6 +1900,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -1734,6 +1914,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">кусок пазла [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">拼圖塊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">peça de quebra-cabeças</column>
+      <column name="definition_fi">palapelin pala</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nelchu':v}</column>
@@ -1744,6 +1925,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">Это относится к части головоломки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指一塊拼圖遊戲。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma peça de um quebra-cabeça. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa palapelin palaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Qay'mol:n}, {teSra':n}</column>
       <column name="examples"></column>
@@ -1753,6 +1935,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1760,6 +1943,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -1773,6 +1957,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">Тип животного</column>
       <column name="definition_zh_HK">動物的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal</column>
+      <column name="definition_fi">eräs eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qa'Hom:n}</column>
@@ -1783,6 +1968,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">Более конкретно, данное животное называется {jajlo' Qa':n}.[2]</column>
       <column name="notes_zh_HK">更具體地說，此動物稱為{jajlo' Qa':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Mais especificamente, este animal é chamado de {jajlo' Qa':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tarkemmin sanottuna tätä eläintä kutsutaan nimellä {jajlo' Qa':n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1792,6 +1978,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1799,6 +1986,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <!-- Note: {Qa':n:2} is in the "extra" section. -->
@@ -1813,6 +2001,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">Крада(тип животного)</column>
       <column name="definition_zh_HK">動物的類型、krada [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, krada</column>
+      <column name="definition_fi">eräs eläin, krada</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uS:n}</column>
@@ -1823,6 +2012,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="notes_ru">Ноги Крада являются популярным Клингонским блюдом. Делается из конечностей Крада.</column>
       <column name="notes_zh_HK">Krada腿是由Krada的末端製成的一種受歡迎的Klingon食品。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">As pernas de Krada são um alimento Klingon popular feito das extremidades de uma krada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Krada-jalat ovat suosittu klingoniruoka, joka on valmistettu kradan ääripäistä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1832,6 +2022,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1839,6 +2030,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -1852,6 +2044,7 @@ Em {Klingon Monopoly:src}, {tlhIngan QaS:n:nolink} é a unidade monetária usada
       <column name="definition_ru">тип животного (похож на {Qa':n:1}, но меньше) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型（類似於{Qa':n:1}、但更小） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal semelhante a um {Qa':n:1}, mas menor</column>
+      <column name="definition_fi">eräs eläin (kuin {Qa':n:1}, mutta pienempi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1874,6 +2067,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [AUTOTRAN
       <column name="notes_pt">Isso não faz barulho ao amanhecer, ao contrário do {jajlo' Qa':n}. É confundido com um pássaro por algum.[2]
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toisin kuin {jajlo' Qa':n}, tämä ei tee aamunkoittoa aamunkoitteessa. Jotkut erehtävät sitä lintuna.[2]
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears in the "Curses" section of the {KCD:src} Language Lab. In the introduction to the holodeck part of the game, it is used in a derogatory manner to describe someone who is weak and scares easily.[3]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1883,6 +2079,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1890,6 +2087,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 10.4, Dec. 2001:src}, [3] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -1903,6 +2101,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="definition_ru">{qa'raj:n}</column>
       <column name="definition_zh_HK">{qa'raj:n}</column>
       <column name="definition_pt">{qa'raj:n}</column>
+      <column name="definition_fi">{qa'raj:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1913,6 +2112,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1922,6 +2122,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1929,6 +2130,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1942,6 +2144,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="definition_ru">К'Ратак</column>
       <column name="definition_zh_HK">K'Ratak [AUTOTRANSLATED]</column>
       <column name="definition_pt">K'Ratak</column>
+      <column name="definition_fi">K'Ratak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1952,6 +2155,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="notes_ru">Это автор {qul naj:n}, который также написал комментарий к {qeS'a':n}. Является сыном М'Линда (смотрите {mI'lInnID:n:name}).</column>
       <column name="notes_zh_HK">這是{qul naj:n}的作者，他還對{qeS'a':n}發表了評論。他是M'Lind的兒子（請參閱{mI'lInnID:n:name}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o autor de {qul naj:n}, que também escreveu um comentário em {qeS'a':n}. Ele é filho de M'Lind (veja {mI'lInnID:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjoittaja {qul naj:n}, joka kirjoitti myös kommentin {qeS'a':n}: een. Hän on M'Lindin poika (ks.{mI'lInnID:n:name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1961,6 +2165,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1968,6 +2173,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNG - The Measure of a Man:src}, [2] {VOY - Author, Author:src}, [3] {The Klingon Art of War:src}, [4] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1981,6 +2187,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="definition_ru">кольцо (на палец)</column>
       <column name="definition_zh_HK">戒指（手指） [AUTOTRANSLATED]</column>
       <column name="definition_pt">anel (para dedo)</column>
+      <column name="definition_fi">sormus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh:n}, {Qeb:n:2}</column>
@@ -1991,6 +2198,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="notes_ru">Это слово может быть использовано для других видов ювелирных изделий, наподобие кольца на палец ноги (хотя веротяно, это будет звучать как {yaD Qeb:n@@yaD:n:1, Qeb:n:1}, или более точно {Qay'wI' Qeb:n@@Qay'wI':n, Qeb:n:1}). Не используется для описания звена в цепи, если конечно цепь не сделана из ювелирных колец.[2]</column>
       <column name="notes_zh_HK">這個詞也可以用於其他種類的（類似）珠寶，例如用於腳趾（儘管可能是{yaD Qeb:n@@yaD:n:1, Qeb:n:1}，或更具體地，例如{Qay'wI' Qeb:n@@Qay'wI':n, Qeb:n:1}）。除非該鏈由（珠寶般的）環組成，否則它不用於鏈中的鏈接。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra também pode ser usada para outros tipos de jóias (semelhantes), como um dedo do pé (embora provavelmente seja {yaD Qeb:n@@yaD:n:1, Qeb:n:1}, ou mais específico, como {Qay'wI' Qeb:n@@Qay'wI':n, Qeb:n:1}). Isso não é usado para um link em uma corrente, a menos que a corrente seja composta de anéis (semelhantes a joias).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää myös muun tyyppisiin (samankaltaisiin) koruihin, kuten varpaisiin (vaikka se todennäköisesti olisi {yaD Qeb:n@@yaD:n:1, Qeb:n:1} tai tarkempi, kuten {Qay'wI' Qeb:n@@Qay'wI':n, Qeb:n:1}). Tätä ei käytetä ketjun lenkkiin, paitsi jos ketju koostuu (korujen kaltaisista) renkaista.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2000,6 +2208,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2007,6 +2216,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.23:src}</column>
     </table>
     <table name="mem">
@@ -2020,6 +2230,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="definition_ru">держатель хвост [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">馬尾辮持有人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">suporte rabo de cavalo</column>
+      <column name="definition_fi">ponnari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choljaH:n}, {DaQ:n}, {naQ:n:2}, {Qeb:n:1}</column>
@@ -2031,6 +2242,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2040,6 +2252,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2047,6 +2260,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2060,6 +2274,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="definition_ru">стебель, стебель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">莖、稈</column>
       <column name="definition_pt">haste, caule</column>
+      <column name="definition_fi">(kasvin) varsi, ruoti, kanta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'InSong:n}, {San'emDer:n}</column>
@@ -2070,6 +2285,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2079,6 +2295,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2086,6 +2303,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2099,6 +2317,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="definition_ru">ствол дерева [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">樹幹</column>
       <column name="definition_pt">tronco (de árvore)</column>
+      <column name="definition_fi">(puun) runko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sor:n}, {bartIq:n}, {por:n}</column>
@@ -2109,6 +2328,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qechjem:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -2118,6 +2338,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2125,6 +2346,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2138,6 +2360,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/SIpF7Zak6CY} [A
       <column name="definition_ru">наука</column>
       <column name="definition_zh_HK">科學</column>
       <column name="definition_pt">Ciência</column>
+      <column name="definition_fi">tiede</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qul:v}, {ngong:n}, {cham:n}</column>
@@ -2166,6 +2389,25 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru">Клингонские науки включают в себя {HolQeD:n}, {HuchQeD:n}, {nughQeD:n}, {porghQeD:n}, и {'otlhQeD:n}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin kielessä on seuraavia tieteitä:
+▶ {DI'ruj QeD:n}
+▶ {HapQeD:n}
+▶ {HolQeD:n}
+▶ {HovQeD:n}
+▶ {HuchQeD:n}
+▶ {mI'QeD:n}
+▶ {nughQeD:n}
+▶ {no'QeD:n}
+▶ {rayQeD:n}
+▶ {roSqa'QeD:n}
+▶ {qunQeD:n}
+▶ {porghQeD:n}
+▶ {tamlerQeD:n}
+▶ {yuQQeD:n}
+▶ {'an'orQeD:n}
+▶ {'otlhQeD:n}
+
+Jokaiselle {QeD:n:nolink}:lle on vastaava {tej:n}.</column>
       <column name="hidden_notes">"Q.E.D."</column>
       <column name="components"></column>
       <column name="examples">{Hov leng QeD:n}</column>
@@ -2175,6 +2417,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2182,6 +2425,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2195,6 +2439,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">научная система [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">科學系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estação de ciências</column>
+      <column name="definition_fi">tiedejärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noch pat:n}</column>
@@ -2205,6 +2450,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru">Это выглядит как {QeD patmey noch patmey je:n:nolink} "наука и системы дистанционного зондирования". [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這似乎是{QeD patmey noch patmey je:n:nolink}的“科學和遙感系統”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso aparece como {QeD patmey noch patmey je:n:nolink} "sistemas de ciência e sensoriamento remoto". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä esiintyy nimellä {QeD patmey noch patmey je:n:nolink} "tiede ja kaukokartoitusjärjestelmät". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{QeD:n}, {pat:n}</column>
       <column name="examples"></column>
@@ -2214,6 +2460,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2221,6 +2468,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2234,6 +2482,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">научная консоль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">科學控制台 [AUTOTRANSLATED]</column>
       <column name="definition_pt">console de ciências</column>
+      <column name="definition_fi">tiedekonsoli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2244,6 +2493,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{QeD:n}, {SeHlaw:n}</column>
       <column name="examples"></column>
@@ -2253,6 +2503,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2260,6 +2511,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2273,6 +2525,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">Офицер по науке, научный офицер</column>
       <column name="definition_zh_HK">科學主任 [AUTOTRANSLATED]</column>
       <column name="definition_pt">oficial de ciências</column>
+      <column name="definition_fi">tiedeupseeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2283,6 +2536,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{QeD:n}, {pIn:n:1}</column>
       <column name="examples"></column>
@@ -2292,6 +2546,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2299,6 +2554,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2312,6 +2568,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">гнев, злость</column>
       <column name="definition_zh_HK">憤怒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">raiva</column>
+      <column name="definition_fi">viha, raivo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QeH:v}</column>
@@ -2322,6 +2579,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Quick" to anger.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2331,6 +2589,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2338,6 +2597,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2351,6 +2611,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">злить, сердить, раздражать, вызывать гнев, сходить с ума, выводить из себя</column>
       <column name="definition_zh_HK">嬲、發怒</column>
       <column name="definition_pt">ser zangado, louco</column>
+      <column name="definition_fi">olla vihainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puQ:v}, {Qay':v:1}, {QeH:n}</column>
@@ -2361,6 +2622,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2370,6 +2632,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2377,6 +2640,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2390,6 +2654,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">лелеять, хранить, нежно любить, ценить, дорожить</column>
       <column name="definition_zh_HK">珍惜</column>
       <column name="definition_pt">valorizar</column>
+      <column name="definition_fi">arvostaa, pitää jotain arvossa; vaalia, helliä, hoivata?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lo'laH:v}</column>
@@ -2400,6 +2665,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2411,6 +2677,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
 ▶ {Qo'noS romuluS je boSuqlaH. vabDot tera' Qejbogh DIvI' ram boSuqlaH.:sen:nolink} "Кронос, Ромул и даже драгоценная Земля жалкой Федерации доступны для захвата."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">treasure, prize, precious</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2418,6 +2685,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru">сокровище, приз, драгоценность</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}, [2] {KLI mailing list 2017.09.18:src}</column>
     </table>
     <table name="mem">
@@ -2431,6 +2699,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">доктор наук, физик</column>
       <column name="definition_zh_HK">醫生</column>
       <column name="definition_pt">doutor, médico</column>
+      <column name="definition_fi">lääkäri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ropyaH:n}, {rachwI':n}, {SID:n}, {vor:v}, {HaqwI':n}</column>
@@ -2441,6 +2710,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru">Это общее слово для "доктора" или "физика". Доктор, который проводит хирургическую операцию, описывается словом {HaqwI':n}.[2]</column>
       <column name="notes_zh_HK">這是“醫生”或“醫師”的通用詞。進行手術的醫生是{HaqwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a palavra geral para "médico" ou "médico". Um médico que realiza a cirurgia é um {HaqwI':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleinen sana "lääkäri" tai "lääkäri". Leikkauksen suorittava lääkäri on {HaqwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2450,6 +2720,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2457,6 +2728,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1998.10.20:src}</column>
     </table>
     <table name="mem">
@@ -2470,6 +2742,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">Крэлл</column>
       <column name="definition_zh_HK">克雷爾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Krell</column>
+      <column name="definition_fi">Krell</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2480,6 +2753,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2489,6 +2763,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2496,6 +2771,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 5.6:src}</column>
     </table>
     <table name="mem">
@@ -2509,6 +2785,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="definition_ru">вешать инструмент на пояс, убирать оружие в кобуру.</column>
       <column name="definition_zh_HK">套、捂（武器）</column>
       <column name="definition_pt">embainhar</column>
+      <column name="definition_fi">panna (ase) tuppeen tai koteloon</column>
       <column name="synonyms"></column>
       <column name="antonyms">{QIq:v}</column>
       <column name="see_also">{vaH:n}, {buq:n}</column>
@@ -2519,6 +2796,7 @@ For every {QeD:n:nolink} there is a corresponding {tej:n}.[2; 3]</column>
       <column name="notes_ru">Это слово не ограничивается оружием. Например, его можно использовать для помещения инструмента в инструментальный пояс. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞不僅限於武器。例如，它可以用於將工具放入工具帶中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra não se limita a armas. Por exemplo, ele pode ser usado para colocar uma ferramenta no cinto de ferramentas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana ei rajoitu aseisiin. Esimerkiksi sitä voidaan käyttää työkalun asettamiseen työkaluvyöhön. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Cram".
 
 This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
@@ -2530,6 +2808,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2537,6 +2816,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2550,6 +2830,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">Дыра (в земле, в дереве и т.д.)</column>
       <column name="definition_zh_HK">洞（就像地上的洞） [AUTOTRANSLATED]</column>
       <column name="definition_pt">buraco (como um buraco no chão)</column>
+      <column name="definition_fi">kuoppa, reikä (maassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qung:n}, {taSman:n}, {mol:v}, {mol:n}, {jaQ:v}, {teb:v}, {ghaw:v}</column>
@@ -2560,6 +2841,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="notes_ru">Может быть использовано для дыры в поверхности земли, пустоте в дереве, и так далее. Разница между {QemjIq:n:nolink} и {qung:n} в том, что первый может быть заполнен ({teb:v}).[1] (т.е {QemjIq:n:nolink} впадина или углубление, в то время как {qung:n:nolink} это прокол или пробой.)</column>
       <column name="notes_zh_HK">它可以用於地面上的孔，樹上的空洞等。 {QemjIq:n:nolink}和{qung:n}之間的區別在於前者可以填充（{teb:v}）.[1]（即{QemjIq:n:nolink}是空腔或凹陷，而{qung:n:nolink}是穿孔或穿孔）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä voidaan käyttää reikään maahan, onttoon puuhun ja niin edelleen. Ero {QemjIq:n:nolink}: n ja {qung:n}: n välillä on se, että edellinen voidaan täyttää ({teb:v}) .[1] (Toisin sanoen {QemjIq:n:nolink} on ontelo tai syvennys, kun taas {qung:n:nolink} on puhkaisu tai reikä.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the Beatles song "A Day in The Life", a line goes "Four thousand holes in Blackburn, Lancashire".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2569,6 +2851,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cavity, indentation, depression</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2576,6 +2859,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru">трещина, выемка, углубление</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -2589,6 +2873,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">мякоть (растения) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">紙漿（植物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">polpa (de uma planta)</column>
+      <column name="definition_fi">hedelmän ydin, sisus, malto, hedelmäliha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oynot:n}</column>
@@ -2599,6 +2884,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2608,6 +2894,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2615,6 +2902,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2628,6 +2916,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">измельченная, высушенная смесь для заваривания чая [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用於釀造茶的磨碎的干燥混合物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mistura moída e seca para a preparação de chá</column>
+      <column name="definition_fi">jauhettu, kuivattu tee teen keittämistä varten</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dargh:n}</column>
@@ -2638,6 +2927,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="notes_ru">Это относится к сухому заварке чая, включая растения или части животных. Для напитка, сделанного из этого, см. {Dargh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指包括植物或動物部分的干茶沖泡物。對於由此製成的飲料，請參見{Dargh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à fermentação do chá seco, incluindo plantas ou partes de animais. Para a bebida feita com isso, consulte {Dargh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kuivattua teetä, joka sisältää kasveja tai eläinosia. Katso tästä valmistettu juoma kohdasta {Dargh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2647,6 +2937,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2654,6 +2945,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2667,6 +2959,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">беспокоиться (о) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擔心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser ansioso (acerca de)</column>
+      <column name="definition_fi">olla ahdistunut, huolestunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rejmorgh:n}, {bIt:v}</column>
@@ -2677,6 +2970,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="notes_ru">Объект, если таковой имеется, - это то, о чем беспокоится субъект. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對象（如果有）是對象所急切的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto, se houver, é o motivo pelo qual o sujeito está ansioso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde, jos sellainen on, on asia, josta kohde on huolissaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2686,6 +2980,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">worry</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2693,6 +2988,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2706,6 +3002,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">любой газ, произведенный в теле [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">體內產生的任何氣體 [AUTOTRANSLATED]</column>
       <column name="definition_pt">qualquer gás produzido dentro do corpo</column>
+      <column name="definition_fi">ruumiin tuottama kaasu (röyhtäys, pieru tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIp:n}</column>
@@ -2716,6 +3013,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="notes_ru">И этот, и {ruq:v} могут использоваться для газа, который поступает из вашей кишки и изо рта, а также для газа, который поступает из вашей кишки в другую сторону. Чтобы различать газы, выбрасываемые из разных отверстий, используйте фразу, включающую {nuj:n}, {Hugh:n} или {Sa'Hut:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這和{ruq:v}都可以用於從腸道流出並從口腔中排出的氣體，也可以用於從腸道排出並以其他方式排出的氣體。要區分從不同孔口發出的氣體，請使用涉及{nuj:n}，{Hugh:n}或{Sa'Hut:n}的短語。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso e o {ruq:v} podem ser usados ​​para o gás que sai do seu intestino e sai da boca e também para o gás que sai do seu intestino e sai do outro lado. Para distinguir entre gases emitidos de diferentes orifícios, use uma frase que envolva {nuj:n}, {Hugh:n} ou {Sa'Hut:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sekä tätä että {ruq:v}: tä voidaan käyttää kaasusta, joka tulee suolistasi ja suustasi, ja myös kaasuun, joka laskee suolistasi ja ulos muulla tavalla. Erottaaksesi eri aukoista peräisin olevat kaasut, käytä ilmausta {nuj:n}, {Hugh:n} tai {Sa'Hut:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It sounds like "decrepit".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2725,6 +3023,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">burp, fart</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2732,6 +3031,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}, [2] {KLI mailing list 2015.08.03:src}</column>
     </table>
     <table name="mem">
@@ -2745,6 +3045,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">цель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">目標 [AUTOTRANSLATED]</column>
       <column name="definition_pt">apontar</column>
+      <column name="definition_fi">tähdätä jotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puS:v:2}</column>
@@ -2769,6 +3070,9 @@ Detta verb används också för att uttrycka idén om "ansikte" (orientera mot) 
       <column name="notes_pt">O objeto é o projétil ou arma e o alvo é marcado com {-Daq:n:suff} (consulte {bach:v} para obter detalhes).
 
 Este verbo também é usado para expressar a idéia de "face" (orientar para) (consulte {Qeq:v:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on ammus tai ase, ja kohde on merkitty merkillä {-Daq:n:suff} (katso lisätietoja kohdasta {bach:v}).
+
+Tätä verbiä käytetään myös ilmaisemaan ajatusta "kasvot" (suunta kohti) (katso {Qeq:v:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "aim" in {KGT:src} and clarified to "aim (at)" at {qep'a' 27 (2020):src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2780,6 +3084,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2787,6 +3092,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {TKW p.191:src}, [3] {ENT - Affliction:src}, [4] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2800,6 +3106,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="definition_ru">лицо (ориентировано на) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">面對（面向） [AUTOTRANSLATED]</column>
       <column name="definition_pt">face (orientar em direção) [AUTOTRANSLATED]</column>
+      <column name="definition_fi">olla kääntyneenä tai kääntyä jotakin kohti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2810,6 +3117,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="notes_ru">Это просто приложение {Qeq:v:1}. Объект - это объект, ориентированный на кого-то или что-то, а находящаяся на нем вещь или человек помечается {-Daq:n:suff}. В этом значении этот глагол часто используется с {-'egh:v:suff} или {-chuq:v:suff}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是{Qeq:v:1}的應用程序。該對像是面向某人或某物的對象，並且所面對的某物或某人用{-Daq:n:suff}標記。具有此含義的此動詞通常與{-'egh:v:suff}或{-chuq:v:suff}.[1]一起使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é apenas uma aplicação do {Qeq:v:1}. O objeto é aquele orientado para alguém ou algo, e a coisa ou pessoa que está sendo confrontada é marcada com {-Daq:n:suff}. Com esse significado, esse verbo é frequentemente usado com {-'egh:v:suff} ou {-chuq:v:suff}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain {Qeq:v:1}-sovellus. Kohde on joku tai jokin suuntautunut, ja kohtaamasi asia tai henkilö on merkitty {-Daq:n:suff}-merkinnällä. Tällä merkityksellä tätä verbiä käytetään usein {-'egh:v:suff}- tai {-chuq:v:suff}-tiedostojen kanssa.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2819,6 +3127,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">orient towards</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2826,6 +3135,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2839,6 +3149,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="definition_ru">тушеное мясо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">燉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">guisar algo (cozinhar)</column>
+      <column name="definition_fi">hauduttaa, muhentaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boqrat:n}, {chatlh:n:1}, {DuD:v}, {tlhIq:n}</column>
@@ -2849,6 +3160,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="notes_ru">Это значит нагревать мясо в крови и приправах животного. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著要加熱動物血液和調味品中的肉。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa aquecer a carne no sangue e nos condimentos dos animais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa lihan lämmittämistä eläimen veressä ja mausteissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2858,6 +3170,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2865,6 +3178,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2878,6 +3192,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="definition_ru">быть плотным, быть тугим, быть тесным, быть узким</column>
       <column name="definition_zh_HK">要緊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser firme</column>
+      <column name="definition_fi">olla tiukka</column>
       <column name="synonyms"></column>
       <column name="antonyms">{QeyHa':v}</column>
       <column name="see_also"></column>
@@ -2888,6 +3203,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The song "Being for the Benefit of Mr. Kite!" by The Beatles is about the circus performer (and tightrope walker) William Kite, who is referred to as "Mr. K".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2897,6 +3213,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2904,6 +3221,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -2917,6 +3235,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="definition_ru">быть свободным, быть рыхлым, быть сыпучим, быть неплотным, быть ослабленным</column>
           <column name="definition_zh_HK">鬆散 [AUTOTRANSLATED]</column>
           <column name="definition_pt">ser solto</column>
+      <column name="definition_fi">olla löysä</column>
           <column name="synonyms"></column>
           <column name="antonyms">{Qey:v}</column>
           <column name="see_also"></column>
@@ -2927,6 +3246,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Qey:v}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -2936,6 +3256,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2943,6 +3264,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -2956,6 +3278,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="definition_ru">рыхлить, ослаблять, расшатывать, взрыхлять</column>
           <column name="definition_zh_HK">鬆開 [AUTOTRANSLATED]</column>
           <column name="definition_pt">afrouxar</column>
+      <column name="definition_fi">löysätä</column>
           <column name="synonyms"></column>
           <column name="antonyms">{QeymoH:v}</column>
           <column name="see_also">{bagh:v}</column>
@@ -2966,6 +3289,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{QeyHa':v}, {-moH:v}</column>
           <column name="examples"></column>
@@ -2975,6 +3299,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2982,6 +3307,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -2995,6 +3321,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="definition_ru">затянуть(веревку, узел), сжимать, сжиматься, натягивать, уплотнять, стянуть веревкой</column>
           <column name="definition_zh_HK">緊縮 [AUTOTRANSLATED]</column>
           <column name="definition_pt">apertar</column>
+      <column name="definition_fi">tiukentaa</column>
           <column name="synonyms"></column>
           <column name="antonyms">{QeyHa'moH:v}</column>
           <column name="see_also">{bagh:v}</column>
@@ -3005,6 +3332,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Qey:v}, {-moH:v}</column>
           <column name="examples"></column>
@@ -3014,6 +3342,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3021,6 +3350,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
     <table name="mem">
@@ -3034,6 +3364,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="definition_ru">быть прохладным (температура) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">涼爽（溫度） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser fresco (temperatura)</column>
+      <column name="definition_fi">olla viileä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghun:v:2}, {tuj:v}</column>
       <column name="see_also">{bIr:v}, {buj:v}, {Hat:n}</column>
@@ -3044,6 +3375,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It was clarified during the Q &amp; A session that the temperature words really are about temperature and not about effect or perception, so that clothing, for example, is not said to be "hot" or "cold" in Klingon.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3053,6 +3385,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3060,6 +3393,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3073,6 +3407,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="definition_ru">Ресторан</column>
       <column name="definition_zh_HK">餐廳 [AUTOTRANSLATED]</column>
       <column name="definition_pt">restaurante</column>
+      <column name="definition_fi">ravintola</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIDjolev:n}, {DaHjaj gheD:n}, {vun:v}</column>
@@ -3083,6 +3418,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3092,6 +3428,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3099,6 +3436,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3112,6 +3450,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="definition_ru">Кабаре (шоу)</column>
       <column name="definition_zh_HK">歌舞表演（節目） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cabaré (show)</column>
+      <column name="definition_fi">kabaree-esitys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI'wI' much:n}</column>
@@ -3122,6 +3461,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="notes_ru">Это шоу, которое показывается в {much Qe':n}.</column>
       <column name="notes_zh_HK">這是在{much Qe':n}進行的表演。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um show realizado em um {much Qe':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {much Qe':n}-esitys. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Qe':n}, {much:n}</column>
       <column name="examples"></column>
@@ -3131,6 +3471,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3138,6 +3479,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -3151,6 +3493,7 @@ Este verbo também é usado para expressar a idéia de "face" (orientar para) (c
       <column name="definition_ru">Мост (наподобие моста через реку)</column>
       <column name="definition_zh_HK">橋</column>
       <column name="definition_pt">ponte (como em um rio)</column>
+      <column name="definition_fi">silta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qa'rI':n}</column>
@@ -3175,6 +3518,9 @@ Ordet för ett fartygs kommandodäck (även kallad en "bridge" på engelska) är
       <column name="notes_pt">Para dizer que uma ponte atravessa algo (um rio, um vale e assim por diante), use {vech:v}.
 
 A palavra para o convés de comando de um navio (também chamada de "ponte" em inglês) é {meH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Käytä {vech:v} sanomaan, että silta ulottuu johonkin (joki, laakso ja niin edelleen).
+
+Aluksen komentokannen sana (jota kutsutaan myös englanniksi "sillaksi") on {meH:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the novel "The Bridge over the River Kwai" ("Le Pont de la Rivière Kwai") by Pierre Boulle.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3184,6 +3530,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3191,6 +3538,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.08.14:src}</column>
     </table>
     <table name="mem">
@@ -3204,6 +3552,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="definition_ru">тень</column>
       <column name="definition_zh_HK">陰影 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sombra</column>
+      <column name="definition_fi">varjo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wov:v}, {Hurgh:v}, {wovmoHwI':n}</column>
@@ -3214,6 +3563,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="notes_ru">Чтобы выразить создание / бросание / создание тени, {QIb:n:nolink} может использоваться в качестве субъекта {nIS:v}. Объект, если указан, будет поверхностью, на которую отбрасывается тень.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了表達投射/投擲/製作陰影，可以將{QIb:n:nolink}用作{nIS:v}的主題。如果指定了對象，則將是將陰影投射到的表面.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para expressar a projeção / lançamento / criação de uma sombra, {QIb:n:nolink} pode ser usado como o assunto de {nIS:v}. O objeto, se especificado, seria a superfície na qual a sombra é projetada.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Varjon heittämisen / heittämisen / tekemisen ilmaisemista varten {QIb:n:nolink}: tä voitaisiin käyttää {nIS:v}: n aiheena. Objekti, jos se on määritelty, olisi pinta, jolle varjo heitetään.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3223,6 +3573,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3230,6 +3581,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3243,6 +3595,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="definition_ru">речь (голосовые звуки)</column>
       <column name="definition_zh_HK">演講（聲音） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fala (sons vocais)</column>
+      <column name="definition_fi">puhe (ääntely, ei esitys)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghogh:n}, {wab:n}, {SoQ:n}</column>
@@ -3253,6 +3606,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="notes_ru">Это относится к речи, как к явлению. Для описания звуков речи, смотрите {QIch wab:n}. Для произношения, смотрите {QIch wab Ho'DoS:n}.[2]</column>
       <column name="notes_zh_HK">這是指言語現象。有關語音，請參閱{QIch wab:n}。有關發音，請參閱{QIch wab Ho'DoS:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao fenômeno da fala. Para sons de fala, consulte {QIch wab:n}. Para pronúncia, consulte {QIch wab Ho'DoS:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa puheen ilmiöön. Katso puheäänet kohdasta {QIch wab:n}. Ääntämistä varten katso {QIch wab Ho'DoS:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3262,6 +3616,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3269,6 +3624,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -3282,6 +3638,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="definition_ru">звук речи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">語音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Som do discurso, fonema</column>
+      <column name="definition_fi">äänne, foneemi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIch wab Ho'DoS:n}</column>
@@ -3292,6 +3649,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="notes_ru">Индивидуальный речевой звук - {QIch wab:n:nolink}. Звуки речи в совокупности являются {QIch wabmey:n@@QIch wab:n, -mey:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Yksittäinen puheääni on {QIch wab:n:nolink}. Puheäänet yhdessä ovat {QIch wabmey:n@@QIch wab:n, -mey:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "speech sound" in {KLI mailing list 2018.02.17:src} and defined again as "phoneme" at {qep'a' 27 (2020):src}.</column>
       <column name="components">{QIch:n}, {wab:n}</column>
       <column name="examples"></column>
@@ -3301,6 +3659,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3308,6 +3667,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.17:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3321,6 +3681,7 @@ A palavra para o convés de comando de um navio (também chamada de "ponte" em i
       <column name="definition_ru">произношение</column>
       <column name="definition_zh_HK">語音</column>
       <column name="definition_pt">pronúncia</column>
+      <column name="definition_fi">ääntäminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qol:v}</column>
@@ -3403,6 +3764,43 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
 Названия Клингонских согласных состоят  из звуков, которые следуют за {ay:sen:nolink}, и названий гласных состоящих из звуков, которым предшествует {':sen:nolink} и следующих за {t:sen:nolink}. Гортанная смычка является исключением, названная {qaghwI':n}.[4]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin äänien ymmärtämiseksi on suositeltavaa, että ostat {The Klingon Dictionary:src}, jossa on täydellisempi kuvaus äänistä, sekä äänitallenteet {Conversational Klingon:src} ja {Power Klingon:src}, joissa voit kuulla niiden puhuvan.
+
+Klingonin kirjoittamiseen roomalaisella (englanninkielisellä) aakkosella käytettävä transkriptiojärjestelmä on foneettinen, mikä tarkoittaa, että sanat kirjoitetaan täsmälleen samalla tavalla kuin ne lausutaan. Seuraavassa Klingonin äänien kuvauksessa, joka on tarkoitettu vain karkeaksi oppaaksi, IPA-foneettiset symbolit näytetään kauttaviivaparin välillä, joka seuraa jokaisen äänen transkriptointiin käytettyä roomalaista kirjainta tai kirjaimia.
+
+Konsonantit {b:sen:nolink} / b /, {ch:sen:nolink} / ʧ /, {j:sen:nolink} / d͡ʒ /, {l:sen:nolink} / l /, {m:sen:nolink} / m /, {n:sen:nolink} / n /, DONOTTRANSLATE10 / n /, {p:sen:nolink} / pʰ /, DONOTTRANSLATE / DONOTTRANSLATE / ja {y:sen:nolink} / j / lausutaan enemmän tai vähemmän kuin amerikanenglannissa.
+
+{D:sen:nolink} / ɖ / ja {S:sen:nolink} / ʂ / ovat retrofleksisiä, toisin sanoen ne lausutaan kielellä, joka koskettaa suun kattoa.
+
+{gh:sen:nolink} / ɣ / on samanlainen kuin {H:sen:nolink} (katso alla), mutta ääni. Se kuulostaa jonkin verran gargarilta.
+
+{H:sen:nolink} / x / on kuin "ch" skotlantilaisessa sanassa "loch" tai saksalaisen säveltäjän "Bach" nimi.
+
+{ng:sen:nolink} / ŋ / on sama ääni kuin englanninkielisten sanojen "sing" tai "thing" lopussa, mutta Klingonissa se voi tulla sanojen alkuun.
+
+{q:sen:nolink} / qʰ / on kuin englanninkielinen "k", mutta kieli ulottuu uvulaa kohti tai koskettaa sitä. Kuulostaa vähän kuin tukehtuisit.
+
+{Q:sen:nolink} / q͡χ / on samanlainen kuin {q:sen:nolink}- ja {H:sen:nolink}-yhdistelmä, ja kuulostaa siltä, ​​että todella tukehdut ja yrität poistaa kurkkuun juuttunutta ruokaa.
+
+Klingon {r:sen:nolink} / r / on hiukan trillattu tai rullattu.
+
+{tlh:sen:nolink} / t͡ɬ / löytyy joiltakin alkuperäiskansojen kieliltä, ​​ja se tuotetaan asettamalla kielesi asentoon sanoa {t:sen:nolink} ja pakottamalla sitten ilma suusi sivujen läpi kuin sanoisit {l:sen:nolink}.
+
+Glotaalinen pysäytys {':sen:nolink} / ʔ / ({qaghwI':n:nolink}) on pieni tauko tai kiinniotto kurkussa, kuten kahden "oh-oh" tavun välissä.
+
+Vokaali {a:sen:nolink} / ɑ / kuulostaa "psalmissa" tai "isältä".
+
+Vokaali {e:sen:nolink} / ɛ / kuulostaa "e": lta "sängyssä" tai "munalta".
+
+Vokaali {I:sen:nolink} / ɪ / kuulostaa "i": ltä "bitissä" tai "misfit". Huomaa, että se kirjoitetaan aina isolla kirjaimella.
+
+Vokaali {o:sen:nolink} / o / kuulostaa "o": lta "nuotissa" tai "mosaiikissa".
+
+Vokaali {u:sen:nolink} / u / kuulostaa sanalta "u" sanassa "luumu" tai "ruoka".
+
+Kaksoiskappaleet {aw:sen:nolink}, {ew:sen:nolink}, {Iw:sen:nolink}, [1; 2; 3]0, {ey:sen:nolink}, {Iy:sen:nolink}, {oy:sen:nolink} ja {uy:sen:nolink} ovat mahdollisia ja kuulostavat olennaisesti niiden komponenteilta. Huomaa, että {ay:sen:nolink} riimii englanniksi "why" tai "my", kun taas {ey:sen:nolink} riimii "way" tai "may".
+
+Klingonin konsonanttien nimet koostuvat äänestä, jota seuraa {ay:sen:nolink}, ja vokaalien nimet koostuvat äänestä, jota edeltää {':sen:nolink} ja jota seuraa {t:sen:nolink}. Glottal stop on poikkeus, jota kutsutaan nimellä {qaghwI':n}.[4]{t:sen:nolink}{v:sen:nolink}{w:sen:nolink}{ay:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{QIch wab:n}, {Ho'DoS:n}</column>
       <column name="examples"></column>
@@ -3412,6 +3810,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">speaking, talking, accent, pronunciation</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3419,6 +3818,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}, [3] {PK:src}, [4] {KLI mailing list 2009.07.27:src}, [5] {KLI mailing list 2018.02.17:src}</column>
     </table>
     <table name="mem">
@@ -3432,6 +3832,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">акцент, произношение</column>
       <column name="definition_zh_HK">口音</column>
       <column name="definition_pt">sotaque</column>
+      <column name="definition_fi">aksentti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sep Hol Sar:n}</column>
@@ -3442,6 +3843,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="notes_ru">"Региональный акцент" будет {Sep QIch wab Ho'DoS:n:nolink} или {Sep QIch wab Sar:n:nolink} или {Sep QIch wab Ho'DoS Sar:n:nolink}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Um "sotaque regional" seria {Sep QIch wab Ho'DoS:n:nolink} ou {Sep QIch wab Sar:n:nolink} ou {Sep QIch wab Ho'DoS Sar:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"Alueellinen aksentti" olisi {Sep QIch wab Ho'DoS:n:nolink}, {Sep QIch wab Sar:n:nolink} tai {Sep QIch wab Ho'DoS Sar:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{QIch wab Ho'DoS:n}, {Sar:n}</column>
       <column name="examples"></column>
@@ -3451,6 +3853,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3458,6 +3861,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.25:src}</column>
     </table>
     <table name="mem">
@@ -3471,6 +3875,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">аллофон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">異音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alofonia</column>
+      <column name="definition_fi">allofoni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3481,6 +3886,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{QIch wab:n}, {Sar:n}</column>
       <column name="examples"></column>
@@ -3490,6 +3896,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3497,6 +3904,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3510,6 +3918,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">рана [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傷口 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ferir</column>
+      <column name="definition_fi">haavoittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIQ:v}, {rIQmoH:v}, {QIH:v:1}</column>
@@ -3520,6 +3929,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3529,6 +3939,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3536,6 +3947,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3549,6 +3961,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">Клингонский агонизатор</column>
       <column name="definition_zh_HK">克林崗激動劑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Agonizador Klingon</column>
+      <column name="definition_fi">eräs klingonien kidutuslaite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3560,6 +3973,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="notes_ru">Это ручное устройство, прижимаемое к врагу.</column>
       <column name="notes_zh_HK">這是一個手持設備，被對手壓著。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um dispositivo portátil, pressionado contra um adversário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kädessä pidettävä laite, joka on painettu vastustajaa vasten. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3569,6 +3983,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3576,6 +3991,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3589,6 +4005,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">повреждать, портить, наносить ущерб, являться причиной ущерба</column>
       <column name="definition_zh_HK">損壞、造成傷害 [AUTOTRANSLATED]</column>
       <column name="definition_pt">danificar, causar dano</column>
+      <column name="definition_fi">vahingoittaa, aiheuttaa vahinkoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIQ:v}, {Qaw':v}, {ghor:v}, {QID:v}, {joch:v}, {QIH:n}, {QIH:v:2}</column>
@@ -3599,6 +4016,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3608,6 +4026,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3615,6 +4034,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3628,6 +4048,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">неправильно, относиться несправедливо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">錯了、不公正待人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tratar injustamente, maltratar</column>
+      <column name="definition_fi">tehdä vääryyttä jollekulle, kohdella epäoikeudenmukaisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIH:v:1}</column>
@@ -3638,6 +4059,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3648,6 +4070,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mistreat</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3655,6 +4078,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3668,6 +4092,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">повреждение, урон, вред, разрушение</column>
       <column name="definition_zh_HK">損壞、破壞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dano, destruição</column>
+      <column name="definition_fi">vahinko, tuho</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIH:v:1}</column>
@@ -3678,6 +4103,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3687,6 +4113,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">wound, injury</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3694,6 +4121,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru">рана, повреждение</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3707,6 +4135,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">объяснять, растолковывать, разъяснять</column>
       <column name="definition_zh_HK">說明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">explicar</column>
+      <column name="definition_fi">selittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuH:v:2,slang}, {Del:v}</column>
@@ -3717,6 +4146,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3726,6 +4156,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3733,6 +4164,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3746,6 +4178,7 @@ The names of the Klingon consonants consist of the sound followed by {ay:sen:nol
       <column name="definition_ru">быть в отчаянии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">絕望 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desesperado</column>
+      <column name="definition_fi">olla epätoivoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tul:v}</column>
@@ -3768,6 +4201,9 @@ Detta ord används inte för att betyda "ivrigt efter, längtan efter, i verklig
       <column name="notes_pt">É usado quando não há saída ou não há nada a perder. Inclui ideias como "última vala, vida ou morte, sem esperança, condenada" .[1]
 
 Esta palavra não é usada para significar "ansioso por, ansiando por, com necessidade real de, tendo um grande desejo por", e assim por diante. Para expressar essas idéias, pode-se usar {-nIS:v} com {-qu':v}, ou talvez {neHqu':sen@@neH:v, -qu':v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään, kun ei ole ulospääsyä tai jos ei ole mitään menetettävää. Se sisältää ideoita, kuten "viimeinen oja, tee tai kuole, toivoton, tuomittu" .[1]
+
+Tätä sanaa ei käytetä tarkoittavan "haluaa, kaipaa, kaipaa sitä, sitä todella tarvitsee, jolla on suuri halu" ja niin edelleen. Näiden ajatusten ilmaisemiseksi voidaan käyttää {-nIS:v} {-qu':v}: n kanssa tai ehkä {neHqu':sen@@neH:v, -qu':v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3777,6 +4213,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">last-ditch, do-or-die, hopeless, doomed</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3784,6 +4221,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.06:src}, [2] {KLI mailing list 2018.02.10:src}</column>
     </table>
     <table name="mem">
@@ -3797,6 +4235,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="definition_ru">яйцо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蛋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ovo</column>
+      <column name="definition_fi">muna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pel'aQ:n:1}</column>
@@ -3807,6 +4246,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3816,6 +4256,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3823,6 +4264,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3836,6 +4278,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="definition_ru">инъекционные [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">注入 [AUTOTRANSLATED]</column>
       <column name="definition_pt">injetar</column>
+      <column name="definition_fi">ruiskuttaa, piikittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3846,6 +4289,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="notes_ru">Это может принимать в качестве объекта {watrIn:n} или {'onroS:n}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以將{watrIn:n}或{'onroS:n}作為其對象。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode levar {watrIn:n} ou {'onroS:n} como seu objeto.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi ottaa kohteeksi {watrIn:n} tai {'onroS:n}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3855,6 +4299,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3862,6 +4307,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -3875,6 +4321,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="definition_ru">Сообщение, послание, уведомление</column>
       <column name="definition_zh_HK">信息 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mensagem</column>
+      <column name="definition_fi">viesti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jabbI'ID:n}, {nav QIn:n}</column>
@@ -3885,6 +4332,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is often used to refer to email messages among Klingonists.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3894,6 +4342,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mail, email, e-mail</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3901,6 +4350,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="search_tags_ru">почта, электронное письмо</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3914,6 +4364,7 @@ Esta palavra não é usada para significar "ansioso por, ansiando por, com neces
       <column name="definition_ru">наконечник копья [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">矛頭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ponta de lança</column>
+      <column name="definition_fi">keihäänkärki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQjej:n}, {QIn pup:n}, {QIn vagh:n}, {SeDveq:n}</column>
@@ -3934,6 +4385,9 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="notes_pt">Esta palavra também se refere à ponta afiada de um lápis. Provavelmente se refere à extremidade afiada de qualquer objeto parecido com um pedaço de pau.[2]
 
 É usado para se referir ao ponto em uma estrela (geométrica) ({DujtlhuQ:n}) .[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa myös lyijykynän teroitettuun päähän. Se viittaa todennäköisesti minkä tahansa tikkumaisen esineen terävään päähän.[2]
+
+Sitä käytetään viittaamaan (geometrisen) tähden pisteeseen ({DujtlhuQ:n}).[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3943,6 +4397,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3950,6 +4405,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 12.2, Jun. 2003:src}, [3] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
         <table name="mem">
@@ -3963,6 +4419,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="definition_ru">острие наконечника с одной острой точкой [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">單尖點的普通矛頭 [AUTOTRANSLATED]</column>
           <column name="definition_pt">lâmina de ponta de lança com ponta afiada única</column>
+      <column name="definition_fi">eräs sileä keihäänkärki, jossa on yksi piikki</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{QIn vagh:n}</column>
@@ -3973,6 +4430,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{QIn:n:2}, {pup:v:1}</column>
           <column name="examples"></column>
@@ -3982,6 +4440,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3989,6 +4448,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -4002,6 +4462,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="definition_ru">Почтовая служба [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">郵政服務 [AUTOTRANSLATED]</column>
           <column name="definition_pt">serviço postal</column>
+      <column name="definition_fi">posti (laitos)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{QIn tum qach:n}</column>
@@ -4012,6 +4473,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{QIn:n:1}, {tum:n}</column>
           <column name="examples"></column>
@@ -4021,6 +4483,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">mail</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4028,6 +4491,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -4041,6 +4505,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="definition_ru">почта (здание) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">郵局（建築物） [AUTOTRANSLATED]</column>
           <column name="definition_pt">Correios (edifício)</column>
+      <column name="definition_fi">postitoimisto (rakennus)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{QIn tum:n}</column>
@@ -4051,6 +4516,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{QIn tum:n}, {qach:n}</column>
           <column name="examples"></column>
@@ -4060,6 +4526,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4067,6 +4534,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -4080,6 +4548,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="definition_ru">острие с несколькими точками [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">帶有多個點的矛頭 [AUTOTRANSLATED]</column>
           <column name="definition_pt">ponta de lança com vários pontos</column>
+      <column name="definition_fi">eräs keihäänkärki, jossa on useita piikkejä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{QIn pup:n}</column>
@@ -4090,6 +4559,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="notes_ru">У него может быть любое количество очков, а не только пять. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">它可能有任意數量的點，而不僅僅是五個。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Pode ter qualquer número de pontos, não apenas cinco. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sillä voi olla mikä tahansa määrä pisteitä, ei vain viisi. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{QIn:n:2}, {vagh:n:1}</column>
           <column name="examples"></column>
@@ -4099,6 +4569,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4106,6 +4577,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -4119,6 +4591,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="definition_ru">почтовая карточка, открытка</column>
           <column name="definition_zh_HK">明信片</column>
           <column name="definition_pt">cartão postal</column>
+      <column name="definition_fi">postikortti</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4129,6 +4602,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">In some early versions of {TNK:src}, "postcard" was translated as {ngeHmeH QIn nav:n:nolink}.</column>
           <column name="components">{QIn:n:1}, {'echletHom:n}</column>
           <column name="examples"></column>
@@ -4138,6 +4612,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4145,6 +4620,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
     <table name="mem">
@@ -4158,6 +4634,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="definition_ru">Кринча, вид животного [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Krincha、動物的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Krincha, tipo de animal</column>
+      <column name="definition_fi">eräs eläin, Krincha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lung:n}</column>
@@ -4168,6 +4645,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="notes_ru">Также пишется "Кренча", это рептильное животное, родом из {Qo'noS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">也被拼寫為“ Krencha”，這是一種生於{Qo'noS:n}的爬行動物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Também escrito "Krencha", este é um animal reptiliano nativo do {Qo'noS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Myös kirjoitettu "Krencha", tämä on matelijaeläin, joka on kotoisin {Qo'noS:n}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4177,6 +4655,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Krencha</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4184,6 +4663,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}</column>
     </table>
     <table name="mem">
@@ -4197,6 +4677,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="definition_ru">Тип копья</column>
       <column name="definition_zh_HK">矛類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de lança</column>
+      <column name="definition_fi">eräs keihästyyppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4207,6 +4688,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="notes_ru">Похож на {ghIntaq:n:1}, за исключением того, что ручка длинее, лезвие шире, а загнутый вниз рог выступает снизу лезвия. Редко используется в наши дни.[1]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso é semelhante a um {ghIntaq:n:1}, exceto que a alça é mais longa, a lâmina é muito mais larga e um chifre curvado para baixo se projeta da parte inferior da lâmina. Raramente é usado hoje em dia.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on samanlainen kuin {ghIntaq:n:1}, paitsi että kahva on pidempi, terä on paljon leveämpi ja alaspäin kaareva sarvi työntyy terän pohjasta. [1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This appears to have been the result of using Bing translator to translate "spear with horn", without understanding that {gheb:n:nolink} means "horn" as in the musical instrument, rather than a hooked point as in a weapon. This word was retroactively "vetted" by Marc Okrand after the book's publication.[2]</column>
       <column name="components">{QIn:n:2}, {gheb:n}</column>
       <column name="examples"></column>
@@ -4216,6 +4698,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4223,6 +4706,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {The Klingon Art of War:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4236,6 +4720,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="definition_ru">быть глупым, быть тупым, быть бестолковым, быть дурацким, быть дурным</column>
       <column name="definition_zh_HK">愚蠢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser estúpido</column>
+      <column name="definition_fi">olla tyhmä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{val:v}</column>
       <column name="see_also">{Dogh:v}, {chatlh!:excl}</column>
@@ -4246,6 +4731,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4255,6 +4741,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4262,6 +4749,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4275,6 +4763,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="definition_ru">рисовать (как оружие) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">畫（作為武器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">empate (como arma)</column>
+      <column name="definition_fi">vetää (ase esiin)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qem:v}</column>
       <column name="see_also">{vaH:n}, {buq:n}</column>
@@ -4285,6 +4774,7 @@ Den används för att hänvisa till punkten på en (geometrisk) stjärna ({Dujtl
       <column name="notes_ru">Это слово не ограничивается оружием. Например, его можно использовать для снятия инструмента с ремня инструмента. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞不僅限於武器。例如，它可用於從工具帶上取下工具。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra não se limita a armas. Por exemplo, ele pode ser usado para remover uma ferramenta de um cinto de ferramentas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana ei rajoitu aseisiin. Sitä voidaan käyttää esimerkiksi työkalun poistamiseen työkaluhihnasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Quick". In gun duels, the winner is often the one with the faster draw. Also, "quick" has an archaic sense of "the living", as in "the quick and the dead".
 
 This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
@@ -4296,6 +4786,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4303,6 +4794,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4316,6 +4808,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">стежок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">縫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ponto (costura)</column>
+      <column name="definition_fi">ommella, kursia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4326,6 +4819,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="notes_ru">Объект - это вещь, сшитая или сшитая вместе. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對像是被縫製或縫合在一起的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é a coisa que está sendo costurada ou costurada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on ommeltu tai ommeltu asia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Criss-cross", "cross stitch".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4335,6 +4829,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4342,6 +4837,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4355,6 +4851,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">нож с волнистым лезвием</column>
       <column name="definition_zh_HK">波浪刀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">faca de lâmina ondulada</column>
+      <column name="definition_fi">erös veitsi, jossa on aaltoileva terä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taj:n}</column>
@@ -4365,6 +4862,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "kris" or "keris" is a type of wavy-bladed knife found in Southeast Asia.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4374,6 +4872,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4381,6 +4880,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4394,6 +4894,7 @@ This word was awarded to {janSIy:n:name,nolink} as a Friend of Maltz.</column>
       <column name="definition_ru">Рождество</column>
       <column name="definition_zh_HK">聖誕</column>
       <column name="definition_pt">Natal</column>
+      <column name="definition_fi">joulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIS chu':n}</column>
@@ -4416,6 +4917,9 @@ Det finns inget traditionellt Klingon-sätt att säga något som "god jul". Ett 
       <column name="notes_pt">Este é o nome de um feriado terráqueo.
 
 Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Uma expressão como {wornagh yItlhutlh!} pode ser mais apropriada.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Terran-loman nimi.
+
+Ei ole perinteistä klingonilaista tapaa sanoa jotain "hyvää joulua". Lauseke, kuten {wornagh yItlhutlh!}, saattaa olla sopivampi.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Maltz thought "Merry Christmas" and "Happy New Year" were silly things to say.[1]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4425,6 +4929,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4432,6 +4937,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2013.12.13:src}</column>
     </table>
     <table name="mem">
@@ -4445,6 +4951,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">Криштак</column>
       <column name="definition_zh_HK">Kri'stak [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kri'stak</column>
+      <column name="definition_fi">Kri'stak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaHbo':n}, {qul ngeng:n}, {qeylIS betleH:n}</column>
@@ -4455,6 +4962,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru">Это название вулкана ({qulHuD:n}) на {Qo'noS:n}, где согласно легенде {qeylIS'e' lIjlaHbe'bogh vay':n:name} погрузил прядь своих волос в жерло, чтобы выковать первый {betleH:n}.</column>
       <column name="notes_zh_HK">這是{Qo'noS:n}上的一座火山（{qulHuD:n}）的名字，傳說中{qeylIS'e' lIjlaHbe'bogh vay':n:name}浸入了自己的一頭頭髮，以鍛造出第一隻{betleH:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um vulcão ({qulHuD:n}) em {Qo'noS:n}, onde a lenda diz que {qeylIS'e' lIjlaHbe'bogh vay':n:name} passou uma mecha de cabelo para forjar o primeiro {betleH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tulivuoren nimi ({qulHuD:n}) {Qo'noS:n} -laitteessa, jossa legenda kertoo {qeylIS'e' lIjlaHbe'bogh vay':n:name} kastanut hiuslukon väärentämään ensimmäistä {betleH:n}-levyä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4464,6 +4972,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4471,6 +4980,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -4484,6 +4994,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">медленно</column>
       <column name="definition_zh_HK">慢慢地 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lentamente</column>
+      <column name="definition_fi">hitaasti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nom:adv}</column>
       <column name="see_also"></column>
@@ -4494,6 +5005,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4503,6 +5015,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4510,6 +5023,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4523,6 +5037,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">быть жалким, быть низжим, быть худшим</column>
       <column name="definition_zh_HK">自卑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser inferior</column>
+      <column name="definition_fi">olla huonompi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIv:v}</column>
@@ -4533,6 +5048,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4542,6 +5058,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4549,6 +5066,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4562,6 +5080,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">военный</column>
       <column name="definition_zh_HK">軍方</column>
       <column name="definition_pt">Militar, Exército</column>
+      <column name="definition_fi">armeija, sotaväki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4572,6 +5091,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru">Это относится к любой военной организации. Официальный Клингонский {QI':n} будет {tlhIngan Hubbeq:n}.</column>
       <column name="notes_zh_HK">這是指任何軍事組織。官方克林崗{QI':n}是{tlhIngan Hubbeq:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a qualquer organização militar. O Klingon {QI':n} oficial é o {tlhIngan Hubbeq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa mihin tahansa sotilaalliseen organisaatioon. Virallinen Klingon {QI':n} on {tlhIngan Hubbeq:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4581,6 +5101,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4588,6 +5109,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4601,6 +5123,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">Название праздника</column>
       <column name="definition_zh_HK">假期的名字 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nome de um feriado</column>
+      <column name="definition_fi">eräs juhla (loma?)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4611,6 +5134,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru">В {PK:src}, это произносится Майклом Дорном, как {Qetlop:sen:nolink}.</column>
       <column name="notes_zh_HK">在{PK:src}中，Michael Dorn像{Qetlop:sen:nolink}一樣發音。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No {PK:src}, isso é pronunciado por Michael Dorn como {Qetlop:sen:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{PK:src}: ssä tämän lausuu Michael Dorn kuten {Qetlop:sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{QI':n}, {lop:n}</column>
       <column name="examples"></column>
@@ -4620,6 +5144,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Qetlop</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4627,6 +5152,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -4640,6 +5166,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">Хитомер</column>
       <column name="definition_zh_HK">「凱托摩爾」</column>
       <column name="definition_pt">Khitomer</column>
+      <column name="definition_fi">Khitomer</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4650,6 +5177,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru">Это название заставы в Клингонской империи рядом с Ромуланской границей, где было заключено важное мирное соглашение с Федерацией.[3]</column>
       <column name="notes_zh_HK">這是羅慕蘭邊境附近克林崗帝國前哨站的名稱，在那裡與聯邦簽署了重要的和平協議。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um posto avançado no Império Klingon, perto da fronteira romulana, onde um importante acordo de paz foi assinado com a Federação.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Klinonin imperiumin etuvartion nimi lähellä Romulanin rajaa, jossa federaation kanssa allekirjoitettiin tärkeä rauhansopimus.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4659,6 +5187,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4666,6 +5195,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {Klingon Monopoly:src}, [3] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -4679,6 +5209,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">Никто не выжил на Хитомере</column>
       <column name="definition_zh_HK">在「凱托摩爾」沒有人倖存下來。</column>
       <column name="definition_pt">Ninguém sobreviveu a Khitomer.</column>
+      <column name="definition_fi">Kukaan ei selviytynyt Khitomeristä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wo'rIv:n:name}</column>
@@ -4689,6 +5220,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{QI'tomer:n}, {-Daq:n}, {Hegh:v}, {-pu':v}, {Hoch:n}</column>
       <column name="examples"></column>
@@ -4698,6 +5230,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4705,6 +5238,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.99:src}</column>
     </table>
     <table name="mem">
@@ -4718,6 +5252,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">Рай (источник происхождения в Клингонской мифологии)</column>
       <column name="definition_zh_HK">天堂（克林崗神話中的創作源泉） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Paraíso (fonte de criação na mitologia klingon)</column>
+      <column name="definition_fi">Paratiisi (luomisen paikka klingonien mytologiassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suto'vo'qor:n}, {ghe'tor:n}</column>
@@ -4728,6 +5263,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru">Есть 2 идиомы, связанные с {QI'tu':n:nolink}, обе связаны с возрастом: {ngo'; QI'tu' rur@@ngo':v, QI'tu':n, rur:v} и {qan; QI'tu' rur@@qan:v:1, QI'tu':n, rur:v}. Первая может быть применена к объекту или идее, которая является очень старой, в то время как вторая может быть применена к старому человеку.[3]</column>
       <column name="notes_zh_HK">{QI'tu':n:nolink}有兩個與年齡相關的習慣用法：{ngo'; QI'tu' rur@@ngo':v, QI'tu':n, rur:v}和{qan; QI'tu' rur@@qan:v:1, QI'tu':n, rur:v}。第一個可能適用於非常古老的對像或構想，而第二個可能適用於老年人。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existem dois idiomas associados ao {QI'tu':n:nolink}, ambos relacionados à sua idade: {ngo'; QI'tu' rur@@ngo':v, QI'tu':n, rur:v} e {qan; QI'tu' rur@@qan:v:1, QI'tu':n, rur:v}. O primeiro pode ser aplicado a um objeto ou idéia muito antigo, enquanto o segundo pode ser aplicado a uma pessoa idosa.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{QI'tu':n:nolink}: een liittyy kaksi idiomia, jotka molemmat liittyvät sen ikään: {ngo'; QI'tu' rur@@ngo':v, QI'tu':n, rur:v} ja {qan; QI'tu' rur@@qan:v:1, QI'tu':n, rur:v}. Ensimmäistä voidaan soveltaa esineeseen tai ideaan, joka on hyvin vanha, kun taas toista voidaan soveltaa vanhaan ihmiseen.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4737,6 +5273,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">heaven, creation, Eden</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4744,6 +5281,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru">Эден, небеса, создание</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KCD:src}, [3] {KGT p.130:src}</column>
     </table>
     <table name="mem">
@@ -4757,6 +5295,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">Вульгарное выражение не имеющее перевода</column>
       <column name="definition_zh_HK">粗俗的表達、無視翻譯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">expressão vulgar que desafia a tradução</column>
+      <column name="definition_fi">eräs kirosana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4767,6 +5306,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru">Смотрите, как это говорит Гаурон: {YouTube video:url:http://youtu.be/IWW3uAXvOeM}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/IWW3uAXvOeM} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/IWW3uAXvOeM} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/IWW3uAXvOeM} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is only noted as a curse in {TKD:src}. The explanation that it is a vulgar expression which defies translation comes from {KCD:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4776,6 +5316,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4783,6 +5324,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -4796,6 +5338,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">Криос Прайм</column>
       <column name="definition_zh_HK">Krios Prime [AUTOTRANSLATED]</column>
       <column name="definition_pt">Krios Prime</column>
+      <column name="definition_fi">Krios I</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4806,6 +5349,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru">Планета в Клингонской империи, колонизированная Клингонами.</column>
       <column name="notes_zh_HK">克林崗帝國的一個星球，曾被克林崗人殖民。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta no Império Klingon, em um ponto colonizado por Klingons. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin imperiumin planeetta, jossa Klingonit asuttivat yhdessä vaiheessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It may or may not be a coincidence that the name of this planet appears to be made up of {QI':n} and {yoS:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4815,6 +5359,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4822,6 +5367,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -4835,6 +5381,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">тенденция, склонность [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傾向，傾向 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tendência, propensão</column>
+      <column name="definition_fi">taipumus, alttius (jonkin tekemiseen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4845,6 +5392,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru">Суффикс {-meH:v} и глагол {chIw:v} используются вместе с этим, чтобы выразить склонность что-либо делать. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">後綴{-meH:v}和動詞{chIw:v}用來表示有做某事的傾向。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O sufixo {-meH:v} e o verbo {chIw:v} são usados ​​com isso para expressar a tendência de fazer algo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Laajennusta {-meH:v} ja verbiä {chIw:v} käytetään tämän kanssa ilmaisemaan taipumusta tehdä jotain. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The typical way to use this was clarified during the Q &amp; A session. MO said he would avoid the verb {ghaj:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4854,6 +5402,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4861,6 +5410,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4874,6 +5424,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">быть опасным, быть рискованным</column>
       <column name="definition_zh_HK">很危險 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser perigoso</column>
+      <column name="definition_fi">olla vaarallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qan:v}, {QaD:v:2}, {Qob:n}, {Qom:v:2}</column>
@@ -4884,6 +5435,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It says on {TKD p.50:src} that a verb expressing a state or quality can be used "immediately following a noun". The {paq'batlh:src} excerpt is an example of two adjectives on a noun ("long and dangerous battle"), where one of the Klingon verbs uses {-bogh:v:suff}, which suggests two verbs used adjectivally cannot follow one noun.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4901,6 +5453,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4908,6 +5461,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -4921,6 +5475,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">опасность, угроза</column>
       <column name="definition_zh_HK">危險</column>
       <column name="definition_pt">perigo</column>
+      <column name="definition_fi">vaara</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qob:v}</column>
@@ -4931,6 +5486,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4942,6 +5498,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4949,6 +5506,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4962,6 +5520,7 @@ Não existe uma maneira tradicional Klingon de dizer algo como "Feliz Natal". Um
       <column name="definition_ru">быть несогласным с чем-то, не соглашаться, расходиться во мнениях</column>
       <column name="definition_zh_HK">不同意 [AUTOTRANSLATED]</column>
       <column name="definition_pt">discordar</column>
+      <column name="definition_fi">olla eri mieltä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qochbe':v}</column>
       <column name="see_also"></column>
@@ -4984,6 +5543,9 @@ This verb can take {'e':n:pro} as its object.[2]</column>
       <column name="notes_pt">A discordância também é expressa pela expressão idiomática {cha' DoSmey DIqIp.:sen:idiom}
 
 Este verbo pode ter {'e':n:pro} como seu objeto.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Erimielisyydet ilmaistaan ​​myös idiomaattisella ilmaisulla {cha' DoSmey DIqIp.:sen:idiom}
+
+Tämä verbi voi ottaa objektiksi {'e':n:pro}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">At {Saarbrücken qepHom'a' 2011:src}, MO accepted {maQoch 'e' wIQochbe':sen:nolink} as a way of expressing "we agree to disagree" in Klingon, though he did not compose the sentence.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4993,6 +5555,7 @@ Este verbo pode ter {'e':n:pro} como seu objeto.[2] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5000,6 +5563,7 @@ Este verbo pode ter {'e':n:pro} como seu objeto.[2] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2011:src}</column>
     </table>
     <table name="mem">
@@ -5013,6 +5577,7 @@ Este verbo pode ter {'e':n:pro} como seu objeto.[2] [AUTOTRANSLATED]</column>
       <column name="definition_ru">соглашаться, сходиться во мнениях, приходить к согласию</column>
       <column name="definition_zh_HK">同意 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aceitar</column>
+      <column name="definition_fi">olla samaa mieltä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qoch:v}</column>
       <column name="see_also">{ghIb:v}</column>
@@ -5047,6 +5612,11 @@ Avtal uttrycks också av det idiomatiska uttrycket {wa' DoS wIqIp.:sen:idiom} [A
 {Qochbe':v:nolink} implica uma ausência de desacordo, enquanto {QochHa':v:nolink} implica que a discordância foi extraviada ou desfeita.[3]
 
 A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:sen:idiom} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksinkertaisesti verbi {Qoch:v} plus pääte {-be':v}.[2]
+
+{Qochbe':v:nolink} tarkoittaa erimielisyyksien puuttumista, kun taas {QochHa':v:nolink} tarkoittaa, että erimielisyydet on väärin sijoitettu tai kumottu.
+
+Sopimus ilmaistaan ​​myös idiomaattisella ilmaisulla {wa' DoS wIqIp.:sen:idiom}[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Qoch:v}, {-be':v}</column>
       <column name="examples">
@@ -5057,6 +5627,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5064,6 +5635,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.11.30:src} (repeated in {s.k 1998.02.23:src}), [3] {s.k 1998.03.02:src}, [4] {msn 1996.08.06:src}</column>
     </table>
     <table name="mem">
@@ -5077,6 +5649,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">Манёвр (двигатели)</column>
       <column name="definition_zh_HK">機動（發動機） [AUTOTRANSLATED]</column>
       <column name="definition_pt">manobrar (motores)</column>
+      <column name="definition_fi">ohjata varovaisesti tai pujotella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jonta':n}, {QuQ:n}</column>
@@ -5087,6 +5660,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5096,6 +5670,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">manoeuvre, manoeuver</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5103,6 +5678,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru">маневр, маневрировать</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5116,6 +5692,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">Тип животного</column>
       <column name="definition_zh_HK">動物的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal</column>
+      <column name="definition_fi">eräs eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Saj:n}</column>
@@ -5126,6 +5703,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru">Животное, что содержится, как домашняя зверушка</column>
       <column name="notes_zh_HK">這種動物被當作寵物飼養。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este animal é mantido como animal de estimação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä eläintä pidetään lemmikkinä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5135,6 +5713,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5142,6 +5721,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5155,6 +5735,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">мозг (орган)</column>
       <column name="definition_zh_HK">大腦（器官） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cérebro (órgão)</column>
+      <column name="definition_fi">aivot (elin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5165,6 +5746,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru">Слово относится к органу. Для контекста "разум", смотрите слово {yab:n}.</column>
       <column name="notes_zh_HK">這個詞是指器官。有關“意識”的含義，請參閱{yab:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se ao órgão. Para o sentido de "mente", consulte {yab:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa urkuun. Katso mielen merkitys kohdasta {yab:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">From Latin "cogito", meaning "to think".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5174,6 +5756,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5181,6 +5764,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5194,6 +5778,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">фырканье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">哼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cheirar</column>
+      <column name="definition_fi">tuhahtaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghugh:v}</column>
@@ -5204,6 +5789,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru">Это похоже на то, что делает свинья, но это не ограничивается свиньями или брезентом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就像豬所做的一樣，但不僅限於豬或雜草。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É assim que um porco faz, mas não se restringe a porcos ou targs. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kuin mitä sika tekee, mutta se ei rajoitu sioihin tai targiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5213,6 +5799,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5220,6 +5807,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5233,6 +5821,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">нажмите [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">輕拍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tocar gentilmente com o dedo</column>
+      <column name="definition_fi">naputtaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5243,6 +5832,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä tarkoittaa koskettaa sormia varovasti johonkin, yleensä muutaman kerran. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5252,6 +5842,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5259,6 +5850,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5272,6 +5864,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">Воевать</column>
       <column name="definition_zh_HK">打仗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer guerra</column>
+      <column name="definition_fi">aloittaa sota</column>
       <column name="synonyms"></column>
       <column name="antonyms">{roj:v}</column>
       <column name="see_also">{vIq:n}, {veS:n}</column>
@@ -5282,6 +5875,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru">Глагол относится к самой идее войны. Для конкретной драки, смотрите {ghob:v}.</column>
       <column name="notes_zh_HK">這個動詞指戰爭的概念。有關具體戰鬥，請參閱{ghob:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo se refere à idéia de guerra. Para lutas de concreto, consulte {ghob:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi viittaa sodan ajatukseen. Katso konkreettiset taistelut kohdasta {ghob:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5291,6 +5885,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5298,6 +5893,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5311,6 +5907,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">телепортировать откуда-то обратно</column>
       <column name="definition_zh_HK">傳送走</column>
       <column name="definition_pt">teletransportar para fora</column>
+      <column name="definition_fi">siirtää pois (siirtimellä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jol:v}</column>
       <column name="see_also">{jol:n}, {lab:v}</column>
@@ -5321,6 +5918,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5330,6 +5928,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5337,6 +5936,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5350,6 +5950,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">испытать землетрясение или дрожь</column>
       <column name="definition_zh_HK">經歷地震或震顫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sofrer um terremoto ou tremor de terra</column>
+      <column name="definition_fi">kokea maanjäristys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jel:v}, {Seq:n}, {Qargh:n}, {Qom:v:2}</column>
@@ -5360,6 +5961,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5387,6 +5989,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">quake, shake</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5394,6 +5997,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru">дрожь</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -5408,6 +6012,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">быть опасным, быть опасным, быть коварным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">危險、危險、奸詐 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser perigoso, ser traiçoeiro</column>
+      <column name="definition_fi">olla vaarallinen, petollinen, epäluotettava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qob:v}, {Qom:v:1}</column>
@@ -5418,6 +6023,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">儘管有其定義，但該動詞在語法上的使用方式是基於其字面意義，因此在形容詞上使用該形容詞是不合語法的。[1, p.163] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Apesar de sua definição, a forma como este verbo é usado gramaticalmente é baseada em seu sentido literal, e não é gramaticalmente usado de forma adjetiva.[1, p.163] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Määritelmästään huolimatta tapa, jolla tätä verbiä käytetään kieliopillisesti, perustuu sen kirjaimelliseen merkitykseen, ja tätä ei ole kieliopillisesti käyttää adjektiivisesti.[1, p.163] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5430,6 +6036,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5437,6 +6044,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5450,6 +6058,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">журнал, технический журнал</column>
       <column name="definition_zh_HK">期刊、日誌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">diário, log</column>
+      <column name="definition_fi">päiväkirja, loki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5460,6 +6069,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Chronos" (Greek for "time"), from which comes the word "chronicle".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5469,6 +6079,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5476,6 +6087,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5489,6 +6101,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">спать</column>
       <column name="definition_zh_HK">睡覺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dormir</column>
+      <column name="definition_fi">nukkua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dum:v}, {leS:v}, {vem:v}, {Doy':v}, {Hob:v}, {naj:v}, {QongDaq:n}</column>
@@ -5499,6 +6112,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{Qong:v:nolink} is used in {TKD:src} to illustrate the pronominal prefixes with no object. While the text strongly suggests that it does not take an object, it isn't explicitly stated.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5508,6 +6122,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5515,6 +6130,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5528,6 +6144,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">кровать</column>
       <column name="definition_zh_HK">床</column>
       <column name="definition_pt">cama</column>
+      <column name="definition_fi">sänky</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qong:v}, {ngogh tun:n}, {QongDaq buq:n}, {tlhIm:n}</column>
@@ -5538,6 +6155,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word may be evidence that at an earlier stage of the language, there may have been a noun {Qong:n:nolink} meaning "sleep" or a verb suffix {-Daq:v:suff,nolink} meaning "place where one does something", or that a noun {Qong:n:nolink} current exists which is unattested elsewhere, but these are just conjectures.[2]</column>
       <column name="components">{Qong:v} or {Qong:n:hyp,nolink}, {Daq:n}</column>
       <column name="examples"></column>
@@ -5547,6 +6165,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5554,6 +6173,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.06.18:src}</column>
     </table>
     <table name="mem">
@@ -5567,6 +6187,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">Клингоны не лежат в кровати</column>
       <column name="definition_zh_HK">克林崗人不躺在床上。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Os klingons não se deitam na cama.</column>
+      <column name="definition_fi">Klingonit eivät makaa sängyssä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5577,6 +6198,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5586,6 +6208,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5593,6 +6216,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.40:src}</column>
     </table>
     <table name="mem">
@@ -5606,6 +6230,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">подушка, спальный мешок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">枕頭、睡袋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">travesseiro, saco de dormir</column>
+      <column name="definition_fi">tyyny, päänalunen?, makuupussi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngogh tun:n}, {QongDaq:n}</column>
@@ -5616,6 +6241,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru">Мальц сказал, что это означает «мешок для кровати», и, возможно, спальный мешок - {QongDaq buq'a':n:nolink}, а подушка - {QongDaq buqHom:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">馬爾茨說，這意味著“床袋”，也許睡袋是{QongDaq buq'a':n:nolink}，枕頭是{QongDaq buqHom:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Maltz disse que isso significa "bolsa de cama", e talvez um saco de dormir seja {QongDaq buq'a':n:nolink} e um travesseiro seja {QongDaq buqHom:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maltz sanoi, että tämä tarkoittaa "sängyn pussi", ja ehkä makuupussi on {QongDaq buq'a':n:nolink} ja tyyny {QongDaq buqHom:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{QongDaq:n}, {buq:n}</column>
       <column name="examples"></column>
@@ -5625,6 +6251,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5632,6 +6259,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2010:src}</column>
     </table>
     <table name="mem">
@@ -5645,6 +6273,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">матрас [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">床墊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colchão</column>
+      <column name="definition_fi">patja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5655,6 +6284,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru">Это очень не-клингонская концепция. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個非常非克林崗語的概念。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um conceito muito não-klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on hyvin ei-klingonilainen käsite. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{QongDaq:n}, {'echlet:n}, {tun:v}</column>
       <column name="examples"></column>
@@ -5664,6 +6294,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5671,6 +6302,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5684,6 +6316,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">спящий корабль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">臥舖船 [AUTOTRANSLATED]</column>
       <column name="definition_pt">navio dorminhoco</column>
+      <column name="definition_fi">makuulaiva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qItI'nga':n}</column>
@@ -5694,6 +6327,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This term does not appear as such in canon, but {QongmeH qItI'nga' Duj:n:nolink} appears as the translation of "a sleeper ship of this [K'Tinga] class" in {SkyBox 15:src}.[1]</column>
       <column name="components">{Qong:v}, {-meH:v}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -5703,6 +6337,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5710,6 +6345,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 15:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -5723,6 +6359,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">изнашиваться</column>
       <column name="definition_zh_HK">穿破了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desgastado</column>
+      <column name="definition_fi">olla loppuun kulunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sab:v}, {ragh:v}, {Qop:v:2}</column>
@@ -5733,6 +6370,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru">Обычно применяется к старому оружию, инструментам, механическим устройствам, и так далее.[2, стр.163]</column>
       <column name="notes_zh_HK">通常適用於舊武器，工具，機械設備等。[2, p.163] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso geralmente é aplicado a armas antigas, ferramentas, dispositivos mecânicos e assim por diante.[2, p.163] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään yleensä vanhoissa aseissa, työkaluissa, mekaanisissa laitteissa ja niin edelleen[2, p.163] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5742,6 +6380,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5749,6 +6388,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5762,6 +6402,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">быть мёртвым (в отношении еды)</column>
       <column name="definition_zh_HK">死了（指食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar morto (referente a alimentos)</column>
+      <column name="definition_fi">olla kuollut (ruoasta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eyHa':v}, {Qop:v:1}</column>
@@ -5772,6 +6413,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru">Используется только в контексте упоминания пищи, которую предполагается съесть живой, например {qagh:n}.[1, стр.163]</column>
       <column name="notes_zh_HK">僅用於指預期要現場食用的食物，例如{qagh:n}.[1, p.163] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado apenas em referência a alimentos que se espera sejam comidos vivos, como {qagh:n}.[1, p.163] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään vain viittaamaan ruokiin, joiden oletetaan syövän elävinä, kuten {qagh:n}.[1, p.163] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5781,6 +6423,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5788,6 +6431,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5801,6 +6445,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">изнашивать, состаривать, истощать, истрепать</column>
       <column name="definition_zh_HK">磨損 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desgastar</column>
+      <column name="definition_fi">kuluttaa loppuun</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5811,6 +6456,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qop:v:1}, {-moH:v}</column>
       <column name="examples"></column>
@@ -5820,6 +6466,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5827,6 +6474,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5840,6 +6488,7 @@ A concordância também é expressa pela expressão idiomática {wa' DoS wIqIp.:
       <column name="definition_ru">Музыка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">音樂</column>
       <column name="definition_pt">música</column>
+      <column name="definition_fi">musiikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QoQ jan:n}, {bom:n}, {much:n}, {Ham:v}, {pun:v}, {'ISQIm:n}, {'IngSav:n}, {jaghIv:n}, {romta':n}, {Savvanwer:n}</column>
@@ -5858,6 +6507,9 @@ Detta avser all musik, vare sig vokal eller instrumental eller båda. [2] [AUTOT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingons sanoo musiikin sanoille {jaqmoH:v}, {SeymoH:v}, {tungHa':v} tai {pIlmoH:v}.
+
+Tämä viittaa mihin tahansa musiikkiin, niin laulu-, instrumentaali- kuin molempiinkin[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This sounds like the Cantonese word for "song" (曲).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5867,6 +6519,7 @@ Detta avser all musik, vare sig vokal eller instrumental eller båda. [2] [AUTOT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5874,6 +6527,7 @@ Detta avser all musik, vare sig vokal eller instrumental eller båda. [2] [AUTOT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
     </table>
     <table name="mem">
@@ -5887,6 +6541,7 @@ Detta avser all musik, vare sig vokal eller instrumental eller båda. [2] [AUTOT
       <column name="definition_ru">музыкальная группа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">音樂組</column>
       <column name="definition_pt">banda musical</column>
+      <column name="definition_fi">musiikkiryhmä, yhtye</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ra':v:2}</column>
@@ -5897,6 +6552,7 @@ Detta avser all musik, vare sig vokal eller instrumental eller båda. [2] [AUTOT
       <column name="notes_ru">Это более общий термин для группы (любого размера), исполняющей музыку, по сравнению с {ghenraq:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與{ghenraq:n}相比，這是一個更廣泛的術語，用於表示一組（任何大小）的音樂。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo mais geral para um grupo (de qualquer tamanho) tocando música, em comparação com {ghenraq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleisempi termi musiikkia soittavalle ryhmälle (kaikenkokoisille) verrattuna {ghenraq:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{QoQ:n}, {ghom:n}</column>
       <column name="examples"></column>
@@ -5906,6 +6562,7 @@ Detta avser all musik, vare sig vokal eller instrumental eller båda. [2] [AUTOT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5913,6 +6570,7 @@ Detta avser all musik, vare sig vokal eller instrumental eller båda. [2] [AUTOT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5926,6 +6584,7 @@ Detta avser all musik, vare sig vokal eller instrumental eller båda. [2] [AUTOT
       <column name="definition_ru">музыкальный инструмент [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">樂器</column>
       <column name="definition_pt">instrumento musical</column>
+      <column name="definition_fi">musiikkisoitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5946,6 +6605,9 @@ Typer av Klingon-musikinstrument inkluderar: slagverk ({'In:n}), vind (ingen tot
       <column name="notes_pt">Isso pode ser encurtado para apenas {jan:n:2} se o contexto for claramente musical, mas isso raramente é feito.[1]
 
 Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (sem termo geral), windbag ou fole ({SuSDeq:n}) e cordas ({HurDagh:n} e {ngItHel:n}). Os instrumentos de sopro incluem o {Dov'agh:n}, o {gheb:n} e o {meSchuS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voidaan lyhentää vain {jan:n:2}-muotoon, jos asiayhteys on selvästi musikaali, mutta näin tehdään harvoin.
+
+Klingonin soittimien tyyppejä ovat: lyömäsoittimet ({'In:n}), tuuli (ei yleistä termiä), tuulipussi tai palkeet ({SuSDeq:n}) ja joustavat ({HurDagh:n} ja {ngItHel:n}). Puhallinsoittimiin kuuluvat {Dov'agh:n}, {gheb:n} ja {meSchuS:n}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{QoQ:n}, {jan:n:1}</column>
       <column name="examples"></column>
@@ -5955,6 +6617,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5962,6 +6625,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.74:src}</column>
     </table>
     <table name="mem">
@@ -5975,6 +6639,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="definition_ru">бороться, сражаться (очень незначительный бой) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥、戰鬥（非常輕微的戰鬥） [AUTOTRANSLATED]</column>
       <column name="definition_pt">lutar, batalhar (luta de menor escala)</column>
+      <column name="definition_fi">taistella (hyvin vähäisessä taistelussa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suv:v}, {may':n}</column>
@@ -5985,6 +6650,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="notes_ru">В порядке возрастания жестокости глаголы, используемые для описания военных столкновений: {Qor:v:nolink}, {tlhaS:v}, {vay:v}, {lul:v}, {Hargh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">按照兇猛的升序，用於描述軍事對抗的動詞是：{Qor:v:nolink}、{tlhaS:v}、{vay:v}、{lul:v}、{Hargh:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Armeijan nousevassa järjestyksessä sotilaallisia yhteenottoja kuvaavia verbejä ovat: {Qor:v:nolink}, {tlhaS:v}, {vay:v}, {lul:v}, {Hargh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5994,6 +6660,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6001,6 +6668,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6014,6 +6682,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="definition_ru">заботиться о ком-то, присматривать за кем-то</column>
       <column name="definition_zh_HK">照顧</column>
       <column name="definition_pt">cuidar, cuidar de</column>
+      <column name="definition_fi">huolehtia jostakusta, hoitaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rach:v}</column>
@@ -6024,6 +6693,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6033,6 +6703,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6040,6 +6711,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6054,6 +6726,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="definition_ru">окно</column>
       <column name="definition_zh_HK">窗口</column>
       <column name="definition_pt">janela</column>
+      <column name="definition_fi">ikkuna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{notron:n}, {lojmIt:n}</column>
@@ -6064,6 +6737,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6073,6 +6747,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6080,6 +6755,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6093,6 +6769,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="definition_ru">быть сожалеющим о чем-то, быть огорчённым, быть опечаленным</column>
       <column name="definition_zh_HK">感到遺憾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desculpar</column>
+      <column name="definition_fi">olla pahoillaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIj:v}, {vup:v}, {pay:v}</column>
@@ -6103,6 +6780,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6112,6 +6790,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6119,6 +6798,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6132,6 +6812,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="definition_ru">лежать, залегать, возлежать, откидываться назад, сидеть развалившись</column>
       <column name="definition_zh_HK">瞓低</column>
       <column name="definition_pt">deitar, reclinar</column>
+      <column name="definition_fi">maata, loikoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ba':v}, {Hu':v}, {Qam:v}, {tor:v:1}, {Dub:n}</column>
@@ -6142,6 +6823,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Lie in a "cot".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6151,6 +6833,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6158,6 +6841,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6171,6 +6855,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="definition_ru">Охотник не возляжет с добычей</column>
       <column name="definition_zh_HK">獵人並沒有躺著獵物。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O caçador não se deita com a presa.</column>
+      <column name="definition_fi">Metsästäjä ei käy makaamaan saaliin kanssa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6181,6 +6866,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6190,6 +6876,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6197,6 +6884,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.161:src}</column>
     </table>
     <table name="mem">
@@ -6210,6 +6898,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="definition_ru">Кротмаг</column>
       <column name="definition_zh_HK">Krotmag [AUTOTRANSLATED]</column>
       <column name="definition_pt">Krotmag</column>
+      <column name="definition_fi">Krotmag</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qotmagh Sep:n}</column>
@@ -6220,6 +6909,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="notes_ru">Это имя лидера, что завоевал прилегающие к его региону территории.</column>
       <column name="notes_zh_HK">這是征服其周邊地區的領導人的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um líder que conquistou áreas vizinhas de sua região. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on johtajan nimi, joka valloitti alueensa naapurialueet. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} and not in the glossary.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6229,6 +6919,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6236,6 +6927,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6249,6 +6941,7 @@ Os tipos de instrumentos musicais Klingon incluem: percussão ({'In:n}), vento (
       <column name="definition_ru">Регион Кротмаг</column>
       <column name="definition_zh_HK">Krotmag州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Região de Krotmag</column>
+      <column name="definition_fi">Krotmagin alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sep Hol Sar:n}</column>
@@ -6271,6 +6964,9 @@ I Krotmag-regionen ersätter högtalarna {b:sen:nolink} med {m:sen:nolink} och {
       <column name="notes_pt">Esta região é nomeada após Krotmag ({Qotmagh:n:name}).
 
 Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nolink} e {D:sen:nolink} por {N:sen:nolink}.[1, p.21] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä alue on nimetty Krotmagin ({Qotmagh:n:name}) mukaan.
+
+Krotmagin alueella kaiuttimet korvaavat {b:sen:nolink}: n {m:sen:nolink}: lla ja {D:sen:nolink}: n {N:sen:nolink}: lla.[1, p.21] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} and not in the glossary.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6280,6 +6976,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6287,6 +6984,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6300,6 +6998,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="definition_ru">делать неспособным, делать непригодным, лишать возможности</column>
       <column name="definition_zh_HK">禁用 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desabilitar, desligar</column>
+      <column name="definition_fi">vammauttaa, tehdä toimintakyvyttömäksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6310,6 +7009,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Be careful not to say this word by accident if you mean {Hotlh:v:2} instead.[2]</column>
       <column name="components"></column>
       <column name="examples">
@@ -6321,6 +7021,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
 ▶ {QaptaHvIS So'wI', Hoch jagh Dujmey DaQotlh.:sen:nolink} "Вырубите все вражеские корабли, пока вы находитесь под маскировкой."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6328,6 +7029,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.189:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6341,6 +7043,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="definition_ru">Бранное слово</column>
       <column name="definition_zh_HK">稱號 [AUTOTRANSLATED]</column>
       <column name="definition_pt">epíteto</column>
+      <column name="definition_fi">eräs haukkumasana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6351,6 +7054,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6360,6 +7064,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6367,6 +7072,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -6380,6 +7086,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="definition_ru">слышать, услышать, внимать, внять, выслушивать, услыхать</column>
       <column name="definition_zh_HK">聽到</column>
       <column name="definition_pt">ouvir, escutar</column>
+      <column name="definition_fi">kuulla, kuunnella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Ij:v}, {qogh tuQmoHHa':sen}</column>
@@ -6390,6 +7097,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="notes_ru">Это означает "слышать", а не просто "слушать". Слушатель должен воспринимать и понимать, что было сказано.[2, стр.31]</column>
       <column name="notes_zh_HK">這意味著“聽”，而不僅僅是“聽”。傾聽者必須真正理解並理解所講的內容.[2, p.31] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "ouvir" e não apenas "ouvir". O ouvinte deve realmente perceber e entender o que está sendo dito.[2, p.31] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "kuule" eikä vain "kuuntele". Kuulijan on todella havaittava ja ymmärrettävä mitä sanotaan[2, p.31] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined only as "hear" in {TKD:src}. The "listen to" definition was added based on the explanation in {TKW:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6400,6 +7108,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6407,6 +7116,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -6421,6 +7131,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="definition_ru">Повзолить кому-то слышать (что-то)</column>
       <column name="definition_zh_HK">讓某人聽到（某事） [AUTOTRANSLATED]</column>
       <column name="definition_pt">deixar alguém ouvir (algo)</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ja':v}</column>
@@ -6431,6 +7142,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="notes_ru">Смотрите {qawmoH:v} для примера того, как использовать глагол, подобный этому.</column>
       <column name="notes_zh_HK">有關如何使用此類動詞的示例，請參見{qawmoH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja {qawmoH:v} para um exemplo de como usar um verbo como este. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in the word lists in {TKD:src}, but appears in the explanation of {-moH:v:suff} in {TKD 4.2.4:src}, where {chenmoH:v} also appears. This entry is here for ease of reference.</column>
       <column name="components">{Qoy:v}, {-moH:v}</column>
       <column name="examples">
@@ -6441,6 +7153,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tell</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6448,6 +7161,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.38:src}</column>
     </table>
     <table name="mem">
@@ -6461,6 +7175,7 @@ Na região de Krotmag, os alto-falantes substituem {b:sen:nolink} por {m:sen:nol
       <column name="definition_ru">Услышьте сыны Кейлеса! (гимн)</column>
       <column name="definition_zh_HK">聽住啊，「凱勒斯」之兒子們！（戰歌）</column>
       <column name="definition_pt">Ouça, Filhos de Kahless! (hino)</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{van bom:n}, {taHjaj wo':sen:lyr}</column>
@@ -6515,6 +7230,7 @@ The line {yoHbogh matlhbogh je SuvwI':sen:nolink} should be {yoHbogh 'ej matlhbo
 Строка {yoHbogh matlhbogh je SuvwI':sen:nolink} является не ошибкой, а сознательным архаизмом, который отражен в "воин храбр и смел". В стандартном Клингонском, это будет {yoHbogh 'ej matlhbogh SuvwI':sen:nolink}.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The actors who performed this song on {KCD:src} mispronounced the intended {Say'moHchu':v:nolink} as {SeymoHchu':v:nolink}. This error has since propagated to other recordings of the song.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6524,6 +7240,7 @@ The line {yoHbogh matlhbogh je SuvwI':sen:nolink} should be {yoHbogh 'ej matlhbo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6531,6 +7248,7 @@ The line {yoHbogh matlhbogh je SuvwI':sen:nolink} should be {yoHbogh 'ej matlhbo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}, [2] {KLI mailing list 2000.12.01:src}</column>
     </table>
     <table name="mem">
@@ -6544,6 +7262,7 @@ The line {yoHbogh matlhbogh je SuvwI':sen:nolink} should be {yoHbogh 'ej matlhbo
       <column name="definition_ru">сертификат [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">證書 [AUTOTRANSLATED]</column>
       <column name="definition_pt">certificar</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaw':n}, {baj:v}</column>
@@ -6568,6 +7287,7 @@ Klingons anser titelakt ({yer ghajwI' chaw':n}) som en typ av {chaw':n:nolink}, 
       <column name="notes_pt">Isso pode ser usado para um certificado ou diploma, mas não para uma licença ou permissão, que seria um {chaw':n}. A diferença é que um {Qoyje':n:nolink} é a prova ou verificação de algum tipo de conquista ou realização, mas não necessariamente permite que você faça nada como resultado disso.
 
 Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como um tipo de {chaw':n:nolink}, em vez de um tipo de {Qoyje':n:nolink}, já que a propriedade é concedida por um governo ou outra autoridade, mas não é uma realização. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Pun: {Qoy:v} "hear" + {je':v:1} "buy" = "hereby". Many certificates begin with "I hereby certify that...".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6577,6 +7297,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">diploma</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6584,6 +7305,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2015.05.29:src}</column>
     </table>
     <table name="mem">
@@ -6597,6 +7319,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="definition_ru">Часы тикают [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">時鐘在滴答作響 [AUTOTRANSLATED]</column>
       <column name="definition_pt">o tempo está passando</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pav:v}, {nom:adv}
@@ -6609,6 +7332,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qoy:v}, {-lu':v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -6618,6 +7342,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6625,6 +7350,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -6639,6 +7365,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="definition_ru">проливать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">灑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">derramar</column>
+      <column name="definition_fi">läikyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qang:v:1}, {lIch:v}, {teb:v}, {buy':v}</column>
@@ -6649,6 +7376,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="notes_ru">Это используется, когда жидкость выплескивается из или вне контейнера, в котором она находилась. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">當液體從所盛裝的容器中溢出或溢出時使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado quando o líquido cai ou sai de qualquer recipiente em que estava. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään, kun neste putoaa sen säiliön päälle tai pois. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6659,6 +7387,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6666,6 +7395,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -6679,6 +7409,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="definition_ru">Нет, я не буду, я отказываюсь, я не согласен</column>
       <column name="definition_zh_HK">不、我不會、我拒絕、我不同意 [AUTOTRANSLATED]</column>
       <column name="definition_pt">não, eu não vou, eu recuso, eu discordo</column>
+      <column name="definition_fi">ei, en, kieltäydyn, olen eri mieltä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghobe':excl}, {-Qo':v:suff}</column>
@@ -6689,6 +7420,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{TKD:src} lists this as "no, I won't, I refuse", and {TKDA:src} adds "no, I disagree".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6698,6 +7430,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6705,6 +7438,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6718,6 +7452,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="definition_ru">Кронос</column>
       <column name="definition_zh_HK">「克洛诺斯」星</column>
       <column name="definition_pt">Kronos</column>
+      <column name="definition_fi">Kronos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yoq yIn yuQ:n}, {tlhIngan:n}, {juHqo':n}</column>
@@ -6728,6 +7463,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="notes_ru">Это название Клингонского родного мира</column>
       <column name="notes_zh_HK">這是克林崗家庭世界的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome do mundo dos Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Klingonin kotimaailman nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6741,6 +7477,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
   "Главная планета Клингонской империи, Qo'noS обычно упоминается просто как "Родной мир". Здесь расположен зал Клингонского верховного совета, являющийся центром Клингонского правительства. Qo'noS планета класса "М" с кислородно/азотной атмосферой."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6748,6 +7485,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {SkyBox 27:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6761,6 +7499,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="definition_ru">литой (литой металл) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鑄造（鑄造金屬） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fundir (metal)</column>
+      <column name="definition_fi">valaa (metallia)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mItlh:v}, {baS laSvargh:n}, {vIncha':n}, {QumeH ngaSwI':n}</column>
@@ -6771,6 +7510,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6780,6 +7520,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6787,6 +7528,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6800,6 +7542,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="definition_ru">форма (для литья) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">模具（用於鑄造） [AUTOTRANSLATED]</column>
       <column name="definition_pt">molde (para fundição)</column>
+      <column name="definition_fi">muotti (metallin valuuta varten)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mItlh:v}, {Qu:v}, {vIncha':n}, {baS laSvargh:n}</column>
@@ -6810,6 +7553,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qu:v}, {-meH:v}, {ngaSwI':n}</column>
       <column name="examples"></column>
@@ -6819,6 +7563,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6826,6 +7571,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6839,6 +7585,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="definition_ru">думать, мыслить, размышлять, раздумывать, обдумывать</column>
       <column name="definition_zh_HK">認為 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pensar</column>
+      <column name="definition_fi">ajatella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-law':v:suff}, {jal:v}, {paQ:v}, {buSHach:n}</column>
@@ -6861,6 +7608,9 @@ Slangbetydelsen av {chong:v:2,slang}, när den appliceras på en person, motsvar
       <column name="notes_pt">Este verbo pode ter {'e':n:pro} como seu objeto.[2]
 
 O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é equivalente a {Qubchu'} "pense claramente" .[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi voi ottaa objektiksi {'e':n:pro}.[2]
+
+{chong:v:2,slang}: n slangimerkitys, kun sitä sovelletaan henkilöön, vastaa {Qubchu'}: n "ajattele selkeästi".[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6872,6 +7622,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
 ▶ {tlhIngan Hol Dajatlh 'e' vIQub.:sen:nolink} "Я думаю, что ты говоришь на Клингонском."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6879,6 +7630,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.07.01:src} (reprinted in {HQ 7.2, p.8, Jun. 1998:src}), [3] {KGT p.148:src}</column>
     </table>
     <table name="mem">
@@ -6892,6 +7644,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">быть счастливым, быть довольным, быть веселым</column>
       <column name="definition_zh_HK">要開心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser feliz</column>
+      <column name="definition_fi">olla iloinen, onnellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'IQ:v}, {QuchHa':v}</column>
       <column name="see_also">{bel:v}, {'It:v}</column>
@@ -6902,6 +7655,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Заметьте, что идиома "счастливого праздника" (где праздник может быть заменен на какое-то конкретное название) не имеет смысла, когда дословно переводится на Клингонский. Чтобы перевести такое выражение, предполагается использовать {tIv:v}. (Смотрите {qoSlIj DatIvjaj!:sen} для примера.)</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Observe que o idioma inglês "(tenha um) feriado feliz" (onde "feriado" pode ser substituído pelo nome real de um feriado) não faz sentido quando traduzido literalmente para o klingon. Para traduzir essa expressão, considere usar {tIv:v}. (Veja {qoSlIj DatIvjaj!:sen} para um exemplo.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että englanninkielisellä ilmaisulla "(pidä a) hyvää lomaa" (jossa loma voi korvata loman todellisen nimen) ei ole järkeä, kun se kirjaimellisesti käännetään klingoniksi. Käännä tällainen lauseke harkitsemalla sen sijaan {tIv:v}. (Katso esimerkki {qoSlIj DatIvjaj!:sen}.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6911,6 +7665,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be merry, be jolly</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6918,6 +7673,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru">быть веселым</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6931,6 +7687,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">лоб</column>
       <column name="definition_zh_HK">額頭</column>
       <column name="definition_pt">testa</column>
+      <column name="definition_fi">otsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIl:v:1}, {vIlHom:n}, {Sep Hol Sar:n}</column>
@@ -6941,6 +7698,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Региональные слова для лба включают в себя: {boD:n}, {jargh:n}, {mIQ:n}, {'aQlo':n}, {Huy'Dung:n}, {tuqvol:n}, и {no''och:n}.</column>
       <column name="notes_zh_HK">前額的區域性單詞包括：{boD:n}、{jargh:n}、{mIQ:n}、{'aQlo':n}、{Huy'Dung:n}、{tuqvol:n}和{no''och:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Palavras regionais para testa incluem: {boD:n}, {jargh:n}, {mIQ:n}, {'aQlo':n}, {Huy'Dung:n}, {tuqvol:n} e {no''och:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Otsan alueellisia sanoja ovat: {boD:n}, {jargh:n}, {mIQ:n}, {'aQlo':n}, {Huy'Dung:n}, {tuqvol:n} ja {no''och:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6950,6 +7708,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6957,6 +7716,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6970,6 +7730,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">быть несчастливым, быть несчастным, быть недовольным, быть невеселым</column>
       <column name="definition_zh_HK">不開心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser infeliz</column>
+      <column name="definition_fi">olla onneton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Quch:v}</column>
       <column name="see_also"></column>
@@ -6980,6 +7741,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Это не в точности тоже самое, что и {'IQ:v}, с того, самого момента, как это значит изменение состояния с счастливого на несчастливое.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso não significa exatamente a mesma coisa que {'IQ:v}, pois implica uma mudança de ser feliz para não ser feliz.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei tarkoita tarkalleen samaa kuin {'IQ:v}, koska se merkitsee muutosta onnellisuudesta olemattomaksi.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Quch:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -6989,6 +7751,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6996,6 +7759,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1998.03.02:src}</column>
     </table>
     <table name="mem">
@@ -7009,6 +7773,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">восстание, мятеж, бунт</column>
       <column name="definition_zh_HK">起義 [AUTOTRANSLATED]</column>
       <column name="definition_pt">insurreição</column>
+      <column name="definition_fi">kapina, kansannousu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daw':n}</column>
@@ -7019,6 +7784,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7028,6 +7794,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7035,6 +7802,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7048,6 +7816,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">бедствие, несчастье, катастрофа</column>
       <column name="definition_zh_HK">災害 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desastre</column>
+      <column name="definition_fi">katastrofi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7058,6 +7827,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Это слово и {lot:n} в основном взаимозаменяемы. Чтобы сослаться на то, от чего, по всей вероятности, невозможно оправиться (например, потеря {pIraqSIS:n}), {lot:n:nolink} лучше.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞和{lot:n}通常可以互換。提到某種不可能恢復的東西（例如{pIraqSIS:n}的損失，{lot:n:nolink}更好）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sana ja {lot:n} ovat enimmäkseen vaihdettavissa. {lot:n:nolink} on parempi viitata johonkin, josta todennäköisesti ei voi toipua (kuten {pIraqSIS:n}: n menetys).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7067,6 +7837,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7074,6 +7845,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2019.01.09:src}</column>
     </table>
     <table name="mem">
@@ -7087,6 +7859,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Крюге</column>
       <column name="definition_zh_HK">「克魯格」</column>
       <column name="definition_pt">Kruge</column>
+      <column name="definition_fi">Kruge</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qovIj:n}</column>
@@ -7097,6 +7870,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">The Chinese transliteration comes from the subtitles of {Star Trek III:src}.[3]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7106,6 +7880,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7113,6 +7888,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 5.6:src}, [2] {KGT:src}, [3] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -7126,6 +7902,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">игра</column>
       <column name="definition_zh_HK">遊戲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">jogo</column>
+      <column name="definition_fi">peli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quj:v}</column>
@@ -7136,6 +7913,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7145,6 +7923,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7152,6 +7931,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7165,6 +7945,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">сыграть в игру</column>
       <column name="definition_zh_HK">玩個遊戲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Jogar um jogo</column>
+      <column name="definition_fi">pelata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reH:v}, {ghet:v}, {Quj:n}</column>
@@ -7175,6 +7956,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Разница между этим словом и {reH:v} в том, что это относится к структурированной игре, в то время как {reH:v:nolink} относится к неструктурированной игре.[2]</column>
       <column name="notes_zh_HK">此與{reH:v}之間的區別在於，這是指結構化遊戲，而{reH:v:nolink}是指非結構化遊戲。此動詞不將{'e':n:pro}作為其賓語。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A diferença entre isso e {reH:v} é que isso se refere ao jogo estruturado, enquanto {reH:v:nolink} se refere ao jogo não estruturado. Este verbo não aceita {'e':n:pro} como seu objeto.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän ja {reH:v}: n ero on siinä, että tämä viittaa jäsenneltyyn peliin, kun taas {reH:v:nolink} viittaa strukturoimattomaan peliin. Tämä verbi ei pidä {'e':n:pro}: ta objektina.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the "Radio Times Star Trek 30th Anniversary Special Issue", cricket (the sport) is translated as {ghew:n:nolink}. Specifically, "Cricket, please." was translated as {DaH ghew yIQuj.:sen:nolink}[3]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7184,6 +7966,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7191,6 +7974,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2011:src}, [3] {Radio Times Star Trek 30th Anniversary Special Issue:src}</column>
     </table>
         <table name="mem">
@@ -7204,6 +7988,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="definition_ru">мяч</column>
           <column name="definition_zh_HK">球 [AUTOTRANSLATED]</column>
           <column name="definition_pt">bola</column>
+      <column name="definition_fi">(pallopelin) pallo</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7214,6 +7999,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="notes_ru">Сферический объект для игры</column>
           <column name="notes_zh_HK">這個詞在玩球的意義上是“球”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esta palavra significa "bola" no sentido de um objeto esférico para jogar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana tarkoittaa "palloa" pallomaisen esineen merkityksessä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Quj:v}, {-meH:v}, {moQ:n}</column>
           <column name="examples"></column>
@@ -7223,6 +8009,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7230,6 +8017,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -7243,6 +8031,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="definition_ru">игровой токен, игровой фрагмент [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">玩遊戲、遊戲片 [AUTOTRANSLATED]</column>
           <column name="definition_pt">ficha de jogo, peça do jogo</column>
+      <column name="definition_fi">pelimerkki, nappula</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7253,6 +8042,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="notes_ru">В {Klingon Monopoly:src} {QujwI' lIw:n:nolink} используется для обозначения игровых фишек, которые заменяют игрока. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">在{Klingon Monopoly:src}中，{QujwI' lIw:n:nolink}用於指代代表玩家的遊戲作品。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Em {Klingon Monopoly:src}, {QujwI' lIw:n:nolink} é usado para se referir às peças do jogo que substituem o jogador. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohdassa {Klingon Monopoly:src} {QujwI' lIw:n:nolink} käytetään viittaamaan peliin, joka seisoo pelaajan edessä. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Quj:v}, {-wI':v}, {lIw:n}</column>
           <column name="examples">
@@ -7263,6 +8053,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7270,6 +8061,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Klingon Monopoly:src}</column>
         </table>
         <table name="mem">
@@ -7283,6 +8075,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="definition_ru">игровая доска [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">遊戲板 [AUTOTRANSLATED]</column>
           <column name="definition_pt">tabuleiro de jogo [AUTOTRANSLATED]</column>
+      <column name="definition_fi">pelilauta</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7293,6 +8086,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Quj:n}, {'echlet:n}</column>
           <column name="examples"></column>
@@ -7302,6 +8096,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7309,6 +8104,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Klingon Monopoly:src}</column>
         </table>
     <table name="mem">
@@ -7322,6 +8118,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">исследовать</column>
       <column name="definition_zh_HK">研究</column>
       <column name="definition_pt">pesquisar</column>
+      <column name="definition_fi">tutkia, tehdä tutkimusta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QeD:n}, {ngong:v}</column>
@@ -7332,6 +8129,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Research is "cruel".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7341,6 +8139,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7348,6 +8147,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7361,6 +8161,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">исследовательская лаборатория [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">研究實驗室</column>
       <column name="definition_pt">laboratório de pesquisa</column>
+      <column name="definition_fi">tutkimuslaboratorio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngong:n}, {ngong:v}</column>
@@ -7371,6 +8172,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qul:v} or {Qul:n:hyp,nolink}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -7380,6 +8182,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">research laboratory</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7387,6 +8190,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7400,6 +8204,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">передавать сигнал, сообщаться, общаться с кем-то, устанавливать связь</column>
       <column name="definition_zh_HK">通信 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comunicar</column>
+      <column name="definition_fi">viestiä, kommunikoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rI':v}</column>
@@ -7410,6 +8215,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Вне соединений, таких как {QumpIn:n}, {Qum:sen:nolink} это просто глагол. Это предполагает, что существительное {Qum:n:archaic} существовало некоторое время в прошлом.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Yhdisteiden, kuten {QumpIn:n}, ulkopuolella {Qum:sen:nolink} löytyy vain verbinä. Tämä viittaa siihen, että substantiivi {Qum:n:archaic} oli olemassa jonkin aikaa aiemmin.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7419,6 +8225,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7426,6 +8233,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.159:src}</column>
     </table>
     <table name="mem">
@@ -7439,6 +8247,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">связь, коммуникационные технологии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通信、關於通信的技術</column>
       <column name="definition_pt">comunicações, tecnologia relacionada às comunicações</column>
+      <column name="definition_fi">viestintä, viestintätekniikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qum:v}</column>
@@ -7449,6 +8258,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Существование {Qum:sen:nolink} как существительного в прошлом подтверждается такими словами, как {QumpIn:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{Qum:sen:nolink}: n olemassaolo substantiivina menneisyydessä on todistettu sanoilla kuten {QumpIn:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7461,6 +8271,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7468,6 +8279,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}, [2] {KGT p.159:src}</column>
     </table>
     <table name="mem">
@@ -7481,6 +8293,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">компьютер связи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通訊計算機 [AUTOTRANSLATED]</column>
       <column name="definition_pt">computador de comunicação</column>
+      <column name="definition_fi">viestintätietokone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7491,6 +8304,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qum:v}, {De'wI':n}</column>
       <column name="examples"></column>
@@ -7500,6 +8314,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7507,6 +8322,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7520,6 +8336,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">система связи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通訊系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sistema de comunicação</column>
+      <column name="definition_fi">viestintäjärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7530,6 +8347,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qum:v}, {pat:n}</column>
       <column name="examples"></column>
@@ -7539,6 +8357,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7546,6 +8365,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7559,6 +8379,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">консоль связи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通訊控制台 [AUTOTRANSLATED]</column>
       <column name="definition_pt">console de comunicação</column>
+      <column name="definition_fi">viestintäkonsoli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7569,6 +8390,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qum:v}, {SeHlaw:n}</column>
       <column name="examples"></column>
@@ -7578,6 +8400,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7585,6 +8408,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7598,6 +8422,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Офицер по связи</column>
       <column name="definition_zh_HK">通訊員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">oficial de comunicações</column>
+      <column name="definition_fi">viestintäupseeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7608,6 +8433,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Первая часть этого слова, {Qum:sen:nolink}, встречается в другом месте только как глагол. Это говорит о том, что существительное {Qum:n:archaic} существовало в прошлом.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">A primeira parte desta palavra, {Qum:sen:nolink}, é encontrada em outro lugar apenas como um verbo. Isso sugere que um substantivo {Qum:n:archaic} existia no passado.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan ensimmäinen osa, {Qum:sen:nolink}, löytyy muualla vain verbinä. Tämä viittaa siihen, että substantiivi {Qum:n:archaic} oli olemassa aikaisemmin.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Qum:v}, {pIn:n:1}</column>
       <column name="examples"></column>
@@ -7617,6 +8443,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7624,6 +8451,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.159:src}</column>
     </table>
     <table name="mem">
@@ -7637,6 +8465,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">коммуникатор, устройство связи</column>
       <column name="definition_zh_HK">通訊器、通訊設備 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comunicador, dispositivo de comunicação</column>
+      <column name="definition_fi">kommunikaattori, viestintälaite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7647,6 +8476,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qum:v}, {-wI':v}</column>
       <column name="examples">
@@ -7660,6 +8490,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
   "Клингонский коммуникатор посылает сигнал сквозь подпространство. Более старые модели восприимчивы к радиации."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7667,6 +8498,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 19:src}</column>
     </table>
     <table name="mem">
@@ -7680,6 +8512,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Я не могу найти свой коммуникатор</column>
       <column name="definition_zh_HK">我找不到我的溝通者。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu não consigo encontrar meu comunicador.</column>
+      <column name="definition_fi">En löydä kommunikaattoriani.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7690,6 +8523,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{Sam:v} is probably better for this sense of "find" than {tu':v}, but that's how the sentence appears on {TKD p.171:src}.</column>
       <column name="components">{QumwI':n}, {-wIj:n}, {vI-:v}, {tu':v}, {-laH:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -7699,6 +8533,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7706,6 +8541,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -7719,6 +8555,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">свиток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滾動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rolo de papel</column>
+      <column name="definition_fi">käärö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7729,6 +8566,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">此單詞用於隱含重要，神聖或古老的捲軸（儘管不一定是全部三個）。任何{Qumran:n:nolink}都是{tetlh:n}，但並非每個{tetlh:n:nolink}都是{Qumran:n:nolink}。在典禮中使用滾動時，通常將其稱為{Qumran:n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra é usada para um pergaminho que é implícito como importante, sagrado ou antigo (embora não seja necessariamente os três). Qualquer {Qumran:n:nolink} é um {tetlh:n}, mas nem todo {tetlh:n:nolink} é um {Qumran:n:nolink}. Quando um pergaminho é usado em uma cerimônia, geralmente é chamado de {Qumran:n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään vieritykseen, jonka oletetaan olevan tärkeä, pyhä tai muinainen (vaikka se ei välttämättä ole kaikkia kolmea). Mikä tahansa {Qumran:n:nolink} on {tetlh:n}, mutta kaikki {tetlh:n:nolink} eivät ole {Qumran:n:nolink}. Kun rullaa käytetään seremoniassa, siihen viitataan tyypillisesti nimellä {Qumran:n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the archaeological site where the Dead Sea Scrolls were discovered.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7738,6 +8576,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7745,6 +8584,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2013.06.03:src}, [2] {KLI mailing list 2013.06.12:src}</column>
     </table>
     <table name="mem">
@@ -7758,6 +8598,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">бог, сверхъестественное существо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">神</column>
       <column name="definition_pt">deus, ser sobrenatural</column>
+      <column name="definition_fi">jumala, yliluonnollinen olento</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuQun:n}, {qa':n}</column>
@@ -7768,6 +8609,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Pouco se sabe sobre os deuses klingons, exceto que parece que eles agiram coletivamente, e nenhum indivíduo se destacou dentre eles. O {Qun'a':n:nolink} pode ou não ser uma tradução apropriada para a divindade suprema de uma religião monoteísta, uma vez que o {Qun'a':n:nolink} ainda seria um dentre muitos.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin jumalista tiedetään vähän, paitsi että näyttää siltä, ​​että he toimivat kollektiivisesti, eikä yksikään yksilö eronnut heidän joukostaan. {Qun'a':n:nolink} saattaa olla sopiva käännös monoteistisen uskonnon korkeimmalle jumaluudelle, koska {Qun'a':n:nolink} olisi silti yksi monien joukosta.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7777,6 +8619,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7784,6 +8627,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 1999.07.19:src}</column>
     </table>
     <table name="mem">
@@ -7797,6 +8641,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">быть округлым, тупым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">圓潤、生硬 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser redondo, contundente</column>
+      <column name="definition_fi">olla pyöristetty, tylsä (ei terävä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jej:v}</column>
       <column name="see_also">{jejHa':v}</column>
@@ -7807,6 +8652,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Например, это может относиться к углу стола, который не является острым углом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">例如，這可能是指桌子的角不是銳角。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Por exemplo, isso pode se referir ao canto de uma tabela que não é um ângulo agudo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata esimerkiksi taulukon kulmaan, joka ei ole terävä kulma. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7816,6 +8662,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7823,6 +8670,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -7836,6 +8684,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">быть молодым</column>
       <column name="definition_zh_HK">年輕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser jovem</column>
+      <column name="definition_fi">olla nuori</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qan:v:1}</column>
       <column name="see_also"></column>
@@ -7846,6 +8695,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7857,6 +8707,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
 ▶ {jIH Qup law' SoH Qup puS:sen:nolink} "Я моложе тебя."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">youth</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7864,6 +8715,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru">юность</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -7877,6 +8729,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">двигатель</column>
       <column name="definition_zh_HK">發動機 [AUTOTRANSLATED]</column>
       <column name="definition_pt">motor</column>
+      <column name="definition_fi">moottori</column>
       <column name="synonyms">{jonta':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{nguSDI':n}, {QoD:v}</column>
@@ -7887,6 +8740,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{baHwI', DoS yIbuS. QuQ neH.:sen}</column>
@@ -7896,6 +8750,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7903,6 +8758,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7916,6 +8772,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">структура, организация [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結構、組織 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estrutura, organização</column>
+      <column name="definition_fi">rakenne, järjestys, asettelu; (eläimen) anatomia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{porghQeD:n}</column>
@@ -7926,6 +8783,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Это не означает здание ({qach:n}) или совокупность людей или состояний ({DIvI':n}, {tlham:n:2}), а скорее то, как вещи сочетаются друг с другом или расположение частей чего-то большего. Это может использоваться, чтобы означать "анатомию", обращаясь к животным. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這並不意味著建築物（{qach:n}）或人或州的集合（{DIvI':n}，{tlham:n:2}），而是事物組合在一起的方式或更大事物的各個部分的排列方式。當提到動物時，它可以用來表示“解剖學”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä ei tarkoita rakennusta ({qach:n}) tai kokoelmaa ihmisiä tai valtioita ({DIvI':n}, {tlham:n:2}), vaan pikemminkin tapaa, jolla asiat sopivat yhteen, tai jonkin suuremman osan järjestelyä. Sitä voidaan käyttää tarkoittamaan "anatomiaa" viitattaessa eläimiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7935,6 +8793,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">organisation, anatomy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7942,6 +8801,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2011:src}</column>
     </table>
     <table name="mem">
@@ -7955,6 +8815,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">заговор, конспирация, тайный сговор</column>
       <column name="definition_zh_HK">陰謀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conspiração</column>
+      <column name="definition_fi">salaliitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daw':n}, {'urmang:n}, {QuS:v}</column>
@@ -7965,6 +8826,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7974,6 +8836,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7981,6 +8844,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7994,6 +8858,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">сговариваться, тайно замышлять, устраивать заговор</column>
       <column name="definition_zh_HK">合謀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conspirar</column>
+      <column name="definition_fi">vehkeillä, tehdä salaliitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nab:v}, {QuS:n}</column>
@@ -8004,6 +8869,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8013,6 +8879,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8020,6 +8887,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8033,6 +8901,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">быть вульгарным, быть похабным</column>
       <column name="definition_zh_HK">粗俗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser vulgar</column>
+      <column name="definition_fi">olla mauton (teosta tms., ei mausta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Doch:v}, {ngIj:v}</column>
@@ -8043,6 +8912,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Crude" or "cute".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8052,6 +8922,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8059,6 +8930,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8072,6 +8944,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">служба поддержки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">支撐</column>
       <column name="definition_pt">suportar</column>
+      <column name="definition_fi">kannatella, tukea (fyysisesti)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dej:v}, {qappam:n}</column>
@@ -8082,6 +8955,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">Это может относиться только к физической поддержке чего-либо. Его нельзя использовать для психологической или любой другой нефизической поддержки. Слово {ghaq:v} используется для денежной поддержки.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只能指在身體上支持某物。它不能用於心理或任何其他非身體類型的支持。 {ghaq:v}一詞用於貨幣支持。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso só pode se referir a apoiar fisicamente alguma coisa. Não pode ser usado para apoio psicológico ou qualquer outro tipo não físico. A palavra {ghaq:v} é usada para suporte monetário.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata vain jonkin fyysiseen tukemiseen. Sitä ei voida käyttää psykologiseen tai muuhun ei-fyysiseen tukeen. Sanaa {ghaq:v} käytetään rahalliseen tukeen.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Crutch".</column>
       <column name="components"></column>
       <column name="examples">
@@ -8092,6 +8966,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8099,6 +8974,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}, [2] {KLI mailing list 2010.07.26:src}</column>
     </table>
     <table name="mem">
@@ -8112,6 +8988,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">координаты</column>
       <column name="definition_zh_HK">坐標</column>
       <column name="definition_pt">coordenadas</column>
+      <column name="definition_fi">koordinaatit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DoD:n}, {baSta':n}</column>
@@ -8122,6 +8999,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8132,6 +9010,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8139,6 +9018,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -8152,6 +9032,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Пусть твои координаты будут свободны от трибблов!</column>
       <column name="definition_zh_HK">願你的坐標沒有摩擦！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Que suas coordenadas estejam livres de tribbles!</column>
+      <column name="definition_fi">Olkoot koordinaattisi vapaita tribbleistä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8162,6 +9043,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8171,6 +9053,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8178,6 +9061,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -8191,6 +9075,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">долг, обязанность, задание, задача, работа</column>
       <column name="definition_zh_HK">職責、任務、任務、任務、家務 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dever, busca, missão, tarefa, trabalho</column>
+      <column name="definition_fi">tehtävä, työtehtävä, komennus, askare</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baj:v}, {vum:v}, {tur:v}, {ghIgh:n:2}, {yaH:n}, {Hoq:n}, {tuH:n}, {bel Qu':n}</column>
@@ -8201,6 +9086,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru">{per yuD:n} обычно заканчивается на {Qu':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{per yuD:n}通常以{Qu':n:nolink}.[2]結尾 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um {per yuD:n} geralmente termina em {Qu':n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{per yuD:n} päättyy yleensä kohtaan {Qu':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8210,6 +9096,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8217,6 +9104,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.48:src}</column>
     </table>
     <table name="mem">
@@ -8230,6 +9118,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">поручение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">使命 [AUTOTRANSLATED]</column>
       <column name="definition_pt">incumbência</column>
+      <column name="definition_fi">asia, askare (pieni tehtävä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8240,6 +9129,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qu':n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -8249,6 +9139,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8256,6 +9147,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8269,6 +9161,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Если воин игнорирует обязанности, действует бесчестно, или он неверен, то он ничто!</column>
       <column name="definition_zh_HK">如果一個戰士無視職責，行為不公正，或者是不忠誠，他就什麼都不是。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Se um guerreiro ignora o dever, age desonrosamente ou é desleal, ele não é nada.</column>
+      <column name="definition_fi">Jos soturi ei noudata velvollisuuksiaan, toimii kunniattomasti tai on epälojaali, hän ei ole mitään.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8279,6 +9172,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qu':n}, {buS:v}, {-Ha':v}, {-chugh:v}, {SuvwI':n}, {batlhHa':adv}, {vang:v}, {-chugh:v}, {qoj:conj}, {matlh:v}, {-Ha':v}, {-chugh:v}, {pagh:n:1}, {ghaH:n}, {SuvwI':n}, {-'e':n}</column>
       <column name="examples"></column>
@@ -8288,6 +9182,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">If a warrior ignores duty, acts dishonourably, or is disloyal, he is nothing.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8295,6 +9190,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru">Если воин игнорирует обязанности, действует бесчестно, или он неверен, то он ничто!</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.139:src}</column>
     </table>
     <table name="mem">
@@ -8308,6 +9204,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Когда начнете миссию, вспомните Актуха и Мелоту.</column>
       <column name="definition_zh_HK">當你開始執行任務時，請記住Aktuh和Melota。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quando você começa uma missão, lembre-se de Aktuh e Melota.</column>
+      <column name="definition_fi">Kun aloitat tehtävän, muista Aktuh ja Melota.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'aqtu':n:name}, {mellota':n:name}</column>
@@ -8318,6 +9215,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8327,6 +9225,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8334,6 +9233,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.187:src}</column>
     </table>
     <table name="mem">
@@ -8347,6 +9247,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">смена, рабочая смена [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">轉移、工作轉移 [AUTOTRANSLATED]</column>
       <column name="definition_pt">turno, turno de trabalho</column>
+      <column name="definition_fi">työvuoro</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghom ngoy':n}, {yaH:n}</column>
@@ -8360,6 +9261,10 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingon-aluksella on kolme vuoroa:
+▶ {Qu' poH wa'DIch:n:nolink} "työvuoro"
+▶ {Qu' poH cha'DIch:n:nolink} "vapaa-aika"
+▶ {Qu' poH wejDIch:n:nolink} "unenvaihto" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8369,6 +9274,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8376,6 +9282,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Haynes BoP Manual p.110:src}</column>
     </table>
     <table name="mem">
@@ -8389,6 +9296,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Операции Миссии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">使命行動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Missão Ops</column>
+      <column name="definition_fi">Mission Ops [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8399,6 +9307,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qu':n}, {vu'wI':n}, {yaH:n}</column>
       <column name="examples"></column>
@@ -8408,6 +9317,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8415,6 +9325,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -8428,6 +9339,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Умереть во время исполнения обязанностей является мечтой каждого Клингона!</column>
       <column name="definition_zh_HK">每一個克林崗人都希望能夠履行職責。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Morrer no cumprimento do dever é a esperança de todo klingon.</column>
+      <column name="definition_fi">Jokainen klingon toivoo kuolevansa suorittaessaan velvollisuuksiaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8438,6 +9350,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8447,6 +9360,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8454,6 +9368,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.74:src}</column>
     </table>
     <table name="mem">
@@ -8467,6 +9382,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="definition_ru">Клингонское проклятие, сказанное в моменты сильного гнева!</column>
       <column name="definition_zh_HK">克林崗詛咒、極度憤怒的時刻說 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Insulto Klingon, dito em momentos de extrema raiva</column>
+      <column name="definition_fi">eräs kirosana (jota käytetään kun on äärimmäisen vihainen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{va:excl}, {Hutvagh:n}</column>
@@ -8477,6 +9393,7 @@ O significado da gíria de {chong:v:2,slang}, quando aplicado a uma pessoa, é e
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is only noted as a curse in {TKD:src}. The explanation that this is something one might say in moments of extreme anger comes from {CK:src}.
 
 In a deleted scene from {Star Trek V:src}, the response to this curse was an invective in Klingon followed by the English "Screw you too!"</column>
@@ -8488,6 +9405,7 @@ In a deleted scene from {Star Trek V:src}, the response to this curse was an inv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8495,5 +9413,6 @@ In a deleted scene from {Star Trek V:src}, the response to this curse was an inv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>

--- a/mem-13-Q.xml
+++ b/mem-13-Q.xml
@@ -7131,7 +7131,7 @@ Krotmagin alueella kaiuttimet korvaavat {b:sen:nolink}: n {m:sen:nolink}: lla ja
       <column name="definition_ru">Повзолить кому-то слышать (что-то)</column>
       <column name="definition_zh_HK">讓某人聽到（某事） [AUTOTRANSLATED]</column>
       <column name="definition_pt">deixar alguém ouvir (algo)</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">antaa jonkun kuulla jotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ja':v}</column>
@@ -7175,7 +7175,7 @@ Krotmagin alueella kaiuttimet korvaavat {b:sen:nolink}: n {m:sen:nolink}: lla ja
       <column name="definition_ru">Услышьте сыны Кейлеса! (гимн)</column>
       <column name="definition_zh_HK">聽住啊，「凱勒斯」之兒子們！（戰歌）</column>
       <column name="definition_pt">Ouça, Filhos de Kahless! (hino)</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">Kulkaa, Kahlessin pojat! (hymni)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{van bom:n}, {taHjaj wo':sen:lyr}</column>
@@ -7262,7 +7262,7 @@ The line {yoHbogh matlhbogh je SuvwI':sen:nolink} should be {yoHbogh 'ej matlhbo
       <column name="definition_ru">сертификат [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">證書 [AUTOTRANSLATED]</column>
       <column name="definition_pt">certificar</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">todistus (asiakirja)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaw':n}, {baj:v}</column>
@@ -7319,7 +7319,7 @@ Os klingons consideram os títulos de propriedade ({yer ghajwI' chaw':n}) como u
       <column name="definition_ru">Часы тикают [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">時鐘在滴答作響 [AUTOTRANSLATED]</column>
       <column name="definition_pt">o tempo está passando</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">kello käy</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pav:v}, {nom:adv}

--- a/mem-14-r.xml
+++ b/mem-14-r.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {r:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{r:sen:nolink}</column>
       <column name="definition_pt">a consoante {r:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {r:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">укреплять, подбадривать, поддерживать, давать силы, строить укрепление, усиливать</column>
       <column name="definition_zh_HK">振奮、強化、加強 [AUTOTRANSLATED]</column>
       <column name="definition_pt">revigorar, fortificar, fortalecer</column>
+      <column name="definition_fi">virkistää, voimistaa, vahvistaa, lujittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'argh:v}</column>
       <column name="see_also">{Qorgh:v}, {rachwI':n}, {HoSmoH:v}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Когда этот глагол применен, к какому-то лицу, то он предполагает улучшение здоровья. Когда глагол применен к неодушевленному объекту, подразумевается улучшение или совершенствование. Имеет отличия от {tI':v} потому что тот глагол обычно не применяется к живым существам, и подразумевает восстановление предыдущего состояния, а не улучшения. Также отличается от {Dub:v} в том, что тот глагол используется для описания улучшений абстрактных вещей.[1]</column>
       <column name="notes_zh_HK">當此動詞應用於人時，表明健康狀況得到改善。當將其應用於無生命的物體時，它意味著改進或改善。它與{tI':v}有所不同，因為該動詞通常不應用於生物，它表示恢復到先前的狀態而不是改善。它與{Dub:v}的不同還在於動詞用於改進更抽象的性質。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kun tätä verbiä sovelletaan henkilöön, se viittaa terveyden parantamiseen. Kun sitä käytetään elottomaan esineeseen, se tarkoittaa parantamista tai parantamista. Se erotetaan {tI':v}: stä, koska kyseistä verbiä ei yleensä sovelleta eläviin olentoihin, ja se ehdottaa palauttamista edelliseen tilaan eikä parannusta. Se eroaa myös {Dub:v}: sta siinä, että kyseistä verbiä käytetään abstraktimpien ominaisuuksien parantamiseen.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -69,6 +75,7 @@
 ▶ {chalqach rachlu'ta'bogh:n:nolink} "Укрепленная башня"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">improve, improvement, heal, healing, health</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -76,6 +83,7 @@
       <column name="search_tags_ru">Улучшать, улучшение, лечить, здоровье</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.10.20:src}, [2] {paq'batlh p.159:src}</column>
     </table>
     <table name="mem">
@@ -89,6 +97,7 @@
       <column name="definition_ru">медсестра [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">護士</column>
       <column name="definition_pt">enfermeira</column>
+      <column name="definition_fi">sairaanhoitaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qel:n:1h}, {SID:n}</column>
@@ -99,6 +108,7 @@
       <column name="notes_ru">В клингоне нет единого термина для «медсестры». Другими возможными терминами помощника врача являются {Qel boQ@@Qel:n:1h, boQ:n:1h} (или {HaqwI' boQ@@HaqwI':n, boQ:n:1h}, если врач является хирургом) и {QelHom:n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗語中沒有“護士”這個單一名詞。醫生助手的其他可能術語是{Qel boQ@@Qel:n:1h, boQ:n:1h}（如果醫生是外科醫生，則為{HaqwI' boQ@@HaqwI':n, boQ:n:1h}）和{QelHom:n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não existe um termo único para "enfermeira" em Klingon. Outros termos possíveis para o assistente de um médico são {Qel boQ@@Qel:n:1h, boQ:n:1h} (ou {HaqwI' boQ@@HaqwI':n, boQ:n:1h} se o médico for cirurgião) e {QelHom:n:nolink}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonissa ei ole yhtä termiä "sairaanhoitaja". Muita lääkäriavustajan mahdollisia termejä ovat {Qel boQ@@Qel:n:1h, boQ:n:1h} (tai {HaqwI' boQ@@HaqwI':n, boQ:n:1h}, jos lääkäri on kirurgi) ja {QelHom:n:nolink}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Nurse "Ratch"ed, from "One Flew Over the Cuckoo's Nest".</column>
       <column name="components">{rach:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -108,6 +118,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -115,6 +126,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.10.20:src}</column>
     </table>
     <table name="mem">
@@ -128,6 +140,7 @@
       <column name="definition_ru">подчинять, добиваться, заставлять, вынуждать, брать силой, навязывать, принуждать, вымучивать, нагнетать, взламывать, неволить, приневоливать, напрягать</column>
       <column name="definition_zh_HK">強迫</column>
       <column name="definition_pt">forçar, compelir</column>
+      <column name="definition_fi">pakottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pe'vIl:adv}</column>
@@ -138,6 +151,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -147,6 +161,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -154,6 +169,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -167,6 +183,7 @@
       <column name="definition_ru">распадаться, разрушаться, разлагаться, хиреть, приходить в упадок, загнивать, ветшать, истлевать, ржаветь, проедать, вытравлять, портиться</column>
       <column name="definition_zh_HK">腐爛、生鏽、腐蝕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">decompor, enferrujar, corroer</column>
+      <column name="definition_fi">rappeutua, hajota, ruostua, syöpyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sab:v}, {Qop:v:1}, {'eyHa':v}, {non:v}, {ngaw:v}</column>
@@ -177,6 +194,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Rag".</column>
       <column name="components"></column>
       <column name="examples">
@@ -188,6 +206,7 @@
 ▶ {Soj raghmoHlu'pu'} "Еда разложилась."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -195,6 +214,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -208,6 +228,7 @@
       <column name="definition_ru">кукла, фигурка, миниатюрный гуманоид [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">娃娃、動作人物、微型人形 [AUTOTRANSLATED]</column>
       <column name="definition_pt">boneca, figura de ação, humanóide em miniatura</column>
+      <column name="definition_fi">nukke, toimintahahmo, miniatyyri (humanoidi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -218,6 +239,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Raggedy Ann is a popular doll.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -227,6 +249,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -234,6 +257,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -247,6 +271,7 @@
       <column name="definition_ru">тип еды, рахт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物類型、racht [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de comida, racht</column>
+      <column name="definition_fi">eräs ruokalaji, racht</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIS:v}, {nogh:v}</column>
@@ -257,6 +282,7 @@
       <column name="notes_ru">Это тип пищи, приготовленной из живых змеевых червей (не путать с {qagh:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種由活蛇蠕蟲製成的食物（請勿與{qagh:n}混淆）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de alimento produzido a partir de vermes de serpente vivos (não deve ser confundido com {qagh:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen elintarvike, joka on valmistettu elävistä käärmematoista (ei pidä sekoittaa {qagh:n}: een). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -266,6 +292,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -273,6 +300,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -286,6 +314,7 @@
       <column name="definition_ru">почка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">腎 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rim</column>
+      <column name="definition_fi">munuainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -296,6 +325,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Rajma is red kidney bean curry.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -305,6 +335,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -312,6 +343,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, via {'ISqu':n:name}</column>
     </table>
     <table name="mem">
@@ -325,6 +357,7 @@
       <column name="definition_ru">быть насильственным, быть неистовым, быть яростным</column>
       <column name="definition_zh_HK">是暴力的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser violento</column>
+      <column name="definition_fi">olla väkivaltainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaQ:v}</column>
@@ -335,6 +368,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -344,6 +378,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -351,6 +386,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -364,6 +400,7 @@
       <column name="definition_ru">быть тривиальным, быть банальным, быть незначительным, быть обыденным, быть пустяковым, быть плёвым, быть пустячным, быть неважным, быть малозначительным, быть несущественным</column>
       <column name="definition_zh_HK">瑣碎、瑣碎、不重要、無足輕重 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser trivial, insignificante, sem importância, ser trivial</column>
+      <column name="definition_fi">olla vähäpätöinen, merkityksetön, yhdentekevä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{potlh:v}</column>
       <column name="see_also">{pav:v}, {ghIlab ghew:n}</column>
@@ -374,6 +411,7 @@
       <column name="notes_ru">Смотрите идиому {pollaH pagh polHa'laH:sen:idiom}.</column>
       <column name="notes_zh_HK">參見成語{pollaH pagh polHa'laH:sen:idiom}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja o idioma {pollaH pagh polHa'laH:sen:idiom}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso idioomi {pollaH pagh polHa'laH:sen:idiom}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -383,6 +421,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -390,6 +429,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -403,6 +443,7 @@
       <column name="definition_ru">ночь</column>
       <column name="definition_zh_HK">晚 [AUTOTRANSLATED]</column>
       <column name="definition_pt">noite</column>
+      <column name="definition_fi">yö</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pem:n}</column>
       <column name="see_also">{ramjep:n:1}, {'uQ:n}, {jajlo':n}, {choS:n}</column>
@@ -413,6 +454,7 @@
       <column name="notes_ru">Противоположностью является {pem:n}, а не {jaj:n}.[2]</column>
       <column name="notes_zh_HK">相反的是{pem:n}，而不是{jaj:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O oposto disso é {pem:n}, não {jaj:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän vastakohta on {pem:n}, ei {jaj:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -422,6 +464,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">evening, nighttime</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -429,6 +472,7 @@
       <column name="search_tags_ru">вечер, ночное время</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.121:src}</column>
     </table>
     <table name="mem">
@@ -442,6 +486,7 @@
       <column name="definition_ru">Мотивы несущественны.</column>
       <column name="definition_zh_HK">動機微不足道。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Motivos são insignificantes.</column>
+      <column name="definition_fi">Motiivit ovat yhdentekeviä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -452,6 +497,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -461,6 +507,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -468,6 +515,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.143:src}</column>
     </table>
     <table name="mem">
@@ -481,6 +529,7 @@
       <column name="definition_ru">полночь</column>
       <column name="definition_zh_HK">午夜</column>
       <column name="definition_pt">meia noite</column>
+      <column name="definition_fi">keskiyö</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pemjep:n}, {DungluQ:n}</column>
       <column name="see_also">{ram:n}, {ghem:n}</column>
@@ -491,6 +540,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ram:n}, {jep:n:hyp}</column>
       <column name="examples"></column>
@@ -500,6 +550,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -507,6 +558,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -520,6 +572,7 @@
       <column name="definition_ru">Птица рамджеп</column>
       <column name="definition_zh_HK">ramjep鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pássaro ramjep</column>
+      <column name="definition_fi">eräs lintu, ramjep</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}, {ramjep:n:1}</column>
@@ -530,6 +583,7 @@
       <column name="notes_ru">Птичья жизненная форма, являющаяся коренной на {Qo'noS:n}, что приходит только в темноте.</column>
       <column name="notes_zh_HK">{Qo'noS:n}原生的鳥類生命形式，僅在黑暗中出現。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Forma de vida aviária nativa do {Qo'noS:n} que só sai no escuro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Qo'noS:n}: lle syntyperäinen lintujen elämänmuoto, joka tulee esiin vain pimeässä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -539,6 +593,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -546,6 +601,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -559,6 +615,7 @@
       <column name="definition_ru">быть ответственным за</column>
       <column name="definition_zh_HK">對...負責任 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser responsável por</column>
+      <column name="definition_fi">olla vastuussa jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -569,6 +626,7 @@
       <column name="notes_ru">Это значит "быть за старшего, иметь власть над кем-то". Будет странным для этого глагола использоваться без объекта.[2]</column>
       <column name="notes_zh_HK">這意味著“負責，有權力”。不帶賓語使用該動詞將很奇怪。 {ngoy':v}.[2]的含義有些重疊 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "estar no comando, ter autoridade sobre". Seria estranho que esse verbo fosse usado sem um objeto. Existe alguma sobreposição de significado com {ngoy':v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "olla vastuussa, sinulla on valta". Olisi outoa, että tätä verbiä käytetään ilman esinettä. Merkityksessä on jonkin verran päällekkäisyyttä {ngoy':v}.[2]: n kanssa [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -578,6 +636,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">be in charge of, have authority over</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -585,6 +644,7 @@
       <column name="search_tags_ru">быть за старшего, иметь власть над кем-то</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.01:src}, [2] {KLI mailing list 2018.02.02:src}</column>
     </table>
     <table name="mem">
@@ -598,6 +658,7 @@
       <column name="definition_ru">быть одинаковым, быть идентичным</column>
       <column name="definition_zh_HK">相同、一樣</column>
       <column name="definition_pt">ser o mesmo</column>
+      <column name="definition_fi">olla sama, identtinen</column>
       <column name="synonyms">{nIb:v}</column>
       <column name="antonyms">{pIm:v}</column>
       <column name="see_also">{Sar:v}, {rur:v}, {nel:v}, {... X law' ... X puS:sen}</column>
@@ -620,6 +681,9 @@ Detta verb kan också användas för att uttrycka begreppet att två saker har s
       <column name="notes_pt">O assunto de {rap:v:nolink} são as coisas que são iguais.[2]
 
 Este verbo também pode ser usado para expressar o conceito de que duas coisas têm a mesma quantidade de alguma qualidade. O verbo {nIb:v} é usado de maneira semelhante, mas geralmente é usado com qualidades mensuráveis ​​e tem a conotação de precisão. No entanto, não é impróprio usar {rap:v:nolink} com uma qualidade mensurável. Veja os exemplos abaixo.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{rap:v:nolink}-aihe on sama asia
+
+Tätä verbiä voidaan käyttää myös ilmaisemaan käsite, että kahdella asialla on sama määrä tiettyä laatua. Verbiä {nIb:v} käytetään samalla tavalla, mutta sitä käytetään yleensä mitattavissa olevilla ominaisuuksilla ja sillä on tarkkuus. Ei ole kuitenkaan väärin käyttää {rap:v:nolink} -laitetta mitattavalla laadulla. Katso alla olevat esimerkit.[3][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Compare with {jaS:adv}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -633,6 +697,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
 ▶ {'ey ro'qegh'Iwchab, rap qagh.} "Гагх такой же вкусный, как кровавый пирог."[3]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -640,6 +705,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.2-12, Dec. 1998:src}, [3] {HQ 13.1, p.8-10, Mar. 2004:src}</column>
     </table>
     <table name="mem">
@@ -653,6 +719,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">весло [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">槳 [AUTOTRANSLATED]</column>
       <column name="definition_pt">remo, leme</column>
+      <column name="definition_fi">airo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vo':v}</column>
@@ -663,6 +730,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Star-Spangled Banner has the phrase "o'er the ramparts we watched", and {rapmar:n:nolink} reversed sounds like "rampart".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -672,6 +740,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -679,6 +748,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -692,6 +762,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">{qISa'ruj:n}</column>
       <column name="definition_zh_HK">{qISa'ruj:n}</column>
       <column name="definition_pt">{qISa'ruj:n}</column>
+      <column name="definition_fi">{qISa'ruj:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -702,6 +773,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -711,6 +783,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -718,6 +791,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Haynes BoP Manual:src}</column>
     </table>
     <table name="mem">
@@ -731,6 +805,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">быть повторным / избыточным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">重複/冗餘 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser repetitivo / redundante</column>
+      <column name="definition_fi">olla toisteinen, tarpeeton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -741,6 +816,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru">Это указывает на то, что что-то является повторением или дополнением чего-то еще. Он может быть использован для описания концепции {bIraqlul:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這表明某物是重複物或其他物。它可以用來描述{bIraqlul:n}的概念。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso indica que algo é uma repetição ou um extra de outra coisa. Pode ser usado para descrever o conceito de {bIraqlul:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä osoittaa, että jokin on toistoa tai ylimääräistä jotain muuta. Sitä voidaan käyttää kuvaamaan {bIraqlul:n}-käsitettä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -750,6 +826,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">repetitive, redundant</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -757,6 +834,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -770,6 +848,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">Военный лагерь</column>
       <column name="definition_zh_HK">營地（軍事術語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">acampamento (termo militar)</column>
+      <column name="definition_fi">sotilasleiri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{waw':n}</column>
@@ -780,6 +859,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -789,6 +869,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -796,6 +877,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -809,6 +891,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">манипулировать рукой, ручкой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用手操縱、處理 [AUTOTRANSLATED]</column>
       <column name="definition_pt">manipular à mão, manusear</column>
+      <column name="definition_fi">käsitellä (käsin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ruQ:v}, {'or:v}</column>
@@ -819,6 +902,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru">Это может быть применено к искусству, оружию или космическим кораблям. Это относится к любой деятельности, которая предполагает некоторый контроль над каким-либо объектом. В контексте мечей, он может быть использован со значением, аналогичным {yan:v}. В контексте космических кораблей (см. {Duj:n:1}) это относится к управлению судном «вручную», а не с помощью компьютера. Смотрите {KGT p.79:src} для объяснения этого глагола. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以應用於藝術，武器或宇宙飛船。它是指涉及對某個對象進行某種控制的任何活動。在劍的上下文中，可以使用與{yan:v}類似的含義。在宇宙飛船的背景下（請參閱{Duj:n:1}），這是指“手動”控制船隻，而不是通過計算機。有關此動詞的說明，請參見{KGT p.79:src}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser aplicado às artes, armas ou naves espaciais. Refere-se a qualquer atividade que envolva ter algum controle sobre algum objeto. No contexto de espadas, pode ser usado com um significado semelhante ao {yan:v}. No contexto de naves espaciais (consulte {Duj:n:1}), isso se refere ao controle de uma embarcação "manualmente", e não por computador. Veja {KGT p.79:src} para uma explicação deste verbo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan soveltaa taiteisiin, aseisiin tai avaruusaluksiin. Se viittaa mihin tahansa toimintaan, johon liittyy jonkinlainen hallinta jonkin objektin suhteen. Miekkojen yhteydessä sitä voidaan käyttää samanlaisella merkityksellä kuin {yan:v}. Avaruusalusten yhteydessä (katso {Duj:n:1}) tämä tarkoittaa aluksen hallintaa "manuaalisesti" eikä tietokoneella. Katso selitys tälle verbille kohdasta {KGT p.79:src}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -828,6 +912,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -835,6 +920,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -848,6 +934,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">пассажир</column>
       <column name="definition_zh_HK">乘客</column>
       <column name="definition_pt">passageiro</column>
+      <column name="definition_fi">matkustaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIQ:v}, {leng:v}, {'orwI':n}</column>
@@ -859,6 +946,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -868,6 +956,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -875,6 +964,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -888,6 +978,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">соединять, связывать, связать</column>
       <column name="definition_zh_HK">連 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conectar</column>
+      <column name="definition_fi">yhdistää, liittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -898,6 +989,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru">Когда скрепляют бумаги вместе, смотрите {Ha'on vevwI':n}, бумаги являются объектом для {rar:v:nolink}.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kun nidot paperit yhteen (katso {Ha'on vevwI':n}), paperit ovat {rar:v:nolink}-objektin kohteena.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -907,6 +999,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -914,6 +1007,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -927,6 +1021,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">связаны [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">相關的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser relacionado</column>
+      <column name="definition_fi">liittyä toisiinsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -937,6 +1032,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru">Это означает, что предметы в целом или концептуально связаны. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著主題通常或在概念上相關。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa que os assuntos são geralmente ou conceitualmente relacionados. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa, että aiheet liittyvät yleensä tai käsitteellisesti toisiinsa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{rar:v}, {-chuq:v}</column>
       <column name="examples"></column>
@@ -946,6 +1042,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -953,6 +1050,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -966,6 +1064,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">разъем, вилка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">連接器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conector, plug</column>
+      <column name="definition_fi">liitin, pistoke</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -976,6 +1075,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rar:v}, {-wI':v}</column>
       <column name="examples">{'ul rarwI':n}, {Hutvav rarwI':n}</column>
@@ -985,6 +1085,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -992,6 +1093,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1005,6 +1107,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">стол, таблица</column>
       <column name="definition_zh_HK">臺</column>
       <column name="definition_pt">mesa</column>
+      <column name="definition_fi">pöytä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quS:n}, {'aqroS:n:1}, {je'ton:n}</column>
@@ -1015,6 +1118,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Tabula rasa".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1024,6 +1128,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1031,6 +1136,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1044,6 +1150,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">настольный компьютер</column>
       <column name="definition_zh_HK">台式電腦、桌上型電腦</column>
       <column name="definition_pt">computador de mesa (desktop)</column>
+      <column name="definition_fi">pöytätietokone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{De'wI'Hom:n}</column>
@@ -1054,6 +1161,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{raS:n}, {De'wI':n}</column>
       <column name="examples"></column>
@@ -1063,6 +1171,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1070,6 +1179,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1083,6 +1193,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">семя, зерно</column>
       <column name="definition_zh_HK">種子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">semente</column>
+      <column name="definition_fi">siemen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIr:n}, {tI:n}, {Do'ol raS'IS:n}</column>
@@ -1093,6 +1204,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1102,6 +1214,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">grain</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1109,6 +1222,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru">зерно</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -1122,6 +1236,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">оставаться, пребывать в конкретном состоянии</column>
       <column name="definition_zh_HK">留 [AUTOTRANSLATED]</column>
       <column name="definition_pt">permanecer, restar</column>
+      <column name="definition_fi">jäädä, pysyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaD:v}, {choH:v}</column>
@@ -1132,6 +1247,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{yIratlh!:sen}</column>
@@ -1141,6 +1257,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">stay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1148,6 +1265,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="search_tags_ru">стой, стоять</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1161,6 +1279,7 @@ Este verbo também pode ser usado para expressar o conceito de que duas coisas t
       <column name="definition_ru">пол, настил</column>
       <column name="definition_zh_HK">地板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chão</column>
+      <column name="definition_fi">lattia</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'aqroS:n:1}, {pa' beb:n}, {rav'eq:n}</column>
       <column name="see_also">{beb:n}, {tlhoy' SaS:n}, {yor:n}, {choQ:n}</column>
@@ -1185,6 +1304,9 @@ Det finns ett Klingon-formspråk, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUT
       <column name="notes_pt">Observe que cada piso, ou nível, em uma embarcação é denominado {choQ:n} (convés).
 
 Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että aluksen jokaista kerrosta tai tasoa kutsutaan {choQ:n} (kanneksi).
+
+On olemassa klingonin idioomi {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1194,6 +1316,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1201,6 +1324,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.133:src}</column>
     </table>
     <table name="mem">
@@ -1214,6 +1338,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="definition_ru">минимальный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">最低限度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mínimo</column>
+      <column name="definition_fi">vähintään, vähimmäismäärä, minimi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'aqroS:n:2}</column>
       <column name="see_also">{rav ... 'aqroS ...:sen}</column>
@@ -1224,6 +1349,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1235,6 +1361,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">least, utmost, extreme, up, above</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1242,6 +1369,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1255,6 +1383,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="definition_ru">{rav ... 'aqroS ...:sen}</column>
       <column name="definition_zh_HK">{rav ... 'aqroS ...:sen}</column>
       <column name="definition_pt">{rav ... 'aqroS ...:sen}</column>
+      <column name="definition_fi">{rav ... 'aqroS ...:sen}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1265,6 +1394,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1274,6 +1404,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1281,6 +1412,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1294,6 +1426,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="definition_ru">между и ... [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">之間 ... [AUTOTRANSLATED]</column>
       <column name="definition_pt">entre ... e ...</column>
+      <column name="definition_fi">välillä ...:sta ...:een, vähintään ... ja enintään ...</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1304,6 +1437,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="notes_ru">Это используется для выражения идеи некоторой (возможно неизвестной) точки между двумя концами диапазона. Чтобы выразить полную растяжку всего диапазона, используйте {qubbID:n} вместо .[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於表達範圍兩端之間某個點（可能是未知的）的想法。要表達整個範圍的完整範圍，請改用{qubbID:n}。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para expressar a ideia de algum ponto (talvez desconhecido) entre duas extremidades de um intervalo. Para expressar toda a extensão de todo o intervalo, use {qubbID:n} em vez disso.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään ilmaisemaan ajatusta jostakin (kenties tuntemattomasta) pisteestä alueen kahden pään välillä. Jos haluat ilmaista koko alueen koko pituuden, käytä sen sijaan {qubbID:n}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1316,6 +1450,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1323,6 +1458,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1336,6 +1472,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="definition_ru">мебель, предмет мебели [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">家具，家具 [AUTOTRANSLATED]</column>
       <column name="definition_pt">móveis, mobília</column>
+      <column name="definition_fi">huonekalu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1346,6 +1483,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="notes_ru">Это относится только к отдельной (подвижной) мебели, а не к чему-то встроенному. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這僅指獨立（移動）家具，而不是指內置的家具。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se apenas a móveis independentes (móveis), não a algo embutido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa vain erillisiä (siirrettäviä) huonekaluja, ei jotain sisäänrakennettua. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Feodor Ingvar Kamprad was the founder of the IKEA furniture company.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1355,6 +1493,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1362,6 +1501,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1375,6 +1515,7 @@ Existe um idioma Klingon, {'IQ; rav rur@@'IQ:v, rav:n:1, rur:v}.[2] [AUTOTRANSLA
       <column name="definition_ru">потолок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">天花板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">teto</column>
+      <column name="definition_fi">katto (huoneessa, joka ei ole rakennuksen ylin huone)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{beb:n}, {rav:n:1}</column>
@@ -1397,6 +1538,9 @@ Det första elementet i detta ord är {rav:n:1} "golv", men det andra elementet 
       <column name="notes_pt">Refere-se ao teto ({'aqroS:n:1}) de uma sala que tem uma sala acima dela. O teto de uma sala que está no topo (ou apenas) da história de uma estrutura é chamado de {pa' beb:n}.[2]
 
 O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento não está relacionado com {'eq:v} "seja antecipado" .[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa huoneen kattoon ({'aqroS:n:1}), jonka yläpuolella on huone. Rakennuksen ylimmässä (tai ainoassa) tarinassa olevan huoneen kattoa kutsutaan sen {pa' beb:n}.[2]
+
+Tämän sanan ensimmäinen osa on {rav:n:1} "lattia", mutta toinen osa ei liity {'eq:v} "ole varhainen" -kohtaan.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1406,6 +1550,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1413,6 +1558,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src}), [2] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1426,6 +1572,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">молния [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">閃電 [AUTOTRANSLATED]</column>
       <column name="definition_pt">soltar raio</column>
+      <column name="definition_fi">salamoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pe'bIl:n}, {tuD:v}, {jev:v:1}</column>
@@ -1436,6 +1583,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru">Обратите внимание, что это глагол в клингоне. В клингоне каждый говорит «это молнии», подобно тому, как кто-то говорит «идет дождь» на английском языке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，這是克林崗語中的動詞。在克林崗語中，有人說“閃電”，就像用英語說“下雨”一樣。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Note que este é um verbo em Klingon. Em Klingon, diz-se "relâmpagos", semelhante a como se diz "chove" em inglês. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä on verbi klingonissa. Klingonissa sanotaan "se salamoita", samalla tavalla kuin sanotaan "sataa" englanniksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1445,6 +1593,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1452,6 +1601,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1465,6 +1615,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">водная птица с красочным оперением [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一隻多彩羽毛的水鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro aquático com plumagem colorida</column>
+      <column name="definition_fi">eräs vesilintu, jolla on värikkäät höyhenet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -1475,6 +1626,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Ducks in a "row".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1484,6 +1636,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">colorful plumage</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1491,6 +1644,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1504,6 +1658,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">генетика [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">遺傳學 [AUTOTRANSLATED]</column>
       <column name="definition_pt">genética</column>
+      <column name="definition_fi">genetiikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{no'QeD:n}, {QeD:n}</column>
@@ -1514,6 +1669,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru">Генетик предположительно был бы {raytej:n}, хотя неясно, что означает корень {ray:n:hyp,nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">遺傳學家大概是{raytej:n}，儘管目前尚不清楚{ray:n:hyp,nolink}的含義是什麼。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um geneticista provavelmente seria um {raytej:n}, embora não esteja claro o que a raiz {ray:n:hyp,nolink} significa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Geneetikko olisi oletettavasti {raytej:n}, vaikka on epäselvää, mitä juuri {ray:n:hyp,nolink} tarkoittaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Gene "R"oddenberry. Also, {ray:n} may be an abbrevation for {roSghaH:n}.</column>
       <column name="components">{ray:n:hyp,nolink}, {QeD:n}</column>
       <column name="examples"></column>
@@ -1523,6 +1679,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1530,6 +1687,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
         <table name="mem">
@@ -1543,6 +1701,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
           <column name="definition_ru">генетик [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">遺傳學家 [AUTOTRANSLATED]</column>
           <column name="definition_pt">geneticista [AUTOTRANSLATED]</column>
+      <column name="definition_fi">geneetikko</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{rayQeD:n}, {tej:n}</column>
@@ -1553,6 +1712,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word does not appear in canon, but is an obvious construction based on {rayQeD:n:nolink}.</column>
           <column name="components">{ray:n:hyp,nolink}, {tej:n}</column>
           <column name="examples"></column>
@@ -1562,6 +1722,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1569,6 +1730,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -1582,6 +1744,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">booth (small building) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">展位（小建築物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Estande, cabine, cabana (prédio pequeno)</column>
+      <column name="definition_fi">koju, koppi (pieni rakennus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qach:n}</column>
@@ -1592,6 +1755,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru">Это предназначено для использования людьми, в то время как {HuDyar:n} обычно используется для хранения вещей, хотя между ними есть дублирование. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是供人使用的，而{HuDyar:n}通常用於存儲事物，儘管它們之間有重疊。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se destina ao uso por pessoas, enquanto um {HuDyar:n} é normalmente usado para armazenar coisas, embora haja sobreposição entre elas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tarkoitettu ihmisten käyttöön, kun taas {HuDyar:n}: tä käytetään tyypillisesti tavaroiden varastointiin, vaikka niiden välillä onkin päällekkäisyyksiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The groundskeeper at Starfleet Academy, Boothby, was portrayed by Ray Walston.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1601,6 +1765,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1608,6 +1773,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1621,6 +1787,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">цели, мишени</column>
       <column name="definition_zh_HK">目標（眾數）</column>
       <column name="definition_pt">alvos</column>
+      <column name="definition_fi">kohteet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1631,6 +1798,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DoS:n:inhps}</column>
       <column name="examples"></column>
@@ -1640,6 +1808,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1647,6 +1816,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1660,6 +1830,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">рис</column>
       <column name="definition_zh_HK">白米、白飯</column>
       <column name="definition_pt">arroz</column>
+      <column name="definition_fi">riisi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIr:n}</column>
@@ -1670,6 +1841,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru">Это то, что Клингоны называют земной пищей.</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人種大米。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que os klingons chamariam de arroz terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-riisiksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1679,6 +1851,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1686,6 +1859,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -1699,6 +1873,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">приказывать, отдавать команду, отдавать приказание, повелевать, командовать</column>
       <column name="definition_zh_HK">命令</column>
       <column name="definition_pt">ordem, comando</column>
+      <column name="definition_fi">käskeä, komentaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lob:v}, {SeH:v}, {ngep:v}, {vun:v}, {ra':v:2}</column>
@@ -1709,6 +1884,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1718,6 +1894,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1725,6 +1902,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1738,6 +1916,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">дирижировать оркестром</column>
       <column name="definition_zh_HK">指揮（管弦樂隊） [AUTOTRANSLATED]</column>
       <column name="definition_pt">reger (uma orquestra)</column>
+      <column name="definition_fi">johtaa (orkesteria)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghenraq:n}, {QoQ ghom:n}, {ra':v:1}</column>
@@ -1748,6 +1927,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1757,6 +1937,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1764,6 +1945,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -1777,6 +1959,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">треугольник</column>
       <column name="definition_zh_HK">三角形</column>
       <column name="definition_pt">triângulo</column>
+      <column name="definition_fi">kolmio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mey':n}, {ra'Duch puj:n}, {ra'Duch quv:n}, {ra'Duch tIQ:n}</column>
@@ -1787,6 +1970,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1796,6 +1980,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1803,6 +1988,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -1816,6 +2002,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">неравносторонний треугольник</column>
       <column name="definition_zh_HK">不等邊三角形</column>
       <column name="definition_pt">triângulo escaleno</column>
+      <column name="definition_fi">erisivuinen kolmio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ra'Duch:n}, {ra'Duch quv:n}, {ra'Duch tIQ:n}</column>
@@ -1826,6 +2013,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ra'Duch:n}, {puj:v}</column>
       <column name="examples"></column>
@@ -1835,6 +2023,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1842,6 +2031,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1855,6 +2045,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">равнобедренный треугольник</column>
       <column name="definition_zh_HK">等腰三角形</column>
       <column name="definition_pt">Triângulo isósceles</column>
+      <column name="definition_fi">tasakylkinen kolmio</column>
       <column name="synonyms">{vayya':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{ra'Duch:n}, {ra'Duch puj:n}, {ra'Duch tIQ:n}</column>
@@ -1865,6 +2056,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ra'Duch:n}, {quv:v}</column>
       <column name="examples"></column>
@@ -1874,6 +2066,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1881,6 +2074,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -1894,6 +2088,7 @@ O primeiro elemento desta palavra é {rav:n:1} "chão", mas o segundo elemento n
       <column name="definition_ru">равносторонний треугольник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">正三角形、等邊三角形</column>
       <column name="definition_pt">Triângulo Equilátero</column>
+      <column name="definition_fi">tasasivuinen kolmio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ra'Duch:n}, {ra'Duch puj:n}, {ra'Duch quv:n}, {vayya':n}</column>
@@ -1914,6 +2109,9 @@ För andra polygoner med lika sidor / vinklar används {HoS:v} istället för {t
       <column name="notes_pt">Este é um triângulo onde cada ângulo interno é 40,5 {lawmey:n:nolink} ou 60 {lawrI'mey:n:nolink}. (Consulte {law:n} e {lawrI':n}.)
 
 Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {tIQ:v:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kolmio, jossa kukin sisäkulma on 40,5 {lawmey:n:nolink} tai 60 {lawrI'mey:n:nolink}. (Katso {law:n} ja {lawrI':n}.)
+
+Muille monikulmioille, joilla on yhtäläiset sivut / kulmat, {HoS:v}: ää käytetään {tIQ:v:nolink}: n sijaan.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ra'Duch:n}, {tIQ:v}</column>
       <column name="examples"></column>
@@ -1923,6 +2121,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1930,6 +2129,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1943,6 +2143,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">командная группа, командный состав [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">指揮小組、指揮人員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">grupo de comando, pessoal de comando</column>
+      <column name="definition_fi">komennuskunta, iskujoukko, kommandojoukko ?; komentoesikunta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ra'ghomquv:n}</column>
@@ -1953,6 +2154,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is not defined, but its meaning is clear from the example and from {ra'ghomquv:n:nolink}.</column>
       <column name="components">{ra':v:1}, {ghom:n}</column>
       <column name="examples">
@@ -1963,6 +2165,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1970,6 +2173,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Smithsonian GO FLIGHT app:src}</column>
     </table>
     <table name="mem">
@@ -1983,6 +2187,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">высшее командование</column>
       <column name="definition_zh_HK">高級指揮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Alto Comando</column>
+      <column name="definition_fi">korkein esikunta ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ejyo' ra'ghomquv:n}</column>
@@ -1993,6 +2198,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru">Высшее командование управляет {tlhIngan Hubbeq:n}.</column>
       <column name="notes_zh_HK">高級命令運行{tlhIngan Hubbeq:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O Alto Comando executa o {tlhIngan Hubbeq:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Korkea komento suorittaa {tlhIngan Hubbeq:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ra'ghom:n}, {quv:v}</column>
       <column name="examples"></column>
@@ -2002,6 +2208,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2009,6 +2216,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2022,6 +2230,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">кофе с ликером [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">咖啡加酒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Café com licor</column>
+      <column name="definition_fi">eräs juoma, jossa kahviin on sekoitettu alkoholia, raktajino</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qa'vIn:n}</column>
@@ -2032,6 +2241,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是將白酒加到咖啡中製成的飲料。其名稱可能源自{ra'wI' taj:n:nolink}的縮寫。在聯邦中很流行的“出口”版本叫做“ raktajino”，它不是酒類，但增加了風味。[1, p.96] [AUTOTRANSLATED]</column>
       <column name="notes_pt">É uma bebida feita com licor adicionado ao café. Seu nome pode ter se originado como uma contração de {ra'wI' taj:n:nolink}. Uma versão de "exportação" chamada "raktajino", popular na Federação, não é alcoólatra, mas tem um sabor adicional.[1, p.96] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on juoma, joka on valmistettu kahviin lisätystä viinistä. Sen nimi on saattanut olla peräisin {ra'wI' taj:n:nolink}-supistuksesta. Federaatiossa suosittu "viennin" versio "raktajino" ei ole alkoholipitoinen, mutta se on lisännyt makua.[1, p.96] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2041,6 +2251,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">raktajino</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2048,6 +2259,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2061,6 +2273,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">командир, командующий</column>
       <column name="definition_zh_HK">指揮官、司令</column>
       <column name="definition_pt">comandante</column>
+      <column name="definition_fi">komentaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaS:n}</column>
@@ -2071,6 +2284,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru">Относится к кому-то с рангом {Sogh:n} или выше.</column>
       <column name="notes_zh_HK">這是指{Sogh:n}或更高級別的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a alguém de classificação {Sogh:n} ou superior. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, jonka sijoitus on {Sogh:n} tai korkeampi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ra':v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2080,6 +2294,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2087,6 +2302,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2100,6 +2316,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Такси</column>
       <column name="definition_zh_HK">出租車 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Táxi</column>
+      <column name="definition_fi">taksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lupwI':n}</column>
@@ -2110,6 +2327,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ra'wI':n}, {lupwI':n}</column>
       <column name="examples"></column>
@@ -2119,6 +2337,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2126,6 +2345,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -2139,6 +2359,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Мы(действие)-вам(множественное число)</column>
       <column name="definition_zh_HK">我們、它們：你們</column>
       <column name="definition_pt">nos-vocês</column>
+      <column name="definition_fi">me-teitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{che-:v:pref}</column>
       <column name="see_also">{Sa-:v:pref}, {pI-:v:pref}</column>
@@ -2149,6 +2370,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{maH:n:1h}: {tlhIH:n} = {re-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2158,6 +2380,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2165,6 +2388,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2178,6 +2402,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">смола [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">樹脂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">resina</column>
+      <column name="definition_fi">hartsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIychorgh:n}</column>
@@ -2188,6 +2413,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2197,6 +2423,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2204,6 +2431,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2217,6 +2445,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">выдыхать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">呼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">expirar</column>
+      <column name="definition_fi">hengittää ulos</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pur:v}</column>
       <column name="see_also">{jev:v:2}, {tlhov:v}, {tlhuH:v:1}, {tagh:n}, {ghIch:n}, {tlhon:n}</column>
@@ -2227,6 +2456,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Retch". Also, the words for inhale and exhale together sound like "poor wretch" ({pur rech:sen:nolink}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2236,6 +2466,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2243,6 +2474,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -2256,6 +2488,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">внешняя стена [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">外牆</column>
       <column name="definition_pt">parede exterior</column>
+      <column name="definition_fi">ulkoseinä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa' reD:n}, {tlhoy':n}, {Hur:n}</column>
@@ -2266,6 +2499,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2275,6 +2509,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2282,6 +2517,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -2295,6 +2531,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">сторона (геометрия) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">側面（幾何） [AUTOTRANSLATED]</column>
       <column name="definition_pt">lado (geometria)</column>
+      <column name="definition_fi">sivu (geometria)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mey':n}, {Dop:n}</column>
@@ -2305,6 +2542,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru">Это слово относится к стороне многоугольника. Его единственное появление в каноне было между числом и одним из {mey':n} или {'Impey':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞是指多邊形的一面。它在佳能中的唯一出現在{mey':n}或{'Impey':n}之間。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se refere ao lado de um polígono. Sua única aparência no cânone foi entre um número e um de {mey':n} ou {'Impey':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa monikulmion sivuun. Sen ainoa esiintyminen kaanonissa on ollut numeron ja yhden välillä {mey':n} tai {'Impey':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{loS reD mey':n}, {vagh reD mey':n}</column>
@@ -2314,6 +2552,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2321,6 +2560,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -2334,6 +2574,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">кровоточить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">流血</column>
       <column name="definition_pt">sangrar</column>
+      <column name="definition_fi">vuotaa (verta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iw:n}, {'aD:n}</column>
@@ -2344,6 +2585,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2354,6 +2596,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2361,6 +2604,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2374,6 +2618,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Регулус</column>
       <column name="definition_zh_HK">軒轅十四星</column>
       <column name="definition_pt">Regulus</column>
+      <column name="definition_fi">Regulus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reghuluSngan:n}, {reghuluS chorgh:n}</column>
@@ -2384,6 +2629,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2393,6 +2639,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2400,6 +2647,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2413,6 +2661,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">М-113 (планета)</column>
       <column name="definition_zh_HK">M-113、軒轅八世 [AUTOTRANSLATED]</column>
       <column name="definition_pt">M-113, Regulus VIII</column>
+      <column name="definition_fi">M-113, Regulus VIII</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reghuluSngan:n}, {reghuluS:n}</column>
@@ -2423,6 +2672,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru">Планета в составе Ромуланской звездной империи.</column>
       <column name="notes_zh_HK">羅慕蘭星空帝國中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta no Império Estelar Romulano. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Romulan-tähtien imperiumissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2432,6 +2682,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2439,6 +2690,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2452,6 +2704,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Регулианское кровавое вино</column>
       <column name="definition_zh_HK">軒轅十四星血酒</column>
       <column name="definition_pt">Vinho de sangue Regulan</column>
+      <column name="definition_fi">reguluslainen veriviini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2462,6 +2715,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru">Туристический напиток.</column>
       <column name="notes_zh_HK">這是一種旅遊飲料。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma bebida turística. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on turistijuoma. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{reghuluS:n}, {'Iw HIq:n}</column>
       <column name="examples"></column>
@@ -2471,6 +2725,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Regulan bloodwine</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2478,6 +2733,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -2491,6 +2747,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Регулианский кровавый червь</column>
       <column name="definition_zh_HK">Regulan紅蟲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Regulan verme de sangue</column>
+      <column name="definition_fi">reguluslainen verimato</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2501,6 +2758,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru">Есть идиома, {tun; reghuluS 'Iwghargh rur@@tun:v, reghuluS 'Iwghargh:n, rur:v}.</column>
       <column name="notes_zh_HK">有一個成語，{tun; reghuluS 'Iwghargh rur@@tun:v, reghuluS 'Iwghargh:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {tun; reghuluS 'Iwghargh rur@@tun:v, reghuluS 'Iwghargh:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {tun; reghuluS 'Iwghargh rur@@tun:v, reghuluS 'Iwghargh:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{reghuluS:n}, {'Iwghargh:n}</column>
       <column name="examples"></column>
@@ -2510,6 +2768,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2517,6 +2776,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2530,6 +2790,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Регулианец</column>
       <column name="definition_zh_HK">軒轅十四星人</column>
       <column name="definition_pt">Regulan</column>
+      <column name="definition_fi">reguluslainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reghuluS:n}</column>
@@ -2540,6 +2801,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reghuluS:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -2549,6 +2811,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2556,6 +2819,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2569,6 +2833,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">всегда, постоянно</column>
       <column name="definition_zh_HK">總是、永遠</column>
       <column name="definition_pt">sempre</column>
+      <column name="definition_fi">aina</column>
       <column name="synonyms">{Hochlogh:adv}</column>
       <column name="antonyms"></column>
       <column name="see_also">{not:adv}, {rut:adv}, {pIj:adv}</column>
@@ -2579,6 +2844,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru">Иногда может быть подходящим использование {-taH:v:suff} (без {reH:adv}) чтобы перевести "всегда". Для примера смотрите {Duj tIvoqtaH.:sen}</column>
       <column name="notes_zh_HK">有時，使用{-taH:v:suff}（不帶{reH:adv}）翻譯“總是”可能是適當的。例如，請參閱{Duj tIvoqtaH.:sen} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Às vezes, pode ser apropriado usar {-taH:v:suff} (sem {reH:adv}) para traduzir "sempre". Por exemplo, consulte {Duj tIvoqtaH.:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Joskus voi olla tarkoituksenmukaista käyttää {-taH:v:suff} (ilman {reH:adv}) kääntämään "aina". Katso esimerkiksi {Duj tIvoqtaH.:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2598,6 +2864,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
 ▶ {reH 'uQvam vIqawtaH.:sen}</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">forever</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2605,6 +2872,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru">вечно</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2618,6 +2886,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">играть</column>
       <column name="definition_zh_HK">玩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">brincar</column>
+      <column name="definition_fi">leikkiä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quj:v}, {ghet:v}</column>
@@ -2628,6 +2897,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru">Разница между этим словом и {Quj:v} в том, что данное слово относится к неструктурированной игре, в то время как {Quj:v:nolink} относится к структурированной игре.[2]</column>
       <column name="notes_zh_HK">此與{Quj:v}之間的區別在於，這是指非結構化遊戲，而{Quj:v:nolink}是指結構化遊戲。此動詞不將{'e':n:pro}作為其賓語。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A diferença entre isso e {Quj:v} é que isso se refere a jogo não estruturado, enquanto {Quj:v:nolink} se refere a jogo estruturado. Este verbo não aceita {'e':n:pro} como seu objeto.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ero tämän ja {Quj:v}: n välillä on se, että tämä viittaa strukturoimattomaan peliin, kun taas {Quj:v:nolink} viittaa strukturoituun peliin. Tämä verbi ei pidä {'e':n:pro}: ta objektina.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2637,6 +2907,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2644,6 +2915,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2011:src}</column>
     </table>
     <table name="mem">
@@ -2657,6 +2929,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Любовь всегда пахнет.</column>
       <column name="definition_zh_HK">愛總是聞到。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O amor é sempre cheirado.</column>
+      <column name="definition_fi">Rakkauden haistaa aina.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2667,6 +2940,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {bang:n}, {largh:v}, {-lu':v}</column>
       <column name="examples"></column>
@@ -2676,6 +2950,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2683,6 +2958,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.159:src}</column>
     </table>
     <table name="mem">
@@ -2696,6 +2972,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Использованный катлютч всегда блестящий.</column>
       <column name="definition_zh_HK">使用過的kut'luch總是有光澤的。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O kut'luch usado é sempre brilhante.</column>
+      <column name="definition_fi">Käytetty kut'luch kiiltää aina.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2706,6 +2983,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {boch:v}, {qutluch:n}, {lo':v}, {-lu':v}, {-bogh:v}</column>
       <column name="examples"></column>
@@ -2715,6 +2993,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2722,6 +3001,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.103:src}</column>
     </table>
     <table name="mem">
@@ -2735,6 +3015,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="definition_ru">Твой отец всегда будет частью тебя.</column>
       <column name="definition_zh_HK">你的父親永遠是你的一部分。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Seu pai é sempre uma parte de você.</column>
+      <column name="definition_fi">Isäsi on osa sinua aina.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2745,6 +3026,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {Du-:v}, {SIgh:v}, {vav:n}, {-lI':n}</column>
       <column name="examples"></column>
@@ -2754,6 +3036,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2761,6 +3044,7 @@ Para outros polígonos com lados / ângulos iguais, {HoS:v} é usado em vez de {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.170:src}</column>
     </table>
     <table name="mem">
@@ -2774,6 +3058,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Всегда есть кто-то храбрый, кто умирает.</column>
       <column name="definition_zh_HK">永遠是勇敢的人死了。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sempre são os corajosos que morrem.</column>
+      <column name="definition_fi">Rohkeat kuolevat aina.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2784,6 +3069,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {Hegh:v}, {yoHwI':n}, {-pu':n}, {-'e':n}</column>
       <column name="examples"></column>
@@ -2793,6 +3079,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2800,6 +3087,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.123:src}</column>
     </table>
     <table name="mem">
@@ -2813,6 +3101,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Пусть ты всегда будешь находить кровавого червя а твоем стакане.</column>
       <column name="definition_zh_HK">願你總能在你的杯子裡找到一隻紅蟲！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Que você sempre encontre um verme de sangue em seu copo!</column>
+      <column name="definition_fi">Olkoon lasissasi aina verimato!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2823,6 +3112,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {HIvje':n}, {-lIj:n}, {-Daq:n}, {'Iwghargh:n}, {Da-:v}, {tu':v}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -2832,6 +3122,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2839,6 +3130,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2852,6 +3144,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Огонь всегда горячее на чьем-то лице.</column>
       <column name="definition_zh_HK">別人臉上的火焰總是更熱。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O fogo é sempre mais quente no rosto de outra pessoa.</column>
+      <column name="definition_fi">Tuli on aina kuumempaa jonkun toisen kasvoilla.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2862,6 +3155,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {latlh:n}, {qab:n}, {-Daq:n}, {qul:n}, {tuj:v}, {... law':sen}, {Hoch:n}, {tuj:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -2871,6 +3165,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">replacement proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2878,6 +3173,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru">поговорка</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2891,6 +3187,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Победитель всегда прав!</column>
       <column name="definition_zh_HK">勝利者永遠是對的。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O vencedor está sempre certo.</column>
+      <column name="definition_fi">Voittaja on aina oikeassa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2901,6 +3198,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {lugh:v}, {charghwI':n}</column>
       <column name="examples"></column>
@@ -2910,6 +3208,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2917,6 +3216,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.179:src}</column>
     </table>
     <table name="mem">
@@ -2930,6 +3230,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Здесь всегда есть оружие!</column>
       <column name="definition_zh_HK">總有武器。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Há sempre armas.</column>
+      <column name="definition_fi">Aseita on aina.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reH 'eb tu'lu'.:sen}</column>
@@ -2940,6 +3241,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru">Смотрите, как Гаурон говорит это: {YouTube video:url:http://youtu.be/jCLUZvNDFZw}</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/jCLUZvNDFZw} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/jCLUZvNDFZw} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/jCLUZvNDFZw} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {nuH:n:1}, {-mey:n}, {tu'lu':v}</column>
       <column name="examples"></column>
@@ -2949,6 +3251,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2956,6 +3259,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -2969,6 +3273,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Клингонский воин всегда готов сражаться!</column>
       <column name="definition_zh_HK">克林崗戰士總是準備戰鬥。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Um guerreiro klingon está sempre preparado para lutar.</column>
+      <column name="definition_fi">Klingonisoturi on aina valmis taistelemaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2979,6 +3284,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {Suv:v}, {-rup:v}, {tlhIngan:n}, {SuvwI':n}</column>
       <column name="examples"></column>
@@ -2988,6 +3294,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2995,6 +3302,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.77:src}</column>
     </table>
     <table name="mem">
@@ -3008,6 +3316,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Великий воин всегда готов!</column>
       <column name="definition_zh_HK">一個偉大的戰士總是準備好。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Um grande guerreiro está sempre preparado.</column>
+      <column name="definition_fi">Mahtava soturi on aina valmis taistelemaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3018,6 +3327,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {Suv:v}, {-rup:v}, {SuvwI':n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -3027,6 +3337,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">replacement proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3034,6 +3345,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru">Поговорка</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -3047,6 +3359,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Один всегда из его племени. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一個是他的部落。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Um é sempre da sua tribo.</column>
+      <column name="definition_fi">Henkilö on aina yhtä heimonsa kanssa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3057,6 +3370,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {tay':v}, {ghot:n}, {tuq:n}, {-Daj:n}, {je:conj}</column>
       <column name="examples"></column>
@@ -3066,6 +3380,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3073,6 +3388,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.34:src}</column>
     </table>
     <table name="mem">
@@ -3086,6 +3402,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Пусть Клингонская империя живет вечно!</column>
       <column name="definition_zh_HK">願克林崗帝國永遠持續下去。</column>
       <column name="definition_pt">Que o Império Klingon continue para sempre.</column>
+      <column name="definition_fi">Eläköön Klingonien keisarikunta ikuisesti.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3096,6 +3413,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {tlhIngan wo':n}, {taH:v:1}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -3105,6 +3423,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3112,6 +3431,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -3125,6 +3445,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Клингоны навсегда!</column>
       <column name="definition_zh_HK">克林崗斯永遠！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Klingons para sempre!</column>
+      <column name="definition_fi">Klingonit ikuisesti!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3135,6 +3456,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {tlhIngan:n}, {-pu':n}, {taH:v:1}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -3144,6 +3466,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3151,6 +3474,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -3164,6 +3488,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Всегда есть шанс.</column>
       <column name="definition_zh_HK">總有機會。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Há sempre uma chance.</column>
+      <column name="definition_fi">On aina mahdollisuus.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reH nuHmey tu'lu'.:sen}</column>
@@ -3174,6 +3499,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {'eb:n}, {tu'lu':v}</column>
       <column name="examples"></column>
@@ -3183,6 +3509,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3190,6 +3517,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.49:src}</column>
     </table>
     <table name="mem">
@@ -3203,6 +3531,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Я буду помнить этот ужин вечно.</column>
       <column name="definition_zh_HK">我將會永遠記住這頓晚餐。</column>
       <column name="definition_pt">Vou me lembrar desse jantar para sempre.</column>
+      <column name="definition_fi">Muistan tämän illallisen ikuisesti.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3213,6 +3542,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {'uQ:n}, {-vam:n}, {vI-:v}, {qaw:v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -3222,6 +3552,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">QI'lop</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3229,6 +3560,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -3242,6 +3574,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">нижнее белье, нижнее белье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">內衣，內衣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">roupas íntimas</column>
+      <column name="definition_fi">alusvaatteet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sut:n}</column>
@@ -3252,6 +3585,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru">Это относится к нижнему белью в целом. Чтобы быть более конкретным, скажите {rejghun yopwaH bID:n@@rejghun:n, yopwaH bID:n} и т. Д. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這一般指內衣。具體來說，例如{rejghun yopwaH bID:n@@rejghun:n, yopwaH bID:n}等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a roupas íntimas em geral. Para ser mais específico, diga {rejghun yopwaH bID:n@@rejghun:n, yopwaH bID:n}, etc. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa alusvaatteisiin yleensä. Tarkemmin sanoen sano {rejghun yopwaH bID:n@@rejghun:n, yopwaH bID:n} jne. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Reg Grundies" is Australian slang for underwear.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3261,6 +3595,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3268,6 +3603,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3281,6 +3617,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">паникёр, нытик</column>
       <column name="definition_zh_HK">杞人憂天 [AUTOTRANSLATED]</column>
       <column name="definition_pt">preocupante</column>
+      <column name="definition_fi">murehtija, pessimisti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qep:v}</column>
@@ -3291,6 +3628,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3300,6 +3638,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3307,6 +3646,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3320,6 +3660,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">Реджак</column>
       <column name="definition_zh_HK">Rejac [AUTOTRANSLATED]</column>
       <column name="definition_pt">Rejac</column>
+      <column name="definition_fi">Rejac</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3330,6 +3671,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru">Он был последователем {tIquvma:n:name}, кому была отдана роль {Sech qengwI':n}. Он был братом {'or'eq:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">他是{tIquvma:n:name}的追隨者，而他被任命為{Sech qengwI':n}。他是{'or'eq:n:name}的兄弟。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ele era um seguidor de {tIquvma:n:name}, que recebeu o papel de {Sech qengwI':n}. Ele era o irmão de {'or'eq:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän oli {tIquvma:n:name}-seuraaja, jolle annettiin {Sech qengwI':n}-rooli. Hän oli {'or'eq:n:name}: n veli. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3339,6 +3681,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3346,6 +3689,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - The Vulcan Hello:src}</column>
     </table>
     <table name="mem">
@@ -3359,6 +3703,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">быть ошеломленным, быть бредовым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">茫然、妄想 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser atordoado, ser delirante</column>
+      <column name="definition_fi">olla sekava, harhainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIS:v}</column>
@@ -3369,6 +3714,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru">Это означает ошеломленный в смысле растерянности, неспособности правильно мыслить, сбит с толку. В этом смысле это означает бред.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著從困惑，無法正確思考，迷惑的意義上感到頭暈。[1]從這個意義上說，它意味著妄想。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa atordoado no sentido de confuso, incapaz de pensar adequadamente, perplexo.[1] Significa ilusório, nesse sentido.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa hämmentynyttä hämmentyneenä, kykenemättömänä ajatella, hämmentyneenä.[1] Se tarkoittaa harhaa tässä mielessä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3378,6 +3724,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3385,6 +3732,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -3398,6 +3746,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">психокинез [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">心理運動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">psicocinese</column>
+      <column name="definition_fi">psykokineesi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'erwI'Daq:n}, {tova'Daq:n}</column>
@@ -3408,6 +3757,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Uri "Geller".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3417,6 +3767,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3424,6 +3775,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3437,6 +3789,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">сосать (например, через солому) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吮吸（例如通過稻草） [AUTOTRANSLATED]</column>
       <column name="definition_pt">chupar (por exemplo, através de canudo)</column>
+      <column name="definition_fi">imeä (pilliä tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIl:v:1}</column>
@@ -3447,6 +3800,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3457,6 +3811,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3464,6 +3819,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3477,6 +3833,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">дизайн, карта, план [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">設計、製圖、計劃</column>
       <column name="definition_pt">desenhar, mapear, planejar</column>
+      <column name="definition_fi">suunnitella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pu'jIn:n}, {Qur:n}, {renwI':n}</column>
@@ -3487,6 +3844,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru">Это слово используется для описания конструкции какого-либо физического объекта; это не будет использоваться в смысле составления плана что-то сделать (что будет {nab:v}). Он отличается от {'ogh:v}, что подразумевает создание чего-то, что не было создано ранее. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Essa palavra é usada para descrever o design de um objeto físico de algum tipo; não seria usado no sentido de fazer um plano para fazer alguma coisa (que seria {nab:v}). Difere de {'ogh:v}, que implica a criação de algo que não foi criado antes. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään kuvaamaan jonkinlaisen fyysisen objektin suunnittelua; sitä ei käytetä siinä mielessä, että tehdään suunnitelma tehdä jotain (mikä olisi {nab:v}). Se eroaa {'ogh:v}: sta, mikä tarkoittaa sellaisen luomista, jota ei ole aiemmin luotu. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Christopher Wren and James Renwick, Jr., were the names of two famous architects.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3496,6 +3854,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3503,6 +3862,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2011:src}</column>
     </table>
     <table name="mem">
@@ -3516,6 +3876,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">дизайнер, архитектор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">設計師、建築師 [AUTOTRANSLATED]</column>
       <column name="definition_pt">designer, arquiteto</column>
+      <column name="definition_fi">suunnittelija, arkkitehti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ren:v}, {pu'jIn:n}, {qurbuSwI':n}</column>
@@ -3526,6 +3887,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ren:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3535,6 +3897,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3542,6 +3905,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2011:src}</column>
     </table>
     <table name="mem">
@@ -3555,6 +3919,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">час</column>
       <column name="definition_zh_HK">小時</column>
       <column name="definition_pt">hora</column>
+      <column name="definition_fi">tunti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tup:n}, {lup:n}</column>
@@ -3565,6 +3930,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3574,6 +3940,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3581,6 +3948,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -3594,6 +3962,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
           <column name="definition_ru">{'arlogh Qoylu'pu'?:sen}</column>
           <column name="definition_zh_HK">{'arlogh Qoylu'pu'?:sen}</column>
           <column name="definition_pt">{'arlogh Qoylu'pu'?:sen}</column>
+      <column name="definition_fi">{'arlogh Qoylu'pu'?:sen}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -3604,6 +3973,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -3613,6 +3983,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3620,6 +3991,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {s.k 1999.02.02:src}</column>
         </table>
     <table name="mem">
@@ -3633,6 +4005,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">десна (оральная анатомия) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">牙齦（口腔解剖） [AUTOTRANSLATED]</column>
       <column name="definition_pt">gengiva (anatomia oral)</column>
+      <column name="definition_fi">ien</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuj:n}, {Ho':n:1}</column>
@@ -3643,6 +4016,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Slangitapa sanoa tämä on {ghaw':n:3}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3652,6 +4026,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3659,6 +4034,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3672,6 +4048,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">воск, парафин, ушная сера</column>
       <column name="definition_zh_HK">蠟 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cera</column>
+      <column name="definition_fi">vaha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{weQ:n}</column>
@@ -3682,6 +4059,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3691,6 +4069,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3698,6 +4077,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3711,6 +4091,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">заклинание, заклинание (заклинание) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">召喚、施放（咒語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">encantar, lançar um feitiço</column>
+      <column name="definition_fi">loitsia, taikoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IDnar:n}, {'IDnar pIn'a':n}</column>
@@ -3721,6 +4102,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="notes_ru">Можно сказать или {tlheH reS@@tlheH:n, reS:v} или просто {reS:sen:nolink} для "он / она читает заклинание". Неясно, может ли что-либо кроме {tlheH:n} быть объектом {reS:v:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">可以說{tlheH reS@@tlheH:n, reS:v}或{reS:sen:nolink}都是“他/她施了咒語”。不清楚{reS:v:nolink}的對像是否可以是{tlheH:n}以外的其他對象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Pode-se dizer {tlheH reS@@tlheH:n, reS:v} ou apenas {reS:sen:nolink} para "ele / ela lança um feitiço". Não está claro se algo diferente de {tlheH:n} pode ser o objeto de {reS:v:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Voidaan sanoa joko {tlheH reS@@tlheH:n, reS:v} tai vain {reS:sen:nolink} sanoille "hän loitsee". On epäselvää, voiko jokin muu kuin {tlheH:n} olla {reS:v:nolink}: n kohde. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3730,6 +4112,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3737,6 +4120,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -3750,6 +4134,7 @@ o      <column name="definition_sv">Det är alltid de modiga som dör.</column>
       <column name="definition_ru">голень, предплечье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">脛前臂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">canela, antebraço</column>
+      <column name="definition_fi">sääri, kyynärvarsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'neH:n}, {nev'ob:n}, {qIv:n}, {DeSqIv:n}, {Do'ghI':n}</column>
@@ -3788,6 +4173,11 @@ Maltz唯一知道提到脛骨的方法是{reStav Hom:n@@reStav:n, Hom:n:1}。 [A
 Refere-se à parte anterior da perna, enquanto toda a parte inferior da perna seria {'uS cha'neH:n@@'uS:n, cha'neH:n}.
 
 A única maneira que Maltz conhecia de se referir à tíbia é o {reStav Hom:n@@reStav:n, Hom:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos on tarpeen tehdä ero säären ja käsivarren välillä, tätä sanaa voi edeltää {'uS:n} tai {DeS:n:1}.
+
+Tämä viittaa säären etuosaan, kun taas koko jalan alaosa olisi {'uS cha'neH:n@@'uS:n, cha'neH:n}.
+
+Ainoa tapa, jolla Maltz tiesi viittaavan sääriluuhun, on {reStav Hom:n@@reStav:n, Hom:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Hebrew letter "shin" comes between the letters "resh" and "tav".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3797,6 +4187,7 @@ A única maneira que Maltz conhecia de se referir à tíbia é o {reStav Hom:n@@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3804,6 +4195,7 @@ A única maneira que Maltz conhecia de se referir à tíbia é o {reStav Hom:n@@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -3817,6 +4209,7 @@ A única maneira que Maltz conhecia de se referir à tíbia é o {reStav Hom:n@@
       <column name="definition_ru">time period ago (past) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">時間段前（過去） [AUTOTRANSLATED]</column>
       <column name="definition_pt">período atrás (passado)</column>
+      <column name="definition_fi">... (ajanjakso) sitten</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIq:n}</column>
       <column name="see_also">{pa'logh:n}, {ret:v}</column>
@@ -3834,6 +4227,14 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Erikoissanaa käytetään osoittamaan aikaisempi aika seuraaville yksiköille:
+▶ {jaj:n} "päivä" - {Hu':n} "päivää sitten"
+▶ {jar:n} "kuukausi" - {wen:n} "kuukausi sitten"
+▶ {DIS:n:2} "vuosi" - {ben:n:1} "vuotta sitten"
+
+Muita aikayksikköjä käytetään {ret:n:nolink}
+
+Tämä on sama sana kuin verbi {ret:v}.[2][1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Retro".</column>
       <column name="components"></column>
       <column name="examples">
@@ -3844,6 +4245,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">past</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3851,6 +4253,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.3, Sept. 1999:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -3864,6 +4267,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">быть самым последним [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">最近 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser mais recente</column>
+      <column name="definition_fi">olla viimeisin, tuorein</column>
       <column name="synonyms">{ghoQ:v:2}</column>
       <column name="antonyms"></column>
       <column name="see_also">{ret:n}, {vorgh:v}</column>
@@ -3874,6 +4278,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Это то же слово, что и существительное {ret:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是與名詞{ret:n}相同的詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a mesma palavra que o substantivo {ret:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sama sana kuin substantiivi {ret:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3889,6 +4294,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3896,6 +4302,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -3909,6 +4316,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">рукоятка, рукоять (ножа, летучей мыши) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手柄、刀柄（刀、蝙蝠） [AUTOTRANSLATED]</column>
       <column name="definition_pt">punho (da faca, bat'leth)</column>
+      <column name="definition_fi">(veitsen, bat'lethin tms.) kahva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{betleH:n}, {taj:n}</column>
@@ -3919,6 +4327,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3928,6 +4337,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3935,6 +4345,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3948,6 +4359,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">вмятина, отступ [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">凹痕</column>
       <column name="definition_pt">dente, afundamento</column>
+      <column name="definition_fi">lovi, painauma</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghul:n}, {Su'nIm:n}</column>
       <column name="see_also">{'ap:v}</column>
@@ -3958,6 +4370,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Это не относится к форматированию абзаца. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這並不涉及如何設置段落格式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não se refere a como formatar um parágrafo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei tarkoita kappaleen muotoilua. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3967,6 +4380,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3974,6 +4388,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3987,6 +4402,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">территория рядом, территория около</column>
       <column name="definition_zh_HK">邊面、邊方</column>
       <column name="definition_pt">área ao lado, área ao lado de</column>
+      <column name="definition_fi">vieressä, alue vieressä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIng:n}, {Dung:n}, {joj:n}, {Hay:n:2h}</column>
@@ -3997,6 +4413,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Чтобы быть более точным, можно использовать {tlhop:n:1}, {'em:n}, {poS:n}, или {nIH:n}. Смотрите также {lurgh:n} для других слов, отнесенных к пространственным направлениям.</column>
       <column name="notes_zh_HK">更具體地說，可以使用{tlhop:n:1}，{'em:n}，{poS:n}或{nIH:n}。另請參見{lurgh:n}以獲取與空間方向有關的其他詞語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tarkemmin sanottuna voidaan käyttää {tlhop:n:1}, {'em:n}, {poS:n} tai {nIH:n}. Katso myös {lurgh:n} muista paikkatietoihin liittyvistä sanoista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4006,6 +4423,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4013,6 +4431,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4026,6 +4445,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">котировка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">引用 [AUTOTRANSLATED]</column>
       <column name="definition_pt">citar</column>
+      <column name="definition_fi">siteerata, lainata jotakuta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4036,6 +4456,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Это используется для цитирования речи или письма кого-то еще. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於引用別人的講話或寫作。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para citar o discurso ou a escrita de outra pessoa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään viittaamaan jonkun muun puheeseen tai kirjoittamiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Reference".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4045,6 +4466,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4052,6 +4474,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4065,6 +4488,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">гражданин</column>
       <column name="definition_zh_HK">公民 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cidadão</column>
+      <column name="definition_fi">kansalainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wo':n}, {Sung:n}, {roghvaH:n}</column>
@@ -4075,6 +4499,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Rube".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4084,6 +4509,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4091,6 +4517,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4104,6 +4531,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">air (everyday word) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">空氣（每日字） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ar (palavra cotidiana)</column>
+      <column name="definition_fi">ilma (jokapäiväinen sana)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lay:n:2h}, {muD:n:1}, {HIS:v}</column>
@@ -4114,6 +4542,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4123,6 +4552,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4130,6 +4560,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4143,6 +4574,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">сжимать и растягивать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擠壓和伸展（風袋樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">espremer e esticar (instrumento de bolsa de ar)</column>
+      <column name="definition_fi">puristaa ja venyttää (säkkipilliä tms. soitinta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeb:v}, {ngaH:v}</column>
@@ -4153,6 +4585,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Это относится к действию попеременного сдавливания и растягивания части мешка {may'ron:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指交替擠壓和拉出{may'ron:n}的袋子部分的動作。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à ação de apertar e esticar alternadamente a parte do saco do {may'ron:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa {may'ron:n}: n pussiosan vuorotellen puristamiseen ja venyttämiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4162,6 +4595,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4169,6 +4603,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4182,6 +4617,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">Рейнальдо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雷納爾多 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Reynaldo</column>
+      <column name="definition_fi">Reynaldo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -4192,6 +4628,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4201,6 +4638,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4208,6 +4646,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -4221,6 +4660,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">быть распространенным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傳播，傳播 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser espalhado, espalhar</column>
+      <column name="definition_fi">olla levinnyt, hajallaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'echletHom:n}</column>
@@ -4231,6 +4671,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Это означает быть разложенным, как колода карт, раздуваемая на столе, или арахисовое масло на кусок хлеба. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著像散佈在桌子上的紙牌或麵包上的花生醬一樣散開。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa espalhar-se como um baralho espalhado sobre uma mesa ou manteiga de amendoim em um pedaço de pão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa levittämistä kuin pöydällä tuuletettu korttipakka tai maapähkinävoita leivän pala. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A rib spreader is a surgical implement for thoracic surgery.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4240,6 +4681,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fanned</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4247,6 +4689,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4260,6 +4703,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">говорить о, обсуждать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">談論、討論 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falar sobre, discutir</column>
+      <column name="definition_fi">puhua jostain, keskustella jostain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jatlh:v}, {ja'chuq:v}, {bop:v}</column>
@@ -4270,6 +4714,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Объектом глагола является тема обсуждения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">動詞的賓語是討論的主題。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto do verbo é o tópico da discussão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbin kohde on keskustelunaihe. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Talk is cheap."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4279,6 +4724,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4286,6 +4732,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4299,6 +4746,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">директива, судебный запрет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">指令，禁令 [AUTOTRANSLATED]</column>
       <column name="definition_pt">diretiva, liminar</column>
+      <column name="definition_fi">käsky, määräys, toimintaohje, direktiivi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chut:n}</column>
@@ -4309,6 +4757,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was requested specifically to translate "Prime Directive".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4318,6 +4767,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4325,6 +4775,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4338,6 +4789,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">дайджест [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">消化</column>
       <column name="definition_pt">digerir</column>
+      <column name="definition_fi">sulattaa (ruokaa mahassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{burgh:n}</column>
@@ -4348,6 +4800,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Это относится к процессу, через который проходит еда. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指食物經歷的過程。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao processo pelo qual os alimentos passam. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa prosessiin, jonka ruoka käy läpi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4357,6 +4810,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4364,6 +4818,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4377,6 +4832,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">быть хромым</column>
       <column name="definition_zh_HK">太蹩腳了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser coxo</column>
+      <column name="definition_fi">olla rampa, ontuva, raajarikkoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIt:v}</column>
@@ -4387,6 +4843,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4396,6 +4853,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">crippled</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4403,6 +4861,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4416,6 +4875,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">питать энергией, активизировать, запускать, заряжать, пропускать ток</column>
       <column name="definition_zh_HK">通電 [AUTOTRANSLATED]</column>
       <column name="definition_pt">energizar</column>
+      <column name="definition_fi">käynnistää, aktivoida (laite, esim. siirrin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Huj:v:2,t}, {jolpat:n}, {laQ:v}</column>
@@ -4426,6 +4886,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru">Сначала происходит ({Huj:v:2,t}) устройства, а потом ({rIH:v:nolink}).</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Um primeiro carrega ({Huj:v:2,t}) um dispositivo antes de energizá-lo ({rIH:v:nolink}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ensimmäinen lataa ({Huj:v:2,t}) laitteen ennen virran kytkemistä ({rIH:v:nolink}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4435,6 +4896,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4442,6 +4904,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4455,6 +4918,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">Активизатор</column>
       <column name="definition_zh_HK">勁量 [AUTOTRANSLATED]</column>
       <column name="definition_pt">energizador</column>
+      <column name="definition_fi">käynnistin, energiansyöttäjä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4465,6 +4929,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rIH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4474,6 +4939,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4481,6 +4947,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4494,6 +4961,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">быть на якоре [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">停泊</column>
       <column name="definition_pt">ser ancorado</column>
+      <column name="definition_fi">olla ankkuroitu, olla kiinnitetty laituriin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{rIjHa':v}</column>
       <column name="see_also">{'otHel:n}</column>
@@ -4504,6 +4972,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4513,6 +4982,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4520,6 +4990,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4533,6 +5004,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">плыть по течению [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">好漂亮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar à deriva</column>
+      <column name="definition_fi">olla tuuliajolla</column>
       <column name="synonyms"></column>
       <column name="antonyms">{rIj:v}</column>
       <column name="see_also">{'ay:v}</column>
@@ -4543,6 +5015,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rIj:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -4552,6 +5025,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4559,6 +5033,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4572,6 +5047,7 @@ This is the same word as the verb {ret:v}.[2]</column>
       <column name="definition_ru">использовать большой палец (ребенок) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用拇指（小孩） [AUTOTRANSLATED]</column>
       <column name="definition_pt">usar o polegar (criança)</column>
+      <column name="definition_fi">käyttää peukaloa (lapsesta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIl:v:2}, {rem:v}</column>
@@ -4596,6 +5072,9 @@ Den reflexiva formen av detta verb har en speciell betydelse. Se exemplet nedan 
       <column name="notes_pt">Esta palavra é usada por crianças pequenas ou por adultos conversando com ou sobre crianças pequenas. Os adultos geralmente usam {Sen:v:1} em vez disso.
 
 A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo e em {SIq:v} para uma explicação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käyttävät pienet lapset tai aikuiset, jotka puhuvat pienille lapsille tai puhuvat niistä. Aikuiset käyttävät yleensä {Sen:v:1}: ää.
+
+Tämän verbin refleksiivisellä muodolla on erityinen merkitys. Katso selitys alla olevasta esimerkistä ja kohdasta {SIq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the nursery rhyme "Little Jack Horner" (see {rIl:v:2}).</column>
       <column name="components"></column>
       <column name="examples">
@@ -4606,6 +5085,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4613,6 +5093,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4626,6 +5107,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="definition_ru">играть (духовой инструмент) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">玩（管樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tocar (um instrumento de sopro)</column>
+      <column name="definition_fi">soittaa (puhallinsoitinta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gheb:n}, {SuS:v}, {chu':v:3}, {rIl:v:1}</column>
@@ -4636,6 +5118,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">此動詞的用法僅限於{gheb:n}，而{SuS:v}是更通用的術語，適用於所有管樂器。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O uso desse verbo é restrito ao {gheb:n}, enquanto {SuS:v} é um termo mais geral que se aplica a todos os instrumentos de sopro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin käyttö on rajoitettu {gheb:n}: een, kun taas {SuS:v} on yleisempi termi, joka koskee kaikkia puhallinsoittimia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to the nursery rhyme "Little Jack Horner" (see {rIl:v:1}).
 
 {gheb rIl:sen:nolink} is a reference to the horn of Gabriel.</column>
@@ -4647,6 +5130,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">horn</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4654,6 +5138,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4667,6 +5152,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="definition_ru">thumb (child) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">拇指（孩子） [AUTOTRANSLATED]</column>
       <column name="definition_pt">polegar (criança)</column>
+      <column name="definition_fi">(lapsen) peukalo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4677,6 +5163,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="notes_ru">Это слово используется маленькими детьми или взрослыми, разговаривающими с маленькими детьми или о них. Взрослые обычно используют {SenwI':n} вместо этого. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞由小孩使用，或與小孩聊天或談論小孩的成年人使用。成人通常使用{SenwI':n}代替。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra é usada por crianças pequenas ou por adultos conversando com ou sobre crianças pequenas. Os adultos normalmente usam {SenwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käyttävät pienet lapset tai aikuiset, jotka puhuvat pienille lapsille tai puhuvat niistä. Aikuiset käyttävät yleensä {SenwI':n}: ää. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{rIl:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4686,6 +5173,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4693,6 +5181,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4706,6 +5195,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="definition_ru">гормон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">激素 [AUTOTRANSLATED]</column>
       <column name="definition_pt">hormônio</column>
+      <column name="definition_fi">hormoni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4716,6 +5206,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that this is not grammatically considered a body part.</column>
       <column name="components"></column>
       <column name="examples">{may' rImbey:n}</column>
@@ -4725,6 +5216,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4732,6 +5224,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4745,6 +5238,7 @@ A forma reflexiva deste verbo tem um significado especial. Veja o exemplo abaixo
       <column name="definition_ru">быть завершенным, быть законченным, быть выполненным</column>
       <column name="definition_zh_HK">完成</column>
       <column name="definition_pt">ser realizado, terminado</column>
+      <column name="definition_fi">olla valmis, olla suoritettu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tagh:v}</column>
       <column name="see_also">{pItlh:excl}, {bertlham:n}, {Dor:v:2}, {ghang:v}, {van:v:2}, {'o'megh:n}</column>
@@ -4769,6 +5263,9 @@ Detta verb används med suffixet {-taH:v} för att bilda {rIntaH:v}, en konstruk
       <column name="notes_pt">Por si só, {rIn:v:nolink} é usado em transmissões de rádio para indicar o fim da transmissão, semelhante a "encerrado".
 
 Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construção usada para indicar finalidade (cf. o sufixo {-ta':v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Itse asiassa {rIn:v:nolink}: tä käytetään radiolähetyksissä osoittamaan lähetyksen loppu, samanlainen kuin "yli".
+
+Tätä verbiä käytetään loppuliitteen {-taH:v} kanssa muodostaen {rIntaH:v}, rakenteen, jota käytetään osoittamaan lopullisuutta (vrt. Loppuliite {-ta':v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4778,6 +5275,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">over</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4785,6 +5283,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="search_tags_ru">конец, окончание</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4798,6 +5297,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="definition_ru">свершившийся факт</column>
       <column name="definition_zh_HK">既成事實 [AUTOTRANSLATED]</column>
       <column name="definition_pt">terminar, fato consumado</column>
+      <column name="definition_fi">se on tehty, tapahtunut tosiasia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-ta':v:suff}, {bIQ'a'Daq 'oHtaH 'etlh'e'.:sen}</column>
@@ -4808,6 +5308,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="notes_ru">Эта специальная конструкция следует за другим глаголом, чтобы обозначить, что действие, описанное в предыдущем глаголе, является свершившимся фактом. Очень похоже по значению на глагольный суффикс {-ta':v:suff}, но имеет дополнительную коннотацию законченности.</column>
       <column name="notes_zh_HK">這種特殊的言語結構跟在另一個動詞之後，表示前一個動詞描述的動作是既成事實。它的含義與動詞後綴{-ta':v:suff}相似，但是具有終結性的附加含義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa construção verbal especial segue outro verbo para indicar que a ação descrita pelo verbo anterior é um fato consumado. É semelhante em significado ao sufixo do verbo {-ta':v:suff}, mas tem a conotação adicional de finalidade. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä erityinen verbaalirakenne seuraa toista verbiä osoittaakseen, että edellisen verbin kuvaama toiminta on tapahtunut. Se on merkitykseltään samanlainen kuin verbiliite {-ta':v:suff}, mutta sillä on lopullisuuden lisäväline. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{rIn:v}, {-taH:v:suff}</column>
       <column name="examples">
@@ -4819,6 +5320,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4826,6 +5328,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.7:src}</column>
     </table>
     <table name="mem">
@@ -4839,6 +5342,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="definition_ru">совет, законодательный орган, законодательное собрание</column>
       <column name="definition_zh_HK">理事會、大會 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conselho, assembleia</column>
+      <column name="definition_fi">neuvosto, (edustajien tms.) kokous</column>
       <column name="synonyms">{yej:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{quprIp:n}</column>
@@ -4849,6 +5353,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4858,6 +5363,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4865,6 +5371,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4878,6 +5385,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="definition_ru">пионер, прорыв, инновации [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">開拓，突破，創新 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pioneiro, romper, inovar</column>
+      <column name="definition_fi">olla uranuurtaja, tehdä läpimurto, olla uudistaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ogh:v}</column>
@@ -4888,6 +5396,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="notes_ru">Это будет относиться к научному прорыву или открытию, но не, скажем, к установлению нового рекорда в соревнованиях по вертящемуся сражению. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這將適用於科學突破或發現，但不適用於在巴特萊斯旋轉比賽中創下新紀錄。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se aplicaria a uma descoberta ou descoberta científica, mas não para, digamos, estabelecer um novo recorde em uma competição rodopiante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä pätee tieteelliseen läpimurtoon tai löytöön, mutta ei esimerkiksi uuden ennätyksen asettamiseen bat'leth-pyörimiskilpailussa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Eu"rek"a.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4897,6 +5406,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4904,6 +5414,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4917,6 +5428,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="definition_ru">быть раненым, быть поврежденным, быть травмированным</column>
       <column name="definition_zh_HK">受傷、傷殘</column>
       <column name="definition_pt">ser ferido, ser danificado</column>
+      <column name="definition_fi">olla loukkaantunut, haavoittunut, vahingoittunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QID:v}, {QIH:v:1}, {ban:v}</column>
@@ -4927,6 +5439,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {TKD:src} this is defined as "be injured". The "be damaged" extension of the meaning is from {Klingon Monopoly:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4938,6 +5451,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
 ▶ {Dumer DIvI' QaS 'ej DuHIv, vaj bIwunchoH 'ej bIrIQchoH.:sen:nolink} "Неожиданная атака Федерации оставила вас незащищенным и поврежденным."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4945,6 +5459,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -4958,6 +5473,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="definition_ru">повреждать, увечить, ранить</column>
       <column name="definition_zh_HK">損傷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ferir</column>
+      <column name="definition_fi">haavoittaa, loukata, vahingoittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QID:v}</column>
@@ -4968,6 +5484,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rIQ:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -4977,6 +5494,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4984,6 +5502,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4997,6 +5516,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="definition_ru">издать треск или щелчок, подать сигнал [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發出破裂或劈啪聲、發出信號 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer um som de estalido ou estalo, emita um sinal</column>
+      <column name="definition_fi">tehdä naksahtava tai napsahtava ääni; lähettää ulos signaali, säteillä, erittää, päästää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rISwI':n:extcan}</column>
@@ -5007,6 +5527,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="notes_ru">Первоначально это относилось только к излучению звука. Позже значение расширилось и означает испускание любого вида сигнала: звука, излучения, запаха и т. Д. Для сравнения, {tlhuD:v} относится только к излучению. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">最初僅指發出聲音。後來，該含義擴展為表示發出任何類型的信號：聲音，輻射，氣味等。相比之下，{tlhuD:v}僅指輻射的發射。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso originalmente se referia apenas à emissão de som. Mais tarde, o significado foi estendido para significar emitir qualquer tipo de sinal: som, radiação, cheiro, etc. Em comparação, {tlhuD:v} refere-se apenas à emissão de radiação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Alun perin tämä tarkoitti vain äänen lähettämistä. Myöhemmin merkitystä laajennettiin tarkoittamaan kaikenlaisen signaalin lähettämistä: ääntä, säteilyä, hajua jne. Vertailun vuoksi {tlhuD:v} viittaa vain säteilyemissioon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Snap, Crackle, Pop are the cartoon mascots of Rice Krispies, a breakfast cereal.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5016,6 +5537,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5023,6 +5545,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Battle at the Binary Stars:src}</column>
     </table>
     <table name="mem">
@@ -5036,6 +5559,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="definition_ru">Призвать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">召喚 [AUTOTRANSLATED]</column>
       <column name="definition_pt">convocar</column>
+      <column name="definition_fi">kutsua joku tai jotkut (paikalle tai koolle)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{rItHa':v}</column>
       <column name="see_also">{rI':v}, {ruSvep:n}, {tuch rIt:sen}</column>
@@ -5046,6 +5570,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5056,6 +5581,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">call, invite</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5063,6 +5589,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -5076,6 +5603,7 @@ Este verbo é usado com o sufixo {-taH:v} para formar {rIntaH:v}, uma construç�
       <column name="definition_ru">пигмент, краска, краситель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">顏料、油漆、染料 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pigmento, tinta, corante</column>
+      <column name="definition_fi">väriaine, maali, pigmentti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nguv:v}, {DIj:v:2}, {rItlh naQ:n}, {nagh beQ:n}, {vol:n}, {ngoH:v:2}, {chum:v}, {qalmuS:n}</column>
@@ -5096,6 +5624,9 @@ Detta avser även bläck, som för en gummistämpel ({toqwIn:n}) .[2] [AUTOTRANS
       <column name="notes_pt">Não há substantivo em Klingon que significa "cor" .[1, p.81]
 
 Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonissa ei ole substantiivia, joka tarkoittaa "väri" .[1, p.81]
+
+Tämä viittaa myös musteeseen, kuten kumileimasimeen ({toqwIn:n}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Ritz" is a brand of paint or dye.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5105,6 +5636,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">color, colour, ink</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5112,6 +5644,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
         <table name="mem">
@@ -5125,6 +5658,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="definition_ru">пигментная палочка [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">顏料棒 [AUTOTRANSLATED]</column>
           <column name="definition_pt">bastão de pigmento</column>
+      <column name="definition_fi">pigmenttitikku, maalitikku ?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{DIj:v:2}, {rItlh:n}, {nItlh naQ:n}, {nItlhpach:n:2}, {rItlh 'echlet:n}, {laS:v}</column>
@@ -5135,6 +5669,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{rItlh:n}, {naQ:n:1}</column>
           <column name="examples"></column>
@@ -5144,6 +5679,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5151,6 +5687,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT:src}</column>
         </table>
         <table name="mem">
@@ -5164,6 +5701,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="definition_ru">трафарет [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">模版 [AUTOTRANSLATED]</column>
           <column name="definition_pt">estêncil</column>
+      <column name="definition_fi">sapluuna, kaavain, malline</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5174,6 +5712,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{rItlh:n}, {vol:n}</column>
           <column name="examples"></column>
@@ -5183,6 +5722,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5190,6 +5730,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -5203,6 +5744,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="definition_ru">чернильница [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">印台 [AUTOTRANSLATED]</column>
           <column name="definition_pt">almofada de tinta</column>
+      <column name="definition_fi">mustetyyny, värityyny</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{toqwIn:n}, {laS:v}</column>
@@ -5213,6 +5755,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{rItlh:n}, {'echlet:n}</column>
           <column name="examples"></column>
@@ -5222,6 +5765,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5229,6 +5773,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
         </table>
     <table name="mem">
@@ -5242,6 +5787,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">Трещина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">分裂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dividido</column>
+      <column name="definition_fi">halkaista, jakaa osiin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIrgh:v}, {pe':v}</column>
@@ -5252,6 +5798,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Например, это то, что топор делает с арбузом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">例如，這就是斧頭對西瓜的作用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Por exemplo, é isso que um machado faz com uma melancia. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Esimerkiksi kirves tekee vesimelonille näin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Rive".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5261,6 +5808,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5268,6 +5816,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -5281,6 +5830,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">посольство</column>
       <column name="definition_zh_HK">大使館 [AUTOTRANSLATED]</column>
       <column name="definition_pt">embaixada</column>
+      <column name="definition_fi">suurlähetystö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duy'a':n}, {'oSwI':n}</column>
@@ -5291,6 +5841,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5300,6 +5851,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5307,6 +5859,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5320,6 +5873,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">Рем</column>
       <column name="definition_zh_HK">雷穆斯星</column>
       <column name="definition_pt">Remus</column>
+      <column name="definition_fi">Remus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{romuluS:n}</column>
@@ -5330,6 +5884,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5339,6 +5894,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5346,6 +5902,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -5359,6 +5916,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">вызывать, передавать приветствие (коммуникации)</column>
       <column name="definition_zh_HK">冰雹（通訊） [AUTOTRANSLATED]</column>
       <column name="definition_pt">chamar (iniciar comunicação)</column>
+      <column name="definition_fi">tervehtiä (viestintä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qum:v}, {rI'Se':n}, {rIt:v}</column>
@@ -5369,6 +5927,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined only as "hail". The "communication" clarification was added to distinguish it from the weather phenomenon ({Heq:v}).</column>
       <column name="components"></column>
       <column name="examples">{rI'meH wovmoHwI':n}</column>
@@ -5378,6 +5937,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5385,6 +5945,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
         <table name="mem">
@@ -5398,6 +5959,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="definition_ru">маяк</column>
           <column name="definition_zh_HK">烽火 [AUTOTRANSLATED]</column>
           <column name="definition_pt">sinalizador</column>
+      <column name="definition_fi">majakka</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Sech qengwI':n}</column>
@@ -5408,6 +5970,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{rI':v}, {-meH:v}, {wovmoHwI':n}</column>
           <column name="examples"></column>
@@ -5417,6 +5980,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5424,6 +5988,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -5437,6 +6002,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="definition_ru">громкоговоритель [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">喇叭、擴音器</column>
           <column name="definition_pt">alto-falante</column>
+      <column name="definition_fi">kaiutin</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{DannI':n}</column>
@@ -5447,6 +6013,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{rI':v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -5456,6 +6023,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5463,6 +6031,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -5476,6 +6045,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">дефлектор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">導流板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">defletor</column>
+      <column name="definition_fi">kimmotin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5486,6 +6056,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{begh:n:inhpl}</column>
       <column name="examples"></column>
@@ -5495,6 +6066,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5502,6 +6074,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5515,6 +6088,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">частота приветствия</column>
       <column name="definition_zh_HK">歡呼頻率 [AUTOTRANSLATED]</column>
       <column name="definition_pt">frequência de saudação</column>
+      <column name="definition_fi">tervehtimistaajuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Se':n}, {chaDvay':n}, {wab HevwI':n}, {rI':v}</column>
@@ -5525,6 +6099,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5534,6 +6109,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5541,6 +6117,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5554,6 +6131,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">торс, туловище</column>
       <column name="definition_zh_HK">軀幹（身體）、軀幹 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tronco (do corpo), torso</column>
+      <column name="definition_fi">ylävartalo, torso</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{porgh:n}, {logh'ob:n}, {chor:n:1}, {Dub:n}, {joQ:n:1}, {DeS:n:1}, {'uS:n}, {volchaH:n}, {mong:n}, {nach:n}, {tIq:n}</column>
@@ -5564,6 +6142,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Не путать с {ro':n}.</column>
       <column name="notes_zh_HK">不要將此與{ro':n}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda isso com {ro':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita tätä kohtaan {ro':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined as "trunk (of body)" in {TKD:src} and glossed as "torso" in the text of {KGT:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5573,6 +6152,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5580,6 +6160,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.195:src}</column>
     </table>
     <table name="mem">
@@ -5593,6 +6174,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">ось [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">軸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">eixo</column>
+      <column name="definition_fi">akseli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baSta':n}, {chItlh:v}, {roDSer:n}</column>
@@ -5603,6 +6185,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Это относится к воображаемой линии, вокруг которой объект вращается или симметрично расположен. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指對象圍繞其旋轉或對稱排列的假想線。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a uma linha imaginária em torno da qual um objeto gira ou é simetricamente disposto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kuvitteelliseen viivaan, jonka ympäri esine pyöri tai on järjestetty symmetrisesti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5612,6 +6195,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5619,6 +6203,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5632,6 +6217,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">страшный сон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">惡夢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pesadelo</column>
+      <column name="definition_fi">painajainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5642,6 +6228,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Это может быть объект {naj:v} «мечта» или {SIQ:v} «терпеть» и некоторых других глаголов, но обычно не {ghaj:v} «иметь» (если только вы каким-то образом буквально не обладаете кошмаром). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能是{naj:v}“夢”或{SIQ:v}“忍受”和其他一些動詞的對象，但通常不是{ghaj:v}“有”（除非您從某種意義上說是一場噩夢）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este pode ser o objeto de {naj:v} "sonho" ou {SIQ:v} "resistir" e alguns outros verbos, mas geralmente não {ghaj:v} "ter" (a menos que você literalmente possua um pesadelo). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi olla {naj:v} "unelma" tai {SIQ:v} "kestää" ja joidenkin muiden verbien kohde, mutta yleensä ei {ghaj:v} "ole" (ellei sinulla ole kirjaimellisesti painajaista). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5651,6 +6238,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5658,6 +6246,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5671,6 +6260,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">голограмма [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">全息圖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">holograma</column>
+      <column name="definition_fi">hologrammi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tojbogh pa':n}, {'otlh:n}</column>
@@ -5681,6 +6271,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Dennis Gabor was the inventor of holography.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5690,6 +6281,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5697,6 +6289,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5710,6 +6303,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">обычно, обычно, регулярно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">習慣性地、習慣性地、定期地 [AUTOTRANSLATED]</column>
       <column name="definition_pt">habitualmente, regularmente</column>
+      <column name="definition_fi">tavanomaisesti, tavanmukaisesti, säännöllisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rut:adv}, {pIj:adv}, {jaS:adv}, {motlh:adv}, {quvyaH:n}</column>
@@ -5720,6 +6314,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5729,6 +6324,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5736,6 +6332,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5749,6 +6346,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">измерение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">尺寸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dimensão</column>
+      <column name="definition_fi">ulottuvuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qIr'a':n}, {tlhey'at:n}, {lurgh:n}, {baSta':n}, {rober:n}</column>
@@ -5759,6 +6357,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Это относится к измерению в системе координат, а не к другому измерению, как в параллельном юниверсе (о котором см. {'u' quq:n} и {'u' Dop:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa ulottuvuuteen koordinaattijärjestelmässä, ei toiseen ulottuvuuteen, kuten rinnakkaisuniversumissa (josta ks. {'u' quq:n} ja {'u' Dop:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Rod Serling's opening narrations (of which there are several) for the TV show "The Twilight Zone" all refer to entering or traveling through another dimension. For example: "You are about to enter another dimension, a dimension not only of sight and sound but of mind."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5768,6 +6367,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5775,6 +6375,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5788,6 +6389,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">брожение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發酵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fermentar</column>
+      <column name="definition_fi">käydä (ruoasta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qompogh:n}</column>
@@ -5798,6 +6400,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5807,6 +6410,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5814,6 +6418,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5827,6 +6432,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">причина брожения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">導致發酵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">causar fermentação</column>
+      <column name="definition_fi">aiheuttaa käyminen (ruoasta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeyvaq Ha'DIbaH:n}</column>
@@ -5837,6 +6443,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Смотрите {KGT p.91:src}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">參見{KGT p.91:src}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {KGT p.91:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {KGT p.91:src}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{rogh:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -5846,6 +6453,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5853,6 +6461,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5866,6 +6475,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">население</column>
       <column name="definition_zh_HK">人口</column>
       <column name="definition_pt">população</column>
+      <column name="definition_fi">väestö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rewbe':n}</column>
@@ -5876,6 +6486,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5885,6 +6496,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5892,6 +6504,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5905,6 +6518,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">заключать мир, добиваться мира, достигать мира, устанавливать мир</column>
       <column name="definition_zh_HK">媾和 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer paz</column>
+      <column name="definition_fi">solmia rauha</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Qoj:v}</column>
       <column name="see_also">{roj:n}</column>
@@ -5915,6 +6529,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5924,6 +6539,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5931,6 +6547,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5944,6 +6561,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">мир(отсутствие войны)</column>
       <column name="definition_zh_HK">和平</column>
       <column name="definition_pt">paz</column>
+      <column name="definition_fi">rauha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{roj:v}, {rojHom:n}</column>
@@ -5954,6 +6572,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5963,6 +6582,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5970,6 +6590,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5983,6 +6604,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">перемирие</column>
       <column name="definition_zh_HK">休戰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trégua</column>
+      <column name="definition_fi">aselepo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{may'qochvan:n:extcan}</column>
@@ -5993,6 +6615,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{roj:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -6002,6 +6625,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6009,6 +6633,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6022,6 +6647,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">мирный договор</column>
       <column name="definition_zh_HK">和平協議</column>
       <column name="definition_pt">tratado de paz</column>
+      <column name="definition_fi">rauhansopimus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qI':v:1}, {mab:n:1}, {Sutlh:v}</column>
@@ -6032,6 +6658,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{roj:n}, {mab:n:1}</column>
       <column name="examples"></column>
@@ -6041,6 +6668,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6048,6 +6676,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6061,6 +6690,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">разговоры о мире</column>
       <column name="definition_zh_HK">和平會談 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conversa de paz</column>
+      <column name="definition_fi">rauhanneuvottelut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sutlh:v}</column>
@@ -6071,6 +6701,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rojmab:n}, {qep:n}</column>
       <column name="examples">
@@ -6082,6 +6713,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
 ▶ {DIvI' rojmab qep ghanglu' 'e' nIDlu', 'ach taH qep.:sen:nolink} "Несмотря на усилия для прекращения, разговоры о мире с Федерацией продолжаются."[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6089,6 +6721,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6102,6 +6735,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">борода</column>
       <column name="definition_zh_HK">鬚</column>
       <column name="definition_pt">bar</column>
+      <column name="definition_fi">parta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loch:n}, {woS:n}</column>
@@ -6112,6 +6746,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Относится к волосам на лице, которые покрывают зону подбородка и шеи.[2]</column>
       <column name="notes_zh_HK">這是指覆蓋下巴和脖子區域的臉上的頭髮。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a pelos no rosto que cobrem a área do queixo e pescoço.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kasvojen hiuksiin, jotka peittävät leuan ja niska-alueen[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6121,6 +6756,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6128,6 +6764,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -6141,6 +6778,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">бритва</column>
       <column name="definition_zh_HK">剃刀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">navalha</column>
+      <column name="definition_fi">partaveitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6151,6 +6789,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rol:n}, {taj:n}</column>
       <column name="examples"></column>
@@ -6160,6 +6799,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6167,6 +6807,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6180,6 +6821,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">соглашение, договоренность</column>
       <column name="definition_zh_HK">符合 [AUTOTRANSLATED]</column>
       <column name="definition_pt">concordância</column>
+      <column name="definition_fi">sopu, yhteisymmärrys, sopimus; kongruenssi (kielitiede)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qI':v:1}</column>
@@ -6190,6 +6832,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Это слово также используется Клингонскими филологами, чтобы упомянуть о правиле, которое определяет использование суффиксов местоимений. Правило Федерации филологи называют "соглашением".[2]</column>
       <column name="notes_zh_HK">克林崗語語法學家還使用此詞來指代控制代詞前綴使用的規則，聯邦文法學家稱之為“協議”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra também é usada pelos gramáticos klingon para se referir à regra que governa o uso de prefixos pronominais, uma regra que os gramáticos da Federação chamam de "acordo".[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käyttävät myös klingonilaiset kielioppilaiset viitaten sääntöön, joka säätelee alkusanan etuliitteiden käyttöä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Rome".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6199,6 +6842,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">agreement</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6206,6 +6850,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru">соглашение</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.172:src}</column>
     </table>
     <table name="mem">
@@ -6219,6 +6864,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">октава [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">八度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">oitava</column>
+      <column name="definition_fi">oktaavi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Savvanwer:n}, {QoQ:n}, {bom:n}</column>
@@ -6229,6 +6875,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Octavian was a Roman ({rom:sen:nolink}) emperor ({ta':n:2}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6238,6 +6885,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6245,6 +6893,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -6258,6 +6907,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">Ромул</column>
       <column name="definition_zh_HK">羅慕路斯星</column>
       <column name="definition_pt">Romulus</column>
+      <column name="definition_fi">Romulus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{romuluSngan:n}, {rIymuS:n}</column>
@@ -6268,6 +6918,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6277,6 +6928,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6284,6 +6936,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6297,6 +6950,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">Ромуланский эль</column>
       <column name="definition_zh_HK">Romulan ale [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ale Romulano</column>
+      <column name="definition_fi">romuluslainen olut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6307,6 +6961,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Считается слишком сильнодействующим для туристов.</column>
       <column name="notes_zh_HK">這被認為對遊客來說太強大了。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é considerado muito potente para os turistas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä pidetään turisteille liian voimakkaana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{romuluS:n}, {HIq:n}</column>
       <column name="examples"></column>
@@ -6316,6 +6971,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6323,6 +6979,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -6336,6 +6993,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">Ромуланец</column>
       <column name="definition_zh_HK">羅慕倫人</column>
       <column name="definition_pt">Romulano</column>
+      <column name="definition_fi">romuluslainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{romuluS:n}</column>
@@ -6346,6 +7004,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Есть идиома, {matlhHa'; romuluSngan rur}.</column>
       <column name="notes_zh_HK">有一個成語，{matlhHa'; romuluSngan rur}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {matlhHa'; romuluSngan rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {matlhHa'; romuluSngan rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{romuluS:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -6355,6 +7014,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6362,6 +7022,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6375,6 +7036,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">Ромуланский зонд-охотник</column>
       <column name="definition_zh_HK">羅慕蘭獵人殺手探測器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sonda romulana de caçador-assassino</column>
+      <column name="definition_fi">romuluslainen metsästäjä-tappajaluotain ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6385,6 +7047,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="notes_ru">Также назван {HoHwI':n} для краткости.</column>
       <column name="notes_zh_HK">這也簡稱為{HoHwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é chamado de {HoHwI':n}, para abreviar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä kutsutaan myös lyhyeksi nimeksi {HoHwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{romuluSngan:n}, {Sam:v}, {-bogh:v}, {'ej:conj}, {HoH:v}, {-bogh:v}, {nejwI':n}</column>
       <column name="examples"></column>
@@ -6394,6 +7057,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6401,6 +7065,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -6414,6 +7079,7 @@ Isso também se refere à tinta, como para um carimbo de borracha ({toqwIn:n}) .
       <column name="definition_ru">катиться, катиться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">轆、翻</column>
       <column name="definition_pt">rolar, estar rolando</column>
+      <column name="definition_fi">kieriä, vieriä, pyöriä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6452,6 +7118,11 @@ Detta verb kan tillämpas på flygplan, för vilka se {ron:v:2}. [AUTOTRANSLATED
 Quando aplicado a uma pessoa, significa que a pessoa está rolando ao acaso. Dar uma cambalhota é {Hay:v} e rolar colina abaixo (como um tronco) é {tetlh:v}.[2]
 
 Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Noppien pelaamisen yhteydessä tämä sana viittaa noppien toimintaan heidän pyörittäessään. (Noppien "heittäminen" tai "heittäminen" olisi {ronmoH:v:nolink}.) [1]
+
+Kun sitä käytetään henkilöön, se tarkoittaa, että henkilö liikkuu sattumanvaraisesti. Kummersuolen suorittaminen on {Hay:v}, ja mäkeä alas vierittäminen (kuten loki) on {tetlh:v}.[2]
+
+Tätä verbiä voidaan soveltaa lentokoneisiin, joista ks. {ron:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6463,6 +7134,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6470,6 +7142,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}, [2] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -6483,6 +7156,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">крен (наклон крыльев самолета, один вверх, один вниз) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滾動（飛機機翼傾斜，一上一下） [AUTOTRANSLATED]</column>
       <column name="definition_pt">rolar (asas da aeronave inclinadas, uma para cima, uma para baixo)</column>
+      <column name="definition_fi">kallistua (lentokoneen kääntyminen pituusakselin suhteen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dav:v:2}, {Der:v:2}, {jer:v}, {jIm:v:2}, {lol:v:2}, {tor:v:2}, {'or:v}, {mI' nagh:n}</column>
@@ -6493,6 +7167,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru">Это просто глагол {ron:v:1}, применяемый к самолету. Для пилота управлять самолетом будет {ronmoH:v:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是應用於飛機的動詞{ron:v:1}。對於飛行員來說，登上飛機是{ronmoH:v:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é apenas o verbo {ron:v:1} aplicado à aeronave. Para um piloto rolar uma aeronave seria {ronmoH:v:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain verbi {ron:v:1}, jota sovelletaan lentokoneisiin. Luotsille lentää ilmaa olisi {ronmoH:v:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The aile"ron"s control the roll on an airplane.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6503,6 +7178,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6510,6 +7186,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -6523,6 +7200,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">быть хворым, быть больным, быть заболевшим, быть нездоровым</column>
       <column name="definition_zh_HK">生病了、病了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar doente, doente</column>
+      <column name="definition_fi">olla sairas, kipeä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIv:v}</column>
       <column name="see_also">{rop:n}, {Qel:n:1h}, {Hergh:n}, {SID:n}, {vor:v}, {ropyaH:n}</column>
@@ -6533,6 +7211,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6542,6 +7221,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6549,6 +7229,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6562,6 +7243,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">Болезнь, заболевание, недуг</column>
       <column name="definition_zh_HK">疾病 [AUTOTRANSLATED]</column>
       <column name="definition_pt">doença</column>
+      <column name="definition_fi">sairaus, tauti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rop:v}, {vor:v}, {ngej:v}, {lerup:n}</column>
@@ -6572,6 +7254,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru">Болезни упоминаются путем наименования болезни, за которым следует {rop:n:nolink}.[2]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">As doenças são referidas pelo nome da doença seguido por {rop:n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sairauksiin viitataan taudin nimellä, jota seuraa {rop:n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6585,6 +7268,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
 ▶ {matlh rop:n:nolink} "Болезнь Мальтца"[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6592,6 +7276,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6605,6 +7290,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">чума, бич, мор, эпидемия</column>
       <column name="definition_zh_HK">鼠疫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">praga</column>
+      <column name="definition_fi">rutto, kulkutauti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rop:n}, {ruDelya' rop'a':n}</column>
@@ -6615,6 +7301,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rop:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -6624,6 +7311,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">epidemic</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6631,6 +7319,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru">эпидемия</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6644,6 +7333,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">Клингоны не болеют.</column>
       <column name="definition_zh_HK">克林崗人不會生病。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Os klingons não ficam doentes.</column>
+      <column name="definition_fi">Klingonit eivät sairastu.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6654,6 +7344,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6663,6 +7354,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6670,6 +7362,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.40:src}</column>
     </table>
     <table name="mem">
@@ -6683,6 +7376,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">scar (from disease, infection, etc.) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">疤痕（來自疾病、感染等） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cicatriz (de doença, infecção, etc.)</column>
+      <column name="definition_fi">(sairauden, infektion tms. aiheuttama) arpi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taq:v}, {mIvwa':n}, {SanDIy:n}</column>
@@ -6693,6 +7387,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru">Это рубец, который является результатом какого-то заболевания, инфекции и т. Д. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是由於某種疾病，感染等導致的疤痕。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma cicatriz que é o resultado de algum tipo de doença, infecção, etc. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on arpi, joka on seurausta jonkinlaisesta sairaudesta, infektiosta jne. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as just "scar", with an accompanying explanation of the kinds of scars.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6702,6 +7397,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6709,6 +7405,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -6722,6 +7419,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">лазарет, больничный изолятор</column>
       <column name="definition_zh_HK">醫療部</column>
       <column name="definition_pt">enfermaria</column>
+      <column name="definition_fi">sairasosasto, sairashytti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qel:n:1h}, {SID:n}</column>
@@ -6732,6 +7430,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{rop:n}, {yaH:n}</column>
       <column name="examples">{ropyaH yIghuHmoH!:sen}</column>
@@ -6741,6 +7440,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6748,6 +7448,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6761,6 +7462,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">госпиталь</column>
       <column name="definition_zh_HK">醫院</column>
       <column name="definition_pt">hospital</column>
+      <column name="definition_fi">sairaala</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ropyaH:n}</column>
@@ -6771,6 +7473,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ropyaH:n}, {qach:n}</column>
       <column name="examples"></column>
@@ -6780,6 +7483,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6787,6 +7491,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6800,6 +7505,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">Предупредите лазарет!</column>
       <column name="definition_zh_HK">警報醫療部！</column>
       <column name="definition_pt">Alerta enfermaria!</column>
+      <column name="definition_fi">Varoita sairasosastoa!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6810,6 +7516,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru">Это было сказано на Клингонском, но не сопровождалось субтитрами</column>
       <column name="notes_zh_HK">此行在克林崗語中被使用，但沒有字幕。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta linha foi falada em klingon, mas não foi legendada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä rivi puhuttiin Klingonissa, mutta sitä ei tekstitetty. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ropyaH:n}, {yI-:v}, {ghuHmoH:v}</column>
       <column name="examples"></column>
@@ -6819,6 +7526,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6826,6 +7534,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -6839,6 +7548,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">опускать что-либо</column>
       <column name="definition_zh_HK">放下 [AUTOTRANSLATED]</column>
       <column name="definition_pt">abaixar</column>
+      <column name="definition_fi">panna alas</column>
       <column name="synonyms"></column>
       <column name="antonyms">{woH:v}</column>
       <column name="see_also">{chagh:v}</column>
@@ -6849,6 +7559,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6858,6 +7569,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6865,6 +7577,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6878,6 +7591,7 @@ Este verbo pode ser aplicado a aeronaves, para as quais consulte {ron:v:2}. [AUT
       <column name="definition_ru">быть толстым, быть упитанным, быть жирным</column>
       <column name="definition_zh_HK">發胖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser gordo (não magro)</column>
+      <column name="definition_fi">olla lihava</column>
       <column name="synonyms">{pI':v}</column>
       <column name="antonyms">{lang:v}</column>
       <column name="see_also">{tlhagh:n}, {juch:v}, {vaS:v}</column>
@@ -6898,6 +7612,9 @@ En "fet bok" skulle vara en {paq qargh:n@@paq:n:1, qargh:v}, såvida inte boken 
       <column name="notes_pt">Isso implica volume devido à gordura corporal ou algo semelhante, enquanto {pI':v} não tem essa conotação. Ambos podem ser usados ​​para expressar "não magro", mas {ror:v:nolink} é mais apropriado para expressar "não magro". Quando este verbo é usado para descrever um objeto inanimado, geralmente ocorre um pouco de antropomorfização, comparando o objeto a uma pessoa ou a um animal.[2]
 
 Um "livro gordo" seria um {paq qargh:n@@paq:n:1, qargh:v}, a menos que o livro ganhe vida como um personagem de desenho animado ou algo parecido. (Nesse caso, o sufixo plural {-pu':n:suff} também pode ser esperado.) [2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä merkitsee suurta määrää kehon rasvasta tai vastaavasta, kun taas {pI':v}: llä ei ole tätä merkitystä. Molempia voidaan käyttää ilmaisemaan "ei ohut", mutta {ror:v:nolink} on tarkoituksenmukaisempi ilmaisemaan "ei laiha". Kun tätä verbiä käytetään kuvaamaan elottomia esineitä, tapahtuu yleensä vähän antropomorfisointia, kohteen vertaamista henkilöön tai eläimeen.
+
+"Rasva kirja" olisi {paq qargh:n@@paq:n:1, qargh:v}, ellei kirja herää eloon sarjakuvahahmona tai vastaavalla tavalla. (Tällöin voidaan odottaa myös monikon pääte {-pu':n:suff}.) [2][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as just "be fat" in {TKD:src}. The clarification was added at {Saarbrücken qepHom'a' 2019:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6907,6 +7624,7 @@ Um "livro gordo" seria um {paq qargh:n@@paq:n:1, qargh:v}, a menos que o livro g
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6914,6 +7632,7 @@ Um "livro gordo" seria um {paq qargh:n@@paq:n:1, qargh:v}, a menos que o livro g
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6927,6 +7646,7 @@ Um "livro gordo" seria um {paq qargh:n@@paq:n:1, qargh:v}, a menos que o livro g
       <column name="definition_ru">быть фантазией [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">幻想 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser fantasia</column>
+      <column name="definition_fi">olla haave, kuvitelma, fantasia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lut:n}, {torSIv:n}</column>
@@ -6949,6 +7669,9 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
 
 “童話”的概念可以表示為{puq lut:n@@puq:n, lut:n}或{lut rorgh:n@@lut:n, rorgh:v}或{puq lut rorgh:n@@puq:n, lut:n, rorgh:v}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on fantastisessa mielessä "olla fantastinen"; se ei tarkoita "ole ihana, loistava" .[1]
+
+Sanan käsite voidaan ilmaista muodossa {puq lut:n@@puq:n, lut:n} tai {lut rorgh:n@@lut:n, rorgh:v} tai {puq lut rorgh:n@@puq:n, lut:n, rorgh:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Ricardo Montalbán (Khan Noonien Singh) played Mr. Roarke on the TV series Fantasy Island.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6958,6 +7681,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fiction, fantastic</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6965,6 +7689,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -6978,6 +7703,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="definition_ru">облизывание [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">𦧺</column>
       <column name="definition_pt">lamber</column>
+      <column name="definition_fi">nuolla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jat:n}</column>
@@ -6988,6 +7714,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6997,6 +7724,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7004,6 +7732,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7017,6 +7746,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="definition_ru">использовать третий палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">使用第三個腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">use o terceiro dedo</column>
+      <column name="definition_fi">käyttää kolmatta varvasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaD:n:1}</column>
@@ -7027,6 +7757,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This little piggy had roast beef.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7036,6 +7767,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7043,6 +7775,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <!-- Not marked "deriv" because {roS:v:3} is hypothetical. -->
@@ -7058,6 +7791,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="definition_ru">парализовать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">癱瘓 [AUTOTRANSLATED]</column>
       <column name="definition_pt">paralisar</column>
+      <column name="definition_fi">halvaannuttaa, lamaannuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mot:v}</column>
@@ -7068,6 +7802,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">According to {HQ 10.2:src}[3], this verb consists of three elements: the verb {roS:v:3,is,hyp}, {-Ha':v}, and {-moH:v}.</column>
       <column name="components">{roS:v:3,is,hyp}, {-Ha':v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -7077,6 +7812,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7084,6 +7820,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 1.3, p.9, Sept. 1992:src}, [2] {KGT:src}, [3] {HQ 10.2, p.10, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -7097,6 +7834,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="definition_ru">третий палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">第三個腳趾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">terceiro dedo do pé</column>
+      <column name="definition_fi">kolmas varvas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaD:n:1}</column>
@@ -7107,6 +7845,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This little piggy had roast beef.</column>
       <column name="components">{roS:v:2}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7116,6 +7855,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7123,6 +7863,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -7136,6 +7877,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="definition_ru">ДНК</column>
       <column name="definition_zh_HK">脫氧核糖核酸</column>
       <column name="definition_pt">DNA</column>
+      <column name="definition_fi">DNA</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uchgha':n}</column>
@@ -7146,6 +7888,7 @@ Begreppet "saga" kan uttryckas som {puq lut:n@@puq:n, lut:n} eller {lut rorgh:n@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"He licks", helix.
 
 It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that this is not grammatically considered a body part.</column>
@@ -7157,6 +7900,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">deoxyribonucleic acid</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7164,6 +7908,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru">ДНК</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -7177,6 +7922,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Розенкранц</column>
       <column name="definition_zh_HK">羅森克蘭茨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Rosencrantz</column>
+      <column name="definition_fi">Rosencrantz</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}, {ghIlDeSten:n:name}</column>
@@ -7187,6 +7933,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7196,6 +7943,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7203,6 +7951,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -7216,6 +7965,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">археологический артефакт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">考古文物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">artefato arqueológico</column>
+      <column name="definition_fi">arkeologinen artefakti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{roSqa'QeD:n}, {roSqa'tej:n}</column>
@@ -7226,6 +7976,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{roSqa':sen@@roS:v:1, -qa':v} "lick again" = "re-lick" = "relic".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7235,6 +7986,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">relic</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7242,6 +7994,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
         <table name="mem">
@@ -7255,6 +8008,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
           <column name="definition_ru">археология [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">考古學 [AUTOTRANSLATED]</column>
           <column name="definition_pt">arqueologia</column>
+      <column name="definition_fi">arkeologia</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{roSqa':n}, {QeD:n}</column>
@@ -7265,6 +8019,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{roSqa':n}, {QeD:n}</column>
           <column name="examples"></column>
@@ -7274,6 +8029,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">archeology</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7281,6 +8037,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 26 (2019):src}</column>
         </table>
         <table name="mem">
@@ -7294,6 +8051,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
           <column name="definition_ru">археолог [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">考古學家 [AUTOTRANSLATED]</column>
           <column name="definition_pt">arqueólogo</column>
+      <column name="definition_fi">arkeologi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{roSqa':n}, {tej:n}</column>
@@ -7304,6 +8062,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{roSqa':n}, {tej:n}</column>
           <column name="examples"></column>
@@ -7313,6 +8072,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">archeologist</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7320,6 +8080,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 26 (2019):src}</column>
         </table>
     <table name="mem">
@@ -7333,6 +8094,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">быть жестким, быть грубым, быть крутым</column>
       <column name="definition_zh_HK">要堅強 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser duro, ser difícil</column>
+      <column name="definition_fi">olla kova, kestävä ?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{puj:v}</column>
       <column name="see_also">{SIQ:v}</column>
@@ -7343,6 +8105,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7352,6 +8115,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7359,6 +8123,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7372,6 +8137,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">кулак</column>
       <column name="definition_zh_HK">拳頭</column>
       <column name="definition_pt">punho</column>
+      <column name="definition_fi">nyrkki</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghIt:n:1}</column>
       <column name="see_also">{tlhaw':v}, {toch:n}, {ghop:n}</column>
@@ -7382,6 +8148,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru">Не путайте это с {ro:n}.</column>
       <column name="notes_zh_HK">不要將此與{ro:n}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda isso com {ro:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita tätä kohtaan {ro:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The game "rock-paper-scissors" is also known as "roshambo", and "rock" is basically a fist.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7392,6 +8159,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7399,6 +8167,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7412,6 +8181,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Покажи мне свой кулак!</column>
       <column name="definition_zh_HK">告訴我你的拳頭！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mostre-me seu punho!</column>
+      <column name="definition_fi">Näytä minulle nyrkkisi!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7422,6 +8192,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru">Данное идиоматическое выражение очень похоже на "ответь за свои слова" или "перейти от слов к делу".</column>
       <column name="notes_zh_HK">這種慣用語是用來挑戰某人採取與他或她剛才所說的相一致的方式採取行動的。 （這類似於英語表達“把錢放在嘴裡”。） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática é usada para desafiar alguém a agir de maneira consistente com algo que ele ou ela acabou de dizer. (É semelhante à expressão em inglês "coloque seu dinheiro onde está sua boca".) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä idiomaattista ilmaisua käytetään haastamaan joku toimimaan tavalla, joka on sopusoinnussa sen kanssa, jonka hän juuri sanoi. (Se on samanlainen kuin englanninkielinen ilmaisu "laittaa rahasi sinne, missä suusi on".) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ro':n}, {-lIj:n}, {HI-:v}, {'ang:v}</column>
       <column name="examples"></column>
@@ -7431,6 +8202,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">challenge, put your money where your mouth is</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7438,6 +8210,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru">вызов, состязание</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.195:src}</column>
     </table>
     <table name="mem">
@@ -7451,6 +8224,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">идиоматическая фраза, которая выражает контраст [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">反而</column>
       <column name="definition_pt">frase idiomática que expressa contraste</column>
+      <column name="definition_fi">vastakkainasettelua ilmaiseva idiomi, toisaalta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7461,6 +8235,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru">Это буквально означает «если открытая рука становится кулаком». Он используется аналогично английскому выражению «с другой стороны». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“如果張開的手變成拳頭”。它的使用方式與英語“另一方面”類似。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "se a mão aberta se tornar um punho". É usado de maneira semelhante à expressão em inglês "por outro lado". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "jos avoimesta kädestä tulee nyrkki". Sitä käytetään samalla tavalla kuin englanninkielistä ilmaisua "toisaalta". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ro':n}, {moj:v}, {-chugh:v}, {ghIt:n:1}</column>
       <column name="examples"></column>
@@ -7470,6 +8245,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">on the other hand, whereas</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7477,6 +8253,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -7490,6 +8267,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Кровавый пирог</column>
       <column name="definition_zh_HK">rokeg血派 [AUTOTRANSLATED]</column>
       <column name="definition_pt">torta de sangue rokeg</column>
+      <column name="definition_fi">eräs ruokalaji, rokeg-veripiirakka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iw:n}, {chab:n:1}, {ro'qegh:n:hyp}</column>
@@ -7500,6 +8278,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7509,6 +8288,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7516,6 +8296,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7529,6 +8310,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">приступать, действовать, осуществлять, сделать это, идти вперед к цели</column>
       <column name="definition_zh_HK">繼續、繼續、做吧 [AUTOTRANSLATED]</column>
       <column name="definition_pt">continuar, vá em frente, faça</column>
+      <column name="definition_fi">jatkaa, edetä, aloittaa (jonkin tekemisestä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaw':v}, {tungHa':v}</column>
@@ -7539,6 +8321,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was used with an object in {Hamlet:src}.
 
 This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.[2]</column>
@@ -7551,6 +8334,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">okay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7558,6 +8342,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru">окей</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <table name="mem">
@@ -7571,6 +8356,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">Руделия</column>
       <column name="definition_zh_HK">Rudellia [AUTOTRANSLATED]</column>
       <column name="definition_pt">Rudellia</column>
+      <column name="definition_fi">Rudellia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ruDelya' rop'a':n}</column>
@@ -7581,6 +8367,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7590,6 +8377,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Rudelia</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7597,6 +8385,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru">Руделия</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -7610,6 +8399,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">Рудельская чума [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">魯德利安瘟疫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">praga Rudelliana</column>
+      <column name="definition_fi">rudellialainen rutto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7620,6 +8410,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ruDelya':n}, {rop'a':n}</column>
       <column name="examples">
@@ -7630,6 +8421,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Rudelian plague</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7637,6 +8429,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -7650,6 +8443,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">антивещество</column>
       <column name="definition_zh_HK">反物質 [AUTOTRANSLATED]</column>
       <column name="definition_pt">antimatéria</column>
+      <column name="definition_fi">antimateria</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hap:n}</column>
@@ -7660,6 +8454,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7669,6 +8464,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">antimatter</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7676,6 +8472,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru">антивещество</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -7689,6 +8486,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
           <column name="definition_ru">антиводород</column>
           <column name="definition_zh_HK">反氫</column>
           <column name="definition_pt">anti-hidrogênio</column>
+      <column name="definition_fi">antivety</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{bIQSIp:n}, {bIQSIp 'ugh:n}</column>
@@ -7699,6 +8497,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{rugh:n}, {bIQSIp:n}</column>
           <column name="examples"></column>
@@ -7708,6 +8507,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">antihydrogen</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7715,6 +8515,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
           <column name="search_tags_ru">антиводород</column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -7728,6 +8529,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
           <column name="definition_ru">Позитрон</column>
           <column name="definition_zh_HK">正電子</column>
           <column name="definition_pt">pósitron</column>
+      <column name="definition_fi">positroni</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{tem:n}</column>
@@ -7738,6 +8540,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{rugh:n}, {tem:n}</column>
           <column name="examples"></column>
@@ -7747,6 +8550,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7754,6 +8558,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 23 (2016):src}</column>
         </table>
     <table name="mem">
@@ -7767,6 +8572,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">румянец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">臉紅 [AUTOTRANSLATED]</column>
       <column name="definition_pt">corar (corar o rosto devido a emoções)</column>
+      <column name="definition_fi">punastua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7777,6 +8583,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Мальц утверждает, что клингоны никогда не краснеют. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">馬爾茨斷言，克林崗人從不臉紅。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Maltz afirma que os klingons nunca coram. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maltz väittää, että klingonit eivät koskaan punastu. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was confirmed as intransitive during the Q &amp; A session.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7786,6 +8593,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7793,6 +8601,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7806,6 +8615,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">быть коротким (ростом) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">做空（身材矮小） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser baixo (em estatura)</column>
+      <column name="definition_fi">olla lyhyt (ihmisestä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{woch:v}, {tIq:v}</column>
       <column name="see_also">{'ab:v}, {'eS:v}</column>
@@ -7816,6 +8626,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Не путайте это слово с {ngaj:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">不要將此詞與{ngaj:v}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda esta palavra com {ngaj:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita tätä sanaa sanaan {ngaj:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Runt".</column>
       <column name="components"></column>
       <column name="examples">
@@ -7831,6 +8642,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7838,6 +8650,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {paq'batlh p.158-159:src}</column>
     </table>
     <table name="mem">
@@ -7851,6 +8664,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">чайник</column>
       <column name="definition_zh_HK">茶壺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chaleira</column>
+      <column name="definition_fi">teekannu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dargh:n}</column>
@@ -7861,6 +8675,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">From the children's rhyme, a teapot is "short" ({run:v}) and "stout" ({pI':v}). Also, too much tee makes a person go "run and pee".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7870,6 +8685,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7877,6 +8693,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7890,6 +8707,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">штрафовать, оштрафовать, обложить налогом, установить цену</column>
       <column name="definition_zh_HK">罰款、稅 [AUTOTRANSLATED]</column>
       <column name="definition_pt">multa, taxa</column>
+      <column name="definition_fi">sakottaa, verottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIp:n}, {bIj:v}, {DIl:v}</column>
@@ -7900,6 +8718,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7909,6 +8728,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7916,6 +8736,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7929,6 +8750,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">отрыжка, пердеть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">打嗝、放屁</column>
       <column name="definition_pt">arrotar, peidar</column>
+      <column name="definition_fi">röyhtäistä, pieraista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIp:n}, {vuj:v}, {ghIm:v}</column>
@@ -7939,6 +8761,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Получаемый газ называется {SIp:n} (общее слово для газа любого вида) или {Qep'It:n} (газ, вырабатываемый внутри тела).[1] Чтобы различать выбросы газа из разных отверстий, используйте фразу, включающую {nuj:n}, {Hugh:n} или {Sa'Hut:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">產生的氣體稱為{SIp:n}（任何種類的氣體的通用詞）或{Qep'It:n}（體內產生的氣體）。[1]要區分不同孔的氣體排放，請使用涉及{nuj:n}，{Hugh:n}或{Sa'Hut:n}的短語。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O gás produzido é chamado {SIp:n} (uma palavra geral para qualquer tipo de gás) ou {Qep'It:n} (um gás produzido no corpo).[1] Para distinguir entre emissão de gases de diferentes orifícios, use uma frase envolvendo {nuj:n}, {Hugh:n} ou {Sa'Hut:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tuotettua kaasua kutsutaan nimellä {SIp:n} (yleinen sana kaikenlaiselle kaasulle) tai {Qep'It:n} (kehossa tuotettu kaasu).[1]{nuj:n}{Hugh:n}{Sa'Hut:n}[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">From the Latin "eructare", or the English "eructation". The belch definition came from {HQ 12.4:src}[1]. It was expanded to also mean fart in a message to the {KLI mailing list:src}.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7948,6 +8771,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">burp</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7955,6 +8779,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}, [2] {KLI mailing list 2015.08.03:src}</column>
     </table>
     <table name="mem">
@@ -7968,6 +8793,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">Рукьевет город [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Ruk'evet市 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Cidade de Ruk'evet</column>
+      <column name="definition_fi">Ruk'evetin kaupunki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sep Hol Sar:n}, {ghIH:v:2}, {Soy':v:2}, {jat:v:2}</column>
@@ -7978,6 +8804,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Это город в {ghevchoq Sep:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{ghevchoq Sep:n}的城市。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma cidade em {ghevchoq Sep:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kaupunki kielellä {ghevchoq Sep:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7987,6 +8814,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7994,6 +8822,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8007,6 +8836,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">управлять вручную, самолично</column>
       <column name="definition_zh_HK">手動控制、手動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">controle manual, à mão</column>
+      <column name="definition_fi">ohjata manuaalisesti, käsin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{raQ:v}, {SeH:v}, {ngep:v}</column>
@@ -8017,6 +8847,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8026,6 +8857,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8033,6 +8865,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8047,6 +8880,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">походить на кого-то, иметь сходство, быть похожим на</column>
       <column name="definition_zh_HK">類似 [AUTOTRANSLATED]</column>
       <column name="definition_pt">assemelhar-se</column>
+      <column name="definition_fi">muistuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rap:v}, {nIb:v}, {... X law' ... X puS:sen}</column>
@@ -8057,6 +8891,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Этот глагол используется для формирования сравнений, например {puj verengan; bIQ rur@@puj:v, verengan:n, bIQ:n, rur:v} "Ференги слабые, как вода".[2; 4] Также может использоваться, чтобы перевести "как" в смысле "выглядит как".[3]</column>
       <column name="notes_zh_HK">該動詞用於形成比喻，例如{puj verengan; bIQ rur@@puj:v, verengan:n, bIQ:n, rur:v}“ Ferengi像水一樣脆弱”。[2; 4]也可以用於翻譯“ like”，即“ looks like”。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse verbo é usado para formar símiles, como {puj verengan; bIQ rur@@puj:v, verengan:n, bIQ:n, rur:v} "o Ferengi é tão fraco quanto a água" .[2; 4] Também pode ser usado para traduzir "like" no sentido de "aparência" .[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään muodostamaan vertauksia, kuten {puj verengan; bIQ rur@@puj:v, verengan:n, bIQ:n, rur:v} "Ferengi on yhtä heikko kuin vesi" .[2; 4] Sitä voidaan käyttää myös kääntämään "kuten" "ulkonäön" merkityksessä.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Possibly a reference to the science fiction play R.U.R. (Rossum's Universal Robots) by Karel Čapek.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8106,6 +8941,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">like</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8113,6 +8949,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru">как, выглядит как</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.127:src}, [3] {s.k 1999.01.04:src}, [4] {HQ 13.1, p.8-10, Mar. 2004:src}</column>
     </table>
     <table name="mem">
@@ -8126,6 +8963,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">Рура Пенте</column>
       <column name="definition_zh_HK">儒拉·彭提</column>
       <column name="definition_pt">Rura Penthe</column>
+      <column name="definition_fi">Rura Penthe</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8136,6 +8974,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Клингонская каторжная колония, планета преимущественно покрытая льдом. Заключенные посланы туда, чтобы там работать {tlhIlHalmey:n@@tlhIlHal:n, -mey:n}.</column>
       <column name="notes_zh_HK">這是克林崗半島的一個殖民地，這個星球大部分被冰覆蓋。囚犯被派往其{tlhIlHalmey:n@@tlhIlHal:n, -mey:n}工作。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma colônia penal de Klingon, um planeta coberto principalmente de gelo. Os presos são enviados para trabalhar em seu {tlhIlHalmey:n@@tlhIlHal:n, -mey:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Klingonin rangaistuslautakunta, planeetta, jota peittää enimmäkseen jää. Vangit lähetetään töihin sen {tlhIlHalmey:n@@tlhIlHal:n, -mey:n}-kielellä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The name is based on Rorapandi, the penal colony island in the Disney movie "20,000 Leagues Under the Sea".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8145,6 +8984,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8152,6 +8992,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {TKW:src}, [3] {Klingon Monopoly:src}, [4] {Star Trek VI:src}, [5] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -8165,6 +9006,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">Он может продать лёд на Рура Пенте.</column>
       <column name="definition_zh_HK">他可以在Rura Penthe賣冰。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ele pode vender gelo no Rura Penthe.</column>
+      <column name="definition_fi">Hän voi myydä jäätä Rura Penthellä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8175,6 +9017,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8184,6 +9027,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8191,6 +9035,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.190:src}</column>
     </table>
     <table name="mem">
@@ -8204,6 +9049,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">связывать, скреплять, привязывать</column>
       <column name="definition_zh_HK">鍵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vinculo</column>
+      <column name="definition_fi">side (ihmisten välillä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ruStay:n}, {chaj:n}, {maqoch:n}, {jup:n}</column>
@@ -8214,6 +9060,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Описывает связь, наподобие той, что существует между кровными братьями.</column>
       <column name="notes_zh_HK">這描述了諸如血兄弟之間存在的聯繫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso descreve um vínculo que existe entre irmãos de sangue. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kuvaa veriveljojen välisen siteen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8247,6 +9094,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
    Связь жизни."[3, p.136-137]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8254,6 +9102,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 17 (2010):src}, [2] {'u':src}, [3] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -8267,6 +9116,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">быть положительно заряженным, иметь положительный заряд [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">帶正電</column>
       <column name="definition_pt">ter carga positiva, ter uma carga positiva</column>
+      <column name="definition_fi">olla positiivisesti varautunut</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ngIng:v}</column>
       <column name="see_also">{tat:n}, {valtIn:n}, {pay'an:n}, {HeySel:n}</column>
@@ -8277,6 +9127,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined as "have a positive charge" in the {qep'a' 23 (2016):src} booklet, but was confirmed to be stative afterwards.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8286,6 +9137,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8293,6 +9145,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -8306,6 +9159,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">название ритуала установления родственной связи</column>
       <column name="definition_zh_HK">結合儀式</column>
       <column name="definition_pt">ritual de ligação</column>
+      <column name="definition_fi">lähentymisrituaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ruS:n}, {tay:n:2}</column>
@@ -8316,6 +9170,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Это ритуал, что позволяет сироте присоединиться к другому дому.</column>
       <column name="notes_zh_HK">這是一項允許孤兒加入另一所房屋的儀式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um ritual que permite que um órfão se junte a outra casa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on rituaali, jonka avulla orpo voi liittyä toiseen taloon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ruS:n}, {tay:n:2}</column>
       <column name="examples"></column>
@@ -8325,6 +9180,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8332,6 +9188,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8345,6 +9202,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">приглашение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">請帖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">convite</column>
+      <column name="definition_fi">kutsu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIt:v}</column>
@@ -8355,6 +9213,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"RSVP".</column>
       <column name="components">{ruS:n}, {vep:n}</column>
       <column name="examples"></column>
@@ -8364,6 +9223,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8371,6 +9231,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -8384,6 +9245,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">иногда, временами, время от времени, изредка, нерегулярно</column>
       <column name="definition_zh_HK">有時、偶爾</column>
       <column name="definition_pt">às vezes, ocasionalmente</column>
+      <column name="definition_fi">joskus, toisinaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reH:adv}, {not:adv}, {pIj:adv}, {roD:adv}, {motlh:adv}</column>
@@ -8394,6 +9256,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined as "sometimes" in {TKD:src} and as "occasionally" in {KGT:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8403,6 +9266,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8410,6 +9274,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8423,6 +9288,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">Все сталкиваются с трибблами непреднамеренно.</column>
       <column name="definition_zh_HK">每個人偶爾都會遇到瑣事。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Todo mundo encontra tribbles ocasionalmente.</column>
+      <column name="definition_fi">Jokainen kohtaa tribblejä toisinaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8433,6 +9299,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8442,6 +9309,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8449,6 +9317,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.184:src}</column>
     </table>
     <table name="mem">
@@ -8462,6 +9331,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">колесо</column>
       <column name="definition_zh_HK">輪、軲轆</column>
       <column name="definition_pt">roda</column>
+      <column name="definition_fi">pyörä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gho:n}, {rutlh:v}</column>
@@ -8472,6 +9342,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8481,6 +9352,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8488,6 +9360,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.05:src} (reprinted in {HQ 8.4, p.9, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -8501,6 +9374,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">колесо компьютерной мыши</column>
       <column name="definition_zh_HK">鼠標滾輪（電腦設備） [AUTOTRANSLATED]</column>
       <column name="definition_pt">roda do mouse (dispositivo de computador)</column>
+      <column name="definition_fi">(tietokoneen) hiiren rulla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8511,6 +9385,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Относится к части компьютерного устройства ввода (смотрите {'eQway':n}).</column>
       <column name="notes_zh_HK">這是指計算機輸入設備的一部分（請參閱{'eQway':n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a parte de um dispositivo de entrada do computador (consulte {'eQway':n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tietokoneen syöttölaitteen osaan (katso {'eQway':n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{rutlh:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -8520,6 +9395,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8527,6 +9403,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -8540,6 +9417,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">быть круглым, округлять, округляться</column>
       <column name="definition_zh_HK">圓</column>
       <column name="definition_pt">ser redondo</column>
+      <column name="definition_fi">olla pyöreä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rutlh:n}, {gho:n}, {'ob:v}</column>
@@ -8550,6 +9428,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8559,6 +9438,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8566,6 +9446,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -8579,6 +9460,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">правосудие, справедливость, юстиция</column>
       <column name="definition_zh_HK">正義</column>
       <column name="definition_pt">justiça</column>
+      <column name="definition_fi">oikeudenmukaisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meqba':n}, {yoj:n}, {may:v}</column>
@@ -8589,6 +9471,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8598,6 +9481,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8605,6 +9489,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8618,6 +9503,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">быть временным</column>
       <column name="definition_zh_HK">暫時</column>
       <column name="definition_pt">ser temporário</column>
+      <column name="definition_fi">olla väliaikainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ru'Ha':v}</column>
       <column name="see_also">{lIw:n}</column>
@@ -8628,6 +9514,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8637,6 +9524,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8644,6 +9532,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8657,6 +9546,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">быть готовым рухнуть или умереть (имеется в виду еда) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">準備崩潰或死亡（指食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser pronto para entrar em colapso ou morrer (referindo-se a comida)</column>
+      <column name="definition_fi">olla valmis kaatumaan ja kuolemaan (ruoasta joka syödään elävänä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8667,6 +9557,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru">Это слово высшего класса для описания пищи, которую следует употреблять в живую. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個上流社會的詞，用來描述應該現場食用的食物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra da classe alta para descrever alimentos que devem ser consumidos vivos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ylemmän luokan sana kuvaamaan ruokaa, joka tulisi syödä suorana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8676,6 +9567,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8683,6 +9575,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8696,6 +9589,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="definition_ru">быть постоянным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">永久的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser permanente</column>
+      <column name="definition_fi">olla pysyvä (ei väliaikainen)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ru':v:1}</column>
       <column name="see_also"></column>
@@ -8706,6 +9600,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ru':v:1}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -8715,6 +9610,7 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8722,5 +9618,6 @@ This was used for "Ok" (while {qIl:v} was used for "Cancel") in Klingon Blockly.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>

--- a/mem-15-S.xml
+++ b/mem-15-S.xml
@@ -8459,9 +8459,9 @@ This verb is also used for the encryption of data (see {So':v:2}).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
-      <column name="notes_fi">Jos kohdetta ei ole, piiloutuu aihe (esim. {NuqDaq So'taH yaS?: Sen: nolink} [1]). Jos objektia on, kohde piilottaa objektin (esim. {Duj So':sen:nolink} tai {Duj So'lu'pu':sen:nolink}[2]).
+      <column name="notes_fi">Jos kohdetta ei ole, piiloutuu aihe (esim. {nuqDaq So'taH yaS?:sen:nolink} [1]). Jos objektia on, kohde piilottaa objektin (esim. {Duj So':sen:nolink} tai {Duj So'lu'pu':sen:nolink}[2]).
 
-Tätä verbiä käytetään myös tietojen salaamiseen (katso {So':v:2}).{nuqDaq So'taH yaS?:sen:nolink} [AUTOTRANSLATED]</column>
+Tätä verbiä käytetään myös tietojen salaamiseen (katso {So':v:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Show".</column>
       <column name="components"></column>
       <column name="examples"></column>

--- a/mem-15-S.xml
+++ b/mem-15-S.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {S:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{S:sen:nolink}</column>
       <column name="definition_pt">a consoante {S:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {S:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">Я-ты (множественное число) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我：你們</column>
       <column name="definition_pt">Eu-vocês</column>
+      <column name="definition_fi">minä-teitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tu-:v:pref}</column>
       <column name="see_also">{re-:v:pref}, {qa-:v:pref}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{jIH:n:1h}: {tlhIH:n} = {Sa-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -68,6 +74,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -75,6 +82,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -88,6 +96,7 @@
       <column name="definition_ru">рифмуется с [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">與韻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rimar com</column>
+      <column name="definition_fi">rimmata jonkin kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa'jaH:n}, {ghuQ:n}</column>
@@ -98,6 +107,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -109,6 +119,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -116,6 +127,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -130,6 +142,7 @@
       <column name="definition_ru">снижаться, ухудшаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">衰退、惡化 [AUTOTRANSLATED]</column>
       <column name="definition_pt">declinar, deteriorar</column>
+      <column name="definition_fi">heikentyä, huonontua</column>
       <column name="synonyms">{'argh:v}</column>
       <column name="antonyms">{Dub:v}</column>
       <column name="see_also">{Qop:v:1}, {ragh:v}, {ngaw:v}</column>
@@ -140,6 +153,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Shab"by.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -149,6 +163,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -156,6 +171,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -169,6 +185,7 @@
       <column name="definition_ru">расширять [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">擴大、擴展</column>
       <column name="definition_pt">expandir</column>
+      <column name="definition_fi">laajeta, levitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Dej:v}</column>
       <column name="see_also">{Sach:v:2}, {Sev:v}, {ngaS:v}, {tInmoH:v}</column>
@@ -179,6 +196,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -189,6 +207,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -196,6 +215,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -209,6 +229,7 @@
       <column name="definition_ru">быть усиленным, конкретизированным, разработанным, расширенным и т.д. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被放大、充實、精心製作、範圍擴大等 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser ampliado, elaborado, aumentado em escopo, etc.</column>
+      <column name="definition_fi">olla vahvistettu, viritelty, laajennettu (soveltamisalaltaan, kattavuudeltaan tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -219,6 +240,7 @@
       <column name="notes_ru">Это расширение значения существующего глагола {Sach:v:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是現有動詞{Sach:v:1}含義的擴展。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma expansão do significado do verbo existente {Sach:v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on olemassa olevan veronin {Sach:v:1} merkityksen laajentaminen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -231,6 +253,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -238,6 +261,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -251,6 +275,7 @@
       <column name="definition_ru">тысяча [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">千</column>
       <column name="definition_pt">mil</column>
+      <column name="definition_fi">tuhat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI':n}, {vatlh:n:num}, {netlh:n:num}</column>
@@ -281,6 +306,11 @@ Medan {SaD law':n:nolink} är ett grammatiskt uttryck, är {SaDmey:n:nolink} int
 Observe que o klingon tem palavras para "dez mil" ({netlh:n:num}) e "cem mil" ({bIp:n:num}) que são independentes da palavra para "mil".
 
 Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} não é.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toinen variantti sanasta, jota käytetään suunnilleen yhtä usein, on {SanID:n:num,nolink}.
+
+Huomaa, että Klingonilla on sanoja "kymmenentuhatta" ({netlh:n:num}) ja "sata tuhatta" ({bIp:n:num}), jotka ovat riippumattomia sanasta "tuhat".
+
+Vaikka {SaD law':n:nolink} on kieliopillinen lauseke, {SaDmey:n:nolink} ei ole.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -302,6 +332,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -309,6 +340,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -322,6 +354,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="definition_ru">тысячелетие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">千年</column>
       <column name="definition_pt">milênio</column>
+      <column name="definition_fi">vuosituhat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vatlh DIS poH:n}, {netlh DIS poH:n}</column>
@@ -332,6 +365,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="notes_ru">Чтобы указать «тысячелетия назад» или «тысячелетия назад», {ret:n} и {pIq:n} используются вместо {poH:n}, соответственно.[1], соответственно [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了表示“千年前”或“從現在開始千年”，分別使用{ret:n}和{pIq:n}代替{poH:n}。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para indicar "milênios atrás" ou "milênios a partir de agora", {ret:n} e {pIq:n} são usados ​​no lugar de {poH:n}, respectivamente.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ilmaisemaan "vuosituhat sitten" tai "vuosituhat nyt" käytetään {ret:n} ja {pIq:n} vastaavasti {poH:n}: n sijasta.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{SaD:n:num}, {DIS:n:2}, {poH:n}</column>
       <column name="examples"></column>
@@ -341,6 +375,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -348,6 +383,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.3, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -361,6 +397,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="definition_ru">быть серьезным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嚴肅點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser sério</column>
+      <column name="definition_fi">olla vakava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qID:v}, {Ho''oy':n}</column>
@@ -371,6 +408,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -380,6 +418,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -387,6 +426,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -400,6 +440,7 @@ Enquanto {SaD law':n:nolink} é uma expressão gramatical, {SaDmey:n:nolink} nã
       <column name="definition_ru">миллиард [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">十億 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bilhão</column>
+      <column name="definition_fi">miljardi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI':n}, {'uy':n:num}</column>
@@ -434,6 +475,13 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on lyhyt miljardi (eli tuhat miljoonaa)
+
+Kymmenille miljardeille luvut muodostavat elementit {maHSaghan:n:num@@maH:n:2, Saghan:n} tai {netlh'uy':n:num@@netlh:n, 'uy':n} ovat mahdollisia.
+
+Satoja miljardeja lukumäärän muodostavat elementit {vatlhSaghan:n:num@@vatlh:n, Saghan:n} tai {bIp'uy':n:num@@bIp:n, 'uy':n} ovat mahdollisia.
+
+Triljoonille luvut muodostavat elementit {SaDSaghan:n:num@@SaD:n, Saghan:n} tai {SanIDSaghan:n:num@@SanID:n, Saghan:n} ovat mahdollisia.[1][2][2][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The astronomer Carl Sagan was famous for saying "billions and billions".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -443,6 +491,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">trillion</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -450,6 +499,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -463,6 +513,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="definition_ru">присутствовать (не отсутствовать) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">在場（不在場） [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar presente (não ausente)</column>
+      <column name="definition_fi">olla läsnä(oleva)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Dach:v:1}</column>
       <column name="see_also">{SaH:v:2}</column>
@@ -473,6 +524,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -482,6 +534,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -489,6 +542,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -502,6 +556,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="definition_ru">заботиться (о), беспокоиться (о) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">關心、關注</column>
       <column name="definition_pt">cuidar, se preocupe</column>
+      <column name="definition_fi">välittää jostain, olla huolissaan jostain</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SaHHa':v}</column>
       <column name="see_also">{Dach:v:2}, {SaH:v:1}</column>
@@ -512,6 +567,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -522,6 +578,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -529,6 +586,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -542,6 +600,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="definition_ru">быть безразличным (о) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不關心</column>
       <column name="definition_pt">não se preocupar com</column>
+      <column name="definition_fi">olla piittaamaton, välinpitämätön jostain</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SaH:v:2}</column>
       <column name="see_also">{pIlHa':v}</column>
@@ -552,6 +611,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is not defined as such, but to translate "apathy" or "apathy creature" for the Klingon Christmas Carol, one of MO's suggestions was {SaHHa'wI':n:nolink} "one who is not concerned".[1]</column>
       <column name="components">{SaH:v:2}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -561,6 +621,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -568,6 +629,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2010.09.01:src}</column>
     </table>
     <table name="mem">
@@ -581,6 +643,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="definition_ru">домашнее животное [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">寵物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">animal de estimação</column>
+      <column name="definition_fi">lemmikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhay':v}, {Ha'DIbaH:n:1}, {yach:v:1}</column>
@@ -591,6 +654,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">寵物作為克林崗人飼養的動物包括{targh:n}，{Qogh:n}和{'er:n}。人族還飼養了類似於{vIghro':n}的動物作為寵物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os animais mantidos por animais de estimação como os Klingons incluem o {targh:n}, o {Qogh:n} e o {'er:n}. Os terráqueos também mantêm um animal parecido com o {vIghro':n} como animais de estimação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Eläimet, joita lemmikkieläimet pitävät klingoneina, ovat {targh:n}, {Qogh:n} ja {'er:n}. Terraanit pitävät lemmikkinä myös {vIghro':n}: ää muistuttavaa eläintä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The English translation of the sentence from {Star Trek Constellations:src} does not appear in the book, but in the author's annotations which was a separate document.</column>
       <column name="components"></column>
       <column name="examples">
@@ -602,6 +666,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
 ▶ {chobelHa'moH, DI'qar. SajlIj 'oHbe' quvwIj'e'.:sen:nolink} "Ты разочаровал меня, Д'Кар. Моя честь не твоя игрушка."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">plaything</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -609,6 +674,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek Constellations p.259:src}</column>
     </table>
     <table name="mem">
@@ -622,6 +688,7 @@ För biljoner är de nummerbildande elementen {SaDSaghan:n:num@@SaD:n, Saghan:n}
       <column name="definition_ru">восходить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">上升</column>
       <column name="definition_pt">ascender (para cima)</column>
+      <column name="definition_fi">nostaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{ghIr:v}</column>
       <column name="see_also">{toS:v}</column>
@@ -644,6 +711,9 @@ Detta ord används inte för sorteringsordning.[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Com base em seu uso no {paq'batlh:src}, o que está sendo ascendido é o objeto, e o destino é marcado com {-Daq:n}.[2]
 
 Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Perustuen sen käyttöön {paq'batlh:src}: ssä, nouseva asia on objekti, ja kohde on merkitty {-Daq:n}.[2]
+
+Tätä sanaa ei käytetä lajittelujärjestykseen.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -665,6 +735,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -672,6 +743,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}, [3] {KLI mailing list 2018.02.10:src}</column>
     </table>
     <table name="mem">
@@ -685,6 +757,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">найти, искать и найти [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">找到、尋找和發現 [AUTOTRANSLATED]</column>
       <column name="definition_pt">localizar, procurar e encontrar</column>
+      <column name="definition_fi">paikallistaa, etsiä ja löytää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIl:v}</column>
@@ -695,6 +768,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Смотрите пример для иллюстрации различия между этим словом и {nej:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請參見示例，以了解此單詞和{nej:v}之間的差異。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja o exemplo para uma ilustração da diferença entre esta palavra e {nej:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso esimerkistä tämän sanan ja {nej:v}: n välinen ero. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -705,6 +779,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -712,6 +787,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -725,6 +801,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">средневековый музыкальный инструмент типа гобоя [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嗩吶</column>
       <column name="definition_pt">shawm</column>
+      <column name="definition_fi">skalmeija (keskiaikainen puhellinsoitin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -735,6 +812,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Это заимствованное слово из стандарта Федерации и относится к типу духовых инструментов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是聯邦標準（Federation Standard）的藉詞，是一種管樂器。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra de empréstimo da Federation Standard e refere-se a um tipo de instrumento de sopro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Federation Standardin laina ja viittaa puhallinsoittotyyppiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -744,6 +822,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -751,6 +830,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -764,6 +844,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">судьба, судьба [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">命運</column>
       <column name="definition_pt">destino</column>
+      <column name="definition_fi">kohtalo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -774,6 +855,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Глагол {chenmoH:v} может использоваться с {San:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">動詞{chenmoH:v}可與{San:n}.[2]一起使用 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O verbo {chenmoH:v} pode ser usado com {San:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbiä {chenmoH:v} voidaan käyttää {San:n}: n kanssa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "fate" in {TKD:src}. It was explained in a {KLI mailing list:src} message that "destiny" is another possible translation.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -783,6 +865,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -790,6 +873,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.166-167:src}, [3] {KLI mailing list 2018.01.08:src}</column>
     </table>
     <table name="mem">
@@ -803,6 +887,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">scar (from combat) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">疤痕（來自戰鬥） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cicatriz (de combate)</column>
+      <column name="definition_fi">arpi (taistelusta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taq:v}, {roptoj:n}, {mIvwa':n}</column>
@@ -813,6 +898,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Это шрам, который является результатом раны, полученной в ходе боя или битвы. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是疤痕，是在戰鬥或戰鬥中受傷的結果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma cicatriz que é o resultado de uma ferida recebida no decorrer de uma luta ou batalha. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on arpi, joka on seurausta taistelun tai taistelun aikana saadusta haavasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as just "scar", with an accompanying explanation of the kinds of scars.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -822,6 +908,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -829,6 +916,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -842,6 +930,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">{SaD:n:num}</column>
       <column name="definition_zh_HK">{SaD:n:num}</column>
       <column name="definition_pt">{SaD:n:num}</column>
+      <column name="definition_fi">{SaD:n:num}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -852,6 +941,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -861,6 +951,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -868,6 +959,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -881,6 +973,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">спор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">孢子</column>
       <column name="definition_pt">esporo</column>
+      <column name="definition_fi">itiö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -891,6 +984,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -900,6 +994,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -907,6 +1002,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Context is for Kings:src}</column>
     </table>
     <table name="mem">
@@ -920,6 +1016,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">споровый привод [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">孢子引擎</column>
       <column name="definition_pt">unidade de esporos</column>
+      <column name="definition_fi">itiöajo, itiömoottori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -930,6 +1027,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{SanmIr:n}, {QuQ:n}</column>
       <column name="examples"></column>
@@ -939,6 +1037,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -946,6 +1045,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Context is for Kings:src}</column>
     </table>
     <table name="mem">
@@ -959,6 +1059,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">zantai (rank) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">zantai（排名） [AUTOTRANSLATED]</column>
       <column name="definition_pt">zantai (rank)</column>
+      <column name="definition_fi">zantai (arvo)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -969,6 +1070,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">От низшего к высшему эти ранги: {tay:n:3}, {Sutay:n}, {veStay:n}, {Santay:n:nolink}, {'Iptay:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從最低到最高，這些排名是：{tay:n:3}，{Sutay:n}，{veStay:n}，{Santay:n:nolink}，{'Iptay:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Do mais baixo ao mais alto, essas classificações são: {tay:n:3}, {Sutay:n}, {veStay:n}, {Santay:n:nolink}, {'Iptay:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Alimmasta korkeimpaan nämä rivit ovat: {tay:n:3}, {Sutay:n}, {veStay:n}, {Santay:n:nolink}, {'Iptay:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a rank from John M. Ford's 1984 novel "The Final Reflection". These ranks are used by many Klingon fan clubs, despite not appearing in canon (i.e., in any TV episode or movie).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -978,6 +1080,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -985,6 +1088,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -998,6 +1102,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">кремний [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">矽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">silício</column>
+      <column name="definition_fi">pii (alkuaine)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Do'ol:n}</column>
@@ -1008,6 +1113,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Silicon Valley is located in Santa Clara.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1017,6 +1123,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1024,6 +1131,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1037,6 +1145,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">растение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">廠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">plantar</column>
+      <column name="definition_fi">kasvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tI:n}, {Qechjem:n}, {por:n}, {namchIl:n}</column>
@@ -1047,6 +1156,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Это относится к отдельному растению, обычно со стеблями, листьями и т. Д. Оно не используется для грибов или водорослей. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指單個植物，通常帶有莖，葉等。它不用於真菌或藻類。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma planta individual, geralmente com caules, folhas, etc. Não é usada para fungos ou algas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa yksittäiseen kasviin, tyypillisesti varret, lehdet jne. Sitä ei käytetä sienille tai leville. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1056,6 +1166,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1063,6 +1174,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1076,6 +1188,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">немного [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bit</column>
+      <column name="definition_fi">bitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hut'on:n}, {SuyDar:n}</column>
@@ -1086,6 +1199,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Это единица информации в информатике. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是計算機科學中的信息單元。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma unidade de informação em ciência da computação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on tietojenkäsittelytieteen tietoyksikkö. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Claude Shannon was the founder of information theory.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1095,6 +1209,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1102,6 +1217,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1115,6 +1231,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">стереть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">泯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">obliterar</column>
+      <column name="definition_fi">hävittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qaw':v}</column>
@@ -1125,6 +1242,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1134,6 +1252,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1141,6 +1260,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1154,6 +1274,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">доброволец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">志願者</column>
       <column name="definition_pt">voluntariar</column>
+      <column name="definition_fi">vapaaehtoistua, ilmoittautua vapaaehtoiseksi johonkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuv:n}, {muv:v}, {jeS 'e' Sap:sen}</column>
@@ -1164,6 +1285,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Apparently, a volunteer is a "sap".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1173,6 +1295,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1180,6 +1303,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1193,6 +1317,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">land; set down on land (like a bird) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">土地;落在陸地上（像鳥一樣） [AUTOTRANSLATED]</column>
       <column name="definition_pt">aterrizar, pousar em terra (como um pássaro)</column>
+      <column name="definition_fi">laskeutua (aluksesta, linnusta tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngun:v}, {tlhot:v}, {puH:n}</column>
@@ -1203,6 +1328,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Se um pássaro pousar em uma árvore, o verbo {ngun:v} será usado e, se estiver na água, {tlhot:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos lintu laskeutuu puuhun, käytetään verbiä {ngun:v} ja jos vedessä, niin {tlhot:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Land "shark" from SNL.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1214,6 +1340,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1221,6 +1348,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 10.4, Dec. 2001:src}, [3] {BoP:src}, [4] {Smithsonian GO FLIGHT app:src}</column>
     </table>
     <table name="mem">
@@ -1234,6 +1362,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">посадочная площадка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">著陸點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">local de aterrissagem</column>
+      <column name="definition_fi">laskeutumispaikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1244,6 +1373,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Saq:v} or {Saq:n:hyp,nolink}, {Daq:n}</column>
       <column name="examples"></column>
@@ -1253,6 +1383,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1260,6 +1391,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -1273,6 +1405,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">десантный отряд [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">登陸派對 [AUTOTRANSLATED]</column>
       <column name="definition_pt">grupo de desembarque</column>
+      <column name="definition_fi">laskujoukko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hoq:n}</column>
@@ -1283,6 +1416,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Saq:v} or {Saq:n:hyp,nolink}, {ghom:n}</column>
       <column name="examples"></column>
@@ -1292,6 +1426,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1299,6 +1434,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1312,6 +1448,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">шасси [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">起落架 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trem de pouso</column>
+      <column name="definition_fi">laskuteline</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1322,6 +1459,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Saq:v} or {Saq:n:hyp,nolink}, {jan:n:1}</column>
       <column name="examples"></column>
@@ -1331,6 +1469,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1338,6 +1477,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1351,6 +1491,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">Saq'Sub [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Saq'Sub [AUTOTRANSLATED]</column>
       <column name="definition_pt">Saq'Sub</column>
+      <column name="definition_fi">Saq'Sub</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1361,6 +1502,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on {qeylIS'e' lIjlaHbe'bogh vay':n:name}: n syntyperäinen alue {Qo'noS:n:place}: lla ja hänen omaisuutensa sijainti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1370,6 +1512,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1377,6 +1520,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -1390,6 +1534,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">плач [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">哭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chorar</column>
+      <column name="definition_fi">itkeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bey:n}, {jach:v}</column>
@@ -1400,6 +1545,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Os klingons não têm canais lacrimais, e não há palavras para lágrimas ou lágrimas. No entanto, os olhos de Klingon ficam avermelhados ({DoqchoH:v:nolink}) de tempos em tempos.[2] Eles também entenderiam {mIn 'onroS:n} para se referir a uma lágrima. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingoneilla ei ole kyynelkanavia, eikä kyyneleitä tai kyyneleitä ole. Klingonien silmät kuitenkin punoittavat ({DoqchoH:v:nolink}) aika ajoin.[2]{mIn 'onroS:n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1409,6 +1555,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1416,6 +1563,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1429,6 +1577,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">быть разнообразным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">各種各樣的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser variado, variado</column>
+      <column name="definition_fi">olla vaihteleva, erilainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIm:v}, {ngang:v}, {law':v}, {rap:v}, {nIb:v}, {Sar:n}</column>
@@ -1439,6 +1588,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1452,6 +1602,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1459,6 +1610,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1472,6 +1624,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">разнообразие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">品種 [AUTOTRANSLATED]</column>
       <column name="definition_pt">variedade</column>
+      <column name="definition_fi">muunnelma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sar:v}, {Segh:n}, {tlhoQ:n}</column>
@@ -1482,6 +1635,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Это означает «разнообразие» в смысле «интересный сорт чая», а не «разнообразие - это пряность жизни».[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指“多種茶”，而不是“多樣性是生活的香料”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "variedade" no sentido de "uma variedade interessante de chá", não "variedade é o tempero da vida".[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "vaihtelua" mielenkiintoisen teevalikoiman merkityksessä, ei "lajike on elämän mauste".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1494,6 +1648,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1501,6 +1656,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2019.01.16:src}</column>
     </table>
     <table name="mem">
@@ -1514,6 +1670,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">SARK [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">薩克 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sark</column>
+      <column name="definition_fi">eräs eläin, sark</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hun:n}, {ba'qIn:n}</column>
@@ -1524,6 +1681,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Это животное напоминает лошадь. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種動物很像一匹馬。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este animal se assemelha a um cavalo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä eläin muistuttaa hevosta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1535,6 +1693,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">horse, mule, equine</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1542,6 +1701,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1555,6 +1715,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">быть горизонтальным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">是水平的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser horizontal</column>
+      <column name="definition_fi">olla vaakasuuntainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chong:v:1}</column>
       <column name="see_also">{SaS:v:2}</column>
@@ -1565,6 +1726,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1574,6 +1736,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1581,6 +1744,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1594,6 +1758,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">быть поверхностным, быть поверхностным, быть некритическим; быть несчастным, не быть хорошим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">淺薄、膚淺、不加批判;不幸、不好 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser superficial, superficial, não crítico; ser infeliz, não ser bom</column>
+      <column name="definition_fi">olla pinnallinen, pintapuolinen, kritiikitön; olla huono-onninen, valitettava</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chong:v:2,slang}</column>
       <column name="see_also">{natlh:v:2,slang}, {SaS:v:1}</column>
@@ -1604,6 +1769,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Это слово применяется к человеку, чтобы унижать его или ее интеллект. Он также используется как выражение неодобрения, аналогично {Do'Ha'.:sen}[1, p.164] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞是用來貶低他或她的智力的。與{Do'Ha'.:sen}[1, p.164]類似，它本身也被用作不贊成的表達 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é aplicada a uma pessoa para depreciar seu intelecto. Também é usado por si só como uma expressão de desaprovação, semelhante a {Do'Ha'.:sen}[1, p.164] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään henkilöön halveksimaan älyä. Sitä käytetään myös itsessään hylkäämisen ilmaisuna, samanlainen kuin {Do'Ha'.:sen}[1, p.164] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1613,6 +1779,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1620,6 +1787,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1633,6 +1801,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">be stuck (in a situation) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陷入困境（在某種情況下） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficar preso (em uma situação)</column>
+      <column name="definition_fi">olla jumissa (tilanteessa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1643,6 +1812,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Это используется для ситуаций, таких как застревание на собрании или в пробке. Это также используется для кошки, застрявшей в дереве. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於遇到會議阻塞或交通阻塞的情況。它也用於卡在樹上的貓。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para situações como estar preso em uma reunião ou preso no trânsito. Também é usado para um gato preso em uma árvore. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään tilanteissa, kuten jumissa kokouksessa tai jumissa liikenteessä. Sitä käytetään myös kissaan, joka on jumissa puuhun. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "be stuck" with an explanation, along with a bunch of other words which can be translated into various senses of "be stuck" in English.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1652,6 +1822,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1659,6 +1830,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1672,6 +1844,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">сельское хозяйство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">農業 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agricultura</column>
+      <column name="definition_fi">maatalous</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Du':n}, {wIj:v}, {qInut:n}</column>
@@ -1682,6 +1855,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1691,6 +1865,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1698,6 +1873,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1711,6 +1887,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">nonave [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">諾瓦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nonave</column>
+      <column name="definition_fi">nooni?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{romta':n}, {QoQ:n}, {bom:n}</column>
@@ -1721,6 +1898,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">Первый и второй {yu:n} в клингонской музыкальной шкале не отличаются друг от друга. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗音樂譜中的第一和第二{yu:n}相距甚遠。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O primeiro e o segundo {yu:n} na escala musical Klingon estão separados por um nonave. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin musiikillisen asteikon ensimmäinen ja toinen {yu:n} ovat erillisiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1730,6 +1908,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1737,6 +1916,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1750,6 +1930,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">жениться (это делает муж) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">娶</column>
       <column name="definition_pt">casar (o marido faz isso)</column>
+      <column name="definition_fi">naida (mies tekee tämän)</column>
       <column name="synonyms">{tlhogh:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{nay:v}, {tlhogh:n}, {loDnal:n}</column>
@@ -1760,6 +1941,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="notes_ru">{Sawchuq:v@@Saw:v, -chuq:v} будет пониматься как однополый брак между двумя мужчинами.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{Sawchuq:v@@Saw:v, -chuq:v}被理解為兩個男人之間的同性婚姻。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">{Sawchuq:v@@Saw:v, -chuq:v} seria entendido como um casamento entre pessoas do mesmo sexo entre dois homens.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Sawchuq:v@@Saw:v, -chuq:v} ymmärrettäisiin kahden miehen välisestä samaa sukupuolta olevasta avioliitosta.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">MO confirmed at {qep'a' 4 (1997):src} that {Saw:v:nolink} and {nay:v:nolink} come from "sure" and "no" said with a Southern drawl.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1769,6 +1951,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1776,6 +1959,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2017.07.13:src}</column>
     </table>
     <table name="mem">
@@ -1789,6 +1973,7 @@ Esta palavra não é usada para ordem de classificação.[3] [AUTOTRANSLATED]</c
       <column name="definition_ru">жест [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手勢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gesto</column>
+      <column name="definition_fi">ele</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1809,6 +1994,9 @@ Maltz visste inte ett generiskt verb för detta.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Usar um gesto é {Sawlay lo':sen@@Sawlay:n, lo':v} ou então um verbo de gesto específico (como {SIq:v}, {qay:v}, etc.).
 
 Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Eleen käyttö on {Sawlay lo':sen@@Sawlay:n, lo':v} tai muuten tietty verbi (kuten {SIq:v}, {qay:v} jne.).
+
+Maltz ei tiennyt yleistä verbiä tälle[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In Chinese, "伴手禮" means souvenir (a gift given when traveling). In particular, "手" means "hand".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1818,6 +2006,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1825,6 +2014,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1838,6 +2028,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">иметь глубину [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有一個深度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter a profundidade de</column>
+      <column name="definition_fi">olla syvyydeltään jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uj:n}, {'ab:v}, {'aD:v}, {juch:v}, {jaQ:v}, {jaQHa':v}, {juv:v}</column>
@@ -1848,6 +2039,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Shallow".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1857,6 +2049,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">deep</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1864,6 +2057,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1877,6 +2071,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть чистыми [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">乾淨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser limpo</column>
+      <column name="definition_fi">olla puhdas</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lam:v}</column>
       <column name="see_also">{lam:n}, {Say'qu'moH:v}, {nIt:v}, {watlh:v}</column>
@@ -1887,6 +2082,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1896,6 +2092,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1903,6 +2100,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1916,6 +2114,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">ванна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沖涼缸</column>
       <column name="definition_pt">banheira</column>
+      <column name="definition_fi">kylpyamme</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puchpa':n}, {QalmeH DoQmIv'a':n}</column>
@@ -1926,6 +2125,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Say':v}, {-moH:v}, {-meH:v}, {DoQmIv'a':n}</column>
       <column name="examples"></column>
@@ -1935,6 +2135,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1942,6 +2143,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1955,6 +2157,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">мыло [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肥皂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sabonete</column>
+      <column name="definition_fi">saippua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1965,6 +2168,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Say':v}, {-moH:v}, {-wI':v}, {tlhagh:n}</column>
       <column name="examples"></column>
@@ -1974,6 +2178,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1981,6 +2186,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -1994,6 +2200,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть стерильным (очень чистым) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">無菌（非常乾淨） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser estéril (muito limpo)</column>
+      <column name="definition_fi">olla steriili (erittäin puhdas)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2004,6 +2211,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Back-derived from {Say'qu'moH:v}.</column>
       <column name="components">{Say':v}, {-qu':v}</column>
       <column name="examples"></column>
@@ -2013,6 +2221,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2020,6 +2229,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2033,6 +2243,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">стерилизовать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">消毒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esterilizar</column>
+      <column name="definition_fi">steriloida</column>
       <column name="synonyms">{woj:v}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2043,6 +2254,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Say'qu':v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -2052,6 +2264,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2059,6 +2272,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 1.3, Sept. 1992:src}</column>
     </table>
     <table name="mem">
@@ -2072,6 +2286,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">пыль, порошок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">灰塵，粉末 [AUTOTRANSLATED]</column>
       <column name="definition_pt">poeira, pó</column>
+      <column name="definition_fi">pöly, jauhe</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Do'ol:n}</column>
@@ -2082,6 +2297,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2091,6 +2307,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2098,6 +2315,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2111,6 +2329,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">general (rank) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">將軍（軍銜）</column>
       <column name="definition_pt">general (rank)</column>
+      <column name="definition_fi">kenraali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2121,6 +2340,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это 2-й ранг {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{yaS:n}的第二等級。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o 2º ranking do {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {yaS:n}: n 2. sijoitus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2130,6 +2350,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2137,6 +2358,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2151,6 +2373,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">ягодицы, задняя часть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">屁股、屎忽、臀部，後端</column>
       <column name="definition_pt">nádegas, extremidade traseira</column>
+      <column name="definition_fi">pakarat, takapuoli, peppu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2161,6 +2384,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word was revealed during a session of singing and dancing the Hokey Pokey. It is the Yiddish word "tuchus" written backwards.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2170,6 +2394,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2177,6 +2402,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 10 (2003):src}</column>
     </table>
     <table name="mem">
@@ -2190,6 +2416,7 @@ Maltz não conhecia um verbo genérico para isso.[1] [AUTOTRANSLATED]</column>
       <column name="definition_ru">Сакрейская область [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">薩克雷伊州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Região de Sakrej</column>
+      <column name="definition_fi">Sakrejin alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sep Hol Sar:n}</column>
@@ -2214,6 +2441,9 @@ Denna region innehåller {HuD beQ yoS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma grande região vários milhares de quilômetros a leste da Primeira Cidade ({veng wa'DIch:n}). No dialeto desta região, os preposicionais tomam sufixos (veja em {lurgh:n} para uma explicação). Além disso, os brindes seguem a ordem normal das palavras, com o sujeito seguindo o verbo (ver {-jaj:v}).
 
 Esta região contém {HuD beQ yoS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on suuri alue useita tuhansia kilometrejä Ensimmäisestä kaupungista itään ({veng wa'DIch:n}). Tämän alueen murteessa prepositioilla on jälkiliitteitä (katso selitys kohdasta {lurgh:n}). Lisäksi paahtoleivät seuraavat normaalia sanajärjestystä, ja aihe seuraa verbiä (katso {-jaj:v}).
+
+Tämä alue sisältää {HuD beQ yoS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is basically "jackass" spelled backwards.
 
 This word appears only in the body of {KGT:src} and not in the glossary.</column>
@@ -2225,6 +2455,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2232,6 +2463,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2245,6 +2477,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">факел [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">火炬</column>
       <column name="definition_pt">tocha</column>
+      <column name="definition_fi">soihtu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghI'boj:n}, {wovmoHbogh jan:n}, {wovmoHwI':n}, {weQ:n}</column>
@@ -2255,6 +2488,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{'ul Sech:n}</column>
@@ -2264,6 +2498,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2271,6 +2506,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2284,6 +2520,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">Факелоносец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">火炬手 [AUTOTRANSLATED]</column>
       <column name="definition_pt">carregador de tocha</column>
+      <column name="definition_fi">soihdunkantaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rI'meH wovmoHwI':n}</column>
@@ -2294,6 +2531,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru">Это церемониальная позиция, роль которой заключается в активации маяка Кахлесса. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個禮儀職位，其作用是激活卡赫勒斯燈塔。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma posição cerimonial cujo papel é ativar o Farol de Kahless. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on seremoniallinen asema, jonka tehtävänä on aktivoida Kahlessin majakka. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Sech:n}, {qeng:n}, {-wI':n}</column>
       <column name="examples"></column>
@@ -2303,6 +2541,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2310,6 +2549,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - The Vulcan Hello:src}</column>
     </table>
     <table name="mem">
@@ -2323,6 +2563,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">Драйв (наземное транспортное средство) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">駕駛（陸地車輛） [AUTOTRANSLATED]</column>
       <column name="definition_pt">dirigir (um veículo terrestre)</column>
+      <column name="definition_fi">ajaa (auto tms. maa-ajoneuvoa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puH Duj:n}, {'or:v}, {yong:v}, {lIgh:v}</column>
@@ -2333,6 +2574,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2342,6 +2584,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2349,6 +2592,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2362,6 +2606,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">остроконечный наконечник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">帶刺的矛頭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ponta de lança farpado</column>
+      <column name="definition_fi">eräs piikkinen keihäänkärki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIn:n:2}</column>
@@ -2372,6 +2617,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2381,6 +2627,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2388,6 +2635,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2401,6 +2649,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">раса (тип, сортировка, класс) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">種族（類型、排序、類） [AUTOTRANSLATED]</column>
       <column name="definition_pt">raça (tipo, classificação, classe)</column>
+      <column name="definition_fi">laji, tyyppi, luokka, rotu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mut:n}, {buv:n}, {yagh:n}, {chovnatlh:n}, {Sar:n}</column>
@@ -2411,6 +2660,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2422,6 +2672,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">model, type</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2429,6 +2680,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2442,6 +2694,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">контроль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">控制 [AUTOTRANSLATED]</column>
       <column name="definition_pt">controlar</column>
+      <column name="definition_fi">hallita, ohjata (laitetta tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIS:v}, {ngep:v}, {ra':v:1}, {ruQ:v}</column>
@@ -2452,6 +2705,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2462,6 +2716,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2469,6 +2724,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2482,6 +2738,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">устройство управления, устройство управления [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">控制裝置，控制裝置 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dispositivo de controle</column>
+      <column name="definition_fi">hallinta- tai ohjauslaite</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2492,6 +2749,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru">Использование этого вне набора принятых выражений, таких как {bIQ SeHjan:n}, считается нечетным. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在集合接受的表達式（例如{bIQ SeHjan:n}）之外使用此字符被認為是奇怪的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O uso deste fora do conjunto, expressões aceitas como {bIQ SeHjan:n} é considerado estranho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän käytön joukon ulkopuolella, hyväksyttyjä lausekkeita, kuten {bIQ SeHjan:n}, pidetään parittomana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{SeH:n:archaic,hyp}, {jan:n:1}</column>
       <column name="examples"></column>
@@ -2501,6 +2759,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2508,6 +2767,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2521,6 +2781,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">панель управления [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">控制面板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">painel de controle</column>
+      <column name="definition_fi">ohjauspaneeli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2531,6 +2792,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru">Это можно использовать для страницы «настройки» или «настройки» в программном обеспечении, но не для отдельных настроек, которые являются {DuH:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">可以將其用於軟件中的“設置”或“首選項”頁面，但不能用於單獨的設置，即{DuH:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para uma página de "configurações" ou "preferências" no software, mas não para configurações individuais, que são {DuH:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää ohjelmiston "asetukset" tai "asetukset" -sivulla, mutta ei yksittäisiä asetuksia, jotka ovat {DuH:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Some information was revealed about {SeH:n:archaic,hyp,nolink} at {qep'a' 27 (2020):src}.</column>
       <column name="components">{SeH:n:archaic,hyp}, {law:n:archaic} or {law:n:hyp,nolink}</column>
       <column name="examples">
@@ -2543,6 +2805,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">console, settings, preferences</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2550,6 +2813,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.02.17:src}, [3] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2563,6 +2827,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">система контроля [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">控制系統</column>
       <column name="definition_pt">Sistema de controle</column>
+      <column name="definition_fi">ohjausjärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2573,6 +2838,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{SeH:v}, {-wI':v}, {pat:n}</column>
       <column name="examples">
@@ -2584,6 +2850,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2591,6 +2858,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2604,6 +2872,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">использовать большой палец (взрослый) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用拇指（成人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">usar o polegar (adulto)</column>
+      <column name="definition_fi">käyttää peukaloa (aikuisesta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh:n}</column>
@@ -2614,6 +2883,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru">Маленькие дети или взрослые, разговаривающие с маленькими детьми или о них, используют {rIl:v:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">小孩或與小孩交談或談論小孩的成年人，請改用{rIl:v:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Crianças pequenas ou adultos conversando com ou sobre crianças pequenas usam o {rIl:v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Pienet lapset tai aikuiset, jotka puhuvat pienten lasten kanssa tai käyttävät niitä, käyttävät sen sijaan {rIl:v:1}-ohjelmaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Seneca Lake.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2623,6 +2893,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2630,6 +2901,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
         <table name="mem">
@@ -2643,6 +2915,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
           <column name="definition_ru">большой палец (взрослый) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">拇指（成人） [AUTOTRANSLATED]</column>
           <column name="definition_pt">polegar (adulto)</column>
+      <column name="definition_fi">(aikuisen) peukalo</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nItlh:n}</column>
@@ -2653,6 +2926,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
           <column name="notes_ru">Маленькие дети или взрослые, разговаривающие с маленькими детьми или о них, используют {rIlwI':n}. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">小孩或與小孩交談或談論小孩的成年人，請改用{rIlwI':n}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Crianças pequenas ou adultos conversando com ou sobre crianças pequenas usam o {rIlwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Pienet lapset tai aikuiset, jotka puhuvat pienten lasten kanssa tai käyttävät niitä, käyttävät sen sijaan {rIlwI':n}-ohjelmaa. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Sen:v:1}, {-wI':v}</column>
           <column name="examples"></column>
@@ -2662,6 +2936,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2669,6 +2944,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
         </table>
         <table name="mem">
@@ -2682,6 +2958,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
           <column name="definition_ru">все (идиоматическая фраза) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">大家（慣用語）</column>
           <column name="definition_pt">todo mundo (frase idiomática)</column>
+      <column name="definition_fi">kaikki (idiomi)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2692,6 +2969,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{SenwI':n}, {rIlwI':n}, {je:conj}</column>
           <column name="examples"></column>
@@ -2701,6 +2979,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2708,6 +2987,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
         </table>
     <table name="mem">
@@ -2721,6 +3001,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">насмехаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嘲笑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">zombar</column>
+      <column name="definition_fi">pilkata, ivata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2731,6 +3012,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="notes_ru">Не сленговый способ сказать это - {nguy:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種說法的非way語方式是{nguy:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A maneira sem gíria de dizer isso é {nguy:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei-slangi tapa sanoa tämä on {nguy:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It was hypothesised during the Q &amp; A session that this might have originated as a gesture (see {Sen:v:1}), but MO wasn't sure.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2740,6 +3022,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2747,6 +3030,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2760,6 +3044,7 @@ This word appears only in the body of {KGT:src} and not in the glossary.</column
       <column name="definition_ru">Шэньчжоу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">神舟號（星艦）</column>
       <column name="definition_pt">Shenzhou</column>
+      <column name="definition_fi">Shenzhou</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DISqa'vI'rIy:n:name}</column>
@@ -2784,6 +3069,9 @@ Eftersom detta är ett icke-Klingon-namn, finns det någon variation i hur Kling
       <column name="notes_pt">Este é o nome de uma nave estelar da Federação (神舟 em chinês).
 
 Como este é um nome não Klingon, há algumas variações em como os Klingons o pronunciam. Alguns pronunciam-se mais como {Senjaw:n:name,nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on federaation tähtialuksen nimi (kiinaksi 神舟).
+
+Koska tämä on muu kuin klingonilainen nimi, siinä on jonkin verran vaihtelua siinä, miten klingonit lausuvat sen. Jotkut lausuvat sen enemmän kuin {Senjaw:n:name,nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2793,6 +3081,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2800,6 +3089,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC:src}</column>
     </table>
     <table name="mem">
@@ -2813,6 +3103,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="definition_ru">{Senjo':n:name}</column>
       <column name="definition_zh_HK">{Senjo':n:name}</column>
       <column name="definition_pt">{Senjo':n:name}</column>
+      <column name="definition_fi">{Senjo':n:name}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2823,6 +3114,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2832,6 +3124,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2839,6 +3132,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC:src}</column>
     </table>
     <table name="mem">
@@ -2852,6 +3146,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="definition_ru">вызвать проблемы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">引起麻煩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">causar problemas</column>
+      <column name="definition_fi">aiheuttaa ongelmia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Seng:n}</column>
@@ -2862,6 +3157,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2871,6 +3167,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2878,6 +3175,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2891,6 +3189,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="definition_ru">беда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">麻煩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">problema</column>
+      <column name="definition_fi">vaikeus, ongelma, hankaluus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Seng:v}</column>
@@ -2901,6 +3200,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2911,6 +3211,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2918,6 +3219,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2931,6 +3233,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="definition_ru">разводить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">品種 [AUTOTRANSLATED]</column>
       <column name="definition_pt">procriar</column>
+      <column name="definition_fi">kasvattaa (eläimiä), teettää poikasia tai pentuja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngagh:v}, {nga'chuq:v}</column>
@@ -2941,6 +3244,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="notes_ru">Клингоны разводят некоторых мелких животных для еды.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗人繁殖了一些小動物作為食物。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os klingons criam alguns pequenos animais como alimento.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonit kasvattaa pieniä eläimiä ruokaa varten[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Shep"herds breed sheep.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2950,6 +3254,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2957,6 +3262,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.89:src}</column>
     </table>
     <table name="mem">
@@ -2970,6 +3276,7 @@ Como este é um nome não Klingon, há algumas variações em como os Klingons o
       <column name="definition_ru">область [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">州、省</column>
       <column name="definition_pt">região</column>
+      <column name="definition_fi">alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yoS:n}, {veng:n}</column>
@@ -2992,6 +3299,19 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa alueeseen, jonka rajat ovat määriteltävissä ja joka oli poliittisesti erillinen aikaisemmin. Yksi sopiva käännös tälle sanalle voi olla "maa".[2]
+
+Jotkut {Qo'noS:n}:n tunnetuista alueista ovat:
+▶ {ghevchoq Sep:n}
+▶ {meqro'vaq Sep:n}
+▶ {noHva'Dut Sep:n}
+▶ {Qotmagh Sep:n}
+▶ {Sa'Qej Sep:n}
+▶ {taq'ev Sep:n}
+▶ {veng wa'DIch Sep:n}
+▶ {voSpegh Sep:n}
+
+{TNK:src}:ssa kategorian "Maat" otsikko käännettiin {Sepmey tlhab:n:nolink} (katso {tlhab:v}).</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3001,6 +3321,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">country</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3008,6 +3329,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.16:src}, [3] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -3021,6 +3343,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">региональный диалект [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地方方言 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dialeto regional</column>
+      <column name="definition_fi">alueellinen murre</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hol Sar:n}, {ta' Hol:n}, {QIch wab Ho'DoS Sar:n}</column>
@@ -3039,6 +3362,15 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Paikkoja, joissa on merkittäviä alueellisia murteita, on:
+▶ {meqro'vaq Sep:n}
+▶ {noHva'Dut Sep:n}
+▶ {Qotmagh Sep:n}
+▶ {ruq'e'vet:n}
+▶ {Sa'Qej Sep:n}
+▶ {taq'ev Sep:n}
+▶ {voSpegh Sep:n}
+▶ {mo'rISqa':n}</column>
       <column name="hidden_notes"></column>
       <column name="components">{Sep:n}, {Hol Sar:n}</column>
       <column name="examples"></column>
@@ -3048,6 +3380,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3055,6 +3388,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.25:src}</column>
     </table>
     <table name="mem">
@@ -3068,6 +3402,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">тип драгоценного камня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">寶石的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de pedra preciosa</column>
+      <column name="definition_fi">eräs jalokivi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naghboch:n}</column>
@@ -3078,6 +3413,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru">Существует идиома {let mInDu'Daj; Separmey rur@@let:v, mIn:n, -Du':n, -Daj:n, Separ:n, -mey:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{let mInDu'Daj; Separmey rur@@let:v, mIn:n, -Du':n, -Daj:n, Separ:n, -mey:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {let mInDu'Daj; Separmey rur@@let:v, mIn:n, -Du':n, -Daj:n, Separ:n, -mey:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {let mInDu'Daj; Separmey rur@@let:v, mIn:n, -Du':n, -Daj:n, Separ:n, -mey:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Sapphire".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3087,6 +3423,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3094,6 +3431,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3107,6 +3445,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">разлом (сейсмический) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斷層（地震） [AUTOTRANSLATED]</column>
       <column name="definition_pt">falha (sísmica)</column>
+      <column name="definition_fi">siirros, murtuma (geologia)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qargh:n}, {Qom:v:1}</column>
@@ -3117,6 +3456,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Seg fault", "Shake".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3126,6 +3466,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3133,6 +3474,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3146,6 +3488,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">быть формальным, быть ритуальным, быть церемониальным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要正式、儀式化、儀式化 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser formal, ser ritualista, ser cerimonial</column>
+      <column name="definition_fi">olla muodollinen, olla rituaalinen, olla seremoniallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tay:v}, {mIv je DaS:n}</column>
@@ -3156,6 +3499,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3165,6 +3509,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3172,6 +3517,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3185,6 +3531,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">{wIlyam SeQpIr:n:name}</column>
       <column name="definition_zh_HK">{wIlyam SeQpIr:n:name}</column>
       <column name="definition_pt">{wIlyam SeQpIr:n:name}</column>
+      <column name="definition_fi">{wIlyam SeQpIr:n:name}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3195,6 +3542,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">His original Klingon name was never spoken in {Star Trek VI:src}, where he was only referred to as "Shakespeare".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3204,6 +3552,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3211,6 +3560,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}, [2] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -3224,6 +3574,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">прогресс [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">進展 [AUTOTRANSLATED]</column>
       <column name="definition_pt">progresso</column>
+      <column name="definition_fi">edistys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhetlh:v}</column>
@@ -3234,6 +3585,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3243,6 +3595,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3250,6 +3603,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3263,6 +3617,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">ушная сера [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">耳垢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cera de ouvido</column>
+      <column name="definition_fi">vaikku, korvavaha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qogh:n:2,body}, {teS:n}, {vI':v}</column>
@@ -3273,6 +3628,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Cerumen".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3282,6 +3638,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3289,6 +3646,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -3302,6 +3660,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">Планета Шермана [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">謝爾曼的星球</column>
       <column name="definition_pt">planeta de Sherman</column>
+      <column name="definition_fi">Shermanin planeetta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuQ:n}</column>
@@ -3312,6 +3671,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3321,6 +3681,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3328,6 +3689,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3341,6 +3703,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">пар [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蒸汽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vapor</column>
+      <column name="definition_fi">höyry</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIQ:n}, {pub:v}</column>
@@ -3351,6 +3714,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It's what it sounds like.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3360,6 +3724,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3367,6 +3732,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3380,6 +3746,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">geyser (steam) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蒸汽噴泉</column>
       <column name="definition_pt">geyser (vapor)</column>
+      <column name="definition_fi">höyrygeysir?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3390,6 +3757,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru">Это если испускает только воду, то это просто {ghItwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果它僅散發出水，那麼它只是一塊{ghItwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se emite apenas água, é apenas um {ghItwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos se päästää vain vettä, se on vain {ghItwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{SeS:n}, {ghItwI':n}</column>
       <column name="examples"></column>
@@ -3399,6 +3767,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3406,6 +3775,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -3419,6 +3789,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">тема [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">學科 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sujeito</column>
+      <column name="definition_fi">subjekti (kielioppi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ovmay:n}, {vI'Hop:n}</column>
@@ -3429,6 +3800,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru">Это грамматический термин. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個語法術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo gramatical. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kieliopin termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Backwards of "roses". "The Subject Was Roses" was a play adapted into a 1968 film.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3438,6 +3810,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3445,6 +3818,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3458,6 +3832,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">повязка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">繃帶 [AUTOTRANSLATED]</column>
       <column name="definition_pt">curativo</column>
+      <column name="definition_fi">side (sairaanhoidossa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hergh:n}, {Sev:v}</column>
@@ -3468,6 +3843,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The existence of the homophonous verb {Sev:v} may suggest that Klingons view the containment of wounds as being analogous to the containment of an enemy.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3477,6 +3853,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3484,6 +3861,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3497,6 +3875,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="definition_ru">содержать (враг) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">包圍（敵人）</column>
       <column name="definition_pt">conter (um inimigo)</column>
+      <column name="definition_fi">hillitä (vihollista), pitää (vihollinen) kurissa/loitolla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sach:v:1}, {Dech:v}, {ngaS:v}, {wegh:v}, {Sev:n}</column>
@@ -3507,6 +3886,7 @@ In {TNK:src}, the category title for "Countries" was translated {Sepmey tlhab:n:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.
 
 The existence of the homophonous noun {Sev:n} may suggest that Klingons view the containment of wounds as being analogous to the containment of an enemy.</column>
@@ -3518,6 +3898,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3525,6 +3906,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3538,6 +3920,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">быть взволнованным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">興奮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar animado</column>
+      <column name="definition_fi">olla innostunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIl:v}, {tlhuH:v:2}</column>
@@ -3548,6 +3931,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3557,6 +3941,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3564,6 +3949,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3577,6 +3963,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">возбуждают [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">激發 [AUTOTRANSLATED]</column>
       <column name="definition_pt">excitar</column>
+      <column name="definition_fi">innostaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3587,6 +3974,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru">Это может быть применено к музыке. [2, p.71] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以應用於音樂。[2, p.71] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser aplicado à música.[2, p.71] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan soveltaa musiikkiin.[2, p.71] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Sey:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -3596,6 +3984,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3603,6 +3992,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3616,6 +4006,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">Гнев возбуждает. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">憤怒激動。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A raiva excita.</column>
+      <column name="definition_fi">Viha innostaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3626,6 +4017,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3635,6 +4027,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3642,6 +4035,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.196:src}</column>
     </table>
     <table name="mem">
@@ -3655,6 +4049,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">frequency (radio) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頻率（無線電） [AUTOTRANSLATED]</column>
       <column name="definition_pt">frequência (rádio)</column>
+      <column name="definition_fi">taajuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chaDvay':n}, {rI'Se':n}, {wab HevwI':n}, {SubmaH:n}</column>
@@ -3665,6 +4060,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3674,6 +4070,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3681,6 +4078,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3694,6 +4092,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">кастрюля [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">平底鍋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">panela</column>
+      <column name="definition_fi">kasari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chanDoq:n}, {gha'poq:n}, {ghevI':n}, {qagh vIychorgh:n}, {qettlhup:n}, {tlhatlh vIychorgh:n}, {'uSu':n}</column>
@@ -3704,6 +4103,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is composed of {Se':n} and {tu':v}, which suggests that Klingons believe Terran saucepans to be satellite dishes. According to the explanation by {qe'San:n:name,nolink}, this was apparently based on "set-to" because there was a heated discussion about it.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3713,6 +4113,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3720,6 +4121,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -3734,6 +4136,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">публикация [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">出版物</column>
       <column name="definition_pt">publicação</column>
+      <column name="definition_fi">julkaisu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Se'vIr malja':n}, {ghItlh:n}, {paq:n:1h}</column>
@@ -3744,6 +4147,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru">Это слово относится к публикации любого рода, печатной или нет. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞是指任何形式的出版物，無論是否印刷。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se refere a uma publicação de qualquer tipo, impressa ou não. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa mihin tahansa julkaisuun, riippumatta siitä, onko se painettu vai ei. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3753,6 +4157,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3760,6 +4165,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh website:src}, [2] {KLI mailing list 2011.10.24:src}</column>
     </table>
     <table name="mem">
@@ -3773,6 +4179,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">Издательство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">出版社 [AUTOTRANSLATED]</column>
       <column name="definition_pt">editora</column>
+      <column name="definition_fi">kustantamo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Se'vIr:n}</column>
@@ -3783,6 +4190,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a pun on the name of a well-known Terran publishing house. (The pun was confirmed by Okrand to {'ISqu':n:name}.[3])</column>
       <column name="components">{Se'vIr:n}, {malja':n}</column>
       <column name="examples"></column>
@@ -3792,6 +4200,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3799,6 +4208,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}, [2] {KLI mailing list 2011.10.24:src}, [3] {KLI mailing list 2011.11.26:src}</column>
     </table>
     <table name="mem">
@@ -3812,6 +4222,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">радио [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">無線電 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rádio</column>
+      <column name="definition_fi">radio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'evnagh Se' HablI':n}</column>
@@ -3822,6 +4233,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru">Это относится к устройству, используемому для двусторонней связи. Для устройства, которое получает (но не отправляет) аудиосигнал, см. {wab HevwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指用於雙向通信的設備。有關接收（但不發送）音頻信號的設備，請參閱{wab HevwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um dispositivo usado para comunicação bidirecional. Para o dispositivo que recebe (mas não envia) um sinal de áudio, consulte {wab HevwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa laitteeseen, jota käytetään kaksisuuntaiseen viestintään. Katso laite, joka vastaanottaa (mutta ei lähetä) äänisignaalia, {wab HevwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Se':n}, {HablI':n}</column>
       <column name="examples"></column>
@@ -3831,6 +4243,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3838,6 +4251,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3851,6 +4265,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">спутниковое [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">衛星</column>
       <column name="definition_pt">satélite</column>
+      <column name="definition_fi">satelliitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bav:v}, {maS:n}</column>
@@ -3861,6 +4276,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3870,6 +4286,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3877,6 +4294,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3890,6 +4308,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">немедленно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">立即 [AUTOTRANSLATED]</column>
       <column name="definition_pt">imediatamente</column>
+      <column name="definition_fi">heti, välittömästi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SIbI'Ha':adv}</column>
       <column name="see_also">{DaH:adv}, {pay':adv}, {quq:v}, {ngugh:adv}</column>
@@ -3900,6 +4319,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3909,6 +4329,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3916,6 +4337,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3929,6 +4351,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">позже, в конце концов [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">後來、最終 [AUTOTRANSLATED]</column>
       <column name="definition_pt">depois, eventualmente</column>
+      <column name="definition_fi">myöhemmin, lopulta</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SIbI':adv}, {DaH:adv}, {tugh:adv}</column>
       <column name="see_also">{-Ha':v:suff}</column>
@@ -3939,6 +4362,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3949,6 +4373,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">until</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3956,6 +4381,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3969,6 +4395,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">досягаемость [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">達到 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alcance</column>
+      <column name="definition_fi">saavuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hot:v}, {qubbID:n}</column>
@@ -3979,6 +4406,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The example sentence from {DSC - Such Sweet Sorrow, Part 2:src} was composed by someone other than Okrand, most probably Robyn Stewart ({Qov:n:name}).</column>
       <column name="components"></column>
       <column name="examples">
@@ -3997,6 +4425,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4004,6 +4433,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}, [3] {KLI mailing list 2019.04.09:src}, [4] {DSC - Such Sweet Sorrow, Part 2:src}</column>
     </table>
     <table name="mem">
@@ -4017,6 +4447,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">терпеливый [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">患者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">paciente</column>
+      <column name="definition_fi">potilas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qel:n:1h}, {rachwI':n}, {ropyaH:n}, {rop:n}, {rop:v}</column>
@@ -4027,6 +4458,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The actor Sid James played a patient in "Carry On Doctor". There are a number of medical abbreviations written "SID".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4036,6 +4468,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4043,6 +4476,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4056,6 +4490,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">влияние [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">影響 [AUTOTRANSLATED]</column>
       <column name="definition_pt">influência</column>
+      <column name="definition_fi">vaikuttaa johonkin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moH:v:2}</column>
@@ -4066,6 +4501,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4075,6 +4511,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4082,6 +4519,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4095,6 +4533,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">изгиб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">彎曲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dobrar</column>
+      <column name="definition_fi">taipua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wan:v}, {wanHa':v}, {'ob:v}</column>
@@ -4105,6 +4544,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4114,6 +4554,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4121,6 +4562,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
        <table name="mem">
@@ -4134,6 +4576,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
          <column name="definition_ru">решить [AUTOTRANSLATED]</column>
          <column name="definition_zh_HK">解決 [AUTOTRANSLATED]</column>
          <column name="definition_pt">resolver, solucionar</column>
+      <column name="definition_fi">ratkaista</column>
          <column name="synonyms"></column>
          <column name="antonyms"></column>
          <column name="see_also"></column>
@@ -4144,6 +4587,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
          <column name="notes_ru">Не сленговый способ сказать это - {pan:v:2}. [AUTOTRANSLATED]</column>
          <column name="notes_zh_HK">這種說法的非way語方式是{pan:v:2}。 [AUTOTRANSLATED]</column>
          <column name="notes_pt">A maneira sem gíria de dizer isso é {pan:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ei-slangi tapa sanoa tämä on {pan:v:2}. [AUTOTRANSLATED]</column>
          <column name="hidden_notes"></column>
          <column name="components">{SIH:v}, {-Ha':v}, {-moH:v}</column>
          <column name="examples"></column>
@@ -4153,6 +4597,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
          <column name="examples_ru"></column>
          <column name="examples_zh_HK"></column>
          <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
          <column name="search_tags"></column>
          <column name="search_tags_de"></column>
          <column name="search_tags_fa"></column>
@@ -4160,6 +4605,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
          <column name="search_tags_ru"></column>
          <column name="search_tags_zh_HK"></column>
          <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
          <column name="source">[1] {qep'a' 27 (2020):src}</column>
        </table>
     <table name="mem">
@@ -4173,6 +4619,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">щель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">裂縫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fenda</column>
+      <column name="definition_fi">viiltää, halkaista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pe':v}, {DuQ:v:1}, {SIj:v:2}</column>
@@ -4183,6 +4630,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4193,6 +4641,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4200,6 +4649,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4213,6 +4663,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">будь проницательным, будь умным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要有洞察力、要聰明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser perspicaz, ser experto</column>
+      <column name="definition_fi">olla oivaltava, älykäs, fiksu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIj:v:1}</column>
@@ -4223,6 +4674,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru">Когда используется в сленговом смысле, этот глагол не принимает объект. [1, p.164] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">當用於the語時，此動詞不帶賓語.[1, p.164] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Slangia käytettäessä tämä verbi ei vie objektia.[1, p.164] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4232,6 +4684,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4239,6 +4692,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4252,6 +4706,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">type of knife (used for food preparation) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刀的類型（用於食物準備） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de faca (usada para preparação de alimentos)</column>
+      <column name="definition_fi">eräs ruoanvalmistukseen käytetty veitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{warjun:n}</column>
@@ -4262,6 +4717,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru">Это используется для более тонкой работы в кулинарии. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於更好地烹飪。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para um trabalho mais refinado na culinária. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään ruoanlaittoon hienommassa työssä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{SIj:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4271,6 +4727,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4278,6 +4735,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4291,6 +4749,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">большое зеркало [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大鏡子</column>
       <column name="definition_pt">espelho grande</column>
+      <column name="definition_fi">iso peili</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nar:v}</column>
@@ -4301,6 +4760,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru">Это больше, чем {neSlo':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這比{neSlo':n}大。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é maior que um {neSlo':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on suurempi kuin {neSlo':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to "Through the Looking-Glass, and What Alice Found There", the sequel to "Alice's Adventures in Wonderland".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4310,6 +4770,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4317,6 +4778,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4330,6 +4792,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">Силрек [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Silrek [AUTOTRANSLATED]</column>
       <column name="definition_pt">Silrek</column>
+      <column name="definition_fi">Silrek</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIr'el:n:name}</column>
@@ -4340,6 +4803,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4349,6 +4813,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4356,6 +4821,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Si Vis Pacem, Para Bellum:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -4369,6 +4835,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">высчитывает [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">計算</column>
       <column name="definition_pt">calcular</column>
+      <column name="definition_fi">laskea (laskutoimitus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boq:v:2}, {togh:v}, {ghun:v:1}</column>
@@ -4379,6 +4846,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru">Смотрите в {boq:v:2} для основных математических операций. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關基本的數學運算，請參見{boq:v:2}下的內容。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {boq:v:2} as operações matemáticas básicas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso matemaattiset perustoiminnot kohdasta {boq:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4388,6 +4856,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4395,6 +4864,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4408,6 +4878,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">сила (физика) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">力量（物理學） [AUTOTRANSLATED]</column>
       <column name="definition_pt">potência (física)</column>
+      <column name="definition_fi">teho (fysiikka)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4418,6 +4889,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="notes_ru">Это количество энергии, переданной или преобразованной за единицу времени. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是每單位時間傳輸或轉換的能量。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é a quantidade de energia transferida ou convertida por unidade de tempo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on siirretyn tai muunnetun energian määrä aikayksikköä kohti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4427,6 +4899,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4434,6 +4907,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4447,6 +4921,7 @@ The existence of the homophonous noun {Sev:n} may suggest that Klingons view the
       <column name="definition_ru">degree (unit of measure for temperature) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">度（溫度測量單位） [AUTOTRANSLATED]</column>
       <column name="definition_pt">grau (unidade de medida para temperatura)</column>
+      <column name="definition_fi">eräs lämpötilan mittayksikkö, SImyon-aste</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gheH:v}, {Hat:n}</column>
@@ -4470,6 +4945,20 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on lämpötilan yksikkö tietyllä asteikolla, ei yleinen sana lämpötilan yksikölle.
+
+Jotkut vertailulämpötilat {SImyon:sen:nolink}-asteikolle (vasen) vs. Celsius (oikea) ovat:
+   0 = -210 typen jäätymispiste
+  96 = -100
+ 100 = -95
+ 183 = 0 veden jäätymispiste
+ 200 = 19
+ 215 = 37 ruumiinlämpöä (ihminen / klingon)
+ 270 = 100 kiehumispistettä vettä - Maan merenpinta
+ 273 = veden kiehumispiste 103 - {Qo'noS:n}-observatorio
+ 300 = 134
+ 500 = 363
+1000 = 937 sulan laavan lämpötila [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4479,6 +4968,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4486,6 +4976,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4499,6 +4990,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="definition_ru">компас [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">羅盤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bússola</column>
+      <column name="definition_fi">kompassi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurgh:n}, {peQnagh:n}, {chan:n}, {tIng:n}, {'ev:v}</column>
@@ -4509,6 +5001,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="notes_ru">Это относится к географическому инструменту, а не к инструменту рисования. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指地理工具，而不是繪圖工具。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à ferramenta geográfica, não à ferramenta de desenho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa maantieteelliseen työkaluun, ei piirtotyökaluun. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is what early compasses were called in China (司南).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4518,6 +5011,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4525,6 +5019,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4538,6 +5033,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="definition_ru">древнее (вымершее) животное, динозавр [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">古代（絕種）動物恐龍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">animal antigo (extinto), dinossauro</column>
+      <column name="definition_fi">muinainen sukupuuttoon kuollut eläin (esim. dinosaurus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'an'or:n}, {loq:v}</column>
@@ -4548,6 +5044,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="notes_ru">Это ненаучный, общий термин для древнего (вымершего) животного любого размера (хотя часто довольно большого). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是任何大小（儘管通常很大）的古老（絕種）動物的非科學通用術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo geral não científico para um animal antigo (extinto) de qualquer tamanho (embora geralmente bastante grande). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ei-tieteellinen, yleinen termi muinaiselle (sukupuuttoon) eläimelle, joka on kaiken kokoinen (tosin usein melko suuri). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The logo and mascot of the Sinclair Oil Corporation is a large green dinosaur. The protagonist of the Disney series Dinosaurs was named Earl Sinclair.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4557,6 +5054,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">extinct</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4564,6 +5062,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -4577,6 +5076,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="definition_ru">газ [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">氣體</column>
       <column name="definition_pt">gás</column>
+      <column name="definition_fi">kaasu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIQSIp:n}, {julSIp:n}, {voQSIp:n}, {yInSIp:n}, {lep:n}, {betgham:n}, {lI'choD:n}, {vID'Ir:n}, {Qep'It:n}, {ruq:v}</column>
@@ -4587,6 +5087,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4596,6 +5097,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4603,6 +5105,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4616,6 +5119,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="definition_ru">Спок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斯波克 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Spock</column>
+      <column name="definition_fi">Spock</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -4628,6 +5132,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este é o primeiro oficial do {'entepray':n:name} sob {jemS tIy qIrq:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {'entepray':n:name}: n ensimmäinen upseeri {jemS tIy qIrq:n:name}: n alla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4637,6 +5142,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4644,6 +5150,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Kauderwelsch Klingonisch:src}</column>
     </table>
     <table name="mem">
@@ -4657,6 +5164,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="definition_ru">щетина, жесткие волосы или нить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">硬毛，硬毛或細絲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cerdas, cabelos duros ou filamentos</column>
+      <column name="definition_fi">kova, jäykkä hius tai säie; harjas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4667,6 +5175,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4676,6 +5185,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4683,6 +5193,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4696,6 +5207,7 @@ Some reference temperatures for the {SImyon:sen:nolink} scale (left) vs. Celsius
       <column name="definition_ru">используйте указательный палец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用食指 [AUTOTRANSLATED]</column>
       <column name="definition_pt">use o dedo indicador</column>
+      <column name="definition_fi">käyttää etusormea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh:n}</column>
@@ -4734,6 +5246,11 @@ Om ett redskap används för en aktivitet som vanligtvis utförs av ett finger, 
 Existem alguns casos especiais de formas reflexivas (com {-'egh:v}) dos verbos de dedo. Veja o exemplo abaixo e também em {rIl:v:1}.
 
 Se um implemento for usado para uma atividade normalmente executada por um dedo, um verbo de dedo pode ser usado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun sitä käytetään substantiivien kanssa, jotka on merkitty {-Daq:n}: llä, sormiverbit tarkoittavat "osoittavat (tällä sormella) kyseisen substantiivin osoittamaan kohteeseen tai kohti".
+
+On joitain erityistapauksia sormiverbien refleksiivisissä ({-'egh:v}) muodoissa. Katso alla oleva esimerkki ja myös kohdassa {rIl:v:1}.
+
+Jos työvälinettä käytetään tyypillisesti sormen suorittamaan toimintaan, voidaan käyttää sormiverbiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Skaneateles Lake.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4749,6 +5266,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">point</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4756,6 +5274,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}, [2] {DSC trailer:src}</column>
     </table>
         <table name="mem">
@@ -4769,6 +5288,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="definition_ru">указательный палец, указательный палец [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">食指、第一根手指 [AUTOTRANSLATED]</column>
           <column name="definition_pt">dedo indicador, primeiro dedo</column>
+      <column name="definition_fi">etusormi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nItlh:n}</column>
@@ -4779,6 +5299,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{SIq:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -4788,6 +5309,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4795,6 +5317,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
         </table>
     <table name="mem">
@@ -4808,6 +5331,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">эльф, гном [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小精靈，侏儒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">elfo, gnomo</column>
+      <column name="definition_fi">haltia, tonttu, maahinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4818,6 +5342,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是克林崗神話中的一種小人物，例如小精靈或侏儒。[1]它也可以用來翻譯人種神話中的“矮人”或“仙女”之類的生物，儘管它可能不適合翻譯“童話”一詞。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on eräänlainen pieni henkilö Klingonin mytologiassa, kuten tonttu tai tonttu. termi "satu" .[2][1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The information that it can also be used to translate "dwarf" or "fairy" was not directed posted to the mailing list, but was also revealed in the discussion about translating The Wizard of Oz.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4827,6 +5352,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4834,6 +5360,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}, [2] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -4847,6 +5374,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">{SIqral bIQtIq:n}</column>
       <column name="definition_zh_HK">{SIqral bIQtIq:n}</column>
       <column name="definition_pt">{SIqral bIQtIq:n}</column>
+      <column name="definition_fi">{SIqral bIQtIq:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4857,6 +5385,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4866,6 +5395,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4873,6 +5403,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -4886,6 +5417,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">река скрал [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斯克拉爾河 [AUTOTRANSLATED]</column>
       <column name="definition_pt">o rio Skral</column>
+      <column name="definition_fi">Skral-joki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIQtIq:n}, {'ej HumtaH 'ej DechtaH 'Iw:sen}</column>
@@ -4896,6 +5428,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4905,6 +5438,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4912,6 +5446,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -4925,6 +5460,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">терпеть, терпеть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">忍受</column>
       <column name="definition_pt">suportar, carregar</column>
+      <column name="definition_fi">kestää jotakin, kärsiä jostakin, kantaa jotakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taH:v:1}, {chergh:v}, {bech:v}, {rotlh:v}, {bep:v}, {vIng:v}</column>
@@ -4935,6 +5471,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Os klingons usam {SIQ:v:nolink} em vez de {tIv:v} para algumas coisas que os humanos podem considerar agradáveis ​​ou neutros. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonit käyttävät {SIQ:v:nolink}: ää {tIv:v}: n sijaan joihinkin asioihin, joita ihmiset saattavat pitää miellyttävinä tai neutraaleina. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4947,6 +5484,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">experience</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4954,6 +5492,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4967,6 +5506,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">получатель, получатель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">監護人、收件人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">celebrante, destinatário</column>
+      <column name="definition_fi">juhlija, vastaanottaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{van'a':n}</column>
@@ -4977,6 +5517,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{SIQ:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4986,6 +5527,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4993,6 +5535,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5006,6 +5549,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">рыться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">亂塗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Scrabble</column>
+      <column name="definition_fi">Scrabble-lautapeli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5016,6 +5560,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru">Это всего лишь клингонское правописание для названия настольной игры терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是人族棋盤遊戲名稱的克林崗語拼寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é apenas a grafia Klingon para o nome do jogo de tabuleiro terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain Klingonin oikeinkirjoitus Terran-lautapelin nimelle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5025,6 +5570,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5032,6 +5578,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5045,6 +5592,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">нить, нить, нить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">弦、線、細絲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">corda, linha, filamento</column>
+      <column name="definition_fi">naru, lanka, rihma, säie, kuitu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhegh:n}, {qoSta':n}, {wal:v}</column>
@@ -5055,6 +5603,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">For "string" as in the variable type, see under {ghItlh:n}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5065,6 +5614,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5072,6 +5622,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5085,6 +5636,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">кукла (кукла) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">木偶（洋娃娃） [AUTOTRANSLATED]</column>
       <column name="definition_pt">marionete (boneca)</column>
+      <column name="definition_fi">sätkynukke, marionetti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5095,6 +5647,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru">Это буквально означает «струнная кукла» и относится к кукле, которая используется в спектаклях кукольного театра. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“弦娃娃”，是指在木偶劇院表演中使用的娃娃。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "boneca de corda" e refere-se a uma boneca usada em apresentações de teatro de bonecos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "kielisukua" ja viittaa nukkeeseen, jota käytetään nukketeatteriesityksissä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "puppet". The word "marionette" was added to distinguish this from {qo'rob:n}.</column>
       <column name="components">{SIrgh:n}, {raghghan:n}</column>
       <column name="examples"></column>
@@ -5104,6 +5657,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5111,6 +5665,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5124,6 +5679,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">крюк [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鉤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gancho</column>
+      <column name="definition_fi">koukku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5134,6 +5690,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Cyril Ritchard played Captain Hook in the 1954 Mary Martin production of the Broadway musical Peter Pan.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5143,6 +5700,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5150,6 +5708,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5163,6 +5722,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">Серебряный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">銀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prata</column>
+      <column name="definition_fi">hopea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}</column>
@@ -5173,6 +5733,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Shirley Silver is an American linguist with whom Marc Okrand has worked in the past.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5182,6 +5743,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5189,6 +5751,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5202,6 +5765,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">бронежилет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">身體護具 [AUTOTRANSLATED]</column>
       <column name="definition_pt">armadura corporal</column>
+      <column name="definition_fi">(vartalolla pidettävä) panssari, haarniska (esim. luotiliivit)</column>
       <column name="synonyms">{may' Sut:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{yoD:n}</column>
@@ -5212,6 +5776,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru">Это старое слово. Мальцу это понравилось больше, чем {may' Sut:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個古老的詞。 Maltz比{may' Sut:n:nolink}更喜歡這個。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra antiga. Maltz gostou disto melhor do que {may' Sut:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vanha sana. Maltz piti tästä paremmin kuin {may' Sut:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5221,6 +5786,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">armour, body armour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5228,6 +5794,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -5241,6 +5808,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">сеть, сеть, сетка, решетка, нексус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">網絡、網、網格、格、nexus [AUTOTRANSLATED]</column>
       <column name="definition_pt">network, rede, teia, malha, nexus</column>
+      <column name="definition_fi">verkko, verkosto, vyyhti, ristikko, säleikkö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5251,6 +5819,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Shiro is the mass of thread-like hyphae which constitutes the mycelium, or vegetative part, of a fungus. This word was revealed to translate "mycelial network" for {DSC:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5260,6 +5829,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5267,6 +5837,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - The Butcher's Knife Cares Not for the Lamb's Cry:src}</column>
     </table>
     <table name="mem">
@@ -5280,6 +5851,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">дождь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chuva</column>
+      <column name="definition_fi">sataa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chal bIQ:n}, {jev:v:1}, {muD Dotlh:n}, {ghay:v}, {Har'ey:n}, {Heq:v}, {peD:v}, {vI'laS:n}, {'eng:n}, {'onroS:n}</column>
@@ -5290,6 +5862,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru">Этот глагол может взять объект. Его тема обычно не установлена.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個動詞可以帶一個賓語。它的主題通常是未知的。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo pode pegar um objeto. Seu assunto geralmente não é declarado.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi voi ottaa objektin. Sen aihe on yleensä ilmoittamaton.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's the sound of rain falling.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5301,6 +5874,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5308,6 +5882,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 1998.05.28:src}, [3] {paq'batlh p.136-137:src}</column>
     </table>
     <table name="mem">
@@ -5322,6 +5897,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">зонтик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雨傘</column>
       <column name="definition_pt">guarda-chuva</column>
+      <column name="definition_fi">sateenvarjo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5332,6 +5908,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">MO said at the {Saarbrücken qepHom'a' 2011:src} that the apparent noun {SIS:n:hyp} is a fossilized remnant which is probably limited to this expression.[2]</column>
       <column name="components">{SIS:n:hyp,nolink}, {yoD:n}</column>
       <column name="examples"></column>
@@ -5341,6 +5918,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5348,6 +5926,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}, [2] {KLI mailing list 2014.11.03:src}</column>
     </table>
     <table name="mem">
@@ -5361,6 +5940,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">задаваться вопросом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">奇蹟 [AUTOTRANSLATED]</column>
       <column name="definition_pt">maravilha</column>
+      <column name="definition_fi">ihmetellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5371,6 +5951,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru">Этот глагол может принять {'e':n:pro} в качестве своего объекта. При использовании в качестве второго глагола в предложении в качестве конструкции объекта, он обычно переводится как «интересно, если» .[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞可以將{'e':n:pro}作為對象。當用作構成對象的句子中的第二個動詞時，通常會翻譯為“ wonder if”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä verbi voi ottaa objektiksi {'e':n:pro}. Kun sitä käytetään lauseen toisena verbinä objektinrakennuksena, se käännetään yleensä "ihmettelen" .[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}, probably as a joke to make us wonder if it was a mistake.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5381,6 +5962,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5388,6 +5970,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.07.01:src} (reprinted in {HQ 7.2, p.8, Jun. 1998:src})</column>
     </table>
     <table name="mem">
@@ -5401,6 +5984,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">трость, тростник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">甘蔗、蘆葦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Palheta</column>
+      <column name="definition_fi">ruoko, kaisla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQ:n:1}, {bambu':n}</column>
@@ -5411,6 +5995,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"C &amp; H" is a brand of cane sugar.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5420,6 +6005,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5427,6 +6013,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5440,6 +6027,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">Семь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">七</column>
       <column name="definition_pt">sete</column>
+      <column name="definition_fi">seitsemän</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Soch:n:2} (musical tone)</column>
@@ -5450,6 +6038,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5459,6 +6048,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5466,6 +6056,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -5479,6 +6070,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="definition_ru">седьмой [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">第七</column>
           <column name="definition_pt">sétimo</column>
+      <column name="definition_fi">seitsemäs</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5489,6 +6081,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Soch:n:1,num}, {-DIch:n:num,suff}</column>
           <column name="examples"></column>
@@ -5498,6 +6091,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">7th</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5505,6 +6099,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -5518,6 +6113,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="definition_ru">семьдесят [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">七十 [AUTOTRANSLATED]</column>
           <column name="definition_pt">setenta</column>
+      <column name="definition_fi">seitsemänkymmentä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5528,6 +6124,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Soch:n:1,num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -5537,6 +6134,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5544,6 +6142,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -5557,6 +6156,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">седьмой тон неатонической музыкальной гаммы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">非音階音階的第七音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sétimo tom da escala musical não-atônica</column>
+      <column name="definition_fi">nonatoonisen musiikkiasteikon seitsemäs sävel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Soch:n:1} (number)</column>
@@ -5567,6 +6167,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin musiikkiasteikon sävyt (katso {yutlhegh:n}) ovat: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}, {vagh:n:2}, {jav:n:2}, {Soch:n:2,nolink}, {chorgh:n:2}, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DOT{yu:n:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5576,6 +6177,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5583,6 +6185,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5596,6 +6199,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">наводнение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">洪水 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inundação</column>
+      <column name="definition_fi">tulva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoD:v}</column>
@@ -5606,6 +6210,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Sodden" means "completely soaked".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5615,6 +6220,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5622,6 +6228,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5635,6 +6242,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">наводнение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">洪水 [AUTOTRANSLATED]</column>
       <column name="definition_pt">inundar</column>
+      <column name="definition_fi">tulvia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoD:n}</column>
@@ -5645,6 +6253,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Sodden" means "completely soaked".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5654,6 +6263,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5661,6 +6271,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5674,6 +6285,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">лейтенант [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陸軍中尉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tenente</column>
+      <column name="definition_fi">luutnantti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5684,6 +6296,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="notes_ru">Это 7-й ранг {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{yaS:n}的第七位。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o 7º ranking do {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {yaS:n}: n 7. sijoitus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5693,6 +6306,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5700,6 +6314,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5713,6 +6328,7 @@ Se um implemento for usado para uma atividade normalmente executada por um dedo,
       <column name="definition_ru">ты [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你</column>
       <column name="definition_pt">você</column>
+      <column name="definition_fi">sinä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-lIj:n}, {-lI':n}</column>
@@ -5735,6 +6351,19 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän pronominin monikko on {tlhIH:n:pro}.
+
+Verbien etuliitteet, kun aihe {SoH:n:nolink} on:
+▶ {SoH:n:nolink}: {pagh:n:1h} = {bI-:v:pref}
+▶ {SoH:n:nolink}: {jIH:n:1h} = {cho-:v:pref}
+▶ {SoH:n:nolink}: {maH:n:1h} = {ju-:v:pref}
+▶ {SoH:n:nolink}: {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n} = {Da-:v:pref}
+
+Verbien etuliitteet, kun {SoH:n:nolink} on objekti:
+▶ {jIH:n:1h}: {SoH:n:nolink} = {qa-:v:pref}
+▶ {maH:n:1h}: {SoH:n:nolink} = {pI-:v:pref}
+▶ {ghaH:n} / {'oH:n}: {SoH:n:nolink} = {Du-:v:pref}
+▶ {chaH:n} / {bIH:n}: {SoH:n:nolink} = {nI-:v:pref} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5744,6 +6373,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5751,6 +6381,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5764,6 +6395,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="definition_ru">May the spirit of Kahless live within you. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">願「凱勒斯」的精神活在你的內心。</column>
       <column name="definition_pt">Que o espírito de Kahless viva dentro de você.</column>
+      <column name="definition_fi">Eläköön Kahlessin henki sisälläsi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5774,6 +6406,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{SoH:n:pro}, {-Daq:n}, {qeylIS:n:name}, {qa':n}, {yIn:v}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -5783,6 +6416,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5790,6 +6424,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -5803,6 +6438,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="definition_ru">Кто ты?</column>
       <column name="definition_zh_HK">你是誰？</column>
       <column name="definition_pt">Quem é você?</column>
+      <column name="definition_fi">Kuka sinä olet?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{... 'oH pongwIj'e'.:sen}, {nuq 'oH ponglIj'e'?:sen}</column>
@@ -5813,6 +6449,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{SoH:n}, {'Iv:ques:1h}</column>
       <column name="examples"></column>
@@ -5822,6 +6459,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">What is your name?</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5829,6 +6467,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -5842,6 +6481,7 @@ Verb prefixes when {SoH:n:nolink} is the object:
       <column name="definition_ru">еда, напиток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物和飲料 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comida, bebida</column>
+      <column name="definition_fi">ruoka, juoma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sop:v}, {tlhutlh:v}, {'ep:v:1}, {vut:v}, {je':v:2}, {ngal:v}, {char:v}, {tlher:v}, {ghoQ:v:1}, {baQ:v:2}, {DeH:v}, {QaD:v:1}, {tlhar:v}</column>
@@ -5860,6 +6500,9 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
 Это слово несет идиоматическое значение «вопрос, забота, дело», см. {Soj:n:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sana koskee sekä ruokia että juomia [2] tai kaikkea ravinnoksi kulutettua.
+
+Tällä sanalla on idiomaattinen merkitys "asia, huoli, suhde", josta ks. {Soj:n:2}.[4]{nay':n}[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example appears to be missing a conjunction.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5871,6 +6514,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nourishment, sustenance</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5878,6 +6522,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT p.83:src}, [3] {SkyBox 21:src}, [4] {Saarbrücken qepHom'a' 2011:src}</column>
     </table>
     <table name="mem">
@@ -5891,6 +6536,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">дело, забота, дело [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">事項關心關心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">assunto, preocupação, caso</column>
+      <column name="definition_fi">asia, juttu, huoli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5901,6 +6547,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Это идиоматическое значение слова {Soj:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是“ {Soj:n:1}”一詞的慣用含義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um significado idiomático da palavra {Soj:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sanan {Soj:n:1} idiomaattinen merkitys. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5911,6 +6558,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5918,6 +6566,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, p.9, Sept. 2003:src}</column>
     </table>
     <table name="mem">
@@ -5931,6 +6580,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">пищевой репликатор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物複製者 [AUTOTRANSLATED]</column>
       <column name="definition_pt">replicador de alimentos</column>
+      <column name="definition_fi">ruokareplikaattori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hap choHwI':n}</column>
@@ -5941,6 +6591,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Это наиболее часто слышимый способ обращения к репликатору, производящему еду. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是提及生產食物的複制器的最常聽到的方式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa é a maneira mais ouvida de se referir a um replicador que produz alimentos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleisimmin kuunneltu tapa viitata ruokaa tuottavaan kopiokoneeseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Soj:n:1}, {choH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5950,6 +6601,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5957,6 +6609,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5970,6 +6623,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">остатки пищи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">剩菜剩飯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sobras de comida</column>
+      <column name="definition_fi">ylijäämäruoka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5980,6 +6634,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Это редко, если еда не была прервана. [1, p.102] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">除非用餐中斷，否則這種情況很少見。[1, p.102] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é raro, a menos que a refeição tenha sido interrompida.[1, p.102] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on harvinaista, ellei ateria keskeytetty[1, p.102] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Soj:n:1}, {chuv:v}</column>
       <column name="examples"></column>
@@ -5989,6 +6644,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5996,6 +6652,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6009,6 +6666,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">палочки для еды [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">筷子</column>
       <column name="definition_pt">chopstick</column>
+      <column name="definition_fi">syömäpuikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6019,6 +6677,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Конечно, {Soj naQmey:n:nolink} всегда используются в парах. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">當然，{Soj naQmey:n:nolink}總是成對使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Obviamente, {Soj naQmey:n:nolink} é sempre usado em pares. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tietenkin {Soj naQmey:n:nolink}: tä käytetään aina pareittain. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Soj:n:1}, {naQ:n:1}</column>
       <column name="examples"></column>
@@ -6028,6 +6687,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6035,6 +6695,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6048,6 +6709,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">хранение продуктов [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物貯藏 [AUTOTRANSLATED]</column>
       <column name="definition_pt">armazenador de alimentos</column>
+      <column name="definition_fi">ruokavarasto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SopmeH pa':n}, {SopwI'pa':n}</column>
@@ -6058,6 +6720,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Это относится к комнате хранения продуктов питания. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指食品儲藏室。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma sala de armazenamento de alimentos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ruokavarastoon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Soj:n:1}, {pol:v}, {-meH:v}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -6067,6 +6730,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6074,6 +6738,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -6087,6 +6752,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">высокая кухня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">高級美食 [AUTOTRANSLATED]</column>
       <column name="definition_pt">culinaria Haute (fina)</column>
+      <column name="definition_fi">haute cuisine, gurmeeruoanlaitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6097,6 +6763,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Это обычно подается только в самых официальных случаях. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">通常僅在最正式的場合下提供此服務。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso geralmente é servido apenas nas ocasiões mais formais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarjoillaan yleensä vain muodollisimmissa tilaisuuksissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Soj:n:1}, {qub:v}</column>
       <column name="examples"></column>
@@ -6106,6 +6773,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6113,6 +6781,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6126,6 +6795,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">продуктовый список [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">購物清單 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lista de compras</column>
+      <column name="definition_fi">ostoslista</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6136,6 +6806,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Глагол для составления такого списка - {gher:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">用於編譯此類列表的動詞是{gher:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O verbo a ser usado para compilar essa lista é {gher:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällaisen luettelon laatimisessa käytettävä verbi on {gher:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Soj:n:1}, {tetlh:n}</column>
       <column name="examples"></column>
@@ -6145,6 +6816,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shopping list</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6152,6 +6824,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.07.09:src} (reprinted in {HQ 8.1, p.8, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -6165,6 +6838,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">сырая, необработанная пища [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">未加工的未加工食品 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alimentos crus e não processados</column>
+      <column name="definition_fi">raaka, käsittelemätön ruoka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoQ:v:1}</column>
@@ -6175,6 +6849,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Refere-se a alimentos aos quais ninguém fez nada.[1, p.84] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ruokaan, johon kukaan ei ole tehnyt mitään[1, p.84] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example appears to be missing a conjunction.</column>
       <column name="components">{Soj:n:1}, {tlhol:v}</column>
       <column name="examples">
@@ -6186,6 +6861,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6193,6 +6869,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 21:src}</column>
     </table>
     <table name="mem">
@@ -6206,6 +6883,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">еда, которая была приготовлена [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">準備好的食物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">comida que não foi preparada</column>
+      <column name="definition_fi">valmistettu ruoka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6216,6 +6894,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Смотрите {KGT p.84:src}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">參見{KGT p.84:src}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {KGT p.84:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {KGT p.84:src}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Soj:n:1}, {vut:v}, {-lu':v}, {-pu':v}, {-bogh:v}</column>
       <column name="examples"></column>
@@ -6225,6 +6904,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6232,6 +6912,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6245,6 +6926,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">Плати за еду! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">支付食物！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Pague pela comida!</column>
+      <column name="definition_fi">Maksa ruoasta!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -6256,6 +6938,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Soj:n:1}, {yI-:v}, {DIl:v}</column>
       <column name="examples"></column>
@@ -6265,6 +6948,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6272,6 +6956,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.191:src}</column>
     </table>
     <table name="mem">
@@ -6285,6 +6970,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">ссора [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吵架 [AUTOTRANSLATED]</column>
       <column name="definition_pt">brigar</column>
+      <column name="definition_fi">riidellä, kinata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoH:v}, {ngach:v}</column>
@@ -6295,6 +6981,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6304,6 +6991,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6311,6 +6999,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6324,6 +7013,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">паруса [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">颿</column>
       <column name="definition_pt">vela</column>
+      <column name="definition_fi">purjehtia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mItlhon:n}, {bIQ Duj:n}, {SuS:n}</column>
@@ -6334,6 +7024,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Soldes" is French for "sales". On English-French bilingual store signs one often sees "Sale / Soldes".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6343,6 +7034,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6350,6 +7042,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -6363,6 +7056,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">корпус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">船殼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">casco</column>
+      <column name="definition_fi">(aluksen tms.) runko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}, {HanDogh:n}, {botjan:n}</column>
@@ -6373,6 +7067,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6382,6 +7077,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6389,6 +7085,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6402,6 +7099,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">инструмент, орудие, инструмент [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">工具、儀器</column>
       <column name="definition_pt">ferramenta, implementar, instrumento</column>
+      <column name="definition_fi">työkalu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jan:n:1}, {vIqraq:n}, {ghevjur:n}, {mupwI':n}</column>
@@ -6412,6 +7110,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6421,6 +7120,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6428,6 +7128,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -6441,6 +7142,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">мускул [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肌肉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">músculo</column>
+      <column name="definition_fi">lihas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hom:n:1}, {Ha'DIbaH:n:1}</column>
@@ -6451,6 +7153,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Some raw" muscle.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6460,6 +7163,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6467,6 +7171,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6480,6 +7185,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">облегчить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">緩解 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aliviar</column>
+      <column name="definition_fi">lievittää, helpottaa; vapauttaa palveluksesta?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6490,6 +7196,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It is unclear whether this verb is used for the relief of pain, anxiety, distress, etc., or for the removal of someone from active duty. If it is used for the latter, then it is related in meaning to {cho':v} and {gheS:v}, and perhaps it also forms the first part of {SonchIy:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6499,6 +7206,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6506,6 +7214,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6519,6 +7228,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">death ritual (for a leader) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">死亡儀式（領導者） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ritual fúnebre (para um líder)</column>
+      <column name="definition_fi">(johtajan) kuolemarituaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Heghtay:n}, {cho'tay:n:hyp}, {'oy'naQ:n}, {nol:n}, {'aQvoH:n}</column>
@@ -6529,6 +7239,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Это церемония, которая предшествует или является начальной частью Обряда наследования (см. {cho'tay:n:hyp}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個儀式，在儀式之前或之後是儀式的初始部分（請參見{cho'tay:n:hyp}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma cerimônia que precede ou é a parte inicial do Rito de Sucessão (consulte {cho'tay:n:hyp}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on seremonia, joka joko edeltää tai on perintöriitin alkuosa (katso {cho'tay:n:hyp}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Perhaps this word is related to {Son:v} and {che':v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6538,6 +7249,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6545,6 +7257,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -6558,6 +7271,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">есть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吃、食</column>
       <column name="definition_pt">comer</column>
+      <column name="definition_fi">syödä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Soj:n:1}, {ghung:v}, {'ep:v:1}, {tlhutlh:v}, {je':v:2}</column>
@@ -6568,6 +7282,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Sup".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6577,6 +7292,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6584,6 +7300,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6597,6 +7314,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">столовая, столовая [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">餐廳、吃飯的房間 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sala de jantar</column>
+      <column name="definition_fi">ruokasali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SopwI'pa':n}, {Soj polmeH pa':n}, {'uQ pa':n}</column>
@@ -6607,6 +7325,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Sop:v}, {-meH:v}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -6616,6 +7335,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6623,6 +7343,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {msn 1997.06.18:src}</column>
     </table>
     <table name="mem">
@@ -6636,6 +7357,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">столовая [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食堂</column>
       <column name="definition_pt">refeitório</column>
+      <column name="definition_fi">ruokala</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SopmeH pa':n}, {Soj polmeH pa':n}</column>
@@ -6646,6 +7368,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Sop:v}, {-wI':v}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -6655,6 +7378,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6662,6 +7386,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6675,6 +7400,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">{Suq:v}</column>
       <column name="definition_zh_HK">{Suq:v}</column>
       <column name="definition_pt">{Suq:v}</column>
+      <column name="definition_fi">{Suq:v}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6685,6 +7411,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Это опечатка для {Suq:v:nolink}, которая появилась в {HQ 6.2:src} в транскрипции {SkyBox 33:src}. Слово написано правильно как {Suq:v:nolink} на самой карте. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{SkyBox 33:src}轉錄中出現在{HQ 6.2:src}中的{Suq:v:nolink}的錯字。該單詞本身在卡上的拼寫正確為{Suq:v:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um erro de digitação para {Suq:v:nolink} que apareceu em {HQ 6.2:src} na transcrição de {SkyBox 33:src}. A palavra está escrita corretamente como {Suq:v:nolink} no próprio cartão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjoitusvirhe {Suq:v:nolink}: lle, joka ilmestyi {HQ 6.2:src}: ssa {SkyBox 33:src}: n transkriptiossa. Sana on kirjoitettu oikein nimellä {Suq:v:nolink} itse kortilla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6694,6 +7421,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6701,6 +7429,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 6.2, p.9, Jun. 1997:src}</column>
     </table>
     <table name="mem">
@@ -6714,6 +7443,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">быть закрытым, закрытым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">關閉</column>
       <column name="definition_pt">ser fechado</column>
+      <column name="definition_fi">olla kiinni, olla suljettu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{poS:v}</column>
       <column name="see_also">{ngaQ:v}</column>
@@ -6724,6 +7454,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6733,6 +7464,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6740,6 +7472,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6753,6 +7486,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">речь, лекция, адрес [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">演講、講座、演講 [AUTOTRANSLATED]</column>
       <column name="definition_pt">discurso, palestra</column>
+      <column name="definition_fi">puhe, luento, puheenvuoro</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jatlh:v}</column>
@@ -6763,6 +7497,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru">Не путайте это слово с {QIch:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">不要將此詞與{QIch:n}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda esta palavra com {QIch:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Älä sekoita tätä sanaa sanaan {QIch:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Socr"ates.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6772,6 +7507,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6779,6 +7515,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6792,6 +7529,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">закрыть, закрыть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">閂（門）、關閉</column>
       <column name="definition_pt">fechar</column>
+      <column name="definition_fi">sulkea</column>
       <column name="synonyms"></column>
       <column name="antonyms">{poSmoH:v}</column>
       <column name="see_also"></column>
@@ -6802,6 +7540,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{SoQ:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -6811,6 +7550,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6818,6 +7558,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6831,6 +7572,7 @@ Detta ord bär den idiomatiska betydelsen av "materia, oro, affär", för vilka 
       <column name="definition_ru">дерево [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">樹</column>
       <column name="definition_pt">árvore</column>
+      <column name="definition_fi">puu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lav:n}, {por:n}, {bartIq:n}, {Qechjem'a':n}, {tI:n}, {perletlh:n}</column>
@@ -6851,6 +7593,9 @@ Detta ord kan också hänvisa till "club" -dräkten i ett spellekskort (se {Degh
       <column name="notes_pt">Existe um idioma, {lugh; Sor rur@@lugh:v, Sor:n, rur:v}, que está conectado ao verbo {Sor:v}.
 
 Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas (ver {Degh:n:1}) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Versioon {Sor:v} liittyy idioomi {lugh; Sor rur@@lugh:v, Sor:n, rur:v}.
+
+Tämä sana voi viitata myös "klubipukuun" pelikorttipakassa (katso {Degh:n:1}).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6860,6 +7605,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6867,6 +7613,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -6880,6 +7627,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">говорить неметафорически [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">非隱喻地說 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falar não metaforicamente</column>
+      <column name="definition_fi">puhua ilman vertauskuvia</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SorHa':v}</column>
       <column name="see_also"></column>
@@ -6890,6 +7638,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru">Этот глагол связан с идиомой {lugh; Sor rur@@lugh:v, Sor:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞與成語{lugh; Sor rur@@lugh:v, Sor:n, rur:v}相關。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo está conectado ao idioma {lugh; Sor rur@@lugh:v, Sor:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi liittyy idioomiin {lugh; Sor rur@@lugh:v, Sor:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Shore" = "littoral" = "literal".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6899,6 +7648,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6906,6 +7656,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2013.07.29:src}</column>
     </table>
     <table name="mem">
@@ -6919,6 +7670,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">говорить метафорически [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">說話比喻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falar metaforicamente</column>
+      <column name="definition_fi">puhua vertauskuvallisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Sor:v}</column>
       <column name="see_also"></column>
@@ -6929,6 +7681,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Sor:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -6938,6 +7691,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6945,6 +7699,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2013.07.29:src}</column>
     </table>
     <table name="mem">
@@ -6958,6 +7713,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">дерево [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">木、木材</column>
       <column name="definition_pt">madeira</column>
+      <column name="definition_fi">puu (aine)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baS:n}, {mep:n}, {'al'on:n}</column>
@@ -6968,6 +7724,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Sor:n}, {Hap:n}</column>
       <column name="examples"></column>
@@ -6977,6 +7734,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6984,6 +7742,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6997,6 +7756,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">деревянный барабан [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">木鼓</column>
       <column name="definition_pt">tambor de madeira</column>
+      <column name="definition_fi">puurumpu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'In:n}</column>
@@ -7007,6 +7767,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru">Одним из видов {Sor Hap 'In:n} является трубка, которая открыта на обоих концах, с продольной прорезью, которая не проходит весь путь до конца, и которая поражена {mupwI'Hom:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一種{Sor Hap 'In:n}是兩端開口的管，縱向狹縫沒有一直延伸到兩端，並被{mupwI'Hom:n}擊中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um tipo de {Sor Hap 'In:n} é um tubo aberto nas duas extremidades, com uma fenda longitudinal que não chega até as extremidades e que é atingida com um {mupwI'Hom:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Eräänlainen {Sor Hap 'In:n} on putki, joka on avoin molemmista päistä, ja jossa on pitkittäinen rako, joka ei mene kokonaan kumpaakaan päähän, ja johon lyödään {mupwI'Hom:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Sor Hap:n}, {'In:n}</column>
       <column name="examples"></column>
@@ -7016,6 +7777,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7023,6 +7785,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.75:src}</column>
     </table>
     <table name="mem">
@@ -7036,6 +7799,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">саботаж [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">破壞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sabotar</column>
+      <column name="definition_fi">sabotoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7046,6 +7810,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7055,6 +7820,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7062,6 +7828,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7075,6 +7842,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">медь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">銅</column>
       <column name="definition_pt">cobre</column>
+      <column name="definition_fi">kupari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}, {jey' Sorpuq:n}</column>
@@ -7085,6 +7853,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is "kupros" backwards, a reference to "Cyprus" which is the origin of the English word "copper".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7094,6 +7863,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7101,6 +7871,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -7114,6 +7885,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">Sauria [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蜥蜴亞目 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sauria</column>
+      <column name="definition_fi">Sauria</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7124,6 +7896,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7133,6 +7906,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7140,6 +7914,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7153,6 +7928,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">Саурский бренди [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Saurian白蘭地 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Conhaque sauriano</column>
+      <column name="definition_fi">saurialainen brandy</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7163,6 +7939,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{KGT p.95:src}</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7172,6 +7949,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7179,6 +7957,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7192,6 +7971,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">мама [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">母親</column>
       <column name="definition_pt">mãe</column>
+      <column name="definition_fi">äiti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vav:n}, {SoSoy:n}, {'emrIgh:n}, {qaytu':n}</column>
@@ -7202,6 +7982,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru">Братьями {SoS:n:nolink} являются {me':n} и {'IrneH:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{SoS:n:nolink}的兄弟姐妹是{me':n}和{'IrneH:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os irmãos de um {SoS:n:nolink} são {me':n} e {'IrneH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{SoS:n:nolink}: n sisarukset ovat {me':n} ja {'IrneH:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The joke with {vav:n:nolink} and {SoS:n:nolink} is that in most human languages, the words for "father" and "mother" contain simple labial sounds (typically either "b" or "p" for father, and "m" for mother), whereas the fricatives {v:sen:nolink} and {S:sen:nolink} are difficult sounds for human infants to make. Also, "SOS" is an internationally recognised distress signal.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7211,6 +7992,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7218,6 +8000,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -7232,6 +8015,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
           <column name="definition_ru">мамочка [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">媽媽 [AUTOTRANSLATED]</column>
           <column name="definition_pt">mamãe</column>
+      <column name="definition_fi">äiti (hellittelynimi)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{vavoy:n}</column>
@@ -7242,6 +8026,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{SoS:n}, {-oy:n}</column>
           <column name="examples"></column>
@@ -7251,6 +8036,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7258,6 +8044,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -7271,6 +8058,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">основное ядро [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">主要核心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">núcleo principal</column>
+      <column name="definition_fi">(tietokoneen) pääydin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoSbor:n:hyp}</column>
@@ -7281,6 +8069,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru">Известно только от {De'wI' SoSbor'a':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">僅從{De'wI' SoSbor'a':n}已知。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Conhecido apenas em {De'wI' SoSbor'a':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tunnetaan vain {De'wI' SoSbor'a':n}-tiedostosta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7290,6 +8079,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7297,6 +8087,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -7310,6 +8101,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">бабушка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">祖母 [AUTOTRANSLATED]</column>
       <column name="definition_pt">avó</column>
+      <column name="definition_fi">isoäiti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vavnI':n}, {'emrIgh:n}</column>
@@ -7320,6 +8112,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7329,6 +8122,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7336,6 +8130,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7349,6 +8144,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">нож матери [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">媽媽的刀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">faca de mãe</column>
+      <column name="definition_fi">eräs veitsi, äidin veitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7359,6 +8155,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{SoS:n}, {taj:n}</column>
       <column name="examples"></column>
@@ -7368,6 +8165,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7375,6 +8173,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -7388,6 +8187,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">быть в беде, быть в беде [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">心疼、陷入困境 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar em apuros, estar angustiado</column>
+      <column name="definition_fi">olla hädänalainen, olla ahdingossa, hädässä, olla avun tarpeessa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QaH:v}, {boQ:v}, {Sotlaw':n}</column>
@@ -7398,6 +8198,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7407,6 +8208,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7414,6 +8216,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7427,6 +8230,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">сигнал бедствия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">求救電話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pedido de socorro</column>
+      <column name="definition_fi">hätäpuhelu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sot:v}</column>
@@ -7437,6 +8241,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Someone is "apparently in distress" ({Sotlaw':sen@@Sot:v, -law':v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7446,6 +8251,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7453,6 +8259,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7466,6 +8273,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">знать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">知道、認識</column>
       <column name="definition_pt">saber</column>
+      <column name="definition_fi">tietää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jIv:v}</column>
       <column name="see_also">{ghov:v}, {jIv:v}, {loy:v}, {Har:v}, {Sov:n}</column>
@@ -7476,6 +8284,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">該動詞可以將{'e':n:pro}作為對象。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo pode usar {'e':n:pro} como seu objeto.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi voi ottaa objektiksi {'e':n:pro}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7486,6 +8295,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7493,6 +8303,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.07.01:src} (reprinted in {HQ 7.2, p.8, Jun. 1998:src})</column>
     </table>
     <table name="mem">
@@ -7506,6 +8317,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">знание [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">知識</column>
       <column name="definition_pt">conhecimento</column>
+      <column name="definition_fi">tieto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngoD:n}, {potlh:n}, {De':n}, {Sov:v}</column>
@@ -7516,6 +8328,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7525,6 +8338,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7532,6 +8346,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7545,6 +8360,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">быть неуклюжим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">笨手笨腳 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desajeitado</column>
+      <column name="definition_fi">olla kömpelö</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mor:v}</column>
       <column name="see_also">{jat:v:2,reg}</column>
@@ -7555,6 +8371,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7564,6 +8381,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7571,6 +8389,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7584,6 +8403,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">быть грязным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">很亂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser bagunçad</column>
+      <column name="definition_fi">olla sotkuinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7594,6 +8414,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="notes_ru">В диалекте {ruq'e'vet:n} это слово используется вместо {ghIH:v:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{ruq'e'vet:n}方言中，使用此詞代替{ghIH:v:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No dialeto {ruq'e'vet:n}, essa palavra é usada em vez de {ghIH:v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{ruq'e'vet:n}-murteessa tätä sanaa käytetään {ghIH:v:1}-sanan sijaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7603,6 +8424,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7610,6 +8432,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7623,6 +8446,7 @@ Esta palavra também pode se referir ao naipe de "clube" em um baralho de cartas
       <column name="definition_ru">прятаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">隱藏，披風 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esconder, camuflar</column>
+      <column name="definition_fi">piiloutua, verhoutua; piilottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{So'Ha':v:1}</column>
       <column name="see_also"></column>
@@ -7635,6 +8459,9 @@ This verb is also used for the encryption of data (see {So':v:2}).</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Jos kohdetta ei ole, piiloutuu aihe (esim. {NuqDaq So'taH yaS?: Sen: nolink} [1]). Jos objektia on, kohde piilottaa objektin (esim. {Duj So':sen:nolink} tai {Duj So'lu'pu':sen:nolink}[2]).
+
+Tätä verbiä käytetään myös tietojen salaamiseen (katso {So':v:2}).{nuqDaq So'taH yaS?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Show".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7644,6 +8471,7 @@ This verb is also used for the encryption of data (see {So':v:2}).</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7651,6 +8479,7 @@ This verb is also used for the encryption of data (see {So':v:2}).</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.69:src}, [2] {KGT p.55:src}</column>
     </table>
     <table name="mem">
@@ -7664,6 +8493,7 @@ This verb is also used for the encryption of data (see {So':v:2}).</column>
       <column name="definition_ru">шифровать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">加密 [AUTOTRANSLATED]</column>
       <column name="definition_pt">criptografar</column>
+      <column name="definition_fi">salata (salausmenetelmällä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{So'Ha':v:2}</column>
       <column name="see_also">{meS:v:2}, {pegh:v:1}</column>
@@ -7674,6 +8504,7 @@ This verb is also used for the encryption of data (see {So':v:2}).</column>
       <column name="notes_ru">Это просто приложение {So':v:1} к данным. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是{So':v:1}對數據的應用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é apenas um aplicativo de {So':v:1} para dados. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain {So':v:1} -sovelluksen tietoja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Show".
 
 Despite the English definition, it may be the case that the grammar follows {So':v:1,nolink}, and that the subject is encrypted if there is no object.</column>
@@ -7685,6 +8516,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7692,6 +8524,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
         <table name="mem">
@@ -7705,6 +8538,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="definition_ru">показать, деклоак [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">取消隱藏，隱藏 [AUTOTRANSLATED]</column>
           <column name="definition_pt">exibir, descamuflar</column>
+      <column name="definition_fi">paljastaa itsensä, poistaa verhoutuminen; paljastaa jokin (piilotettu)</column>
           <column name="synonyms"></column>
           <column name="antonyms">{So':v:1}</column>
           <column name="see_also">{So'wI' yIchu'Ha'!:sen}</column>
@@ -7715,6 +8549,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="notes_ru">Этот глагол также используется для дешифрования данных (см. {So'Ha':v:2}). [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">此動詞還用於數據解密（請參閱{So'Ha':v:2}）。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este verbo também é usado para a descriptografia de dados (consulte {So'Ha':v:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös tietojen salauksen purkamiseen (katso {So'Ha':v:2}). [AUTOTRANSLATED]</column>
           <column name="hidden_notes">This is not defined in canon, but is an obvious construction and is spoken in {Star Trek III:src} and {Star Trek V:src}.</column>
           <column name="components">{So':v:1}, {-Ha':v}</column>
           <column name="examples">
@@ -7725,6 +8560,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">uncloak</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7732,6 +8568,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Star Trek III:src}</column>
         </table>
         <table name="mem">
@@ -7745,6 +8582,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="definition_ru">расшифровывать [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">解密 [AUTOTRANSLATED]</column>
           <column name="definition_pt">decifrar</column>
+      <column name="definition_fi">purkaa (salaus)</column>
           <column name="synonyms"></column>
           <column name="antonyms">{So':v:2}</column>
           <column name="see_also">{baghHa':v}, {meSHa':v:2}</column>
@@ -7755,6 +8593,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="notes_ru">Это всего лишь приложение {So'Ha':v:1} к данным. Когда этот термин используется для расшифровки данных, это означает, что дешифрование разрешено, и способ сделать это известен.[1] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這只是{So'Ha':v:1}對數據的應用。當將此術語用於數據解密時，它意味著解密已被授權並且知道解密的方式.[1] [AUTOTRANSLATED]</column>
           <column name="notes_pt">Este é apenas um aplicativo de {So'Ha':v:1} para dados. Quando esse termo é usado para a descriptografia de dados, isso implica que a descriptografia está autorizada e a maneira de fazê-lo é conhecida.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain {So'Ha':v:1} -sovelluksen tietoja. Kun tätä termiä käytetään tietojen salauksen purkamiseen, se tarkoittaa, että salauksen purku on sallittu ja tapa tapa tehdä se tiedetään.[1] [AUTOTRANSLATED]</column>
           <column name="hidden_notes">Despite the English definition, it may be the case that the grammar follows {So':v:1,nolink}, and that the subject is decrypted if there is no object.</column>
           <column name="components">{So':v:2}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -7764,6 +8603,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7771,6 +8611,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
         </table>
         <table name="mem">
@@ -7784,6 +8625,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="definition_ru">маскировочное устройство [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">隱形罩</column>
           <column name="definition_pt">dispositivo de camuflagem</column>
+      <column name="definition_fi">verhoutumislaite</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7794,6 +8636,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">On {SkyBox 33:src}, the last two Klingon sentences were not translated into English: "A cloaking device which didn't disrupt weaponry was installed in one experimental ship. This ship was demonstrated on Stardate 9521.6 but it was destroyed."</column>
           <column name="components">{So':v:1}, {-wI':v}</column>
           <column name="examples">
@@ -7807,6 +8650,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7814,6 +8658,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}, [2] {SkyBox 33:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
         </table>
         <table name="mem">
@@ -7827,6 +8672,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="definition_ru">плащевой массив [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">斗篷陣 [AUTOTRANSLATED]</column>
           <column name="definition_pt">matriz de camuflagem</column>
+      <column name="definition_fi">verhoutumislaitesarja</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -7837,6 +8683,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{So'wI':n}, {DaH:n}</column>
           <column name="examples"></column>
@@ -7846,6 +8693,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7853,6 +8701,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {BoP:src}</column>
         </table>
         <table name="mem">
@@ -7866,6 +8715,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="definition_ru">Включите маскирующее устройство! [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">啟動隱形裝置！</column>
           <column name="definition_pt">Ativar o dispositivo de camuflagem!</column>
+      <column name="definition_fi">Aktivoi verhoutumislaite!</column>
           <column name="synonyms"></column>
           <column name="antonyms">{So'wI' yIchu'Ha'!:sen}</column>
           <column name="see_also">{yISo'rup.:sen}</column>
@@ -7876,6 +8726,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/BpdgUluBJOQ} [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/BpdgUluBJOQ} [AUTOTRANSLATED]</column>
           <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/BpdgUluBJOQ} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/BpdgUluBJOQ} [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{So'wI':n}, {yI-:v}, {chu':v:2}</column>
           <column name="examples"></column>
@@ -7885,6 +8736,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7892,6 +8744,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD p.60:src}</column>
         </table>
         <table name="mem">
@@ -7905,6 +8758,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="definition_ru">Отключить маскировочное устройство! [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">解除隱形罩！</column>
           <column name="definition_pt">Desativar dispositivo de camuflagem!</column>
+      <column name="definition_fi">Sulje verhoutumislaite!</column>
           <column name="synonyms"></column>
           <column name="antonyms">{So'wI' yIchu'!:sen}</column>
           <column name="see_also">{So'Ha':v:1}, {yISo'Ha'rup, yIghuS.:sen}</column>
@@ -7915,6 +8769,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{So'wI':n}, {yI-:v}, {chu':v:2}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -7924,6 +8779,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7931,6 +8787,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Star Trek III:src}</column>
         </table>
     <table name="mem">
@@ -7944,6 +8801,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">SOH-Хим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蘇志 [AUTOTRANSLATED]</column>
       <column name="definition_pt">soh-chim</column>
+      <column name="definition_fi">eräs kummia muistuttava sovittu sukulaisuussuhde, soh-chim</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7954,6 +8812,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">與之最接近的是繼父或繼母，其作用類似於教父。該角色被授予一個家庭朋友，如果父母無行為能力，該朋友將照看孩子。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A aproximação mais próxima a isto é uma espécie de meio-irmão ou meia-irmã, cujo papel é semelhante ao de um padrinho. O papel é conferido a um amigo da família que cuidaria de uma criança se seus pais fossem incapacitados[2].</column>
+      <column name="notes_fi">Lähin arvio tästä on eräänlainen velipuoli tai sisarpuoli, jonka rooli on samanlainen kuin ristivanhemman. Rooli annetaan perheen ystävälle, joka hoitaisi lasta, jos heidän vanhempansa eivät olisi kykeneviä toimintaan.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7963,6 +8822,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7970,6 +8830,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}, [2] {TNG - Parallels:src}</column>
     </table>
     <table name="mem">
@@ -7983,6 +8844,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">Вы (множественное число) - нет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你們：無</column>
       <column name="definition_pt">vocês-nenhum</column>
+      <column name="definition_fi">te-ei mitään</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bI-:v:pref}, {bo-:v:pref}, {pe-:v:pref}</column>
@@ -7993,6 +8855,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{tlhIH:n}: {pagh:n:1h} = {Su-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8002,6 +8865,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">you-none</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8009,6 +8873,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8022,6 +8887,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">быть твердым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要堅實 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser sólido</column>
+      <column name="definition_fi">olla kiinteä, vankka?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lep:n}, {ngoS:v}, {taS:n}, {let:v}, {Sub:v:2}</column>
@@ -8032,6 +8898,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8041,6 +8908,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8048,6 +8916,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8061,6 +8930,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">будь смелым, будь героическим, будь смелым, будь доблестным, будь бесстрашным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勇敢、勇敢、勇敢、勇敢、勇敢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser corajoso, ser heroico, ser intrépido</column>
+      <column name="definition_fi">olla rohkea, urhea, sankarillinen, peloton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sub:n}, {Sub:v:1}</column>
@@ -8071,6 +8941,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This appears several times in the E-K word list under variations of the listed definitions (different orders and subsets of the terms).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8080,6 +8951,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8087,6 +8959,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8100,6 +8973,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">герой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">英雄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">herói</column>
+      <column name="definition_fi">sankari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ho':n:2,slang}, {Sub:v:2}</column>
@@ -8110,6 +8984,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "sub" (submarine sandwich) is also called a "hero" in some places. Also, "sub" is the opposite of "super" as in "superhero".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8119,6 +8994,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8126,6 +9002,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8139,6 +9016,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">доля, отношение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">分數、比率 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fração, proporção, razão</column>
+      <column name="definition_fi">murtoluku, osamäärä, suhde</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Se':n}</column>
@@ -8149,6 +9027,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru">Это также может использоваться для обозначения «частоты» в таких конструкциях, как {wanI' SubmaH:n} или {yay SubmaH:n}. См. {pe''egh:v}, чтобы узнать, как сказать что-то вроде «4 из 5 баллов». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{wanI' SubmaH:n}或{yay SubmaH:n}等結構中，這也可以用來表示“頻率”。有關如何說“ 5分中的4分”之類的內容，請參見{pe''egh:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser usado para significar "frequência" em construções como {wanI' SubmaH:n} ou {yay SubmaH:n}. Consulte {pe''egh:v} para obter uma explicação sobre como dizer algo como "4 de 5 pontos". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää myös tarkoittamaan "taajuutta" sellaisissa rakenteissa kuin {wanI' SubmaH:n} tai {yay SubmaH:n}. Katso {pe''egh:v} selitys siitä, kuinka sanoa jotain "4/5 pistettä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The slash used to separate the parts of a fraction is called the "solidus" ({Sub:v:1}, {maH:n:1}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8158,6 +9037,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">frequency</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8165,6 +9045,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -8178,6 +9059,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">Зал Героев [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">英雄殿堂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Salão dos Heróis</column>
+      <column name="definition_fi">Sankareiden sali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8188,6 +9070,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Sub:n}, {-pu':n}, {vaS:n}</column>
       <column name="examples"></column>
@@ -8197,6 +9080,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8204,6 +9088,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8217,6 +9102,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">посещение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">訪問 [AUTOTRANSLATED]</column>
       <column name="definition_pt">visitar</column>
+      <column name="definition_fi">vierailla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIQ:v}, {leng:v}, {Sum:v}, {Hop:v}</column>
@@ -8227,6 +9113,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The German verb for "to visit" is "besuchen".</column>
       <column name="components"></column>
       <column name="examples">
@@ -8238,6 +9125,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">see</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8245,6 +9133,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}, [3] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -8258,6 +9147,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">мечта, галлюцинация [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">幻夢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sonho, alucinação</column>
+      <column name="definition_fi">uni, hallusinaatio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naj:v}, {'ergh:v}, {luvnup:n}</column>
@@ -8268,6 +9158,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru">Это относится к сну, который приходит во сне, а не в смысле надежды, цели или желания. Он также используется для обозначения галлюцинаций.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指夢境發生在睡覺時而不是在希望，目標或慾望的意義上。它也用於指幻覺.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um sonho que ocorre quando a pessoa está dormindo, e não no sentido de esperança, objetivo ou desejo. Também é usado para se referir a uma alucinação.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa uneen, joka tapahtuu nukkuessa eikä toivon, tavoitteen tai halun merkityksessä. Sitä käytetään myös viittaamaan hallusinaatioihin[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was confirmed at {qep'a' 27 (2020):src} during the Q &amp; A session.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8277,6 +9168,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8284,6 +9176,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -8297,6 +9190,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">быть зеленым, синим, желтым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">綠色、藍色、黃色</column>
       <column name="definition_pt">ser verde, azul, amarelo</column>
+      <column name="definition_fi">olla vihreä, sininen, keltainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Doq:v}, {nguv:v}, {SuD:v:2}</column>
@@ -8307,6 +9201,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru">Слово {SuDqu':v@@SuD:v:1, -qu':v}, вероятно, можно было бы описать как «зеленый». {SuD 'ej wov:sen@@SuD:v:1, 'ej:conj, wov:v} имеет желтоватый оттенок. (Также слышен {SuD 'ach wov:sen@@SuD:v:1, 'ach:conj, wov:v}.) [2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">單詞{SuDqu':v@@SuD:v:1, -qu':v}可能被描述為“綠色”。 {SuD 'ej wov:sen@@SuD:v:1, 'ej:conj, wov:v}指淡黃色。 （也聽到了{SuD 'ach wov:sen@@SuD:v:1, 'ach:conj, wov:v}。）[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra {SuDqu':v@@SuD:v:1, -qu':v} provavelmente seria descrita como "verde". {SuD 'ej wov:sen@@SuD:v:1, 'ej:conj, wov:v} refere-se a uma coloração amarelada. ({SuD 'ach wov:sen@@SuD:v:1, 'ach:conj, wov:v} também é ouvido.) [2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sana {SuDqu':v@@SuD:v:1, -qu':v} olisi todennäköisesti kuvattu "vihreäksi". {SuD 'ej wov:sen@@SuD:v:1, 'ej:conj, wov:v} viittaa kellertävään sävyyn. (Myös {SuD 'ach wov:sen@@SuD:v:1, 'ach:conj, wov:v} kuuluu.) [2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">All natural languages found on Earth divide colours into "warm" and "cool" in the same way. Klingon distinguishes between {Doq:v} and {SuD:v:1,nolink}, but it groups "yellow" with the "cool" colours rather than with the "warm" colours.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8320,6 +9215,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8327,6 +9223,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.82:src}, [3] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8340,6 +9237,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">играть, рисковать, рисковать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">賭博、抓住機會、冒險 [AUTOTRANSLATED]</column>
       <column name="definition_pt">jogar, arriscar</column>
+      <column name="definition_fi">uhkapelata, ottaa riski</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI' nagh:n}, {SuD:v:1}, {Haw:v}, {'al:v:2}</column>
@@ -8350,6 +9248,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The example was placed here deliberately rather than in the {SuD:v:1} "be green" entry.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8360,6 +9259,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">random</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8367,6 +9267,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {PK:src}</column>
     </table>
     <table name="mem">
@@ -8380,6 +9281,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">Кто-то ревнует. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有人嫉妒。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Alguém está com ciúmes.</column>
+      <column name="definition_fi">Joku on kateellinen.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{veqlargh:n}, {ghal:v}</column>
@@ -8390,6 +9292,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru">Буквальное значение этого идиоматического выражения - «глаза Фек'лра зеленые». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是“費克爾的眼睛是綠色的”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O significado literal dessa expressão idiomática é "os olhos de Fek'lhr são verdes". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän idiomaattisen ilmaisun kirjaimellinen merkitys on "Fek'lhrin silmät ovat vihreitä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{SuD:v:1}, {veqlargh:n}, {mIn:n}, {-Du':n}</column>
       <column name="examples"></column>
@@ -8399,6 +9302,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8406,6 +9310,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.4, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -8419,6 +9324,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">установить (в офисе) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">安裝（在辦公室） [AUTOTRANSLATED]</column>
       <column name="definition_pt">instalar (no escritório)</column>
+      <column name="definition_fi">asettaa (virkaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cho':v}, {gheS:v}</column>
@@ -8429,6 +9335,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8444,6 +9351,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8451,6 +9359,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {paq'batlh p.178-179:src}</column>
     </table>
     <table name="mem">
@@ -8464,6 +9373,7 @@ Despite the English definition, it may be the case that the grammar follows {So'
       <column name="definition_ru">готов, готов [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">準備好、站在旁邊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pronto, aguardando</column>
+      <column name="definition_fi">olen valmis, odotan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eH:excl}</column>
@@ -8488,6 +9398,9 @@ Denna utrop utesluter att talaren håller på att ge ett kommando eller är redo
       <column name="notes_pt">Isso também é escrito como {Su':excl:nolink}. Alguns falantes do klingon pronunciam essa palavra como se fosse {SSS:excl:nolink}.
 
 Esta exclamação indica que o falante está prestes a dar um comando, ou está pronto para fazer algo ou que foram feitos preparativos para que algo aconteça. ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kirjoitetaan myös nimellä {Su':excl:nolink}. Jotkut klingonilaiset puhuvat tämän sanan ikään kuin se olisi {SSS:excl:nolink}.
+
+Tämä huutomerkki osoittaa, että puhuja on antamassa komentoa, tai on valmis tekemään jotain tai että jotain on tapahtunut. ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8497,6 +9410,7 @@ Esta exclamação indica que o falante está prestes a dar um comando, ou está 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8504,6 +9418,7 @@ Esta exclamação indica que o falante está prestes a dar um comando, ou está 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8517,6 +9432,7 @@ Esta exclamação indica que o falante está prestes a dar um comando, ou está 
       <column name="definition_ru">беспокоить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">騷擾、打擾</column>
       <column name="definition_pt">perturbar</column>
+      <column name="definition_fi">häiritä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qagh:v}</column>
@@ -8527,6 +9443,7 @@ Esta exclamação indica que o falante está prestes a dar um comando, ou está 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8537,6 +9454,7 @@ Esta exclamação indica que o falante está prestes a dar um comando, ou está 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8544,6 +9462,7 @@ Esta exclamação indica que o falante está prestes a dar um comando, ou está 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8557,6 +9476,7 @@ Esta exclamação indica que o falante está prestes a dar um comando, ou está 
       <column name="definition_ru">быть рядом, быть рядом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">靠近、就在附近 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar perto, estar próximo</column>
+      <column name="definition_fi">olla lähellä, olla läheinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hop:v}</column>
       <column name="see_also">{chol:v}, {chuq:n}</column>
@@ -8577,6 +9497,9 @@ Uttrycket {jISum:sen:nolink} har en idiomatisk filosofisk betydelse, "Jag är i 
       <column name="notes_pt">O uso desta palavra envolve o conceito de dêixis. Geralmente indica que o sujeito está perto do locutor, a menos que o contexto seja configurado para indicar que a ação está ocorrendo em outro lugar (por exemplo, usando {-Daq:n}). O sufixo {-chuq:v} não é usado com este verbo.[2]
 
 A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Estou em contato com meu eu interior" (à maneira Klingon) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan käyttöön liittyy deixiksen käsite. Yleensä se tarkoittaa, että kohde on puhujan lähellä, ellei kontekstia ole asetettu osoittamaan, että toiminta tapahtuu muualla (esimerkiksi käyttämällä {-Daq:n}-toimintoa). Laajennusta {-chuq:v} ei käytetä tässä verbissä.[2]
+
+Ilmaisulla {jISum:sen:nolink} on idiomaattinen filosofinen merkitys: "Olen yhteydessä sisäiseen minääni" (klingonin tapaan).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">When you "zoom in" on something, it looks much closer.</column>
       <column name="components"></column>
       <column name="examples">
@@ -8587,6 +9510,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">close</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8594,6 +9518,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 7.4, p.9-10, Dec. 1998:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -8607,6 +9532,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">дисциплина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">學科 [AUTOTRANSLATED]</column>
       <column name="definition_pt">disciplina</column>
+      <column name="definition_fi">kurinalaisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8617,6 +9543,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8626,6 +9553,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8633,6 +9561,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8646,6 +9575,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">пыльца [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">花粉</column>
       <column name="definition_pt">pólen</column>
+      <column name="definition_fi">siitepöly</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhar:v}</column>
@@ -8656,6 +9586,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Gesundheit."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8665,6 +9596,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8672,6 +9604,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -8685,6 +9618,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">родной [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">本地人</column>
       <column name="definition_pt">nativo</column>
+      <column name="definition_fi">syntyperäinen asukas, paikallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nov:n}, {Hur'Iq:n}</column>
       <column name="see_also">{rewbe':n}, {ngan:n}</column>
@@ -8695,6 +9629,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8704,6 +9639,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">local</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8711,6 +9647,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8724,6 +9661,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">Прыгать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">跳</column>
       <column name="definition_pt">saltar</column>
+      <column name="definition_fi">hypätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8734,6 +9672,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Sup"erman can jump higher than a building.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8743,6 +9682,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">leap</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8750,6 +9690,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8763,6 +9704,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">ресурс</column>
       <column name="definition_zh_HK">資源（單數）</column>
       <column name="definition_pt">recurso</column>
+      <column name="definition_fi">resurssi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIl:v}, {tlhIl:n}</column>
@@ -8773,6 +9715,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jo:n:inhpl}</column>
       <column name="examples"></column>
@@ -8782,6 +9725,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8789,6 +9733,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8802,6 +9747,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">хлопкоподобное растение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">棉樣植物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">planta semelhate ao algodão</column>
+      <column name="definition_fi">eräs puuvillaa muistuttava kasvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8812,6 +9758,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru">Это клингонское растение, части которого используются для изготовления ткани. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是克林崗工廠，部分工廠用於製布。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma planta Klingon, cujas partes são usadas para fazer roupas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Klingonin tehdas, jonka osista valmistetaan kangasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The song "Pick a Bale of Cotton" has lyrics that go "Gonna jump ({Sup:v}) down, spin ({DIng:v}) around / Pick a bale of cotton."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8821,6 +9768,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8828,6 +9776,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -8841,6 +9790,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">Вид струнного музыкального инструмента</column>
       <column name="definition_zh_HK">弦樂器的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de instrumento de cordas</column>
+      <column name="definition_fi">eräs kielisoitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pang:v}, {yach:v:2}, {Heng:v}</column>
@@ -8851,6 +9801,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru">Это тип {HurDagh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種{HurDagh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de {HurDagh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen {HurDagh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The word "ukelele" means "jumping flea" in Hawaiian.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8860,6 +9811,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ukelele</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8867,6 +9819,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8880,6 +9833,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">приобретать, получать, получать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">獲得、獲得、得到 [AUTOTRANSLATED]</column>
       <column name="definition_pt">adquirir, obter, pegar</column>
+      <column name="definition_fi">hankkia, saada</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8890,6 +9844,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is translated as "gain" on {SkyBox 33:src}.[2]</column>
       <column name="components"></column>
       <column name="examples">
@@ -8900,6 +9855,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gain</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8907,6 +9863,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 33:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -8920,6 +9877,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">готовить куд определенным образом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">以特定的方式準備kud [AUTOTRANSLATED]</column>
       <column name="definition_pt">preparar kud de uma maneira específica</column>
+      <column name="definition_fi">valmistaa kudia eräällä tietyllä tavalla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Su'lop:n}, {quD:n}</column>
@@ -8930,6 +9888,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru">Смотрите {KGT p.91:src}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">參見{KGT p.91:src}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {KGT p.91:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {KGT p.91:src}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Suq:v}, {-qa':v}</column>
       <column name="examples"></column>
@@ -8939,6 +9898,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8946,6 +9906,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8959,6 +9920,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">ядро [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">核心</column>
       <column name="definition_pt">testemunho</column>
+      <column name="definition_fi">ydin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8969,6 +9931,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru">Это может быть использовано для ядра яблока, планеты или Солнца. Но он не используется для обозначения ядра группы, которое называется {qolqoS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能用於蘋果，行星或太陽的核心。但這不是用來指代組的核心，即{qolqoS:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para o núcleo de uma maçã, um planeta ou o sol. Mas não é usado para se referir ao núcleo de um grupo, que é {qolqoS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää omenan, planeetan tai auringon ytimeen. Mutta sitä ei käytetä viittaamaan ryhmän ytimeen, joka on {qolqoS:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Viscous"?</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8978,6 +9941,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8985,6 +9949,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -8998,6 +9963,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">быть токсичным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有毒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser tóxico</column>
+      <column name="definition_fi">olla myrkyllinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tar:n}, {lam:v}</column>
@@ -9008,6 +9974,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9017,6 +9984,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9024,6 +9992,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9037,6 +10006,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">Силовое поле</column>
       <column name="definition_zh_HK">力場</column>
       <column name="definition_pt">campo de força</column>
+      <column name="definition_fi">voimakenttä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{botjan:n}, {HoSchem:n}, {peQchem:n}, {pIvchem:n}, {tlhamchem:n}</column>
@@ -9047,6 +10017,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Surma':n}, {chem:n:hyp}</column>
       <column name="examples"></column>
@@ -9056,6 +10027,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9063,6 +10035,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9076,6 +10049,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">кожа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">皮膚 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pele</column>
+      <column name="definition_fi">nylkeä, kuoria</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIr:n}</column>
@@ -9086,6 +10060,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Skin surgery".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9095,6 +10070,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9102,6 +10078,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9115,6 +10092,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">force (physics concept) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">力（物理概念） [AUTOTRANSLATED]</column>
       <column name="definition_pt">força (conceito de física)</column>
+      <column name="definition_fi">voima (fysiikka)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Surmen:n}, {wa'lay:n}</column>
@@ -9125,6 +10103,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Based on back-derivation from {Surchem:n}, "force" would've been {Sur:n:hyp,nolink}. The other part is from "F = ma".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9134,6 +10113,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9141,6 +10121,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9154,6 +10135,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">давление [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">壓力</column>
       <column name="definition_pt">pressão</column>
+      <column name="definition_fi">paine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Surma':n}</column>
@@ -9164,6 +10146,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru">Это физический термин. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個物理術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo da física. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on fysiikan termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Force ({Surma':n}) applied per unit area ({men:v}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9173,6 +10156,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9180,6 +10164,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -9193,6 +10178,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">ветер, бриз [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">風</column>
       <column name="definition_pt">vento, brisa</column>
+      <column name="definition_fi">tuuli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{muD Dotlh:n}, {jev:v:1}, {cheq:v}, {vung:v}, {ver:v:1}, {SuS:v}, {SolDeS:n}, {mItlhon:n}</column>
@@ -9203,6 +10189,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It sounds like the wind blowing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9212,6 +10199,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9219,6 +10207,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9232,6 +10221,7 @@ A expressão {jISum:sen:nolink} tem um significado filosófico idiomático, "Est
       <column name="definition_ru">удар (в духовой инструмент), чтобы произвести звук [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吹（進入管樂器）產生聲音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">soprar (em instrumento de sopro) para produzir som</column>
+      <column name="definition_fi">puhaltaa (puhallinsoittimeen) äänen tuottamiseksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuS:n}, {rIl:v:2}, {chu':v:3}</column>
@@ -9248,6 +10238,9 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on yleinen termi, jota käytetään kaikkiin puhallinsoittimiin, kun taas {rIl:v:2} on rajoitettu koskemaan {gheb:n}.[2]
+
+Tätä voidaan käyttää myös kynttilän puhaltamiseen ({weQ:n}). Toisin kuin {jo':v}: ssä, ilma pääsee esineestä, joka on puhallettu päälle / sisään / sisään (tai ei koskaan mene siihen). Jos käytetään {-Daq:n}-ohjelmaa, se tarkoittaa epäonnistumista: ilmaa puhallettiin kohti kohdetta, mutta ohitettiin se.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9257,6 +10250,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9264,6 +10258,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 10.2, Jun. 2001:src}, [3] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -9277,6 +10272,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">пустозвон, сильфон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">風袋、風箱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Schusdek (instrumento de sopro)</column>
+      <column name="definition_fi">(säkkipillin tms.) säkki, palkeet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9287,6 +10283,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru">Это категория музыкальных инструментов с гибкой сумкой, которая попеременно наполняется и опорожняется из воздуха. Звук создается воздухом, проходящим по полосам материала, которые вибрируют (см. {joQ:n:2}). Известные типы {SuSDeq:n:nolink} включают {may'ron:n} и {DIron:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是具有柔性袋的樂器的一種，該袋交替地填充和排空空氣。聲音是由空氣經過振動的材料條產生的（請參見{joQ:n:2}）。 {SuSDeq:n:nolink}的已知類型包括{may'ron:n}和{DIron:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on soittimien luokka, jossa on joustava pussi, joka täytetään vuorotellen ilmalla. Ääni syntyy, kun ilma kulkee värisevien materiaalinauhojen yli (katso {joQ:n:2}). Tunnettuja {SuSDeq:n:nolink}-tyyppejä ovat {may'ron:n} ja {DIron:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In Cantonese Chinese, "風笛" means "bagpipes".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9296,6 +10293,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9303,6 +10301,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9316,6 +10315,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">одежда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">服裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">roupas</column>
+      <column name="definition_fi">vaatetus, vaatteet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIp:n}, {mop:n}, {jech:n}, {rejghun:n}, {weSjech:n}</column>
@@ -9326,6 +10326,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Suit".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9335,6 +10336,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9342,6 +10344,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9355,6 +10358,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">гардероб, шкаф для одежды [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">衣櫃</column>
       <column name="definition_pt">guarda-roupa, armário de roupas</column>
+      <column name="definition_fi">vaatekaappi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9365,6 +10369,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Sut:n}, {DeSwar:n}</column>
       <column name="examples"></column>
@@ -9374,6 +10379,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9381,6 +10387,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -9394,6 +10401,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">iron (clothing iron) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鐵（衣鐵） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ferro (ferro para roupas)</column>
+      <column name="definition_fi">silitysrauta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9404,6 +10412,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Sut:n}, {Hab:v}, {-moH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -9413,6 +10422,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">clothing iron</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9420,6 +10430,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -9433,6 +10444,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">сутай (ранг) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蘇泰（等級） [AUTOTRANSLATED]</column>
       <column name="definition_pt">sutai (rank)</column>
+      <column name="definition_fi">sutai (arvo)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9443,6 +10455,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru">От низшего к высшему эти ранги: {tay:n:3}, {Sutay:n:nolink}, {veStay:n}, {Santay:n}, {'Iptay:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從最低到最高，這些排名是：{tay:n:3}，{Sutay:n:nolink}，{veStay:n}，{Santay:n}，{'Iptay:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Do mais baixo ao mais alto, essas classificações são: {tay:n:3}, {Sutay:n:nolink}, {veStay:n}, {Santay:n}, {'Iptay:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Alimmasta korkeimpaan nämä rivit ovat: {tay:n:3}, {Sutay:n:nolink}, {veStay:n}, {Santay:n}, {'Iptay:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a rank from John M. Ford's 1984 novel "The Final Reflection". These ranks are used by many Klingon fan clubs, despite not appearing in canon (i.e., in any TV episode or movie).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9452,6 +10465,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9459,6 +10473,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -9472,6 +10487,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">Сто-Во-Кор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">STO-VO-韓 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sto-Vo-Kor</column>
+      <column name="definition_fi">Sto-Vo-Kor</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QI'tu':n}</column>
@@ -9482,6 +10498,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru">Загробная жизнь почитаемых мертвецов, куда все настоящие воины отправляются после смерти, чтобы сражаться в вечной битве. Ближайший клингон эквивалентен небу. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">尊貴死者的來世，所有真正的戰士死後與永恆的戰鬥死去。最接近天堂的克林崗語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A vida após a morte dos mortos honrados, onde todos os verdadeiros guerreiros vão depois que morrem para lutar uma batalha eterna. O Klingon mais próximo equivalente ao céu. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kunnioitettujen kuolleiden jälkimaailma, johon kaikki todelliset soturit menevät kuolemansa jälkeen taistelemaan ikuista taistelua. Lähin taivasta vastaava Klingon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Used by DeCandido in 2001 novel {Diplomatic Implausibility:src}; confirmed by MO at {qep'a' 17 (2010):src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9491,6 +10508,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">heaven, afterlife, Stovokor, Sto'Vo'Kor</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9498,6 +10516,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 17 (2010):src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -9511,6 +10530,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">вести переговоры [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">談判</column>
       <column name="definition_pt">negociar</column>
+      <column name="definition_fi">neuvotella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qI':v:1}, {mab:n:1}, {rojmab:n}, {rojmab qep:n}</column>
@@ -9521,6 +10541,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9532,6 +10553,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9539,6 +10561,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9552,6 +10575,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">борьба [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">作戰、鬥爭</column>
       <column name="definition_pt">lutar, guerrear</column>
+      <column name="definition_fi">taistella jotakuta vastaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIgh:v}, {may':n}, {Suvchu':v}</column>
@@ -9562,6 +10586,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Armeijan nousevassa järjestyksessä sotilaallisia yhteenottoja kuvaavia verbejä ovat: {Qor:v}, {tlhaS:v}, {vay:v}, {lul:v}, {Hargh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9575,6 +10600,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9582,6 +10608,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -9595,6 +10622,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="definition_ru">If a warrior does not fight, he does not breathe. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">如果一個戰士沒有戰鬥，他就不會呼吸。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Se um guerreiro não luta, ele não respira.</column>
+      <column name="definition_fi">Jos soturi ei taistele, hän ei hengitä.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9605,6 +10633,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Suv:v}, {-be':v}, {-chugh:v}, {SuvwI':n}, {tlhuH:v:0}, {-be':v}</column>
           <column name="examples"></column>
@@ -9614,6 +10643,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9621,6 +10651,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.193:src}</column>
         </table>
         <table name="mem">
@@ -9634,6 +10665,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="definition_ru">биться насмерть [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">戰鬥到死</column>
           <column name="definition_pt">lute até a morte</column>
+      <column name="definition_fi">taistella kuolemaan asti</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{ghIqtal:excl}, {Hay'chu':v}, {HIvneS:v}, {HubneS:v}</column>
@@ -9644,6 +10676,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Suv:v}, {-chu':v:suff}</column>
           <column name="examples"></column>
@@ -9653,6 +10686,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9660,6 +10694,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.49:src}</column>
         </table>
         <table name="mem">
@@ -9673,6 +10708,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="definition_ru">Грубая сила - не самый важный актив в бою. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">蠻力不是戰鬥中最重要的利基。</column>
           <column name="definition_pt">A força bruta não é o ativo mais importante em uma luta.</column>
+      <column name="definition_fi">Raaka voima yksinään ei ole tärkeää taistelussa.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9683,6 +10719,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Suv:v}, {-lu':v}, {-taH:v}, {-vIS:v}, {yap:v}, {-be':v}, {HoS:n:1}, {neH:adv}</column>
           <column name="examples"></column>
@@ -9692,6 +10729,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9699,6 +10737,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.21:src}</column>
         </table>
         <table name="mem">
@@ -9712,6 +10751,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="definition_ru">Клингоны рождены, чтобы сражаться и побеждать. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">克林崗人出生於戰鬥和征服。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Os klingons nascem para lutar e para conquistar.</column>
+      <column name="definition_fi">Klingonit ovat syntyneet taistelemaan ja valloittamaan.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9722,6 +10762,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -9731,6 +10772,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9738,6 +10780,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.5:src}</column>
         </table>
         <table name="mem">
@@ -9751,6 +10794,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="definition_ru">воин [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">戰士</column>
           <column name="definition_pt">guerreiro</column>
+      <column name="definition_fi">soturi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9761,6 +10805,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="notes_ru">Это слово относится к конкретному воину. Воинственность как концепция, см. {vaj:n}. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這個詞指的是特定的戰士。有關戰士的概念​​，請參閱{vaj:n}。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Esta palavra se refere a um guerreiro específico. Para a guerreira como conceito, consulte {vaj:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa tiettyyn soturiin. Katso sodankäynnin käsitteestä {vaj:n}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{Suv:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -9770,6 +10815,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9777,6 +10823,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKDA:src}</column>
         </table>
         <table name="mem">
@@ -9790,6 +10837,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="definition_ru">Здесь нет старых воинов. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">沒有老戰士。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Não há velhos guerreiros.</column>
+      <column name="definition_fi">Ei ole vanhoja sotureita.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9800,6 +10848,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{SuvwI':n}, {-pu':n}, {qan:v:1}, {tu'lu':v}, {-be':v}</column>
           <column name="examples"></column>
@@ -9809,6 +10858,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9816,6 +10866,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.29:src}</column>
         </table>
     <table name="mem">
@@ -9829,6 +10880,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">торговец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">商人</column>
       <column name="definition_pt">comerciante</column>
+      <column name="definition_fi">kauppias</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{malja':n}, {Huq:v}, {ngevwI':n}</column>
@@ -9839,6 +10891,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9848,6 +10901,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9855,6 +10909,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -9868,6 +10923,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="definition_ru">торговое судно [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">商船 [AUTOTRANSLATED]</column>
           <column name="definition_pt">navio mercante</column>
+      <column name="definition_fi">kauppa-alus</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -9878,6 +10934,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{Suy:n}, {Duj:n:1}</column>
           <column name="examples"></column>
@@ -9887,6 +10944,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -9894,6 +10952,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
     <table name="mem">
@@ -9907,6 +10966,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">кубит (квантовый бит) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">量子比特（量子比特） [AUTOTRANSLATED]</column>
       <column name="definition_pt">qubit (bit quântico)</column>
+      <column name="definition_fi">kubitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{San'on:n}, {mergh:v}, {'otlhQeD:n}, {maySon:n}</column>
@@ -9917,6 +10977,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru">Иногда также используется {SuyDar San'on:n@@SuyDar:n, San'on:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有時也使用{SuyDar San'on:n@@SuyDar:n, San'on:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Às vezes, {SuyDar San'on:n@@SuyDar:n, San'on:n} também é usado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Joskus käytetään myös {SuyDar San'on:n@@SuyDar:n, San'on:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9926,6 +10987,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9933,6 +10995,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -9946,6 +11009,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">пот, пот [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">汗</column>
       <column name="definition_pt">suor, transpiração</column>
+      <column name="definition_fi">hiki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HID:v}</column>
@@ -9956,6 +11020,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Genius is 1% inspiration and 99% perspiration."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9965,6 +11030,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9972,6 +11038,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -9985,6 +11052,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">тип животных, стрелять [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、射擊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, atirar</column>
+      <column name="definition_fi">eräs eläin, shooy</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qoghogh:v}</column>
@@ -9995,6 +11063,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru">Называть кого-то {Suy':n:nolink} считается оскорбительным, сравнимым с тем, чтобы называть кого-то «свиньей» в стандарте Федерации. [1, p.196] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Chamar alguém de {Suy':n:nolink} é considerado um insulto, comparável a chamar alguém de "porco" no Federation Standard.[1, p.196] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jonkun kutsuminen {Suy':n:nolink}: ksi katsotaan loukkaavaksi, mikä on verrattavissa jonkun kutsumiseen "sikaksi" Federation Standardissa.[1, p.196] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Sooey" is a sound used in calling pigs. The Hog Call, a traditional cheer at the University of Arkansas, goes "Woo, Pig! Sooey!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10004,6 +11073,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pig</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10011,6 +11081,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10024,6 +11095,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">{SuH:excl}</column>
       <column name="definition_zh_HK">{SuH:excl}</column>
       <column name="definition_pt">{SuH:excl}</column>
+      <column name="definition_fi">{SuH:excl}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10034,6 +11106,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10043,6 +11116,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10050,6 +11124,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10063,6 +11138,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">сахар [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">糖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">açúcar</column>
+      <column name="definition_fi">sokeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{na'ran:n}, {HaQchor:n}</column>
@@ -10073,6 +11149,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru">В {TNK:src} сахар (обычный столовый сахар) переводится как {Su'ghar qutmey:n:nolink}. Предположительно, тогда один {Su'ghar qut:n:nolink} будет одним зерном сахара. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{TNK:src}-ohjelmassa sokeri (tavallinen ruokasokeri) käännetään nimellä {Su'ghar qutmey:n:nolink}. Oletettavasti yksi {Su'ghar qut:n:nolink} olisi siis yksi sokerirake. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10082,6 +11159,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10089,6 +11167,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -10102,6 +11181,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">тип еды [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物種類 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de comida</column>
+      <column name="definition_fi">eräs ruokalaji</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10112,6 +11192,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="notes_ru">Это частично переваривается и используется в качестве соуса под названием {quD:n} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它被部分消化並用作一種叫做{quD:n}的調味料 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é parcialmente digerido e usado como um molho chamado {quD:n} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä pilkotaan osittain ja käytetään kastikkeena nimeltä {quD:n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is "slop".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10121,6 +11202,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10128,6 +11210,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10142,6 +11225,7 @@ Detta kan också användas för att blåsa ut ett ljus ({weQ:n}). Till skillnad 
       <column name="definition_ru">приподнятый профиль, гребни, рисунок, рельеф [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">凸起的輪廓、脊、圖案、浮雕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">perfil elevado, cristas, padrão, relevo</column>
+      <column name="definition_fi">kohokuvio, epätasaisuus, kaiverrus, harju</column>
       <column name="synonyms">{ghul:n}</column>
       <column name="antonyms">{retlaw:n}</column>
       <column name="see_also">{taw':v}</column>
@@ -10194,6 +11278,13 @@ Esta palavra é contrastada com {vem:n}, que é o traço deixado para trás quan
 Quando usada para se referir à impressão digital, etc., como uma parte do corpo, essa palavra assume o sufixo plural {-Du':n}. (Caso contrário, leva o sufixo {-mey:n}.)
 
 Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado em vez de {nItlh:n} e {yaD:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleinen termi kaikenlaiselle korotetulle profiilille tai helpotukselle, kuten sormenpäiden harjanteet, auton renkaan kuviot tai kengän profiili. Sitä ei kuitenkaan voida käyttää otsaan oleviin harjanteisiin.
+
+Tätä sanaa verrataan sanaan {vem:n}, joka on jäljessä oleva jälki, kun joku koskettaa jotain. Vertaa esimerkiksi {nItlh Su'nIm:n}: n "sormenjälkeä" (sormenpäässä olevat harjanteet) {nItlh Su'nIm vem:n}: n "sormenjälkeen" (merkki, joka on jätetty taakse kosketuksen jälkeen).
+
+Kun sitä käytetään viittaamaan sormenjälkiin jne., Runko-osaksi, tämä sana vie monikon {-Du':n}. (Muuten se tarvitsee loppuliitteen {-mey:n}.)
+
+Seuraavissa esimerkeissä voidaan käyttää tiettyä sormen tai varpaan nimeä {nItlh:n} ja {yaD:n:1}: n sijaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10207,6 +11298,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10214,6 +11306,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -10227,6 +11320,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="definition_ru">бабочка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蝴蝶</column>
       <column name="definition_pt">borboleta</column>
+      <column name="definition_fi">eräs perhosta muistuttava eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghew:n}</column>
@@ -10237,6 +11331,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="notes_ru">Это летающее насекомое с большими крыльями. Это происходит как {'ughDuq ghargh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一隻翅膀飛舞的昆蟲。它起源於{'ughDuq ghargh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um inseto voador com asas largish. Ele se origina como um {'ughDuq ghargh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lentävä hyönteinen, jolla on suuret siivet. Se on peräisin {'ughDuq ghargh:n}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The {'ugh:sen:nolink}ly {Duq:sen:nolink}ling becomes a {Su'wan:sen:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10246,6 +11341,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">moth, Lepidoptera</column>
       <column name="search_tags_de">Tagfalter, Nachtfalter, Motte</column>
       <column name="search_tags_fa"></column>
@@ -10253,5 +11349,6 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>

--- a/mem-16-t.xml
+++ b/mem-16-t.xml
@@ -8732,7 +8732,7 @@ Tätä verbiä voidaan käyttää refleksiivisesti tarkoittamaan "nauti", "pidä
       <column name="definition_ru">техника боя [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥技術 [AUTOTRANSLATED]</column>
       <column name="definition_pt">técnica de luta</column>
-      <column name="definition_fi">liike (taistelussa, pelissä tms.)</column>
+      <column name="definition_fi">liike, siirto (taistelussa, pelissä tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moQbara':n}, {much:v:3}, {tuH:n}</column>

--- a/mem-16-t.xml
+++ b/mem-16-t.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {t:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{t:sen:nolink}</column>
       <column name="definition_pt">a consoante {t:sen:nolink}</column>
+      <column name="definition_fi">konsonatti {t:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">рекорд</column>
       <column name="definition_zh_HK">記錄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">documento, arquivo, registro</column>
+      <column name="definition_fi">nauhoite, tietue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{De':n}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -70,6 +76,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">file</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -77,6 +84,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -90,6 +98,7 @@
       <column name="definition_ru">бар, салун, коктейль-лаундж</column>
       <column name="definition_zh_HK">酒吧、沙龍、雞尾酒休息室 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bar, salão, salão de cocktails</column>
+      <column name="definition_fi">baari, kapakka, salonki, cocktailbaari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chom:n}</column>
@@ -100,6 +109,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -112,6 +122,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -119,6 +130,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek The Experience:src}</column>
     </table>
         <table name="mem">
@@ -132,6 +144,7 @@
           <column name="definition_ru">Встретимся в коктейль-лаундже.</column>
           <column name="definition_zh_HK">我們將在雞尾酒休息室見面。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Nos encontraremos no salão de coquetéis.</column>
+      <column name="definition_fi">Tapaamme cocktailbaarissa.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -142,6 +155,7 @@
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -151,6 +165,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -158,6 +173,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD p.170:src}</column>
         </table>
     <table name="mem">
@@ -171,6 +187,7 @@
       <column name="definition_ru">перевернуть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">翻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">virar</column>
+      <column name="definition_fi">kääntyä (kokonaan) ympäri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -209,6 +226,11 @@ Man använder troligen {tachmoH:v@@tach:v, -moH:v} än {yoymoH:v:nolink} när ma
 Se alguém tombasse na cama, normalmente diria {jItach:sen@@jI-:v, tach:v}. Pode-se dizer {jItach'eghmoH:sen@@jI-:v, tach:v, -'egh:v, -moH:v} se houver uma luta ou esforço específico envolvido.
 
 É mais provável que alguém use {tachmoH:v@@tach:v, -moH:v} do que {yoymoH:v:nolink} ao mover alguém da posição deitada para a posição supina (ou vice-versa). É mais provável que alguém use {yoymoH:v:nolink} do que {tachmoH:v:nolink} ao virar hambúrgueres ou panquecas. Qualquer um seria bom para virar as cartas, com {yoymoH:v:nolink} implicando uma ação mais rápida ou mais nítida. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytettäisiin, jos jokin kääntyisi kokonaan läpi omasta aloitteestaan ​​tai näennäisesti omasta aloitteestaan ​​(vaikka syy olisi tiedossa). Jos jokin muu käänsi sen, katso {yoymoH:v}. Jos se kaatui, mutta ei käännetty kokonaan, katso {qaw':v}.
+
+Jos joku käännetään sängyssä, sanotaan tavallisesti {jItach:sen@@jI-:v, tach:v}. Voisi sanoa {jItach'eghmoH:sen@@jI-:v, tach:v, -'egh:v, -moH:v}, jos siihen liittyy erityistä taistelua tai vaivaa.
+
+On todennäköisempää käyttää {tachmoH:v@@tach:v, -moH:v} kuin {yoymoH:v:nolink} siirrettäessä joku alttiista selkänojaan (tai päinvastoin). Yksi käyttää todennäköisemmin {yoymoH:v:nolink}: tä kuin {tachmoH:v:nolink}, kun käännät hampurilaisia ​​tai pannukakkuja. Kumpikin olisi hieno korttien kääntämisestä, kun {yoymoH:v:nolink} tarkoittaa nopeampaa tai terävämpää toimintaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -218,6 +240,7 @@ Se alguém tombasse na cama, normalmente diria {jItach:sen@@jI-:v, tach:v}. Pode
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -225,6 +248,7 @@ Se alguém tombasse na cama, normalmente diria {jItach:sen@@jI-:v, tach:v}. Pode
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.06.09:src}</column>
     </table>
     <table name="mem">
@@ -238,6 +262,7 @@ Se alguém tombasse na cama, normalmente diria {jItach:sen@@jI-:v, tach:v}. Pode
       <column name="definition_ru">быть замороженным</column>
       <column name="definition_zh_HK">被凍結 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser congelado</column>
+      <column name="definition_fi">olla jäässä, jäätynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuch:n}, {bIQ:n}, {mev:v}</column>
@@ -248,6 +273,7 @@ Se alguém tombasse na cama, normalmente diria {jItach:sen@@jI-:v, tach:v}. Pode
       <column name="notes_ru">Это слово также имеет идиоматический смысл "не двигайся!" когда задано как команда, либо как {yItaD:sen@@yI-:v, taD:v} (говорят с одним человеком), либо как {petaD:sen@@pe-:v, taD:v} (говорят с группой людей) .[2; 3] Чтобы приказать кому-либо буквально заморозить, будут использоваться суффиксы {-'egh:v} и {-moH:v}: {yItaD'eghmoH:sen@@yI-:v, taD:v, -'egh:v, -moH:v} "Заморозьте себя!" («Заставь себя замерзнуть!»)[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Essa palavra também tem o senso idiomático de "não se mexa!" quando dado como um comando, como {yItaD:sen@@yI-:v, taD:v} (falado com uma pessoa) ou {petaD:sen@@pe-:v, taD:v} (falado com um grupo de pessoas). [2; 3] Para solicitar que alguém congele literalmente, os sufixos {-'egh:v} e {-moH:v} são usados: {yItaD'eghmoH:sen@@yI-:v, taD:v, -'egh:v, -moH:v} "Congele a si mesmo!" ("Faça com que você fique congelado!")[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä sanalla on myös idiomaattinen tunne "älä liiku!" kun se annetaan komentona, joko {yItaD:sen@@yI-:v, taD:v} (puhuttu yhdelle henkilölle) tai {petaD:sen@@pe-:v, taD:v} (puhuttu ihmisryhmälle) .[2; 3] Jos joku käskee kirjaimellisesti jäätymään, käytettäisiin loppuliitteitä {-'egh:v} ja {-moH:v}: {yItaD'eghmoH:sen@@yI-:v, taD:v, -'egh:v, -moH:v} "Pysäytä itsesi!" ("Tee itsesi jäätyneeksi!") [3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Despite the fact that {KGT:src} says the suffixes {-'egh:v} and {-moH:v} are generally used when giving commands with a verb describing a state, {yItamchoH!:sen} is in {TKD:src}, and MO has written {yIpIv!:sen} in a letter. Also, the KLI lists {yIDoghQo'!:sen} among its example Klingon phrases.
 
 Canon violations of this rule include:
@@ -262,6 +288,7 @@ Canon violations of this rule include:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">don't move, freeze</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -269,6 +296,7 @@ Canon violations of this rule include:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KCD:src}, [3] {KGT p.117:src}</column>
     </table>
     <table name="mem">
@@ -282,6 +310,7 @@ Canon violations of this rule include:
       <column name="definition_ru">замерзать</column>
       <column name="definition_zh_HK">凍結 [AUTOTRANSLATED]</column>
       <column name="definition_pt">congelar</column>
+      <column name="definition_fi">jäädyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuch:n}, {bIQ:n}, {pub:v}</column>
@@ -292,6 +321,7 @@ Canon violations of this rule include:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{taD:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -301,6 +331,7 @@ Canon violations of this rule include:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -308,6 +339,7 @@ Canon violations of this rule include:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -321,6 +353,7 @@ Canon violations of this rule include:
       <column name="definition_ru">таД (планета) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">taD（星球） [AUTOTRANSLATED]</column>
       <column name="definition_pt">taD (planeta)</column>
+      <column name="definition_fi">taD (planeetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HuDyuQ:n:place}</column>
@@ -331,6 +364,7 @@ Canon violations of this rule include:
       <column name="notes_ru">Название покрытой льдом колониальной планеты в империи клингонов. Его название буквально означает «замороженный» ({taD:v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗帝國冰封殖民地星球的名稱。它的名字字面意思是“凍結”（{taD:v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O nome de um planeta de colônia coberta de gelo no Império Klingon. Seu nome significa literalmente "congelado" ({taD:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jääpeitteisen siirtomaa-planeetan nimi Klingonin valtakunnassa. Sen nimi tarkoittaa kirjaimellisesti "jäädytettyä" ({taD:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -340,6 +374,7 @@ Canon violations of this rule include:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -347,6 +382,7 @@ Canon violations of this rule include:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -360,6 +396,7 @@ Canon violations of this rule include:
       <column name="definition_ru">легкое</column>
       <column name="definition_zh_HK">肺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pulmão</column>
+      <column name="definition_fi">keuhko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhuH:v:1}, {tlhuH:n}, {pur:v}, {rech:v}</column>
@@ -370,6 +407,7 @@ Canon violations of this rule include:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -379,6 +417,7 @@ Canon violations of this rule include:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -386,6 +425,7 @@ Canon violations of this rule include:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -399,6 +439,7 @@ Canon violations of this rule include:
       <column name="definition_ru">начать процесс, инициировать (труды)</column>
       <column name="definition_zh_HK">開始一個過程、啟動（程序） [AUTOTRANSLATED]</column>
       <column name="definition_pt">iniciar um processo, iniciar (procedimentos)</column>
+      <column name="definition_fi">aloittaa (tapahtumaketju, menettely, prosessi tms.); alkaa (tapahtumaketjusta, tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{rIn:v}</column>
       <column name="see_also">{bI'reS:n}</column>
@@ -437,6 +478,11 @@ Istället för att använda verbet {tagh:v:nolink}, överväga att använda verb
 Se o iniciador do processo for desconhecido, obscuro ou indefinido, o processo se torna o sujeito do verbo (nesse caso, não leva objeto): {taghbej mu'qaD veS:sen:nolink} "A guerra de maldições começou definitivamente." [3]
 
 Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:suff}. Por exemplo, um aluno que é iniciante pode ser descrito como {ghojchoHwI'} (aquele que está começando a aprender) ou como {ghojchoH} (começando a aprender). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin aihe on henkilö tai asia, joka aloittaa prosessin, ja esine on prosessi. Esimerkiksi: {Qu' DataghDI' 'aqtu' mellota' je tIqaw.:sen} "Kun aloitat tehtävän, muista Aktuh ja Melota." [2]
+
+Jos prosessin käynnistin on tuntematon, epäselvä tai määrittelemätön, prosessista tulee verbin aihe (jolloin se ei vie mitään objektia): {taghbej mu'qaD veS:sen:nolink} "Kiroussota on varmasti alkanut." [3]
+
+Harkitse verbiliitteen {-choH:v:suff} sijaan, että käytät verbiä {tagh:v:nolink}. Esimerkiksi opiskelija, joka on aloittelija, voidaan kuvata {ghojchoHwI'}: ksi (joka alkaa oppia) tai sanoa {ghojchoH} (alkaa oppia). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -446,6 +492,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">start</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -453,6 +500,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {TKW:src}, [3] {PK:src}</column>
     </table>
     <table name="mem">
@@ -466,6 +514,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="definition_ru">наконец, наконец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">終於、最後 [AUTOTRANSLATED]</column>
       <column name="definition_pt">finalmente, por fim</column>
+      <column name="definition_fi">viimeinkin, vihdoin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tagha'Ha':adv:hyp}</column>
       <column name="see_also">{Qav:v}, {wej:adv}</column>
@@ -476,6 +525,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -486,6 +536,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -493,6 +544,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.05:src} (reprinted in {HQ 8.4, p.8, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -506,6 +558,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="definition_ru">продолжать, длиться, выживать</column>
       <column name="definition_zh_HK">繼續、繼續、忍受、生存 [AUTOTRANSLATED]</column>
       <column name="definition_pt">continuar, seguir em frente, suportar, sobreviver</column>
+      <column name="definition_fi">jatkua, kestää, säilyä, selviytyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIQ:v}, {yIn:v}</column>
@@ -516,6 +569,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -529,6 +583,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -536,6 +591,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT:src}, [3] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -549,6 +605,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="definition_ru">быть под отрицательным углом</column>
       <column name="definition_zh_HK">處於負角度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar em um ângulo negativo</column>
+      <column name="definition_fi">olla negatiivisessa kulmassa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tor:v:2}, {lol:v:2}, {tom:v}, {Dop:v:2}</column>
@@ -559,6 +616,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="notes_ru">Это относится к кораблю в космосе, который повернул нос вниз. Поворот на отрицательный угол в 90 градусов означал бы, что нос корабля был направлен вниз относительно его предыдущей ориентации.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指太空中的船頭向下旋轉的船隻。旋轉90度的負角將意味著船頭相對於先前的方向筆直指向下方。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma nave espacial que girou o nariz para baixo. Uma rotação em um ângulo negativo de 90 graus significaria que o nariz do navio estava apontado diretamente para baixo em relação à sua orientação anterior.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa avaruudessa olevaan alukseen, joka on pyörittänyt nenäänsä alaspäin. 90 asteen negatiivisen kulman kiertäminen tarkoittaisi, että aluksen nenä osoitti suoraan alaspäin edelliseen suuntaan nähden.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -568,6 +626,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -575,6 +634,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2004.06.08:src}</column>
     </table>
     <table name="mem">
@@ -588,6 +648,7 @@ Em vez de usar o verbo {tagh:v:nolink}, considere usar o sufixo verbal {-choH:v:
       <column name="definition_ru">Быть или не быть. </column>
       <column name="definition_zh_HK">生存還是毀滅。</column>
       <column name="definition_pt">Ser ou não ser.</column>
+      <column name="definition_fi">Ollakko vai eikö olla.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taH:v:1}</column>
@@ -633,6 +694,42 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on kuuluisa linja {Hamlet:n:name}: ltä.
+
+Koko III, kohtaus I, yksinäinen saarnaus menee seuraavasti:
+▶ {taH pagh taHbe'.:sen:nolink} {DaH mu'tlheghvam vIqelnIS.@@DaH:adv, mu'tlhegh:n, -vam:n, vI-:v, qel:v:1, -nIS:v}
+   {quv'a ', yabDaq San vaQ cha, pu' je SIQDI '? @@ quv: v, -'a': v, yab: n, -Daq: n, San: n, vaQ: v, cha: n , pu ': n: 1, je: conj, SIQ: v, -DI': v}
+   DONOTTRANSLATE 5
+   {'ej, Suvmo', rInmoHDI '? Hegh. Qong - Qong neH -}
+   DONOTTRANSLATE 7
+   {cho'nISbogh porghDaj rInmoHlaH net Har.}
+   {yIn mevbogh mIwvam'e' wIruchqangbej.}
+   DONOTTRANSLATE 10
+   DONOTTRANSLATE 11
+   DONOTTRANSLATE 12
+   DONOTTRANSLATE 13
+   {SIQmoHmo' qechvam. Qugh yIn nI'moH 'oH.}
+   {reH vaq 'ej qIpqu' bov; mayHa'taH HI';}
+   DONOTTRANSLATE 16
+   DONOTTRANSLATE 17
+   DONOTTRANSLATE 18
+   {qatlh Hochvam lajqang vay '? wa 'taj neH lo'DI',}
+   {Qu'Daj Qatlh qIllaH ghaH! tep qengqang 'Iv?}
+   DONOTTRANSLATE 21
+   {mISbe'chugh neHtaHghach, ghaH ghIjmo' DuHvam -}
+   {Hegh tlha' vay' - Hegh tlha' qo''e' tu'bogh pagh.}
+   {not chegh lengwI'ma', qo'vetlh veHmey 'elDI'.}
+   {vaj Seng DIghajbogh, lajtaHmeH qaq law';}
+   {latlh DISovbe'bogh, ghoSchoHmeH qaq puS.}
+   {vaj nuch DIDa 'e' raDlaw' ghobmaj, qelDI'.}
+   {'ej, pIvmo', wovqu'taHvIS wuqbogh qab,}
+   {'oH ropmoH rIntaH Sotbogh qech ghom Hurgh.}
+   {'ej Qu'mey potlh DItulbogh qIl je qechvam.}
+   31
+   {toH be', qa''a'pu'vaD bItlhobtaHvIS,}
+   {jIyempu' 'e' yIQIjchoH je.}[2]
+
+Katso näiden linjojen esitys artistilta {Brian Rivera:url:http://www.imdb.com/name/nm2092459/}: {YouTube video:url:http://youtu.be/CiRMGYQfXrs}{quv'a', yabDaq San vaQ cha, pu' je SIQDI'?@@quv:v, -'a':v, yab:n, -Daq:n, San:n, vaQ:v, cha:n, pu':n:1, je:conj, SIQ:v, -DI':v}{pagh, Seng bIQ'a'Hey SuvmeH nuHmey SuqDI',@@pagh:conj, Seng:n, bIQ'a':n, -Hey:n, Suv:v, -meH:v, nuH:n:1, -mey:n, Suq:v, -DI':v}{'ej, Suvmo', rInmoHDI'? Hegh. Qong - Qong neH -}{'ej QongDI', tIq 'oy', wa'SanID Daw''e' je}{Hegh. Qong. QongDI' chaq naj. toH, waQlaw' ghu'vam!}{HeghDaq maQongtaHvIS, tugh vay' wInajlaH,}{volchaHmajvo' jubbe'wI' bep wIwoDDI';}{'e' wIqelDI', maHeDnIS. Qugh DISIQnIS,}{Dochchu' HemwI'; ruv mImlu'; tIchrup patlh;}{'oy'moH muSHa'ghach 'Il vuvHa'lu'bogh;}{quvwI'pu' tuv quvHa'moH quvHa'wI'pu';}{qatlh Hochvam lajqang vay'? wa' taj neH lo'DI',}{Qu'Daj Qatlh qIllaH ghaH! tep qengqang 'Iv?}{Doy'moHmo' yInDaj, bepmeH bechqang 'Iv,}{vIDHa'choH nab. baQa'! 'ovelya 'IH!} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">These lines have been translated from the original Klingon by Nick Nicholas and Andrew Strader.</column>
       <column name="components">{taH:v:1}, {pagh:conj}, {taH:v:1}, {-be':v}</column>
       <column name="examples"></column>
@@ -642,6 +739,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -649,6 +747,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}, [2] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -662,6 +761,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">(бранное слово: классическое оскорбление)</column>
       <column name="definition_zh_HK">綽號（經典侮辱） [AUTOTRANSLATED]</column>
       <column name="definition_pt">epíteto (um clássico insulto)</column>
+      <column name="definition_fi">eräs haukkumasana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -672,6 +772,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is just described as an epithet in {TKD:src}. Its description as a "classical insult" comes from {CK:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -681,6 +782,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -688,6 +790,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -701,6 +804,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">нож, кинжал</column>
       <column name="definition_zh_HK">刀、匕首</column>
       <column name="definition_pt">faca, punhal</column>
+      <column name="definition_fi">veitsi, tikari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daqtagh:n}, {qutluch:n}, {QIS:n}, {ghonDoq:n}, {tajtIq:n}, {rol taj:n}, {ret'aq:n}</column>
@@ -711,6 +815,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -724,6 +829,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -731,6 +837,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 2:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -744,6 +851,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">Боковое лезвие клинка d'k tahg</column>
       <column name="definition_zh_HK">額外的刀片在d k tahg上 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lâmina extra em um d'k tahg</column>
+      <column name="definition_fi">ylimääräinen terä d'k tahgissa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daqtagh:n}</column>
@@ -754,6 +862,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{taj:n}, {-Hom:n}</column>
       <column name="examples">
@@ -767,6 +876,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -774,6 +884,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 2:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
     <table name="mem">
@@ -787,6 +898,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">Нож с длинным лезвием</column>
       <column name="definition_zh_HK">刀型（長刀） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de faca (lâmina longa)</column>
+      <column name="definition_fi">eräs pitkäteräinen veitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -797,6 +909,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{taj:n}, {tIq:v}</column>
       <column name="examples"></column>
@@ -806,6 +919,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -813,6 +927,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -826,6 +941,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">угол</column>
       <column name="definition_zh_HK">角度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ângulo</column>
+      <column name="definition_fi">kulma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tajvajHom:n}, {tajvaj'a':n}, {tajvaj leD:n}, {tajvaj:n:2}</column>
@@ -836,6 +952,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">角度以{lawrI':n}（或在更遠的古代或傳統文獻中為{law:n}）測量。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os ângulos são medidos em {lawrI':n} (ou {law:n} nos tempos mais antigos ou em documentos tradicionais).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kulmat mitataan muodossa {lawrI':n} (tai {law:n} muinaisina aikoina tai perinteisissä asiakirjoissa).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -845,6 +962,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -852,6 +970,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -865,6 +984,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">угол комнаты</column>
       <column name="definition_zh_HK">一個房間的一角 [AUTOTRANSLATED]</column>
       <column name="definition_pt">canto de um quarto</column>
+      <column name="definition_fi">(huoneen) nurkka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tajvaj:n:1}, {po'oH:n}</column>
@@ -875,6 +995,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -884,6 +1005,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -891,6 +1013,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -904,6 +1027,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">острый угол [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">銳角 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ângulo agudo</column>
+      <column name="definition_fi">terävä kulma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tajvaj'a':n}, {tajvaj leD:n}</column>
@@ -914,6 +1038,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tajvaj:n:1}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -923,6 +1048,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -930,6 +1056,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -943,6 +1070,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">тупой угол [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鈍角 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ângulo obtuso</column>
+      <column name="definition_fi">tylppä kulma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tajvajHom:n}, {tajvaj leD:n}</column>
@@ -953,6 +1081,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tajvaj:n:1}, {-'a':n}</column>
       <column name="examples"></column>
@@ -962,6 +1091,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -969,6 +1099,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -982,6 +1113,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">прямой угол [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">直角 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ângulo reto</column>
+      <column name="definition_fi">suora kulma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tajvajHom:n}, {tajvaj'a':n}</column>
@@ -992,6 +1124,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tajvaj:n:1}, {leD:v}</column>
       <column name="examples"></column>
@@ -1001,6 +1134,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1008,6 +1142,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1021,6 +1156,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">пушка</column>
       <column name="definition_zh_HK">大砲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">canhão</column>
+      <column name="definition_fi">tykki</column>
       <column name="synonyms">{baHjan:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1031,6 +1167,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1040,6 +1177,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gun, launcher, missile</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1047,6 +1185,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1060,6 +1199,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">пушечная техника [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大砲機械 [AUTOTRANSLATED]</column>
       <column name="definition_pt">maquinaria de canhão</column>
+      <column name="definition_fi">tykin koneisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1070,6 +1210,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tal:n}, {jo':n}</column>
       <column name="examples"></column>
@@ -1079,6 +1220,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1086,6 +1228,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1099,6 +1242,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">пушечная охрана [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大砲守衛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">guarda de canhão</column>
+      <column name="definition_fi">tykin vartija ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1109,6 +1253,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tal:n}, {Qan:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1118,6 +1263,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1125,6 +1271,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1138,6 +1285,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">при́вод нацеливания орудия</column>
       <column name="definition_zh_HK">加農炮控制馬達 [AUTOTRANSLATED]</column>
       <column name="definition_pt">motor de controle de canhão</column>
+      <column name="definition_fi">tykin ohjausmoottori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1148,6 +1296,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tal:n}, {SeH:v}, {-wI':v}, {nguSDI':n}</column>
       <column name="examples"></column>
@@ -1157,6 +1306,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1164,6 +1314,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1177,6 +1328,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">Таларианец (человек) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">塔拉里安（人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Talariano (pessoa)</column>
+      <column name="definition_fi">talarialainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngan:n}</column>
@@ -1187,6 +1339,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Presumably, there is a place called {talar:n:place,fic,nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1196,6 +1349,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1203,6 +1357,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1216,6 +1371,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">быть тихим</column>
       <column name="definition_zh_HK">安靜、清淨</column>
       <column name="definition_pt">ficar quieto</column>
+      <column name="definition_fi">olla hiljainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chuS:v}</column>
       <column name="see_also">{tlhup:v}, {Hew:n}</column>
@@ -1226,6 +1382,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1236,6 +1393,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">silent</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1243,6 +1401,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1256,6 +1415,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">обменивать, подставлять</column>
       <column name="definition_zh_HK">交換、替代 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trocar, substituir</column>
+      <column name="definition_fi">vaihtaa, korvata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mech:v}, {qa':v}</column>
@@ -1266,6 +1426,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1276,6 +1437,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">replace</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1283,6 +1445,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1296,6 +1459,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">архивы</column>
       <column name="definition_zh_HK">檔案 [AUTOTRANSLATED]</column>
       <column name="definition_pt">arquivos</column>
+      <column name="definition_fi">arkistot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1306,6 +1470,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru">Это появилось в {STC 104:src} как {DIvI' tamey ngo':n:nolink} "Архивы Федерации". Единственная архивная запись будет {ta ngo':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso apareceu em {STC 104:src} como {DIvI' tamey ngo':n:nolink} "Arquivos da Federação". Um único registro de arquivo morto seria {ta ngo':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ilmestyi {STC 104:src}: ssä nimellä {DIvI' tamey ngo':n:nolink} "Federation Archives". Yksi arkistotietue olisi {ta ngo':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ta:n}, {-mey:n}, {ngo':v}</column>
       <column name="examples"></column>
@@ -1315,6 +1480,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1322,6 +1488,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -1335,6 +1502,7 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="definition_ru">свет, свечение, освещение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">光、發光、照明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">luz, luminescência, iluminação</column>
+      <column name="definition_fi">valo, luminesenssi, valaistus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wov:v}, {wovmoHwI':n}, {'otlh:n}</column>
@@ -1355,6 +1523,9 @@ Ett svagt ljus skulle vara {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (medan {
       <column name="notes_pt">Para "luz" no sentido de "brilho", por exemplo, os olhos de alguém sendo "sensíveis à luz", considere {wovtaHghach:n@@wov:v, -taH:v, -ghach:v} em vez disso.[1]
 
 Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamghay Hurgh:n@@tamghay:n, Hurgh:v} soa estranho) .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos esimerkiksi "valo" tarkoittaa "kirkkautta", esimerkiksi jos jonkun silmät ovat "herkkiä valolle", harkitse sen sijaan {wovtaHghach:n@@wov:v, -taH:v, -ghach:v}.
+
+Hämärä valo olisi {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (kun taas {tamghay Hurgh:n@@tamghay:n, Hurgh:v} kuulostaa oudolta).[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Tom G. Smith of Industrial Light &amp; Magic, who oversaw visual effects production for {Star Trek II:src} and {Star Trek III:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1364,6 +1535,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1371,6 +1543,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.26:src}, [2] {KLI mailing list 2018.01.29:src}</column>
     </table>
     <table name="mem">
@@ -1384,6 +1557,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="definition_ru">заставить замолчать</column>
       <column name="definition_zh_HK">安靜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">silêncio</column>
+      <column name="definition_fi">hiljentää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1394,6 +1568,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tam:v:1}, {-moH:v}</column>
       <column name="examples"></column>
@@ -1403,6 +1578,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1410,6 +1586,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1423,6 +1600,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="definition_ru">элемент (в химии) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">元素（化學） [AUTOTRANSLATED]</column>
       <column name="definition_pt">elemento (em química)</column>
+      <column name="definition_fi">alkuaine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeySel:n}, {'o'rIS:n}, {yugh:v}</column>
@@ -1452,6 +1630,26 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tunnettuja sanoja alkuaineille ovat:
+▶ {bettI':n}
+▶ {bIQSIp:n}
+▶ {butnat:n}
+▶ {ghav:n}
+▶ {jey':n}
+▶ {julSIp:n}
+▶ {letbIng:n}
+▶ {no'negh:n}
+▶ {ngIDvoS:n}
+▶ {popSop:n}
+▶ {qol'om:n}
+▶ {SIrlIy:n}
+▶ {Sorpuq:n}
+▶ {velSo':n}
+▶ {voQSIp:n}
+▶ {yInSIp:n}
+▶ {yuHSIQ:n}
+▶ {'apraQ:n}
+▶ {'uSqan:n}</column>
       <column name="hidden_notes">A reference to Tom Lehrer, who performed the song "The Elements" about the chemical elements.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1461,6 +1659,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1468,6 +1667,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
         <table name="mem">
@@ -1481,6 +1681,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
           <column name="definition_ru">химия [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">化學</column>
           <column name="definition_pt">química</column>
+      <column name="definition_fi">kemia</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{tamler:n}, {QeD:n}, {HapQeD:n}, {yugh:v}, {'uch:v:3}, {ghIqtu':n}, {tamlertej:n}</column>
@@ -1491,6 +1692,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{tamler:n}, {QeD:n}</column>
           <column name="examples"></column>
@@ -1500,6 +1702,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1507,6 +1710,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 26 (2019):src}</column>
         </table>
         <table name="mem">
@@ -1520,6 +1724,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
           <column name="definition_ru">химик (ученый) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">化學家（科學家） [AUTOTRANSLATED]</column>
           <column name="definition_pt">químico (cientista)</column>
+      <column name="definition_fi">kemisti</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{tamlerQeD:n}, {tej:n}</column>
@@ -1530,6 +1735,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word does not appear in canon, but is an obvious construction based on {tamlerQeD:n:nolink}.</column>
           <column name="components">{tamler:n}, {tej:n}</column>
           <column name="examples"></column>
@@ -1539,6 +1745,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1546,6 +1753,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -1559,6 +1767,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="definition_ru">поездка, спотыкаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">絆、跌</column>
       <column name="definition_pt">tropeçar</column>
+      <column name="definition_fi">kompastua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1569,6 +1778,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1578,6 +1788,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1585,6 +1796,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1599,6 +1811,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="definition_ru">бычье животное [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">像牛一樣的動物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um animal tipo touro</column>
+      <column name="definition_fi">eräs naudan kaltainen eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1609,6 +1822,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta palavra foi usada em {ghIlghameS:n:nolink}, onde {QI'tu' tangqa':n:nolink} se refere ao Boi do Céu. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytettiin {ghIlghameS:n:nolink}: ssä, jossa {QI'tu' tangqa':n:nolink} viittaa taivaan härään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Lakota or Sioux word for "buffalo" is "tatanka".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1618,6 +1832,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1625,6 +1840,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.4, Dec. 2000:src}</column>
     </table>
     <table name="mem">
@@ -1638,6 +1854,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="definition_ru">маш, сквош [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">搗碎、南瓜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">amassar, esmagar</column>
+      <column name="definition_fi">soseuttaa, muhentaa, musertaa, puristaa, litistää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mup:v}, {qompogh:n}, {beQmoH:v}, {gho':v}</column>
@@ -1648,6 +1865,7 @@ Uma luz fraca seria {tamghay wovHa':n@@tamghay:n, wov:v, -Ha':v} (enquanto {tamg
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to the sound made.
 
 The English translation of the sentence from {Star Trek Constellations:src} does not appear in the book, but in the author's annotations which was a separate document. The {'e':n:pro} was probably a mistake, but can be rationalized as a typo for {-'e':n:suff}.</column>
@@ -1661,6 +1879,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
 ▶ {yIntaH qIrq 'e' vIneH. DaSwIj bIngDaq latlhpu' vItap.:sen@@yIn:v, -taH:v, qIrq:n:name, -'e':n, vI-:v, neH:v, DaS:n, -wIj:n, bIng:n, -Daq:n, latlh:n, -pu':n, vI-:v, tap:v} "Кирка я хочу взять живым. Остальных я разотру под своим ботинком."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">grind, crush</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1668,6 +1887,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Star Trek Constellations p.232:src}</column>
     </table>
     <table name="mem">
@@ -1681,6 +1901,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="definition_ru">вишня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">櫻桃 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cereja</column>
+      <column name="definition_fi">eräs kirsikan kaltainen hedelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1691,6 +1912,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on kirsikkaa muistuttava hedelmä. Kun tarvitaan selvennystä, maan hedelmää edeltää {tera':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1700,6 +1922,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1707,6 +1930,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1720,6 +1944,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="definition_ru">быть шрам [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傷痕累累 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser marcado</column>
+      <column name="definition_fi">olla arpinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{roptoj:n}, {mIvwa':n}, {SanDIy:n}, {pe':v}</column>
@@ -1730,6 +1955,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1739,6 +1965,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1746,6 +1973,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1759,6 +1987,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="definition_ru">шрам [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">瘢痕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cicatriz</column>
+      <column name="definition_fi">arpeuttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1769,6 +1998,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{taq:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -1778,6 +2008,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1785,6 +2016,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1798,6 +2030,7 @@ The English translation of the sentence from {Star Trek Constellations:src} does
       <column name="definition_ru">Такьевский район [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Tak'ev州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">região Tak'ev</column>
+      <column name="definition_fi">Tak'evin alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sep Hol Sar:n}</column>
@@ -1822,6 +2055,9 @@ Denna dialekt är typ halvvägs mellan standarddialekten och {Qotmagh Sep:n}-dia
       <column name="notes_pt">Os residentes desta região superam em muito os residentes de {Qotmagh Sep:n}.
 
 Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto {Qotmagh Sep:n}. Os alto-falantes substituem {b:sen:nolink} por {mb:sen:nolink} e {D:sen:nolink} por {ND:sen:nolink}.[1, p.22] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän alueen asukkaat ovat huomattavasti enemmän kuin {Qotmagh Sep:n}-asukkaat.
+
+Tämä murre on tavallaan puolivälissä tavallisen murteen ja {Qotmagh Sep:n}-murteen välillä. Kaiuttimet korvaavat {b:sen:nolink}: lla {mb:sen:nolink}: n ja {D:sen:nolink}: lla {ND:sen:nolink}: lla.[1, p.22] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} on p.22 and not in the glossary. It appears as {taq'ev:n:nolink} and not as {taq'ev Sep:n:nolink}, but it is implied that this is the name of a region (see {Sep:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1831,6 +2067,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1838,6 +2075,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1851,6 +2089,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">быть странным</column>
       <column name="definition_zh_HK">奇異、怪誕</column>
       <column name="definition_pt">ser estranho</column>
+      <column name="definition_fi">olla outo, pelottava, luonnoton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jum:v}, {Huj:v:1}</column>
@@ -1861,6 +2100,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru">Это означает «странный», как в странном, неестественном, возможно, жутком.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著“怪異”，如古怪，不自然，可能令人毛骨悚然。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "estranho", como em bizarro, antinatural, talvez assustador.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "outoa" kuin outossa, luonnottomassa, ehkä kammottavassa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1870,6 +2110,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bizarre, unnatural, creepy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1877,6 +2118,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -1890,6 +2132,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">выхлоп</column>
       <column name="definition_zh_HK">排氣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">escapamento</column>
+      <column name="definition_fi">pakokaasu, paote</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIm:v}, {vuj:v}</column>
@@ -1900,6 +2143,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to a line from the movie "Dr. Strangelove" ({taQ:v}, {bang:n}): "A big plane like a '52... varrrooom! Its jet exhaust... frying chickens in the barnyard!"</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1909,6 +2153,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1916,6 +2161,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1929,6 +2175,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">моча, фекалии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">尿液、糞便 [AUTOTRANSLATED]</column>
       <column name="definition_pt">urina, materia fecal</column>
+      <column name="definition_fi">virtsa, uloste</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{turmIq:n}, {qeQ:n}, {ghIm:v}, {vuj:v}, {puch:n}</column>
@@ -1939,6 +2186,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1948,6 +2196,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1955,6 +2204,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -1968,6 +2218,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">яд</column>
       <column name="definition_zh_HK">毒</column>
       <column name="definition_pt">veneno</column>
+      <column name="definition_fi">myrkky</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngej:v}, {Hergh:n}, {SuQ:v}</column>
@@ -1978,6 +2229,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Rat" poison, or "tar".</column>
       <column name="components"></column>
       <column name="examples">
@@ -1988,6 +2240,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1995,6 +2248,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2008,6 +2262,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">медленно передвигающийся [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">緩步類 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tardigrade</column>
+      <column name="definition_fi">eräs eläin, tardigrade</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2018,6 +2273,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru">Это просто стандартное слово федерации с произношением клингона. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是帶有克林崗語發音的聯邦標准單詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é apenas uma palavra padrão da Federação com a pronúncia klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain Federation Standard -sana, jolla on Klingon-ääntäminen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2027,6 +2283,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2034,6 +2291,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2047,6 +2305,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">тарг</column>
       <column name="definition_zh_HK">《targ》（動物類型）</column>
       <column name="definition_pt">targ</column>
+      <column name="definition_fi">eräs eläin, targi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{namwech:n}, {welwelwel:excl}, {ghughugh:v}, {Qoghogh:v}, {Saj:n}, {qeSHoS:n}, {ngavyaw':n}, {qovIj:n}</column>
@@ -2057,6 +2316,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru">Это своего рода животное, чем-то напоминающее собаку. Он популярен как домашнее животное, но его сердце также считается деликатесом.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種有點像狗的動物。它作為寵物很受歡迎，但它的心臟也被視為美味佳餚。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de animal que lembra um cachorro. É popular como animal de estimação, mas seu coração também é considerado uma iguaria.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen eläin, joka muistuttaa hieman koiraa. Se on suosittu lemmikkinä, mutta sen sydäntä pidetään myös herkkuna[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2066,6 +2326,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dog, pig, boar</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2073,6 +2334,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -2086,6 +2348,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">сердце тарга (продукт питания) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">targ的心臟（食品） [AUTOTRANSLATED]</column>
       <column name="definition_pt">coração do targ (um item alimentar)</column>
+      <column name="definition_fi">eräs elintarvike, targin sydän</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2096,6 +2359,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{targh:n}, {tIq:n}</column>
       <column name="examples"></column>
@@ -2105,6 +2369,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2112,6 +2377,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -2125,6 +2391,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">Действуй, вступай в отношения со своим таргом!</column>
       <column name="definition_zh_HK">與你的targ交配！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Vá ser parceiro com seu targ!</column>
+      <column name="definition_fi">Mene panemaan targiasi!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2135,6 +2402,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2144,6 +2412,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mu'qaD veS, curse warfare</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2151,6 +2420,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2164,6 +2434,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">Ваш тарг имеет больший мозг, чем все ваши предки вместе взятые! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你的targ比你祖先放在一起的大腦更大！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Seu targ tem um cérebro maior do que todos os seus antepassados ​​juntos!</column>
+      <column name="definition_fi">Targillasi on suuremmat aivot kuin kaikilla esivanhemmillasi yhteensä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2174,6 +2445,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{targh:n}, {-lIj:n}, {yab:n}, {tIn:v}, {... law':sen}, {no':n}, {-lI':n}, {Hoch:n}, {yab:n}, {-Du':n}, {tIn:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -2183,6 +2455,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mu'qaD veS, curse warfare</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2190,6 +2463,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2203,6 +2477,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">раствор (жидкий)</column>
       <column name="definition_zh_HK">溶液（液體） [AUTOTRANSLATED]</column>
       <column name="definition_pt">solução (líquido)</column>
+      <column name="definition_fi">liuos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{betgham:n}, {ngoS:v}, {Sub:v:1}, {jeD:v}, {pey:n}, {bIQ:n}</column>
@@ -2213,6 +2488,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2222,6 +2498,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">liquid, potion</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2229,6 +2506,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2242,6 +2520,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">ров [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">溝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Abandonar</column>
+      <column name="definition_fi">oja, kaivanto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QemjIq:n}, {ghaw:v}</column>
@@ -2252,6 +2531,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Tasman Sea separates Australia from New Zealand, and is colloquially called "the Ditch".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2261,6 +2541,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2268,6 +2549,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -2281,6 +2563,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">ион</column>
       <column name="definition_zh_HK">離子</column>
       <column name="definition_pt">íon</column>
+      <column name="definition_fi">ioni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jolvoy':n}, {ngIng:v}, {ruS:v}, {valtIn:n}, {tem:n}, {HeySel:n}</column>
@@ -2291,6 +2574,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2300,6 +2584,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2307,6 +2592,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2320,6 +2606,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">вернуть что-нибудь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">歸還一些東西 [AUTOTRANSLATED]</column>
       <column name="definition_pt">retornar alguma coisa, devolver</column>
+      <column name="definition_fi">palauttaa jotain, panna jotain takaisin paikoilleen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nobHa':v}, {ngIp:v}, {tatlh'egh:v}</column>
@@ -2330,6 +2617,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru">Этот глагол означает что-то вернуть куда-нибудь, например, оружие в оружейную стойку. Чтобы выразить концепцию возвращения на место, используйте {chegh:v}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este verbo significa devolver algo em algum lugar, por exemplo, uma arma no porta-armas. Para expressar o conceito de retorno a um local, use {chegh:v}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2340,6 +2628,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2347,6 +2636,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 1999.07.19:src}</column>
     </table>
     <table name="mem">
@@ -2360,6 +2650,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">возвращаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">回歸（自己） [AUTOTRANSLATED]</column>
       <column name="definition_pt">retorna (você mesmo)</column>
+      <column name="definition_fi">palauttaa itsensä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2370,6 +2661,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">儘管不常見，但動詞{tatlh:v}可以與後綴{-'egh:v}一起使用，以傳達與{chegh:v}類似的含義。 {tatlh'egh:v:nolink}表格似乎表明行動的執行者正在強迫他/她自己做某事，也許是因為這很困難或不希望這樣做。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Embora não seja comum, o verbo {tatlh:v} pode ser usado com o sufixo {-'egh:v} para transmitir um significado semelhante ao {chegh:v}. A forma {tatlh'egh:v:nolink} parece sugerir que o executor da ação está se forçando a fazer algo, talvez por ser difícil ou não desejável. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikka verbiä {tatlh:v} ei ole yleistä, sitä voidaan käyttää loppuliitteen {-'egh:v} kanssa välittämään samanlainen merkitys kuin {chegh:v}. {tatlh'egh:v:nolink}-muoto näyttää viittaavan siihen, että toiminnan tekijä pakottaa itsensä tekemään jotain, ehkä siksi, että se on vaikeaa tai ei toivottavaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tatlh:v}, {-'egh:v}</column>
       <column name="examples">
@@ -2380,6 +2672,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2387,6 +2680,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 1999.07.19:src}</column>
     </table>
     <table name="mem">
@@ -2400,6 +2694,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">сотрясения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">搖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sacudir</column>
+      <column name="definition_fi">ravistaa, ravistella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jel:v}</column>
@@ -2410,6 +2705,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru">Это то, что кто-то может сделать, чтобы разбудить кого-то, или то, что можно сделать с напитком или конечностью. То, что замерзание может сделать для кого-то, это {jelmoH:v@@jel:v, -moH:v}, а не {tav:v:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是某人可能會叫醒別人的事情，或者是某人可能會喝一杯或四肢。凍結溫度可能對某人造成的影響是{jelmoH:v@@jel:v, -moH:v}，而不是{tav:v:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que alguém pode fazer para acordar alguém, ou o que alguém pode fazer com uma bebida ou um membro. O que as temperaturas de congelamento podem fazer a alguém é {jelmoH:v@@jel:v, -moH:v}, não {tav:v:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä joku voi tehdä herättääkseen jonkun tai mitä voi tehdä juomalle tai raajalle. Mitä jäätymislämpötilat voivat tehdä jollekin, on {jelmoH:v@@jel:v, -moH:v}, ei {tav:v:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2419,6 +2715,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2426,6 +2723,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -2439,6 +2737,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="definition_ru">дорога, улица, путь и т. д. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">道路、街道、路徑等 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rua, estrada, caminho, etc.</column>
+      <column name="definition_fi">tie, katu, polku tms.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIq:v}, {nagh HeH:n}, {wonmugh:n}</column>
@@ -2449,6 +2748,7 @@ Este dialeto é uma espécie de meio caminho entre o dialeto padrão e o dialeto
       <column name="notes_ru">Это физический аналог {He:n}, то, что можно увидеть и по которому можно пройти. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{He:n}的物理對應物，可以看到和行走。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a contrapartida física de um {He:n}, algo que se pode ver e andar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {He:n}: n fyysinen vastine, jonka voi nähdä ja kävellä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A reference to the Tao (道), obviously.
 
 Marc Okrand noted that he can't answer yet the question of whether an airlane (a fixed pathway in the air where airplanes are supposed to go) is a {taw:n:nolink} or a {He:n:nolink}.</column>
@@ -2460,6 +2760,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2467,6 +2768,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2480,6 +2782,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="definition_ru">block (city block) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">街區（城市街區） [AUTOTRANSLATED]</column>
       <column name="definition_pt">quarteirão (quarteirão da cidade)</column>
+      <column name="definition_fi">kortteli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2490,6 +2793,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{taw:n}, {'ay':n}</column>
       <column name="examples"></column>
@@ -2499,6 +2803,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2506,6 +2811,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2519,6 +2825,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="definition_ru">Тави'Ян [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">塔維安 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Tawi'Yan</column>
+      <column name="definition_fi">miekankantaja, Tawi'Yan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yan:n}, {qelHay'ya:n}</column>
@@ -2529,6 +2836,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">克林崗人（或多或少）是婚禮上“伴郎”。通常將其翻譯為“持劍者”，但是從詞源上講這是不正確的。它是一個舊單詞的凍結形式，經過某種程度的修改，顯然類似於{taywI'yan:n:nolink}，與儀式或儀式{tay:n:2}和劍{yan:n}有關，但舊語法結構的細節未知。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Contraparte Klingon (mais ou menos) do "padrinho" em um casamento. Isso normalmente é traduzido como "portador da espada", mas etimologicamente isso não está certo. É uma forma congelada e um tanto modificada de uma palavra antiga que aparentemente era algo como {taywI'yan:n:nolink}, tendo algo a ver com cerimônia ou ritual {tay:n:2} e espada {yan:n}, mas os detalhes da antiga construção gramatical são desconhecidos.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin vastine (enemmän tai vähemmän) "parhaan miehen" häät. Tämä käännetään yleensä "miekkakantajaksi", mutta etymologisesti se ei ole aivan oikein. Se on jäädytetty ja hieman muunnettu muoto vanhasta sanasta, joka oli ilmeisesti jotain {taywI'yan:n:nolink}, jolla oli jotain tekemistä seremonian tai rituaalin {tay:n:2} ja miekan {yan:n} kanssa, mutta vanhan kielioppirakenteen yksityiskohtia ei tunneta.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2538,6 +2846,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sword bearer, sword-bearer, best man</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2545,6 +2854,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {DS9 - You Are Cordially Invited:src}</column>
     </table>
     <table name="mem">
@@ -2558,6 +2868,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="definition_ru">абсолютно безнадежная ситуация [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">絕對絕望的情況 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma situação absolutamente sem esperança</column>
+      <column name="definition_fi">täysin toivoton tilanne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2568,6 +2879,7 @@ Marc Okrand noted that he can't answer yet the question of whether an airlane (a
       <column name="notes_ru">Чтобы быть еще более решительным, можно сказать, {tawleHnu' pogh:n@@tawleHnu':n, pogh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">更強調一點的是，您可以說{tawleHnu' pogh:n@@tawleHnu':n, pogh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para ser ainda mais enfático, pode-se dizer {tawleHnu' pogh:n@@tawleHnu':n, pogh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat olla vielä painokkaampi, voidaan sanoa {tawleHnu' pogh:n@@tawleHnu':n, pogh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Maltz didn't know how gloves are involved or if there is a word which just happens to be a homophone of {pogh:n} that he didn't remember.
 
 This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop:n}) basket ({'unwat:n})".</column>
@@ -2579,6 +2891,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">snafu, foobar, fubar, fugazi</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2586,6 +2899,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
         <table name="mem">
@@ -2599,6 +2913,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
           <column name="definition_ru">{tawleHnu':n}</column>
           <column name="definition_zh_HK">{tawleHnu':n}</column>
           <column name="definition_pt">{tawleHnu':n}</column>
+      <column name="definition_fi">{tawleHnu':n}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2609,6 +2924,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -2618,6 +2934,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2625,6 +2942,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
         </table>
     <table name="mem">
@@ -2638,6 +2956,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">быть хилым, рельефным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">凹凸不平，浮雕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser ridículo, estampado</column>
+      <column name="definition_fi">olla uurteinen, harjanteinen, kohokuvioitu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'ap:v}</column>
       <column name="see_also">{Su'nIm:n}, {ghul:n}</column>
@@ -2648,6 +2967,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru">Это слово может быть использовано для обозначения ископаемого в камне. Он не используется при обращении к лбу. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞可能用來指嵌入石頭的化石。指額頭時不使用它。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra pode ser usada para se referir a um fóssil incorporado em uma pedra. Não é utilizado quando se refere a testas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää viittaamaan kiveen upotettuun fossiiliin. Sitä ei käytetä viitattaessa otsaihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2657,6 +2977,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">convex</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2664,6 +2985,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2677,6 +2999,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">быть цивилизованным</column>
       <column name="definition_zh_HK">文明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser civilizado</column>
+      <column name="definition_fi">olla sivistynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tayqeq:n}, {tay:n:2}</column>
@@ -2687,6 +3010,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Klingons apparently consider a people to be civilized if they have rituals (see {tay:n:2}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2696,6 +3020,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2703,6 +3028,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2716,6 +3042,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">церемония, обряд, ритуал</column>
       <column name="definition_zh_HK">儀式、禮儀</column>
       <column name="definition_pt">cerimônia, rito, ritual</column>
+      <column name="definition_fi">seremonia, rituaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SeQ:v}, {tay:v}</column>
@@ -2726,6 +3053,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is something that "tie"s a community together. Also, the procedure of putting on a neck"tie" is a kind of ritual.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2743,6 +3071,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2750,6 +3079,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2763,6 +3093,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">тай (ранг) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">tai（等級） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tai (rank)</column>
+      <column name="definition_fi">tai (arvo)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2773,6 +3104,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">從最低到最高，這些排名是：{tay:n:3,nolink}、{Sutay:n}、{veStay:n}、{Santay:n}、{'Iptay:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Alimmasta korkeimpaan nämä rivit ovat: {tay:n:3,nolink}, {Sutay:n}, {veStay:n}, {Santay:n}, {'Iptay:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a rank from John M. Ford's 1984 novel "The Final Reflection". These ranks are used by many Klingon fan clubs, despite not appearing in canon (i.e., in any TV episode or movie).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2782,6 +3114,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2789,6 +3122,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2802,6 +3136,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">цивилизовать</column>
       <column name="definition_zh_HK">教化 [AUTOTRANSLATED]</column>
       <column name="definition_pt">civilizar</column>
+      <column name="definition_fi">sivistää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2812,6 +3147,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tay:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -2821,6 +3157,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2828,6 +3165,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2841,6 +3179,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">цивилизация</column>
       <column name="definition_zh_HK">文明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">civilização</column>
+      <column name="definition_fi">sivilisaatio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nugh:n}</column>
@@ -2851,6 +3190,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru">Это слово, по-видимому, состоит из {tay:n:2} или {tay:v} и {qeq:n} или {qeq:v}. Возможно, это показатель того, что клингоны считают важным для цивилизации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞似乎由{tay:n:2}或{tay:v}和{qeq:n}或{qeq:v}組成。也許這表明克林崗人對文明的重要性。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra parece ser composta por {tay:n:2} ou {tay:v} e {qeq:n} ou {qeq:v}. Talvez seja uma indicação do que os klingons consideram importante para uma civilização. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana näyttää koostuvan seuraavista: {tay:n:2} tai {tay:v} ja {qeq:n} tai {qeq:v}. Ehkä tämä on osoitus siitä, mitä Klingons pitää tärkeänä sivilisaatiolle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2860,6 +3200,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">civilisation</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2867,6 +3208,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2880,6 +3222,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">быть вместе</column>
       <column name="definition_zh_HK">在一起 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser junto</column>
+      <column name="definition_fi">olla yhdessä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mob:v:1}, {nItebHa':adv}, {muv:v}</column>
@@ -2890,6 +3233,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru">Этот глагол также используется для определения принадлежности к клингонскому дому (см. Пояснение в {tuq:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞還用於指定Klingon House的成員身份（請參閱{tuq:n}下的說明）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado para especificar a associação em uma casa Klingon (consulte a explicação em {tuq:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös määrittelemään jäsenyys Klingon Housessa (katso selitys kohdassa {tuq:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Tie" together.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2906,6 +3250,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2913,6 +3258,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW p.34:src}, [3] {paq'batlh p.158-159:src}</column>
     </table>
     <table name="mem">
@@ -2926,6 +3272,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">Тай'Гокор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Ty'Gokor [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ty'Gokor</column>
+      <column name="definition_fi">Ty'Gokor</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2936,6 +3283,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru">Планета в империи клингонов, где происходит вступление в орден Бат'лет.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗帝國的一顆行星，在那兒，被引入巴蒂斯騎士團。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta no Império Klingon, onde ocorre a indução à Ordem dos Bat'leth.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Klingonin valtakunnassa, jossa tapahtuu induktio Bat'lethin ritarikuntaan.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2945,6 +3293,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2952,6 +3301,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}, [2] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -2965,6 +3315,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">Кровь и вода не смешиваются. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">血液和水不混合。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sangue e água não se misturam.</column>
+      <column name="definition_fi">Veri ja vesi eivät sekoitu.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2975,6 +3326,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2984,6 +3336,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2991,6 +3344,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.34:src}</column>
     </table>
     <table name="mem">
@@ -3004,6 +3358,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">совершать</column>
       <column name="definition_zh_HK">完成 [AUTOTRANSLATED]</column>
       <column name="definition_pt">realizar</column>
+      <column name="definition_fi">suorittaa, toteuttaa, saada päätökseen/valmiiksi/aikaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chav:v}, {DIgh:v}</column>
@@ -3014,6 +3369,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3024,6 +3380,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">do</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3031,6 +3388,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3044,6 +3402,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">поступок, достижение</column>
       <column name="definition_zh_HK">行為、成就 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ação, realização</column>
+      <column name="definition_fi">teko, suoritus, saavutus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chav:n}</column>
@@ -3054,6 +3413,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3064,6 +3424,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3071,6 +3432,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3084,6 +3446,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">император</column>
       <column name="definition_zh_HK">皇帝</column>
       <column name="definition_pt">imperador</column>
+      <column name="definition_fi">keisari</column>
       <column name="synonyms">{voDleH:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3094,6 +3457,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3103,6 +3467,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3110,6 +3475,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3123,6 +3489,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">стандартный диалект [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">標準方言 [AUTOTRANSLATED]</column>
       <column name="definition_pt">dialeto padrão</column>
+      <column name="definition_fi">yleiskieli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hol Sar:n}, {Sep Hol Sar:n}</column>
@@ -3133,6 +3500,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru">Это сокращение от {ta' tlhIngan Hol:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{ta' tlhIngan Hol:n}的縮寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é abreviação de {ta' tlhIngan Hol:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhyt sanalle {ta' tlhIngan Hol:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ta':n:2}, {Hol:n}</column>
       <column name="examples"></column>
@@ -3142,6 +3510,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3149,6 +3518,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3162,6 +3532,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">Императорский клингон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">皇帝的克林崗語</column>
       <column name="definition_pt">O Klingon do imperador</column>
+      <column name="definition_fi">keisarin klingon</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3172,6 +3543,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru">Это стандартный диалект клингона. Это также называется {ta' Hol:n} для краткости. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是克林崗語的標準方言。它也簡稱為{ta' Hol:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o dialeto padrão de Klingon. Também é chamado de {ta' Hol:n}, para abreviar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Klingonin tavallinen murre. Sitä kutsutaan myös lyhyeksi nimeksi {ta' Hol:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ta':n:2}, {tlhIngan Hol:n}</column>
       <column name="examples"></column>
@@ -3181,6 +3553,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3188,6 +3561,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3201,6 +3575,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">Великие дела, отличные песни. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">偉大的事蹟，偉大的歌曲。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Grandes feitos, grandes canções.</column>
+      <column name="definition_fi">Hienoja tekoja, hienoja lauluja.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3211,6 +3586,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ta':n:1}, {-mey:n}, {Dun:v}, {bom:n}, {-mey:n}, {Dun:v}</column>
       <column name="examples"></column>
@@ -3220,6 +3596,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3227,6 +3604,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.15:src}</column>
     </table>
     <table name="mem">
@@ -3240,6 +3618,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">заполнить</column>
       <column name="definition_zh_HK">填 [AUTOTRANSLATED]</column>
       <column name="definition_pt">preencher</column>
+      <column name="definition_fi">täyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{buy':v}, {ghoD:v}, {lIch:v}, {ngaS:v}, {naQ:v}, {chIm:v}, {qorgh:v}, {Qoy':v}</column>
@@ -3250,6 +3629,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru">Этот глагол может использоваться для заполнения отверстия ({QemjIq:n}), но не для простого закрытия отверстия ({qung:n}), которое будет {qorgh:v}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞可用於填充洞（{QemjIq:n}），而不是僅用於阻止開口（{qung:n}），這將是{qorgh:v}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse verbo pode ser usado para preencher um buraco ({QemjIq:n}), mas não apenas para interromper uma abertura ({qung:n}), que seria {qorgh:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä voidaan käyttää reiän täyttämiseen ({QemjIq:n}), mutta ei vain aukon pysäyttämiseen ({qung:n}), mikä olisi {qorgh:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{tebwI':n}</column>
@@ -3259,6 +3639,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3266,6 +3647,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2013:src}</column>
     </table>
     <table name="mem">
@@ -3279,6 +3661,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">юрисдикция</column>
       <column name="definition_zh_HK">管轄權 [AUTOTRANSLATED]</column>
       <column name="definition_pt">jurisdição</column>
+      <column name="definition_fi">oikeuden- tai lainkäyttö, tuomiovalta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meqba':n}, {loH:n}, {qum:n}, {yer:n}, {Daq'a':n}</column>
@@ -3289,6 +3672,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3298,6 +3682,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3305,6 +3690,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3318,6 +3704,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">food server in a Dok'e (fast-food restaurant) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Dok'e（快餐店）的食物服務器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">servidor de comida em um Dok'e (restaurante de comida rápida)</column>
+      <column name="definition_fi">tarjoilija Dok'e-ravintolassa (pikaruokaravintolassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jabwI':n}, {chom:n}, {vutwI':n}, {Do Qe':n}</column>
@@ -3328,6 +3715,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{teb:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -3337,6 +3725,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3344,6 +3733,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3357,6 +3747,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">вид животного, тегбат [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、teg'bat [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, teg'bat</column>
+      <column name="definition_fi">eräs eläin, teg'bat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'awje':n}</column>
@@ -3367,6 +3758,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3376,6 +3768,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3383,6 +3776,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3396,6 +3790,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">быть верным</column>
       <column name="definition_zh_HK">是真實的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser verdadeiro</column>
+      <column name="definition_fi">olla tosi, olla totta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngeb:v}, {'ol:v}, {vIt:v}, {vIt:n}, {lugh:v}, {qar:v}</column>
@@ -3406,6 +3801,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The computer programming control flow concepts "if" and "while" were translated as {teHchugh:sen:nolink} and {teHtaHvIS:sen:nolink}, respectively, in Klingon Blockly. Setting a boolean variable to "true" was translated as {teHmoH:sen:nolink}, while setting one to "false" was translated as {teHbe'moH:sen:nolink}.[4]</column>
       <column name="components"></column>
       <column name="examples">
@@ -3428,6 +3824,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3435,6 +3832,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2012.03.19:src}, [3] {paq'batlh p.54-55:src}, [4] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <table name="mem">
@@ -3448,6 +3846,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">ученый</column>
       <column name="definition_zh_HK">科學家</column>
       <column name="definition_pt">cientista</column>
+      <column name="definition_fi">tieteentekijä, tiedemies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3458,6 +3857,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru">Как правило, для каждого {QeD:n} существует соответствующий {tej:n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Geralmente, para cada {QeD:n}, existe um {tej:n:nolink} correspondente.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yleensä jokaiselle {QeD:n}: lle on vastaava {tej:n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3467,6 +3867,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3474,6 +3875,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -3487,6 +3889,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="definition_ru">крыло</column>
       <column name="definition_zh_HK">翅膀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">asa</column>
+      <column name="definition_fi">siipi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{laq:v:1}</column>
@@ -3497,6 +3900,7 @@ This refers to the expression "going to hell ({Hel:sen:nolink}) in a hand ({ghop
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.
 
 This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-mey:n:suff} otherwise.</column>
@@ -3508,6 +3912,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3515,6 +3920,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3528,6 +3934,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">механизм управления крылом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">機翼控制機制 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mecanismo de controle de asa</column>
+      <column name="definition_fi">siipien ohjausmekanismi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3538,6 +3945,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tel:n}, {SeH:v}, {-wI':v}, {jo':n}</column>
       <column name="examples"></column>
@@ -3547,6 +3955,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3554,6 +3963,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3567,6 +3977,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">перегородка крыла [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">翼擋板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">defletor asa</column>
+      <column name="definition_fi">siipilevy?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3577,6 +3988,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tel:n}, {vID'Ir:n}</column>
       <column name="examples"></column>
@@ -3586,6 +3998,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3593,6 +4006,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3606,6 +4020,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">свет крыла [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">翼燈 [AUTOTRANSLATED]</column>
       <column name="definition_pt">iluminação de asa</column>
+      <column name="definition_fi">siipivalo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3616,6 +4031,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tel:n}, {-Daq:n}, {wovmoHwI':n}</column>
       <column name="examples"></column>
@@ -3625,6 +4041,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3632,6 +4049,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3645,6 +4063,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">Теллар Прайм [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Tellar Prime [AUTOTRANSLATED]</column>
       <column name="definition_pt">Tellar Prime</column>
+      <column name="definition_fi">Tellar I</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tellarngan:n}</column>
@@ -3655,6 +4074,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru">Это родная планета члена-основателя Объединенной федерации планет ({yuQjIjDIvI':n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是行星聯合會（{yuQjIjDIvI':n}）創始成員的故鄉行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o planeta natal de um membro fundador da Federação Unida de Planetas ({yuQjIjDIvI':n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Yhdistyneiden planeettojen federaation ({yuQjIjDIvI':n}) perustajajäsenen planeetta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3664,6 +4084,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3671,6 +4092,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3684,6 +4106,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">Телларит [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Tellarite [AUTOTRANSLATED]</column>
       <column name="definition_pt">Tellarite</column>
+      <column name="definition_fi">tellariitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tellar wa':n}</column>
@@ -3694,6 +4117,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tellar wa':n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -3703,6 +4127,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3710,6 +4135,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3723,6 +4149,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">Тэллунская солнечная система</column>
       <column name="definition_zh_HK">特魯倫星系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sistema estrelar Tellun</column>
+      <column name="definition_fi">Tellun-tähtijärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hovtay':n}</column>
@@ -3733,6 +4160,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru">Эта звездная система находится недалеко от границы Федерация-Клингон и содержит две планеты: {Doy'yuS:n} и {'elaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個恆星系統位於聯邦-克林崗州邊界附近，包含兩個行星{Doy'yuS:n}和{'elaS:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este sistema estelar está localizado próximo à fronteira da Federação-Klingon e contém os dois planetas {Doy'yuS:n} e {'elaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3742,6 +4170,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3749,6 +4178,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3762,6 +4192,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">поджелудочная железа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">胰腺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pâncreas</column>
+      <column name="definition_fi">haima</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3772,6 +4203,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Backwards of {'aylet:sen:nolink} "islet". The islets of Langerhans, or pancreatic islets, are clusters of cells within the pancreas.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3781,6 +4213,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3788,6 +4221,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -3801,6 +4235,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">наставник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">導師 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mentor</column>
+      <column name="definition_fi">mentori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghojmoHwI':n}</column>
@@ -3811,6 +4246,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Tell 'em", also behind ({'em:n}) the wing ({tel:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3820,6 +4256,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3827,6 +4264,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3840,6 +4278,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">отрицать</column>
       <column name="definition_zh_HK">拒絕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">negar</column>
+      <column name="definition_fi">kiistää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chID:v}</column>
       <column name="see_also">{tlhoch:v}</column>
@@ -3850,6 +4289,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru">Это означает «противоречить, дезавуировать, утверждать, что оно ложное» и тому подобное. Это не означает «отказывайся, отвергай, отказывайся, не разрешай».[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著“矛盾，否認，聲稱是錯誤的”等。這並不意味著“拒絕，拒絕，拒絕，不允許”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "contradizer, negar, reivindicar como falso" e similares. Não significa "recusar, rejeitar, recusar, não permitir".[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "ristiriitaista, hylkäävää, väittävän vääräksi" ja vastaavia. Se ei tarkoita "kieltäydy, hylkää, hylkää, älä salli" .[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3859,6 +4299,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">contradict, disavow, claim as false</column>
       <column name="search_tags_de">widersprechen, verleugnen, als falsch bezeichnen</column>
       <column name="search_tags_fa"></column>
@@ -3866,6 +4307,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -3879,6 +4321,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">Электрон</column>
       <column name="definition_zh_HK">電子</column>
       <column name="definition_pt">elétron</column>
+      <column name="definition_fi">elektroni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeySel:n}, {yomIj:n}, {valtIn:n}, {tat:n}, {ngIng:v}, {rugh tem:n}</column>
@@ -3889,6 +4332,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3898,6 +4342,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3905,6 +4350,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -3918,6 +4364,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">садиться на корабль</column>
       <column name="definition_zh_HK">從事 [AUTOTRANSLATED]</column>
       <column name="definition_pt">embarcar</column>
+      <column name="definition_fi">nousta (alukseen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIt:v}</column>
@@ -3928,6 +4375,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3937,6 +4385,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3944,6 +4393,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3957,6 +4407,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">uncle (father's brother) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">叔叔（父親的兄弟） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tio (irmão do pai)</column>
+      <column name="definition_fi">setä (isän veli)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vav:n}, {'e'mam:n}</column>
@@ -3967,6 +4418,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru">Дитя {tennuS:n:nolink} - это {tey':n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{tennuS:n:nolink}: n lapsi on {tey':n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to "Uncle Tenoose" from the Danny Thomas Show.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3976,6 +4428,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">father's brother</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3983,6 +4436,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -3996,6 +4450,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">дядя (муж сестры отца) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">叔叔（父親的姐姐的丈夫） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tio (marido da irmã do pai)</column>
+      <column name="definition_fi">isän sisaren aviomies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vav:n}, {'e'mam:n}</column>
@@ -4006,6 +4461,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tennuS:n}, {'e'nal:n}</column>
       <column name="examples"></column>
@@ -4015,6 +4471,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">father's sister's husband</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4022,6 +4479,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -4035,6 +4493,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">page (in a book) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頁面（在一本書中） [AUTOTRANSLATED]</column>
       <column name="definition_pt">página (em um livro)</column>
+      <column name="definition_fi">sivu (kirjassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nav:n}</column>
@@ -4045,6 +4504,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru">Это используется только для пронумерованных страниц в книге или что-то подобное. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這僅用於書中編號頁或類似內容。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado apenas para páginas numeradas em um livro ou algo semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään vain kirjan tai vastaavan numeroituihin sivuihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4054,6 +4514,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4061,6 +4522,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -4074,6 +4536,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">космическая станция</column>
       <column name="definition_zh_HK">太空站</column>
       <column name="definition_pt">estação Espacial</column>
+      <column name="definition_fi">avaruusasema</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ejyo'waw':n}, {logh:n}, {vergh:n}</column>
@@ -4084,6 +4547,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4093,6 +4557,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4100,6 +4565,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4113,6 +4579,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">груз</column>
       <column name="definition_zh_HK">貨物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">carga</column>
+      <column name="definition_fi">rahti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leng buq:n}</column>
@@ -4123,6 +4590,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4132,6 +4600,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4139,6 +4608,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4152,6 +4622,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">грузовой транспортер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">貨物運輸車 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transportador de carga</column>
+      <column name="definition_fi">rahdinsiirrin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wey jolpat:n}</column>
@@ -4162,6 +4633,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tep:n}, {jolpat:n}</column>
       <column name="examples">
@@ -4172,6 +4644,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4179,6 +4652,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -4192,6 +4666,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">грузовой перевозчик</column>
       <column name="definition_zh_HK">貨物運輸船、貨物升降機 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transportador de carga, elevador de carga</column>
+      <column name="definition_fi">rahtihissi tai -nosturi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4202,6 +4677,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru">На плакате {BoP:src} это тип крана. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{BoP:src}海報中，這是一種起重機。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No pôster {BoP:src}, esse é um tipo de guindaste. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{BoP:src}-julisteessa tämä on eräänlainen nosturi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tep:n}, {qeng:v}, {-wI':v:suff}</column>
       <column name="examples"></column>
@@ -4211,6 +4687,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4218,6 +4695,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -4231,6 +4709,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">снимать</column>
       <column name="definition_zh_HK">刪除、起飛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">remover, decolar</column>
+      <column name="definition_fi">poistaa, ottaa pois, irrottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuQHa'moH:v}, {nge':v}, {jotlh:v}</column>
@@ -4241,6 +4720,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="notes_ru">Для удаления чего-то из интерьера, рассмотрите {lel:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了從內部去除某些東西，請考慮​​使用{lel:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para remover algo do interior, considere o {lel:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Harkitse {lel:v}, jos haluat poistaa jotain sisustuksesta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <!-- This needs an example. -->
@@ -4251,6 +4731,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4258,6 +4739,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4271,6 +4753,7 @@ This word takes the suffix {-Du':n:suff} when it refers to a body part, and {-me
       <column name="definition_ru">Земля</column>
       <column name="definition_zh_HK">地球</column>
       <column name="definition_pt">Terra</column>
+      <column name="definition_fi">Maa (planeetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yoq yIn yuQ:n}, {yInSIp:n}, {Human:n}, {tera'ngan:n}, {DIvI' Hol:n}, {Saturn:n}, {juHqo':n}</column>
@@ -4290,6 +4773,16 @@ Earth is a major planet in the Federation ({DIvI':n}) and the third planet in th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on ihmisen kotimaailman nimi. Katso "maa" tarkoittaa "lika", katso {lam:n}.
+
+Maa on suuri planeetta federaatiossa ({DIvI':n}) ja kolmas planeetta {Sol:n}-tähtijärjestelmässä. Maanosat ovat:
+▶ {'amerI'qa' tIng chan tIng:n} "Etelä-Amerikka"
+▶ {'amerI'qa' 'ev chan 'ev:n} "Pohjois-Amerikka"
+▶ {'antartIq:n} "Etelämanner"
+▶ {'aSralya':n} "Australia"
+▶ {'aSya':n} "Aasia"
+▶ {'avrI'qa':n} "Afrikka"
+▶ {'ewrop:n} "Eurooppa" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4299,6 +4792,7 @@ Earth is a major planet in the Federation ({DIvI':n}) and the third planet in th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Terra</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4306,6 +4800,7 @@ Earth is a major planet in the Federation ({DIvI':n}) and the third planet in th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -4319,6 +4814,7 @@ Earth is a major planet in the Federation ({DIvI':n}) and the third planet in th
       <column name="definition_ru">житель Земли</column>
       <column name="definition_zh_HK">地球人</column>
       <column name="definition_pt">terráqueo</column>
+      <column name="definition_fi">Maan asukas, maapallolainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}, {Human:n}</column>
@@ -4343,6 +4839,9 @@ Observera att en människa ({Human:n}) är medlem av de viktigaste inhemska spr�
       <column name="notes_pt">Existe um idioma, {Hoj; tera'ngan rur@@Hoj:v, tera'ngan:n, rur:v}.
 
 Observe que um humano ({Human:n}) é um membro das principais espécies da Terra com capacidade de linguagem indígena ({tera':n:place}), enquanto o Terran ({tera'ngan:n:nolink}) se refere a qualquer habitante do planeta. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {Hoj; tera'ngan rur@@Hoj:v, tera'ngan:n, rur:v}.
+
+Huomaa, että ihminen ({Human:n}) on tärkeimpien maan alkuperäiskielen kykenevien lajien ({tera':n:place}) jäsen, kun taas Terran ({tera'ngan:n:nolink}) viittaa mihin tahansa planeetan asukkaaseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -4352,6 +4851,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">human, Earthling</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4359,6 +4859,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4372,6 +4873,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="definition_ru">аллигатор, крокодил [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鱷魚</column>
       <column name="definition_pt">jacaré, crocodilo</column>
+      <column name="definition_fi">alligaattori, krokotiili</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4382,6 +4884,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {bIQ:n}, {lung:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -4391,6 +4894,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4398,6 +4902,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -4411,6 +4916,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="definition_ru">простуда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">普通感冒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gripe comum</column>
+      <column name="definition_fi">flunssa</column>
       <column name="synonyms">{tera' tlhuH rop:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4421,6 +4927,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="notes_ru">Мальц говорит, что клингоны не болеют простудой (хотя, несмотря на то, что он говорит, клингоны не застрахованы от других, несколько похожих болезней). Другим способом обозначения этой земной болезни, обычно не сочувствующим, является {tera' rop bIr:n:nolink}, что, конечно, является ошибочным переводом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">馬爾茨說，克林崗人不會感冒（儘管，儘管他說了什麼，但克林貢人不能免於其他類似疾病的困擾）。通常，沒有同情心地提及地球疾病的另一種方法是{tera' rop bIr:n:nolink}，這當然是誤導的翻譯。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Maltz diz que os klingons não ficam resfriados (apesar do que ele diz, os klingons não estão imunes a outras aflições um tanto parecidas). Outra maneira de se referir a essa doença da Terra, geralmente não simpatizante, é o {tera' rop bIr:n:nolink}, que é, obviamente, uma tradução equivocada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maltz sanoo, että klingonit eivät saa vilustumista (vaikka hänen sanoistaan ​​huolimatta klingonit eivät ole immuuneja muista, jonkin verran samanlaisista ahdistuksista). Toinen tapa viitata tähän Maan tautiin, yleensä epäsympaattisesti, on {tera' rop bIr:n:nolink}, joka on tietysti väärä käännös. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {ghIch:n}, {rop:n}</column>
       <column name="examples"></column>
@@ -4430,6 +4937,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4437,6 +4945,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4450,6 +4959,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="definition_ru">улитка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蝸牛</column>
       <column name="definition_pt">caracol</column>
+      <column name="definition_fi">etana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4460,6 +4970,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="notes_ru">Если контекст понятен, его можно сократить до {nagh DIr charwI':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果上下文清楚，可以將其縮短為{nagh DIr charwI':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se o contexto estiver claro, isso pode ser reduzido para {nagh DIr charwI':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos asiayhteys on selkeä, se voidaan lyhentää muotoon {nagh DIr charwI':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {nagh:n}, {DIr:n}, {char:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4469,6 +4980,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4476,6 +4988,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -4489,6 +5002,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="definition_ru">апельсин (плод)</column>
       <column name="definition_zh_HK">橙（水果）</column>
       <column name="definition_pt">laranja (fruta)</column>
+      <column name="definition_fi">appelsiini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tanje'rIn:n}</column>
@@ -4499,6 +5013,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {na'ran:n}</column>
       <column name="examples"></column>
@@ -4508,6 +5023,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4515,6 +5031,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4528,6 +5045,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="definition_ru">грейпфрут [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">葡萄柚 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Toranja</column>
+      <column name="definition_fi">greippi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4538,6 +5056,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {na'ran:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -4547,6 +5066,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4554,6 +5074,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4567,6 +5088,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="definition_ru">лимон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">檸檬</column>
       <column name="definition_pt">limão</column>
+      <column name="definition_fi">sitruuna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4577,6 +5099,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {na'ran:n}, {wIb:v}</column>
       <column name="examples"></column>
@@ -4586,6 +5109,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4593,6 +5117,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4606,6 +5131,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="definition_ru">огурец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">黃瓜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pepino</column>
+      <column name="definition_fi">kurkku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4616,6 +5142,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {peb'ot:n}</column>
       <column name="examples"></column>
@@ -4625,6 +5152,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4632,6 +5160,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4645,6 +5174,7 @@ Observe que um humano ({Human:n}) é um membro das principais espécies da Terra
       <column name="definition_ru">Дата Земли, Время Земли [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地球日期、地球時間</column>
       <column name="definition_pt">dia da terra, hora da terra</column>
+      <column name="definition_fi">Maan päivämäärä, Maan aika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HovpoH:n}</column>
@@ -4676,6 +5206,28 @@ The Terran months are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä termiä käytetään kutsussa {Star Trek The Exhibition:src}. Kutsu kuuluu:
+▶ {tera' poH jaj wa', jar wa', jaj loSDIch, DIS wa'-Hut-Hut-chorgh. HovpoHvetlh latlh nab yIHutlh.:sen:nolink} "Tallenna tämä tähtitaiva: sunnuntai 4. tammikuuta 1998".
+
+Kutsun tietojen perusteella kerrotessasi maapallon päivämäärää:
+▶ viikonpäivät kartoitetaan niiden Klingon-analogeihin (katso {Hogh:n});
+▶ {jar:n}, jota seuraa numero, merkitsee kuukauden tammikuusta alkaen {jar wa':n:nolink};
+▶ kuukauden päivä annetaan järjestyksessä, {jaj loSDIch:n:nolink} "neljäs päivä";
+▶ vuosi määritetään antamalla sen numerot sanan {DIS:n:2}.[1] jälkeen
+
+Terran-kuukaudet ovat:
+▶ {jar wa':n:nolink} "tammikuu"
+▶ {jar cha':n:nolink} "helmikuu"
+▶ {jar wej:n:nolink} "Maaliskuu"
+▶ {jar loS:n:nolink} "huhtikuu"
+▶ {jar vagh:n:nolink} "toukokuu"
+▶ {jar jav:n:nolink} "kesäkuu"
+▶ {jar Soch:n:nolink} "heinäkuu"
+▶ {jar chorgh:n:nolink} "elokuu"
+▶ {jar Hut:n:nolink} "syyskuu"
+▶ {jar wa'maH:n:nolink} "lokakuu"
+▶ {jar wa'maH wa':n:nolink} "marraskuu"
+▶ {jar wa'maH cha':n:nolink} "joulukuu"[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {poH:n}</column>
       <column name="examples"></column>
@@ -4685,6 +5237,7 @@ The Terran months are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Terran date, Terran time, January, February, March, April, May, June, July, August, September, October, November, December</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4692,6 +5245,7 @@ The Terran months are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek The Exhibition:src}, [2] {KLI mailing list 2012.04.01:src}</column>
     </table>
     <table name="mem">
@@ -4705,6 +5259,7 @@ The Terran months are:
       <column name="definition_ru">простуда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">普通感冒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gripe comum</column>
+      <column name="definition_fi">flunssa</column>
       <column name="synonyms">{tera' ghIch rop:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4715,6 +5270,7 @@ The Terran months are:
       <column name="notes_ru">Мальц говорит, что клингоны не болеют простудой (хотя, несмотря на то, что он говорит, клингоны не застрахованы от других, несколько похожих болезней). Другим способом обозначения этой земной болезни, обычно не сочувствующим, является {tera' rop bIr:n:nolink}, что, конечно, является ошибочным переводом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">馬爾茨說，克林崗人不會感冒（儘管，儘管他說了什麼，但克林貢人不能免於其他類似疾病的困擾）。通常，沒有同情心地提及地球疾病的另一種方法是{tera' rop bIr:n:nolink}，這當然是誤導的翻譯。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Maltz diz que os klingons não ficam resfriados (apesar do que ele diz, os klingons não estão imunes a outras aflições um tanto parecidas). Outra maneira de se referir a essa doença da Terra, geralmente não simpatizante, é o {tera' rop bIr:n:nolink}, que é, obviamente, uma tradução equivocada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maltz sanoo, että klingonit eivät saa vilustumista (vaikka hänen sanoistaan ​​huolimatta klingonit eivät ole immuuneja muista, jonkin verran samanlaisista ahdistuksista). Toinen tapa viitata tähän Maan tautiin, yleensä epäsympaattisesti, on {tera' rop bIr:n:nolink}, joka on tietysti väärä käännös. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {tlhuH:n}, {rop:n}</column>
       <column name="examples"></column>
@@ -4724,6 +5280,7 @@ The Terran months are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4731,6 +5288,7 @@ The Terran months are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4744,6 +5302,7 @@ The Terran months are:
       <column name="definition_ru">гриб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蘑菇 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cogumelo</column>
+      <column name="definition_fi">sieni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4754,6 +5313,7 @@ The Terran months are:
       <column name="notes_ru">Это то, что клингоны называют грибом терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族真菌。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que os klingons chamariam de fungo terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-sieneksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {yav:n}, {'atlhqam:n}</column>
       <column name="examples"></column>
@@ -4763,6 +5323,7 @@ The Terran months are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4770,6 +5331,7 @@ The Terran months are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4783,6 +5345,7 @@ The Terran months are:
       <column name="definition_ru">плющ (терран) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">常春藤（人族） [AUTOTRANSLATED]</column>
       <column name="definition_pt">hera (terráqueo)</column>
+      <column name="definition_fi">muratti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4793,6 +5356,7 @@ The Terran months are:
       <column name="notes_ru">Это относится к терранскому заводу. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指人種植物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à planta terráquea. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa Terranin tehtaaseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tera':n}, {'arDeH:n}</column>
       <column name="examples"></column>
@@ -4802,6 +5366,7 @@ The Terran months are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4809,6 +5374,7 @@ The Terran months are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4822,6 +5388,7 @@ The Terran months are:
       <column name="definition_ru">ухо (внутренний орган слуха) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">耳朵（內聽器官） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ouvido (órgão interno de audição)</column>
+      <column name="definition_fi">sisäkorva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qogh:n:2,body}, {Serrum:n}</column>
@@ -4832,6 +5399,7 @@ The Terran months are:
       <column name="notes_ru">Это относится к органу слуха внутри головы, в то время как {qogh:n:2,body} относится к внешнему лоскуту кожи, хряща и т. Д. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指頭內部的聽覺器官，而{qogh:n:2,body}是指皮膚，軟骨等的外部皮瓣。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao órgão da audição dentro da cabeça, enquanto {qogh:n:2,body} refere-se ao retalho externo da pele, cartilagem, etc. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kuuloelimeen pään sisällä, kun taas {qogh:n:2,body} viittaa ihon, ruston jne. Ulkoiseen läppään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4841,6 +5409,7 @@ The Terran months are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4848,6 +5417,7 @@ The Terran months are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
     </table>
         <table name="mem">
@@ -4861,6 +5431,7 @@ The Terran months are:
           <column name="definition_ru">наушник [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">聽筒 [AUTOTRANSLATED]</column>
           <column name="definition_pt">fone de ouvido</column>
+      <column name="definition_fi">kuuloke</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{DannI':n}</column>
@@ -4871,6 +5442,7 @@ The Terran months are:
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This was not given an English definition, but was described as the device Uhura wears (which contrasts with a {DannI':n:nolink} in not covering both ears).</column>
           <column name="components">{teS:n}, {HablI':n}</column>
           <column name="examples"></column>
@@ -4880,6 +5452,7 @@ The Terran months are:
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">headset, earbud</column>
           <column name="search_tags_de">Hörmuschel</column>
           <column name="search_tags_fa"></column>
@@ -4887,6 +5460,7 @@ The Terran months are:
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -4900,6 +5474,7 @@ The Terran months are:
       <column name="definition_ru">плитка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">瓦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">telha</column>
+      <column name="definition_fi">(lautapelin tms.) pala, laatta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{majyang:n}, {SIQab'el:n}, {Qay'mol:n}</column>
@@ -4910,6 +5485,7 @@ The Terran months are:
       <column name="notes_ru">Это относится к части, используемой в игре (например, Эрудит) или головоломки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指在遊戲（例如拼字遊戲）或拼圖中使用的棋子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma peça usada em um jogo (como Scrabble) ou um quebra-cabeça. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa pelissä käytettyyn kappaleeseen (kuten Scrabble) tai palapeliin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">From the Latin "tessera".</column>
       <column name="components"></column>
       <column name="examples">
@@ -4920,6 +5496,7 @@ The Terran months are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4927,6 +5504,7 @@ The Terran months are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4940,6 +5518,7 @@ The Terran months are:
       <column name="definition_ru">таять</column>
       <column name="definition_zh_HK">熔化 [AUTOTRANSLATED]</column>
       <column name="definition_pt">derreter</column>
+      <column name="definition_fi">sulattaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pub:v}</column>
@@ -4950,6 +5529,7 @@ The Terran months are:
       <column name="notes_ru">Объект - это та вещь, которая плавится. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對像是被融化的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é a coisa que é derretida. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on sulanut asia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4963,6 +5543,7 @@ The Terran months are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4970,6 +5551,7 @@ The Terran months are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.76-77:src}</column>
     </table>
     <table name="mem">
@@ -4983,6 +5565,7 @@ The Terran months are:
       <column name="definition_ru">эмаль, покрытие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">搪瓷，塗料 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esmalte, revestimento</column>
+      <column name="definition_fi">pinnoite, päällystys, lakka (esim. emali)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vel:v}</column>
@@ -4993,6 +5576,7 @@ The Terran months are:
       <column name="notes_ru">Это относится к любому виду искусственного покрытия, а не только к эмали. Это не относится к зубам. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指任何種類的人造塗層，而不僅僅是搪瓷。它不適用於牙齒。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a qualquer tipo de revestimento artificial, não apenas ao esmalte. Não se aplica aos dentes. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa mihin tahansa keinotekoiseen pinnoitteeseen, ei vain emaliin. Se ei koske hampaita. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5002,6 +5586,7 @@ The Terran months are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5009,6 +5594,7 @@ The Terran months are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5022,6 +5608,7 @@ The Terran months are:
       <column name="definition_ru">прокрутка, прокрутка, список [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滾動、滾動、列表 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rolar, listar</column>
+      <column name="definition_fi">rulla, käärö; lista, luettelo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gher:v}, {patlh:v}, {Dop:v:1}, {mem:n}, {HIDjolev:n}, {buv:n}, {ghu'lIS:n}, {natlIS:n}</column>
@@ -5032,6 +5619,7 @@ The Terran months are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這個詞可以用於任何類似滾動的內容，並且通常也用於表示任何種類的列表，而{Qumran:n}則是一種更為禮儀的滾動形式。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra pode ser usada para qualquer coisa enrolada como um pergaminho e também costuma denotar qualquer tipo de lista, enquanto {Qumran:n} se refere a um tipo mais cerimonial de pergaminho.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää mihin tahansa käärittyyn kuin vieritys, ja se on yleisesti tullut merkitsemään kaikenlaista luetteloa, kun taas {Qumran:n} viittaa seremoniallisempaan vieritykseen.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Klingon phrase as printed on the {BoP:src} poster contains typos.
 
 This word was used for the "list" variable type in Klingon Blockly.[4]</column>
@@ -5047,6 +5635,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5054,6 +5643,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {BoP:src}, [3] {KLI mailing list 2013.06.12:src}, [4] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <table name="mem">
@@ -5067,6 +5657,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">катиться (спускаться с холма, как бревно) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滾（像原木一樣下山坡） [AUTOTRANSLATED]</column>
       <column name="definition_pt">rolar (descendo uma colina como um tronco)</column>
+      <column name="definition_fi">vieriä (mäkeä alas kuin tukki)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ron:v:1}, {Hay:v}</column>
@@ -5077,6 +5668,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Хотя этот глагол связан с существительным {tetlh:n}, он не используется для свитков (если только свиток не катится вниз по склону). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">儘管此動詞與名詞{tetlh:n}相關，但它不用於滾動（除非滾動碰巧從山上滾下來）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Embora esse verbo esteja relacionado ao substantivo {tetlh:n}, ele não é usado para pergaminhos (a menos que um pergaminho esteja rolando ladeira abaixo). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vaikka tämä verbi liittyy substantiiviin {tetlh:n}, sitä ei käytetä vierityksiin (paitsi jos vieritys sattuu vierimään mäkeä alas). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5086,6 +5678,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5093,6 +5686,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -5106,6 +5700,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">приз</column>
       <column name="definition_zh_HK">獎</column>
       <column name="definition_pt">prêmio</column>
+      <column name="definition_fi">palkinto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pop:n}, {van'a':n}, {Hoy':v}, {SIQwI':n}</column>
@@ -5116,6 +5711,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5125,6 +5721,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5132,6 +5729,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5145,6 +5743,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">скрести [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">raspar</column>
+      <column name="definition_fi">kaapia, raapia pois</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hew:n}, {nan:v:1}, {ghItlh:v}</column>
@@ -5155,6 +5754,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">除了其字面意義外，這還可以用於在某種情況下接近或沒有擺動空間或餘地的感覺。參見{tey:v:2}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Além de seu significado literal, isso também pode ser usado para a sensação de estar próximo ou não ter espaço de manobra ou margem de manobra em uma situação. Consulte {tey:v:2}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kirjaimellisen merkityksen lisäksi tätä voidaan käyttää myös tunteeseen olla lähellä tai olla vailla tilaa tai liikkumavaraa tilanteessa. Katso {tey:v:2}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5164,6 +5764,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5171,6 +5772,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5184,6 +5786,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">be uncomfortable, be close, not have wiggle room or leeway  [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不舒服、靠近、沒有擺動的空間或餘地 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desconfortável, estar perto, não ter espaço de manobra ou margem de manobra</column>
+      <column name="definition_fi">olla epämiellyttävä, epätyydyttävä, kireä, täpärä, ilman liikkumavaraaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{teybe':v}</column>
       <column name="see_also">{tey:v:1}</column>
@@ -5194,6 +5797,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5204,6 +5808,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5211,6 +5816,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5224,6 +5830,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">быть удобным, не быть рядом, иметь пространство для маневра или свободу действий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要舒服、不要靠近、有擺動的空間或迴旋餘地 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser confortável, não estar perto, ter espaço de manobra ou margem de manobra</column>
+      <column name="definition_fi">olla mukava, miellyttävä, ei täpärä, olla liikkumavaraa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tey:v:2}</column>
       <column name="see_also"></column>
@@ -5234,6 +5841,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tey:v:2}, {-be':v}</column>
       <column name="examples">
@@ -5244,6 +5852,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5251,6 +5860,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5264,6 +5874,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">файл (инструмент) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">檔案（工具） [AUTOTRANSLATED]</column>
       <column name="definition_pt">arquivo (ferramenta)</column>
+      <column name="definition_fi">viila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ho' teywI':n}, {yachwI':n}</column>
@@ -5274,6 +5885,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это означает «файл» в смысле пилочки для ногтей и тому подобного, а не файл данных (см. {ta:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在指甲銼之類的意義上，這意味著“文件”，而不是數據文件（有關此信息，請參見{ta:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "arquivo" no sentido de uma lixa de unhas e similares, não um arquivo de dados (para o qual consulte {ta:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "tiedostoa" kynsitiedoston ja vastaavien merkityksessä, ei datatiedostoa (josta ks. {ta:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined as "file" in {KGT:src}. The "tool" part was added for clarification.</column>
       <column name="components">{tey:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5283,6 +5895,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5290,6 +5903,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5303,6 +5917,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">сообщать по секрету</column>
       <column name="definition_zh_HK">信任 [AUTOTRANSLATED]</column>
       <column name="definition_pt">confiar</column>
+      <column name="definition_fi">tunnustaa, uskoutua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pegh:v:1}, {pegh:n}</column>
@@ -5313,6 +5928,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5322,6 +5938,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5329,6 +5946,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5342,6 +5960,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">двоюродный брат (ребенок {tennuS:n} или {me':n}) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">表弟（{tennuS:n}或{me':n}的孩子） [AUTOTRANSLATED]</column>
       <column name="definition_pt">primo (filho de {tennuS:n} ou {me':n})</column>
+      <column name="definition_fi">serkku (isän veljen ({tennuS:n}) tai äidin sisaren ({me':n}) lapsi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lor:n:0}, {vIn:n}, {yur:n}, {tey':n:2}</column>
@@ -5352,6 +5971,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это слово относится к ребенку сестры матери или ребенку брата отца (т. Е. «Параллельные двоюродные братья»). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞是指一個人的母親的妹妹的孩子或一個人的父親的兄弟的孩子（即“表親”）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se ao filho da irmã da mãe ou ao filho do irmão do pai (ou seja, "primos paralelos"). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa äidin sisaren lapseen tai isän veljen lapseen (eli "rinnakkaisiin serkkuihin"). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5361,6 +5981,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5368,6 +5989,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -5381,6 +6003,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">племянник племянница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">侄子侄女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sobrinho, sobrinha</column>
+      <column name="definition_fi">veljenpoika tai veljentytär (miehen veljen lapsi), sisarenpoika tai sisarentytär (naisen sisaren lapsi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tey':n:1}, {lor:n:2}</column>
@@ -5391,6 +6014,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Для мужчины это слово относится к ребенку его брата. Для женщины это относится к ребенку ее сестры. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於一個男人來說，這個詞是指他兄弟的孩子。對於一個女人，它指的是她姐姐的孩子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para um homem, essa palavra se refere ao filho de seu irmão. Para uma mulher, refere-se ao filho de sua irmã. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Miehelle tämä sana viittaa veljensä lapseen. Naiselle se viittaa sisarensa lapseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5400,6 +6024,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5407,6 +6032,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -5420,6 +6046,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">двоюродная сестра, племянница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">女錶弟、侄女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prima, sobrinha</column>
+      <column name="definition_fi">naispuolinen serkku (isän veljen tytär tai äidin sisaren tytär), sisarentytär (naisen sisaren tytär), veljentytär (miehen veljen tytär)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5430,6 +6057,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">{tey':n:0} женского пола, то есть двоюродная сестра, которая является ребенком сестры своей матери или ребенка брата отца, или племянница в смысле дочери брата мужчины или дочери сестры женщины. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{tey':n:0}的女性，即是表親，表親是母親的姐姐的孩子或父親的兄弟的孩子，或者是侄女的侄女。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma {tey':n:0} feminina, isto é, uma prima que é filha da irmã de uma mãe ou filha do irmão de um pai, ou uma sobrinha no sentido de filha do irmão de um homem ou filha da irmã de uma mulher. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nainen {tey':n:0}, ts. Serkku, joka on äitinsä sisaren lapsi tai isän veljen lapsi tai veljentytär miehen veljen tyttären tai naisen sisaren tyttären merkityksessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tey':n:0}, {be':n}</column>
       <column name="examples"></column>
@@ -5439,6 +6067,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5446,6 +6075,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -5459,6 +6089,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">кузен, племянник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">男錶弟、侄子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">primo, sobrinho</column>
+      <column name="definition_fi">miespuolinen serkku (isän veljen poika tai äidin sisaren poika), sisarenpoika (naisen sisaren poika), veljenpoika (miehen veljen poika)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5469,6 +6100,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Мужчина {tey':n:0}, то есть двоюродный брат, который является сыном сестры своей матери или сына брата своего отца, или племянником в смысле сына брата мужчины или сына сестры женщины. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">男性{tey':n:0}，即是堂兄，是母親的姐姐的兒子或父親的兄弟的兒子的侄子，或者是男人的兄弟的兒子或女人的姐妹的兒子的侄子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um {tey':n:0} masculino, isto é, um primo que é filho da irmã de uma mãe ou filho do irmão de um pai, ou sobrinho no sentido de filho do irmão de um homem ou filho da irmã de uma mulher. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Mies {tey':n:0}, eli serkku, joka on äitinsä sisaren poika tai isän veljen poika tai veljenpoika miehen veljen pojan tai naisen sisaren pojan merkityksessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tey':n:0}, {loD:n}</column>
       <column name="examples"></column>
@@ -5478,6 +6110,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5485,6 +6118,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -5498,6 +6132,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">императив: ты-их, вы-их</column>
       <column name="definition_zh_HK">（命令）你、你們：他們、它們</column>
       <column name="definition_pt">imperativo: você-eles, vocês-eles</column>
+      <column name="definition_fi">imperatiivi: sinä/te-heitä/niitä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Da-:v:pref}, {bo-:v:pref}</column>
@@ -5509,6 +6144,8 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SoH:n}: {chaH:n} / {bIH:n} = {tI-:v:pref,nolink} (imp.)
+{tlhIH:n}: {chaH:n} / {bIH:n} = {tI-:v:pref,nolink} (imp.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5518,6 +6155,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5525,6 +6163,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5538,6 +6177,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">растительность</column>
       <column name="definition_zh_HK">植被、植物</column>
       <column name="definition_pt">vegetação</column>
+      <column name="definition_fi">kasvillisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lav:n}, {Sor:n}, {poch:v}, {tIr:n}, {'InSong:n}, {raS'IS:n}, {San'emDer:n}, {namchIl:n}</column>
@@ -5548,6 +6188,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5557,6 +6198,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">plant</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5564,6 +6206,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <!-- Note: {tIb:v} is in the "extra" section, since it's a typo. -->
@@ -5578,6 +6221,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">оскорблять</column>
       <column name="definition_zh_HK">侮辱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">insultar</column>
+      <column name="definition_fi">loukata jotakuta (jonkun tunteita tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yI':v}</column>
       <column name="see_also">{vaq:v}, {nuS:v}, {qaD:v}, {maw:v}, {tuHmoH:v}, {vuv:v}, {naD:v}</column>
@@ -5588,6 +6232,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5597,6 +6242,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5604,6 +6250,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5617,6 +6264,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">обычай</column>
       <column name="definition_zh_HK">習慣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">personalizadas</column>
+      <column name="definition_fi">tapa, tottumus, käytäntö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurDech:n}, {quH:n}</column>
@@ -5627,6 +6275,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5638,6 +6287,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">way, path, culture</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5645,6 +6295,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -5658,6 +6309,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">тип животных, т'гла [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物的類型、t'gla [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, t'gla</column>
+      <column name="definition_fi">eräs eläin, t'gla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chatlh!:excl}</column>
@@ -5668,6 +6320,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Существует идиома {Dogh; tIghla' rur:sen@@Dogh:v, tIghla':n, rur:v}. [1, p.127] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語{Dogh; tIghla' rur:sen@@Dogh:v, tIghla':n, rur:v}.[1, p.127] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma {Dogh; tIghla' rur:sen@@Dogh:v, tIghla':n, rur:v}.[1, p.127] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {Dogh; tIghla' rur:sen@@Dogh:v, tIghla':n, rur:v}.[1, p.127] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5677,6 +6330,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5684,6 +6338,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5697,6 +6352,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">луч</column>
       <column name="definition_zh_HK">射線、光束 [AUTOTRANSLATED]</column>
       <column name="definition_pt">raio, feixe</column>
+      <column name="definition_fi">säde</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5707,6 +6363,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это слово относится к любому лучу энергии. Это расширение традиционного значения {tIH:n:2} (копья) для современного оружия. [2, p.65] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta palavra se refere a qualquer feixe de energia. É uma extensão do significado tradicional de {tIH:n:2} (haste de lança) para armamento moderno.[2, p.65] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa mihin tahansa energiapalkkiin. Se on {tIH:n:2}: n (keihäsakseli) perinteisen merkityksen laajennus nykyaikaisiin aseisiin.[2, p.65] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5717,6 +6374,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5724,6 +6382,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5737,6 +6396,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">древко копья [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">軸（長矛） [AUTOTRANSLATED]</column>
       <column name="definition_pt">eixo (da lança)</column>
+      <column name="definition_fi">(keihään) varsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQjej:n}</column>
@@ -5747,6 +6407,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это слово было адаптировано к современному оружию; см. {tIH:n:1} (луч энергии). Он также используется для обозначения железных дорог, для которых см. {tIHmey:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞已被改編為現代武器。參見{tIH:n:1}（能量束）。它也曾經用來談論鐵路，請參閱{tIHmey:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra foi adaptada para armas modernas; consulte {tIH:n:1} (feixe de energia). Também é usado para falar sobre ferrovias, para as quais consulte {tIHmey:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on mukautettu nykyaikaisiin aseisiin; katso {tIH:n:1} (energiasäde). Sitä käytetään myös puhumaan rautateistä, joista ks. {tIHmey:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5756,6 +6417,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5763,6 +6425,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5776,6 +6439,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">железнодорожные пути [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鐵軌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trilhos de trem</column>
+      <column name="definition_fi">rautatiekiskot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lupwI' mIr:n}, {tlharwIl Duj:n}</column>
@@ -5786,6 +6450,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это основано на {tIH:n:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這基於{tIH:n:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é baseado em {tIH:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä perustuu {tIH:n:2}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It's not clear whether a singular {tIH:n:nolink} would refer to a single rail (i.e., half a track), a single section of track, or something else.</column>
       <column name="components">{tIH:n:2}, {-mey:n}</column>
       <column name="examples"></column>
@@ -5795,6 +6460,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">train tracks</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5802,6 +6468,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>
     <table name="mem">
@@ -5815,6 +6482,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">идти на борту</column>
       <column name="definition_zh_HK">登機、上船、上車</column>
       <column name="definition_pt">embarcar</column>
+      <column name="definition_fi">nousta (alukseen), entrata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIt:v}</column>
@@ -5825,6 +6493,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5835,6 +6504,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5842,6 +6512,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5855,6 +6526,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">группа шедшая на борту</column>
       <column name="definition_zh_HK">登船隊</column>
       <column name="definition_pt">grupo de embarque</column>
+      <column name="definition_fi">entrausryhmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hoq:n}</column>
@@ -5865,6 +6537,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tIj:v}, {-wI':v}, {ghom:n}</column>
       <column name="examples"></column>
@@ -5874,6 +6547,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5881,6 +6555,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5894,6 +6569,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">выделять слюну [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">分泌唾液</column>
       <column name="definition_pt">salivar</column>
+      <column name="definition_fi">kuolata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhepQe':n}, {bol:v:1}, {tuy':v}</column>
@@ -5904,6 +6580,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5913,6 +6590,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5920,6 +6598,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -5933,6 +6612,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">большой</column>
       <column name="definition_zh_HK">大</column>
       <column name="definition_pt">ser grande</column>
+      <column name="definition_fi">olla iso, suuri</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mach:v}</column>
       <column name="see_also">{muq:v}</column>
@@ -5943,6 +6623,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "tin" is a box used to hold "match"es.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5952,6 +6633,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">large, huge</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5959,6 +6641,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5972,6 +6655,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">площадь к юго-западу, площадь к юго-западу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">西南面、西南方</column>
       <column name="definition_pt">área sudoeste, área em direção sudoeste</column>
+      <column name="definition_fi">lounaassa, alue lounaassa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurgh:n}, {chan:n}, {'ev:n}, {SInan:n}</column>
@@ -5982,6 +6666,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это примерно 220 градусов на терранском компасе, если север равен 0 и градусы отсчитываются по часовой стрелке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果north為0且順時針計數度數，則在Terran羅盤中約為220度。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é aproximadamente 220 graus em uma bússola terráquea, se o norte for 0 e os graus forem contados no sentido horário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on noin 220 astetta Terran-kompassilla, jos pohjoinen on 0 ja astetta lasketaan myötäpäivään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5991,6 +6676,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5998,6 +6684,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.21:src} (reprinted in {HQ 8.4, p.6, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -6011,6 +6698,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">повсюду, повсюду [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">四周圍、到處</column>
       <column name="definition_pt">por todo lado, em todo o lugar</column>
+      <column name="definition_fi">siellä täällä, kaikkialla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIng:n}, {'ev:n}, {chan:n}, {Dat:n}</column>
@@ -6021,6 +6709,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6031,6 +6720,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6038,6 +6728,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.21:src} (reprinted in {HQ 8.4, p.6, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -6051,6 +6742,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">на запад, область на запад [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">西面、西方</column>
       <column name="definition_pt">oeste, área em direção ao oeste</column>
+      <column name="definition_fi">lännessä, alue länteen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurgh:n}</column>
@@ -6061,6 +6753,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это средняя точка между основными направлениями {tIng:n} и {'ev:n}. Он также называется {'ev tIng:n:nolink} примерно с той же частотой.[1] На компасе Terran это 270 градусов, если север равен 0, а градусы отсчитываются по часовой стрелке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是基本方向{tIng:n}和{'ev:n}之間的中點。它也被稱為{'ev tIng:n:nolink}，其頻率大致相同。[1]在Terran羅盤上為270度，如果north為0且順時針計數度。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o ponto intermediário entre as direções cardinais {tIng:n} e {'ev:n}. Também é conhecido como {'ev tIng:n:nolink} com aproximadamente a mesma frequência.[1] São 270 graus em uma bússola terráquea, se o norte for 0 e os graus forem contados no sentido horário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on keskipiste kardinaalisuuntien {tIng:n} ja {'ev:n} välillä. Sitä kutsutaan myös nimellä {'ev tIng:n:nolink} suunnilleen samalla taajuudella.[1] Terran-kompassilla on 270 astetta, jos pohjoinen on 0 ja astetta lasketaan myötäpäivään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tIng:n}, {'ev:n}</column>
       <column name="examples"></column>
@@ -6070,6 +6763,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6077,6 +6771,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.21:src} (reprinted in {HQ 8.4, p.6, Dec. 1999:src})</column>
     </table>
     <table name="mem">
@@ -6090,6 +6785,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">тип струнного инструмента [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">弦樂器的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de instrumento de cordas</column>
+      <column name="definition_fi">eräs kielisoitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pang:v}, {yach:v:2}, {Heng:v}</column>
@@ -6100,6 +6796,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это тип {HurDagh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種{HurDagh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de {HurDagh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen {HurDagh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6109,6 +6806,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6116,6 +6814,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6130,6 +6829,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">пепел, пепел [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">灰，灰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cinzas</column>
+      <column name="definition_fi">tuhkat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qul:n}</column>
@@ -6140,6 +6840,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Tippecanoe and Tyler Too". Ash Tyler is a character in {Star Trek Discovery:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6149,6 +6850,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6156,6 +6858,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -6169,6 +6872,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">быть длинным</column>
       <column name="definition_zh_HK">長（尺寸）</column>
       <column name="definition_pt">ser longo, comprimento (de um objeto)</column>
+      <column name="definition_fi">olla pitkä (esineestä tms., ei ihmisestä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{run:v}</column>
       <column name="see_also">{woch:v}, {'ab:v}, {'aD:v}</column>
@@ -6179,6 +6883,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Не путайте это слово с {nI':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">不要將此詞與{nI':v}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não confunda esta palavra com {nI':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6188,6 +6893,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6195,6 +6901,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6208,6 +6915,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">сердце</column>
       <column name="definition_zh_HK">心（也像徵性地使用） [AUTOTRANSLATED]</column>
       <column name="definition_pt">coração (também usado simbolicamente)</column>
+      <column name="definition_fi">sydän</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ro:n}</column>
@@ -6218,6 +6926,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Глагол, используемый для «удара» (как в сердцебиении) - {joq:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">用於“跳動”（如心跳）的動詞是{joq:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O verbo usado para "batida" (como em um batimento cardíaco) é {joq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"Sykkeelle" käytetty verbi (kuten sydämenlyönnissä) on {joq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Tick tock, the sound of a heart beat. The heart is also colloquially called the "ticker".</column>
       <column name="components"></column>
       <column name="examples">
@@ -6228,6 +6937,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6235,6 +6945,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -6248,6 +6959,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">Настоящая сила в сердце. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">真正的力量是在心裡。</column>
       <column name="definition_pt">O verdadeiro poder está no coração</column>
+      <column name="definition_fi">Todellinen voima on sydämessä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6258,6 +6970,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tIq:n}, {-Daq:n}, {HoS:n:1}, {-na':n}, {tu'lu':v}</column>
       <column name="examples"></column>
@@ -6267,6 +6980,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6274,6 +6988,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.23:src}</column>
     </table>
     <table name="mem">
@@ -6287,6 +7002,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">тусклая сумма [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">點心</column>
       <column name="definition_pt">dim sum</column>
+      <column name="definition_fi">dim sum (kantonilainen ruokalaji)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6297,6 +7013,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Это относится к типу еды терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指人族食物的一種。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um tipo de comida terráquea. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa eräänlaiseen Terran-ruokaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tIq:n}, {Hom:n:2}</column>
       <column name="examples"></column>
@@ -6306,6 +7023,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6313,6 +7031,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.04.26:src}</column>
     </table>
     <table name="mem">
@@ -6326,6 +7045,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">Ударь их сильно и удари их быстро. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用力擊打它們并快速擊中它們。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Atinja-os forte e rápido</column>
+      <column name="definition_fi">Lyö heitä lujaa ja lyö heitä nopeasti.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6336,6 +7056,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6345,6 +7066,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6352,6 +7074,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.8:src}</column>
     </table>
     <table name="mem">
@@ -6365,6 +7088,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">тиклет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《tik'leth》長劍</column>
       <column name="definition_pt">tik'leth</column>
+      <column name="definition_fi">eräs teräase, tik'leth</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yan:n}, {'etlh:n}, {tIq:v}</column>
@@ -6375,6 +7099,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Острое оружие, похожее на длинный меч Земли. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一種有刃武器，類似於地球長劍。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma arma afiada, semelhante a uma espada longa da Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Teräinen ase, samanlainen kuin maapallomiekka. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6384,6 +7109,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sword, longsword</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6391,6 +7117,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Diplomatic Implausibility:src}</column>
     </table>
     <table name="mem">
@@ -6404,6 +7131,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">Тебе надо показать своё сердце.</column>
       <column name="definition_zh_HK">你必須展示出你的心。</column>
       <column name="definition_pt">Você precisa mostrar o seu coração</column>
+      <column name="definition_fi">Sinun on paljastettava sydämesi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIqwIj Sa'angnIS.:sen}</column>
@@ -6414,6 +7142,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6423,6 +7152,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6430,6 +7160,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -6443,6 +7174,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">вид животного, ткнаг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、tknag [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, tknag</column>
+      <column name="definition_fi">eräs eläin, tknag</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6453,6 +7185,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Ткнаг - опасный хищник, родом из клингонской планеты Таганика.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">tknag是克林崗星球塔甘尼卡（Taganika）原生的危險食肉動物。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O tknag é um perigoso carnívoro nativo do planeta Klingon Taganika.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tknag on vaarallinen lihansyöjä, joka on kotoisin Taglingan Klingon-planeetalta.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6462,6 +7195,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6469,6 +7203,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -6482,6 +7217,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">ткнаг копыта (продукт питания) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">tknag蹄（食品） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Cascos tknag (um item alimentar)</column>
+      <column name="definition_fi">eräs elintarvike, tknagin sorkat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6492,6 +7228,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="notes_ru">Как элемент питания, они всегда упоминаются во множественном числе. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">作為食品，它們總是以復數形式提及。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Como item alimentar, eles são sempre referidos no plural. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Elintarvikkeina niihin viitataan aina monikossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6501,6 +7238,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6508,6 +7246,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -6521,6 +7260,7 @@ This word was used for the "list" variable type in Klingon Blockly.[4]</column>
       <column name="definition_ru">Т'Кувма [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">T'Kuvma [AUTOTRANSLATED]</column>
       <column name="definition_pt">T'Kuvma</column>
+      <column name="definition_fi">T'Kuvma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6545,6 +7285,9 @@ Hans anhängare inkluderar {lIr'el:n:name} och {voq:n:name}. Hans flaggskepp är
       <column name="notes_pt">T'Kuvma foi proclamado "T'Kuvma, o Inesquecível" ({tIquvma lIjlaHbe'bogh vay':sen:nolink}) por seus seguidores, em uma alusão a Kahless, o Inesquecível (ver {qeylIS'e' lIjlaHbe'bogh vay':n:name}).
 
 Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um navio sarcófago coberto de caixões (ver {nebeylI':n}, {nev'aQ:n}, {pel'aQ:n:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hänen seuraajansa julistivat T'Kuvman olevan "T'Kuvma unohtumaton" ({tIquvma lIjlaHbe'bogh vay':sen:nolink}) viittaamalla unohtumattomaan Kahlessiin (katso {qeylIS'e' lIjlaHbe'bogh vay':n:name}).
+
+Hänen kannattajansa ovat {lIr'el:n:name} ja {voq:n:name}. Hänen lippulaivansa on arkkuissa peitetty sarkofagialus (ks.{nebeylI':n}, {nev'aQ:n}, {pel'aQ:n:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6554,6 +7297,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6561,6 +7305,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - The Vulcan Hello:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6574,6 +7319,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="definition_ru">Мне надо вам покозать свою сердцу.</column>
       <column name="definition_zh_HK">我必須向你展示出我的心。</column>
       <column name="definition_pt">Eu devo te mostrar meu coração.</column>
+      <column name="definition_fi">Minun on paljastettava sinulle sydämeni.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIqlIj Da'angnIS.:sen}</column>
@@ -6584,6 +7330,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6593,6 +7340,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6600,6 +7348,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.203:src}</column>
     </table>
     <table name="mem">
@@ -6613,6 +7362,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="definition_ru">быть древним</column>
       <column name="definition_zh_HK">古老</column>
       <column name="definition_pt">ser antigo</column>
+      <column name="definition_fi">olla muinainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qan:v:1}, {ngo':v}</column>
@@ -6623,6 +7373,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="notes_ru">Этот глагол также используется для равносторонних треугольников (см. {ra'Duch tIQ:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞也用於等邊三角形（請參閱{ra'Duch tIQ:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado para triângulos equilaterais (consulte {ra'Duch tIQ:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös tasasivuisiin kolmioihin (katso {ra'Duch tIQ:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Antique".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6632,6 +7383,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6639,6 +7391,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6652,6 +7405,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="definition_ru">зерно</column>
       <column name="definition_zh_HK">糧食 [AUTOTRANSLATED]</column>
       <column name="definition_pt">grão</column>
+      <column name="definition_fi">jyvä, vilja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loSpev:n}, {ngat:n:2}, {raS'IS:n}, {naH:n}, {tI:n}, {poch:v}, {yob:v}</column>
@@ -6662,6 +7416,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Tear" shaped.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6671,6 +7426,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6678,6 +7434,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6691,6 +7448,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="definition_ru">хлеб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">麵包</column>
       <column name="definition_pt">pão</column>
+      <column name="definition_fi">leipä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jInjoq:n}</column>
@@ -6701,6 +7459,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tIr:n}, {ngogh:n}</column>
       <column name="examples"></column>
@@ -6710,6 +7469,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6717,6 +7477,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}, [2] {Saarbrücken qepHom'a' 2010:src}</column>
     </table>
     <table name="mem">
@@ -6730,6 +7491,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="definition_ru">тост [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">多士、西多（烤麵包）</column>
       <column name="definition_pt">torrada</column>
+      <column name="definition_fi">paahtoleipä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6740,6 +7502,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="notes_ru">Это относится к физическому куску сушеного хлеба, а не к восклицаниям, сделанным во время питья. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指乾麵包的實際一塊，而不是指喝酒時的驚嘆號。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se ao pedaço físico de pão seco, e não às exclamações feitas ao beber. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa fyysiseen palaan kuivattua leipää, eikä juomisen yhteydessä tehtyihin huudahduksiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tIr ngogh:n}, {QaD:v:1}</column>
       <column name="examples"></column>
@@ -6749,6 +7512,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6756,6 +7520,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6769,6 +7534,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="definition_ru">укладываться в стопку, накладываться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">堆放，疊放 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser dispostos em uma pilha, ser sobrepostos</column>
+      <column name="definition_fi">olla järjestetty pinoon, olla päällekkäin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mergh:v}</column>
@@ -6779,6 +7545,7 @@ Seus apoiadores incluem {lIr'el:n:name} e {voq:n:name}. Seu carro-chefe é um na
       <column name="notes_ru">«Наложение A и B» - это {A B je tIrmoHchu':sen:nolink}. Одним из способов сказать «наложить A на (к) B» является {B-Daq A lanchu':sen:nolink} (см. {lan:v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">“疊加A和B”是{A B je tIrmoHchu':sen:nolink}。說“在B上疊加A”的一種方式是{B-Daq A lanchu':sen:nolink}（請參閱{lan:v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">"Sobrepor A e B" é {A B je tIrmoHchu':sen:nolink}. Uma maneira de dizer "sobrepor A em (a) B" é {B-Daq A lanchu':sen:nolink} (consulte {lan:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"Päällekkäin A ja B" on {A B je tIrmoHchu':sen:nolink}. Yksi tapa sanoa "päällekkäin A päälle (kohtaan B)" on {B-Daq A lanchu':sen:nolink} (katso {lan:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Tier".
 
 In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu':sen:nolink} was incorrectly written as {lalchu':sen:nolink}.</column>
@@ -6790,6 +7557,7 @@ In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6797,6 +7565,7 @@ In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -6810,6 +7579,7 @@ In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu'
       <column name="definition_ru">быть легким</column>
       <column name="definition_zh_HK">輕（重量）</column>
       <column name="definition_pt">ser leve (peso)</column>
+      <column name="definition_fi">olla kevyt</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'ugh:v}</column>
       <column name="see_also">{cheb:n}, {ngI':v}</column>
@@ -6820,6 +7590,7 @@ In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu'
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Tissue".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6829,6 +7600,7 @@ In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu'
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6836,6 +7608,7 @@ In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu'
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6849,6 +7622,7 @@ In the printed booklet for {qep'a' 26 (2019):src}, there was a typo and {lanchu'
       <column name="definition_ru">пользоваться</column>
       <column name="definition_zh_HK">享受</column>
       <column name="definition_pt">desfrutar</column>
+      <column name="definition_fi">nauttia jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bel:v}, {bel:n}</column>
@@ -6879,6 +7653,11 @@ Detta verb kan användas reflexivt för att betyda "njuta av dig själv", "ha de
 Os klingons normalmente não falam sobre música em termos de diversão, mas sim em termos do que ela faz ao ouvinte. Por exemplo, a música pode ser dita {jaqmoH:v}, {SeymoH:v}, {tungHa':v} ou {pIlmoH:v}.[2]
 
 Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-se" .[3; 4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso verbit, joita käytetään ruoan tai musiikin nauttimisen ilmaisemiseen klingonilaisten keskuudessa, ks.{DuQ:v:2} ja {'ey:v}.[2]
+
+Klingonit eivät yleensä puhu musiikista nautinnon kannalta, vaan pikemminkin sen suhteen, mitä se tekee kuuntelijalle. Esimerkiksi musiikista voidaan sanoa {jaqmoH:v}, {SeymoH:v}, {tungHa':v} tai {pIlmoH:v}.
+
+Tätä verbiä voidaan käyttää refleksiivisesti tarkoittamaan "nauti", "pidä hauskaa".[2][3; 4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The {msn:src} example had a typo: {ghoHtah:sen:nolink} instead of {ghoHtaH:sen:nolink}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6891,6 +7670,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6898,6 +7678,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {Star Trek V:src}, [4] {msn 1996.11.10:src}, [5] {"A Klingon Christmas Carol" trailer:src}</column>
     </table>
     <table name="mem">
@@ -6911,6 +7692,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">реагировать эмоционально, вести себя эмоционально [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">情緒反應、情緒表現 [AUTOTRANSLATED]</column>
       <column name="definition_pt">reagir emocionalmente, comportar-se emocionalmente</column>
+      <column name="definition_fi">reagoida tunteella, käyttäytyä tunteellisesti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{meq:v}</column>
       <column name="see_also">{jem:v}</column>
@@ -6921,6 +7703,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It is stated that this cannot take an object.</column>
       <column name="components"></column>
       <column name="examples">
@@ -6931,6 +7714,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">feelings</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6938,6 +7722,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - The Butcher's Knife Cares Not for the Lamb's Cry:src}</column>
     </table>
     <table name="mem">
@@ -6951,6 +7736,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">быть кудрявым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">捲曲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser encaracolado</column>
+      <column name="definition_fi">olla kihara, kiemurainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIb:n}</column>
@@ -6961,6 +7747,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The request was specifically for a word applicable to hair, though the given word seems more general.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6970,6 +7757,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6977,6 +7765,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6990,6 +7779,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">чинить</column>
       <column name="definition_zh_HK">修理</column>
       <column name="definition_pt">consertar, reparar</column>
+      <column name="definition_fi">korjata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7000,6 +7790,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">В отличие от {rach:v}, этот глагол, как правило, не применяется к существам и предлагает только восстановление предыдущего состояния (и не обязательно улучшение) .[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與{rach:v}不同，此動詞通常不應用於存在者，它僅建議恢復到先前的狀態（不一定是改善）。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ao contrário de {rach:v}, esse verbo geralmente não é aplicado aos seres e sugere apenas a restauração para um estado anterior (e não necessariamente para melhoria).[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Toisin kuin {rach:v}, tätä verbiä ei tyypillisesti sovelleta olentoihin, ja se ehdottaa vain palauttamista edelliseen tilaan (eikä välttämättä parannusta).[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7009,6 +7800,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7016,6 +7808,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1998.10.20:src}</column>
     </table>
         <table name="mem">
@@ -7029,6 +7822,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
           <column name="definition_ru">ремонтник, ремонтница [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">修理工</column>
           <column name="definition_pt">reparador, reparadora</column>
+      <column name="definition_fi">korjaaja</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{mutlh:v}</column>
@@ -7039,6 +7833,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{tI':v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -7048,6 +7843,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7055,6 +7851,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2012.01.10:src}</column>
         </table>
     <table name="mem">
@@ -7068,6 +7865,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">T'Ong [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">「堂」號（星艦）</column>
       <column name="definition_pt">T'Ong</column>
+      <column name="definition_fi">T'Ong</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7078,6 +7876,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7087,6 +7886,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7094,6 +7894,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 4.3, Sept. 1995:src}</column>
     </table>
     <table name="mem">
@@ -7107,6 +7908,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">тип животного, тика [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《tika》貓（動物類型）</column>
       <column name="definition_pt">tipo de animal, gato tika</column>
+      <column name="definition_fi">eräs kissan kaltainen eläin, tika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIghro':n}</column>
@@ -7117,6 +7919,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">Существует идиома {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {bIt; tI'qa' vIghro' rur@@bIt:v, tI'qa' vIghro':n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{bIt:v:nolink} is actually written incorrectly as {tIb:v:nolink} on {KGT p.132:src}, in the statement of the idiom.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7126,6 +7929,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7133,6 +7937,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7146,6 +7951,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">Трель (планета) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">顫音（行星） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Trill (planeta)</column>
+      <column name="definition_fi">Trill (planeetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tI'rIlngan:n}, {boqyIn:n}</column>
@@ -7156,6 +7962,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">Это название планеты. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome do planeta. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on planeetan nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7165,6 +7972,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7172,6 +7980,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
         <table name="mem">
@@ -7185,6 +7994,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
           <column name="definition_ru">Трель (человек) [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">顫音（人） [AUTOTRANSLATED]</column>
           <column name="definition_pt">Trill (pessoa)</column>
+      <column name="definition_fi">trilli</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{tI'rIl:n}</column>
@@ -7195,6 +8005,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This was confirmed during the Q &amp; A session.</column>
           <column name="components">{tI'rIl:n}, {ngan:n}</column>
           <column name="examples"></column>
@@ -7204,6 +8015,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7211,6 +8023,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -7224,6 +8037,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">T'vis [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">T'vis [AUTOTRANSLATED]</column>
       <column name="definition_pt">T'vis</column>
+      <column name="definition_fi">T'vis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7234,6 +8048,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">Сын Баро. Смотрите {barot:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">巴洛的兒子。參見{barot:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O filho de Barot. Consulte {barot:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Barotin poika. Katso {barot:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7243,6 +8058,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7250,6 +8066,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.182:src}</column>
     </table>
     <table name="mem">
@@ -7263,6 +8080,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">проверять, доказывать</column>
       <column name="definition_zh_HK">最後測試、證明 [AUTOTRANSLATED]</column>
       <column name="definition_pt">testar conclusivamente, provar</column>
+      <column name="definition_fi">testata perusteellisesti, todistaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Daj:v:2}</column>
       <column name="see_also">{'ol:v}, {waH:v:1}, {nuD:v}, {poj:v}</column>
@@ -7273,6 +8091,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word appears in a deleted line from {Star Trek V:src}: {logh veQDaq bachchugh, yoH 'e' toblaHbe' SuvwI'.@@logh:n, veQ:n, -Daq:n, bach:v, -chugh:v, yoH:v, 'e':n, tob:v, -laH:v, -be':v, SuvwI':n} "Shooting space garbage is no test of a warrior's mettle." This line was changed to {vaj toDuj Daj ngeHbej DI vI'.:sen} (while maintaining the original English subtitle) in the process of editing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7282,6 +8101,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7289,6 +8109,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7302,6 +8123,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">ладонь</column>
       <column name="definition_zh_HK">手掌</column>
       <column name="definition_pt">Palma da mão</column>
+      <column name="definition_fi">kämmen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yo:v}, {weq:v}, {ghop:n}, {chap:n}, {ro':n}, {bem:n}, {ghIt:n:1}</column>
@@ -7312,6 +8134,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7321,6 +8144,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7328,6 +8152,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7341,6 +8166,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">спасать</column>
       <column name="definition_zh_HK">保存、救援 [AUTOTRANSLATED]</column>
       <column name="definition_pt">salvar, resgatar</column>
+      <column name="definition_fi">pelastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pol:v}, {choq:v}, {toD:n}</column>
@@ -7352,6 +8178,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_zh_HK"></column>
       <!-- white knight, prince, frog, toad? -->
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7361,6 +8188,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7368,6 +8196,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7381,6 +8210,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">спасение</column>
       <column name="definition_zh_HK">拯救 [AUTOTRANSLATED]</column>
       <column name="definition_pt">resgate</column>
+      <column name="definition_fi">pelastus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toD:v}</column>
@@ -7391,6 +8221,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7400,6 +8231,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7407,6 +8239,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7420,6 +8253,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">спасательное судно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">救援船 [AUTOTRANSLATED]</column>
       <column name="definition_pt">navio de resgate</column>
+      <column name="definition_fi">pelastusalus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7430,6 +8264,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{toD:n}, {Duj:n:1}</column>
       <column name="examples">
@@ -7440,6 +8275,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7447,6 +8283,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -7460,6 +8297,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">(бранное слово)</column>
       <column name="definition_zh_HK">稱號 [AUTOTRANSLATED]</column>
       <column name="definition_pt">epíteto</column>
+      <column name="definition_fi">eräs haukkumasana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7470,6 +8308,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7479,6 +8318,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7486,6 +8326,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7499,6 +8340,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">храбрость</column>
       <column name="definition_zh_HK">勇氣、勇敢</column>
       <column name="definition_pt">coragem, bravura</column>
+      <column name="definition_fi">rohkeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7509,6 +8351,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">Для смелости удивительного или неожиданного вида, см. {qajunpaQ:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">要獲得令人驚訝或意外的勇氣，請參閱{qajunpaQ:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para coragem de um tipo surpreendente ou inesperado, consulte {qajunpaQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7519,6 +8362,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7526,6 +8370,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -7539,6 +8384,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">Борода - это символ мужества. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鬍鬚是標志勇氣。</column>
       <column name="definition_pt">A barba é um símbolo de coragem.</column>
+      <column name="definition_fi">Parta on rohkeuden merkki.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7549,6 +8395,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7558,6 +8405,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7565,6 +8413,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.85:src}</column>
     </table>
     <table name="mem">
@@ -7578,6 +8427,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">считать</column>
       <column name="definition_zh_HK">數數</column>
       <column name="definition_pt">contagem</column>
+      <column name="definition_fi">laskea jotkin (asioiden lukumäärä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chel:v}, {SIm:v}, {mI':n}</column>
@@ -7588,6 +8438,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7597,6 +8448,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7604,6 +8456,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7617,6 +8470,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">ну, уж, значит</column>
       <column name="definition_zh_HK">好吧！</column>
       <column name="definition_pt">Então! Aha!</column>
+      <column name="definition_fi">niin, no, ahaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7627,6 +8481,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">Это примерно как английское "Ага!" ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這大致類似於英語中的“啊哈！” （{TKD 5.5:src}） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é mais ou menos como o inglês "Aha!" ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on suunnilleen kuin englantilainen "Aha!" ({TKD 5.5:src}) [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7636,6 +8491,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">aha!</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7643,6 +8499,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7657,6 +8514,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">обманывать</column>
       <column name="definition_zh_HK">欺騙、欺騙、虛張聲勢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">enganar, truque, blefar</column>
+      <column name="definition_fi">huijata, pettää, harhauttaa, bluffata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngor:v}, {jech:v}, {ghet:v}, {HIgh:v}, {Qaq:v}, {nep:v}, {chem:v}, {ghIchwIj DabochmoHchugh ghIchlIj qanob.:sen}</column>
@@ -7667,6 +8525,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">Если обман связан с честью или социальным статусом, см. {Qaq:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果欺騙涉及榮譽或社會地位，請參閱{Qaq:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se o engano envolver honra ou status social, consulte {Qaq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos petokseen liittyy kunnia tai sosiaalinen asema, katso {Qaq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7679,6 +8538,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7686,6 +8546,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7699,6 +8560,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">голодеке [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">全息甲板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Holodeck</column>
+      <column name="definition_fi">holokansi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DI'ruj velqa':n}, {rob'agh:n}</column>
@@ -7709,6 +8571,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{toj:v}, {-bogh:v}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -7718,6 +8581,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7725,6 +8589,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -7738,6 +8603,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">холодек приключение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">holodeck冒險 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aventura holodeck</column>
+      <column name="definition_fi">holokansiseikkailu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7748,6 +8614,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {STC 104:src} this was given as the plural {tojbogh pa' tuHmey:n:nolink} "Holodeck Adventures".</column>
       <column name="components">{tojbogh pa':n}, {tuH:n}</column>
       <column name="examples"></column>
@@ -7757,6 +8624,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7764,6 +8632,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -7777,6 +8646,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">пройти, пройти, пройти среди [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">經歷，通過，通過 [AUTOTRANSLATED]</column>
       <column name="definition_pt">passar, atravessar, passar entre</column>
+      <column name="definition_fi">kulkea jonkin läpi, kulkea jonkin keskellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vegh:v}, {'aw:v}</column>
@@ -7787,6 +8657,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">Это используется для путешествий через недифференцированную массу или коллекцию объектов, используя пространство между ними (лес, толпа, вода, почва, пространство). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它用於穿越未分化的物體或使用它們之間的空間（森林，人群，水，土壤，空間）收集物體。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É usado para viajar através de uma massa indiferenciada ou coleção de objetos usando o espaço entre eles (uma floresta, uma multidão, água, solo, espaço). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään erilaistumattoman massan tai esineiden kokoelman kulkemiseen käyttämällä niiden välistä tilaa (metsä, väkijoukko, vesi, maaperä, tila). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Toll" booth.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7796,6 +8667,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7803,6 +8675,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7816,6 +8689,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">наклоняться, наклоняться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傾斜、歪</column>
       <column name="definition_pt">inclinar, inclinar-se</column>
+      <column name="definition_fi">kallistua, olla kallistunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taH:v:2}</column>
@@ -7826,6 +8700,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="notes_ru">Это может быть использовано для движения головы. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以用於頭部運動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para um movimento da cabeça. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää pään liikkeessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It is explicitly stated that this verb is intransitive, and that {tommoH:v@@tom:v, -moH:v} is used for the subject tilting the object.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7835,6 +8710,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7842,6 +8718,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -7855,6 +8732,7 @@ Este verbo pode ser usado reflexivamente para significar "divirta-se", "divirta-
       <column name="definition_ru">техника боя [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥技術 [AUTOTRANSLATED]</column>
       <column name="definition_pt">técnica de luta</column>
+      <column name="definition_fi">liike (taistelussa, pelissä tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{moQbara':n}, {much:v:3}, {tuH:n}</column>
@@ -7875,6 +8753,9 @@ Det används också för att namnge kampsportställningar. För att beordra någ
       <column name="notes_pt">Refere-se a uma única técnica executada em uma luta ou, por extensão, a uma única manobra jogada em um jogo.[3]
 
 Também é usado para nomear posturas de artes marciais. Para comandar alguém a assumir uma postura ou pose, o verbo {much:v:3} é usado. A palavra {tonSaw':n:nolink} pode ser deixada de fora do nome se o contexto for claro.[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa yhteen taistelussa suoritettuun tekniikkaan tai jatkossa yhteen pelin pelaamiseen.
+
+Sitä käytetään myös taistelulajien kantojen nimeämiseen. Käsketään joku lyödä asenne tai poseeraa, käytetään verbiä {much:v:3}. Sana {tonSaw':n:nolink} voidaan jättää nimen ulkopuolelle, jos asiayhteys on selkeä.[3][4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">To translate "The Final Reflection", where "reflection" is a maneuver in a game (see {tlhInja:n}), Maltz suggested {tonSaw' Qav:n:nolink} or {neSlo' tonSaw' Qav:n:nolink}.[3]</column>
       <column name="components"></column>
       <column name="examples">
@@ -7899,6 +8780,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">move, maneuver, manoeuvre, manoeuver, stance, pose</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7906,6 +8788,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {paq'batlh:src}, [3] {KLI mailing list 2010.09.01:src}, [4] {KLI mailing list 2019.03.01:src}</column>
     </table>
     <table name="mem">
@@ -7919,6 +8802,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="definition_ru">воронка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">漏斗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">funil</column>
+      <column name="definition_fi">suppilo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7929,6 +8813,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Tom Terrific is a cartoon character who wears a funnel-shaped "thinking cap".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7938,6 +8823,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7945,6 +8831,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -7958,6 +8845,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="definition_ru">грузовое судно</column>
       <column name="definition_zh_HK">貨輪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cargueiro</column>
+      <column name="definition_fi">rahtialus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7968,6 +8856,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tong:n:hyp,nolink}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -7977,6 +8866,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7984,6 +8874,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7997,6 +8888,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="definition_ru">топалин</column>
       <column name="definition_zh_HK">topaline [AUTOTRANSLATED]</column>
       <column name="definition_pt">topaline</column>
+      <column name="definition_fi">eräs mineraali, topaliini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIl:n}, {tlhIl:v}</column>
@@ -8007,6 +8899,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="notes_ru">Это редкий минерал, который добывается. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種稀有的礦物質。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um mineral raro que é extraído. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on harvinainen mineraali, jota louhitaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8016,6 +8909,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8023,6 +8917,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8036,6 +8931,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="definition_ru">вид животного, топа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物的類型、托帕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, topah</column>
+      <column name="definition_fi">eräs eläin, topah</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8046,6 +8942,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="notes_ru">Существует идиома {tlhIb; toppa' rur}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{tlhIb; toppa' rur}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {tlhIb; toppa' rur}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {tlhIb; toppa' rur}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8055,6 +8952,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8062,6 +8960,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8075,6 +8974,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="definition_ru">быть населенным</column>
       <column name="definition_zh_HK">有人居住 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser habitado</column>
+      <column name="definition_fi">olla asuttu, asutettu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{chIm:v}</column>
       <column name="see_also">{Dab:v}</column>
@@ -8085,6 +8985,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8094,6 +8995,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8101,6 +9003,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8114,6 +9017,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="definition_ru">вид животного, токвирский сцинк [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、Tokvirian石龍子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, Tokvirian skink</column>
+      <column name="definition_fi">eräs eläin, tokvirilainen skinkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8124,6 +9028,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="notes_ru">Его маленькие яйца едят целыми, скорлупой и всеми, горсткой. [1, p.88] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它的小雞蛋被少數幾個人全部，全部和全部吃掉。[1, p.88] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Sen pienet munat syövät kokonaiset, kuoren ja kaikki, kourallinen.[1, p.88] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8133,6 +9038,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8140,6 +9046,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8153,6 +9060,7 @@ Também é usado para nomear posturas de artes marciais. Para comandar alguém a
       <column name="definition_ru">штамп [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戳子</column>
       <column name="definition_pt">carimbo (de borracha)</column>
+      <column name="definition_fi">kumileimaisin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8177,6 +9085,9 @@ För att använda en sådan stämpel måste man först trycka upp den ({laS:v}) 
       <column name="notes_pt">Refere-se a uma ferramenta ou dispositivo, e não a um selo postal (para o qual consulte {HIjmeH chaw':n}).
 
 Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de tinta ({rItlh 'echlet:n}) e, em seguida, fechá-lo ({Dut:v:1}). A imagem resultante é chamada de {yang:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa työkaluun tai laitteeseen eikä postimerkkiin (katso {HIjmeH chaw':n}).
+
+Tällaisen leiman käyttäminen on ensin mustettava se ylös ({laS:v}) mustetyynyllä ({rItlh 'echlet:n}) ja sitten lyödä se alas ({Dut:v:1}). Tuloksena olevaa kuvaa kutsutaan {yang:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -8187,6 +9098,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8194,6 +9106,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -8207,6 +9120,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="definition_ru">тип животного, похожий на терранскую хищную птицу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物的類型、類似於人族的猛禽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, semelhante à ave de rapina terráquea</column>
+      <column name="definition_fi">eräs petolintua muistuttava eläinlaji</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}, {'apuStoQ:n}</column>
@@ -8217,6 +9131,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8226,6 +9141,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8233,6 +9149,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 1997.04.07:src}, [2] {HQ 10.4, p.5, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -8246,6 +9163,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="definition_ru">хищная птица (военный корабль)</column>
       <column name="definition_zh_HK">猛禽（船） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ave de rapina (navio)</column>
+      <column name="definition_fi">eräs alustyyppi, petolintu, Bird of Prey</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}, {qISa'ruj:n}, {qIvo'rIt:n}, {bI'rel tlharghDuj:n}</column>
@@ -8256,6 +9174,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{toQ:n}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -8265,6 +9184,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8272,6 +9192,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KLI mailing list 1997.04.07:src}</column>
     </table>
     <table name="mem">
@@ -8285,6 +9206,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="definition_ru">становиться на колени</column>
       <column name="definition_zh_HK">跪低、踎低</column>
       <column name="definition_pt">ajoelhar</column>
+      <column name="definition_fi">polvistua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eD:v:1}, {ba':v}, {Hu':v}, {Qam:v}, {Qot:v}, {'ung:v}, {joD:v}, {qIv:n}</column>
@@ -8295,6 +9217,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="notes_ru">Этот глагол описывает действия человека или животного. Это также может быть применено к самолетам, для которых см. {tor:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞描述了人或動物的行為。它也可以應用於飛機，請參見{tor:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo descreve a ação de uma pessoa ou animal. Também pode ser aplicado a aeronaves, para as quais veja {tor:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi kuvaa ihmisen tai eläimen toimintaa. Sitä voidaan soveltaa myös lentokoneisiin, joista ks. {tor:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8304,6 +9227,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bow, kowtow, kow-tow</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8311,6 +9235,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -8324,6 +9249,7 @@ Para usar tal carimbo, deve-se primeiro cobri-lo ({laS:v}) com uma almofada de t
       <column name="definition_ru">pitch (aircraft tilts nose up or down) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">俯仰（飛機向上或向下傾斜） [AUTOTRANSLATED]</column>
       <column name="definition_pt">arremesso (a aeronave inclina o nariz para cima ou para baixo)</column>
+      <column name="definition_fi">nyökätä (lentokoneen kääntyminen poikkiakselin suhteen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dav:v:2}, {Der:v:2}, {jer:v}, {jIm:v:2}, {lol:v:2}, {ron:v:2}, {'or:v}</column>
@@ -8348,6 +9274,9 @@ Höjning nedåt indikeras med en negativ vinkel (se {taH:v:2}). [AUTOTRANSLATED]
       <column name="notes_pt">Este é apenas o verbo {tor:v:1} aplicado a aeronaves.
 
 A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain verbi {tor:v:1}, jota sovelletaan lentokoneisiin.
+
+Nousu alaspäin ilmaistaan ​​negatiivisella kulmalla (katso {taH:v:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The eleva"tor"s control the pitch on an airplane.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8357,6 +9286,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8364,6 +9294,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -8377,6 +9308,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">Торг</column>
       <column name="definition_zh_HK">托格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Torg</column>
+      <column name="definition_fi">Torg</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8387,6 +9319,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8396,6 +9329,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8403,6 +9337,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8416,6 +9351,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">Torghn [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Torghn [AUTOTRANSLATED]</column>
       <column name="definition_pt">Torghn</column>
+      <column name="definition_fi">Torghn</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8426,6 +9362,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Он отец Пок ({paq:n:2,name}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">他是博克（{paq:n:2,name}）的父親。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ele é pai de Pok ({paq:n:2,name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on Pokin isä ({paq:n:2,name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8435,6 +9372,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8442,6 +9380,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -8455,6 +9394,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">художественная литература [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小說 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficção</column>
+      <column name="definition_fi">fiktio, kaunokirjallisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lut:n}, {rorgh:v}</column>
@@ -8465,6 +9405,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Tor Books is a publisher of speculative (see {SIv:v}) fiction.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8474,6 +9415,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8481,6 +9423,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8494,6 +9437,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">взобраться</column>
       <column name="definition_zh_HK">爬</column>
       <column name="definition_pt">subir, escalar</column>
+      <column name="definition_fi">kiivetä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sal:v}</column>
@@ -8504,6 +9448,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Com base no seu uso no {paq'batlh:src}, o objeto escalado é o objeto, o destino é marcado com {-Daq:n} e o ponto de partida é marcado com {-vo':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Perustuen sen käyttöön {paq'batlh:src}: ssä, kiipeilevä asia on objekti, kohde on merkitty {-Daq:n}: lla ja aloituspiste on merkitty {-vo':n}: lla.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <!-- These need page numbers and proofreading. -->
@@ -8532,6 +9477,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8539,6 +9485,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -8552,6 +9499,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">снаряды для скалолазания, тренажерный зал в джунглях [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">攀登器具、叢林健身房 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aparelhos de escalada, ginásio na selva</column>
+      <column name="definition_fi">kiipeilyteline</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8562,6 +9510,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{toS:v}, {-wI':v}, {qal'aq:n}</column>
       <column name="examples"></column>
@@ -8571,6 +9520,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8578,6 +9528,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -8591,6 +9542,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">коммодор</column>
       <column name="definition_zh_HK">準將 [AUTOTRANSLATED]</column>
       <column name="definition_pt">commodoro</column>
+      <column name="definition_fi">kommodori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8601,6 +9553,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Это 3-й ранг {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{yaS:n}的第三等級。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o terceiro ranking do {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8610,6 +9563,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8617,6 +9571,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8630,6 +9585,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">разделение мыслей [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">心靈分享 [AUTOTRANSLATED]</column>
       <column name="definition_pt">compartilhamento de mente</column>
+      <column name="definition_fi">ajatusten jakaminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'erwI'Daq:n}, {relleghDaq:n}</column>
@@ -8640,6 +9596,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Это относится к моменту ясности между двумя воинами на поле битвы.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指兩個戰士在戰場上的清晰時刻。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um momento de clareza entre dois guerreiros no campo de batalha.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa selvyyden hetkeen kahden soturin välillä taistelukentällä.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8649,6 +9606,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">insight, clarity</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8656,6 +9614,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {DS9 - Soldiers of the Empire:src}</column>
     </table>
     <table name="mem">
@@ -8669,6 +9628,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">служить (хозяина)</column>
       <column name="definition_zh_HK">服務（主人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">servir (um mestre)</column>
+      <column name="definition_fi">palvella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8679,6 +9639,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Toy".</column>
       <column name="components"></column>
       <column name="examples">
@@ -8689,6 +9650,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8696,6 +9658,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8709,6 +9672,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">слуга</column>
       <column name="definition_zh_HK">僕人、奴僕</column>
       <column name="definition_pt">servo</column>
+      <column name="definition_fi">palvelija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8719,6 +9683,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{toy':v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -8728,6 +9693,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8735,6 +9701,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8748,6 +9715,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">раб</column>
       <column name="definition_zh_HK">奴隸</column>
       <column name="definition_pt">escravo</column>
+      <column name="definition_fi">orja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8758,6 +9726,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{toy':v}, {-wI':v}, {-'a':n}</column>
       <column name="examples">
@@ -8768,6 +9737,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8775,6 +9745,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -8788,6 +9759,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">тактика</column>
       <column name="definition_zh_HK">戰術、策略</column>
       <column name="definition_pt">táticas</column>
+      <column name="definition_fi">taktiikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dup:n}</column>
@@ -8798,6 +9770,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"tic-tac-toe".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8807,6 +9780,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8814,6 +9788,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -8827,6 +9802,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">вид животного, тоббадж [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、tobbaj [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, tobbaj</column>
+      <column name="definition_fi">eräs eläin, tobbaj</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8837,6 +9813,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8846,6 +9823,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8853,6 +9831,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
         <table name="mem">
@@ -8866,6 +9845,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
           <column name="definition_ru">Примите эти чучела ног. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">接受這些填充到'baj腿。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Aceite estas pernas recheadas de to'baj.</column>
+      <column name="definition_fi">Hyväksy nämä täytetyt tobbajin jalat.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -8876,6 +9856,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -8885,6 +9866,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">QI'lop</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -8892,6 +9874,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {PK:src}</column>
         </table>
     <table name="mem">
@@ -8905,6 +9888,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">Торат [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Torath [AUTOTRANSLATED]</column>
       <column name="definition_pt">Torath</column>
+      <column name="definition_fi">Torath</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIr'el:n:name}</column>
@@ -8915,6 +9899,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8924,6 +9909,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8931,6 +9917,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Si Vis Pacem, Para Bellum:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -8944,6 +9931,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">связка, сухожилие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">韌帶、肌腱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ligamento, tendão</column>
+      <column name="definition_fi">nivelside, jänne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uS:n}, {DeS:n:1}</column>
@@ -8954,6 +9942,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8963,6 +9952,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8970,6 +9960,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -8983,6 +9974,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">занять некоторое время, чтобы обдумать вопрос [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">花點時間考慮一件事 [AUTOTRANSLATED]</column>
       <column name="definition_pt">levar algum tempo para considerar um assunto</column>
+      <column name="definition_fi">ajatella asiaa huolellisesti ajan kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8993,6 +9985,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Это идиоматическое выражение буквально означает «жевать связку». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是“咀嚼韌帶”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa literalmente "mastigar ligamento". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "pureskella nivelsiteitä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9005,6 +9998,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9012,6 +10006,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.119:src}</column>
     </table>
     <table name="mem">
@@ -9025,6 +10020,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">вы-меня</column>
       <column name="definition_zh_HK">你們：我</column>
       <column name="definition_pt">vocês-eu</column>
+      <column name="definition_fi">te-minua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Sa-:v:pref}</column>
       <column name="see_also">{cho-:v:pref}, {che-:v:pref}, {HI-:v:pref}</column>
@@ -9035,6 +10031,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{tlhIH:n}: {jIH:n:1h} = {tu-:v:pref,nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9044,6 +10041,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">you-me</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9051,6 +10049,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9064,6 +10063,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">мигания [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">眨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">piscar</column>
+      <column name="definition_fi">räpäyttää (silmiä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wang:v}</column>
@@ -9074,6 +10074,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Это значит невольно мигать. Сленговым способом сказать, что это {mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}. Например, {mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1} означает «Я моргаю». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著不由自主地眨眼。 this語是{mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}。例如，{mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1}表示“我眨眼”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa piscar involuntariamente. Uma forma de gíria para dizer isso é {mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}. Por exemplo, {mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1} significa "Eu pisco". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa vilkkua tahattomasti. Slangitapa sanoa tämä on {mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}. Esimerkiksi {mInDu '(wIj) vIyIv: sen @@ mIn: n, -Du': n, -wIj: n, vI-: v, yIv: v: 1} tarkoittaa "vilkkuu".{mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It was stated during the Q &amp; A session that this does not generally take an object. It is used for eyes, not lights.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9083,6 +10084,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9090,6 +10092,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -9103,6 +10106,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">запрещать</column>
       <column name="definition_zh_HK">禁止</column>
       <column name="definition_pt">proibir</column>
+      <column name="definition_fi">kieltää</column>
       <column name="synonyms">{bot:v}</column>
       <column name="antonyms">{chaw':v}</column>
       <column name="see_also"></column>
@@ -9113,6 +10117,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Touching is forbidden. Reverse of {chut:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9122,6 +10127,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9129,6 +10135,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9142,6 +10149,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">the future (as a whole) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">未來（整體而言） [AUTOTRANSLATED]</column>
       <column name="definition_pt">o futuro (como um todo)</column>
+      <column name="definition_fi">tulevaisuus (kokonaisuutena)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pa'logh:n}</column>
       <column name="see_also">{pIq:n}</column>
@@ -9152,6 +10160,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Для сравнения, {'op pIq:n@@'op:n, pIq:n} означает «в какой-то момент в будущем». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">相比之下，{'op pIq:n@@'op:n, pIq:n}的意思是“將來的某個時候”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em comparação, {'op pIq:n@@'op:n, pIq:n} significa "em algum momento no futuro". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vertailun vuoksi {'op pIq:n@@'op:n, pIq:n} tarkoittaa "jossain vaiheessa tulevaisuudessa". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {Star Trek VI:src}, Chancellor Gorkon makes a toast to "the undiscovered country... the future". The phrase "The Undiscovered Country" (TUC) comes from Hamlet's soliloquy and is also the name of the film.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9161,6 +10170,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9168,6 +10178,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -9182,6 +10193,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">предсказывать, видеть будущее, знать будущее [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">預言、看未來、了解未來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">para profetizar, ver o futuro, conhecer o futuro</column>
+      <column name="definition_fi">profetoida, nähdä tulevaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuch rItwI':n}</column>
@@ -9192,6 +10204,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Для клингонов пророчество - это как-то «вызвать» будущее. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於克林崗人而言，預言就是能夠以某種方式“召喚”未來。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para os klingons, profetizar é ser capaz de "convocar" o futuro de alguma forma. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonsille ennustaminen tarkoittaa kykyä "kutsua" tulevaisuus jotenkin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TOS - Mirror, Mirror:src}, Mirror Spock says to Kirk: "One man cannot summon the future."</column>
       <column name="components">{tuch:n}, {rIt:v}</column>
       <column name="examples"></column>
@@ -9201,6 +10214,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9208,6 +10222,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.01:src}</column>
     </table>
     <table name="mem">
@@ -9221,6 +10236,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">пророк, будущий провидец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">先知、未來先知 [AUTOTRANSLATED]</column>
       <column name="definition_pt">profeta, vidente do futuro</column>
+      <column name="definition_fi">profeetta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9231,6 +10247,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Это также может быть сокращено до {rItwI':n:nolink}, если контекст понятен. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果上下文清楚，也可以將其縮短為{rItwI':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser reduzido para {rItwI':n:nolink}, se o contexto estiver claro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voidaan myös lyhentää muotoon {rItwI':n:nolink}, jos asiayhteys on selkeä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tuch:n}, {rIt:v}, {-wI':n}</column>
       <column name="examples"></column>
@@ -9240,6 +10257,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9247,6 +10265,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.01:src}</column>
     </table>
     <table name="mem">
@@ -9260,6 +10279,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">гром [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雷</column>
       <column name="definition_pt">trovão</column>
+      <column name="definition_fi">ukkostaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{raw:v}, {pe'bIl:n}, {jev:v:1}, {borqu':v}</column>
@@ -9270,6 +10290,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9279,6 +10300,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9286,6 +10308,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -9299,6 +10322,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">скоро</column>
       <column name="definition_zh_HK">不久 [AUTOTRANSLATED]</column>
       <column name="definition_pt">em breve</column>
+      <column name="definition_fi">pian</column>
       <column name="synonyms"></column>
       <column name="antonyms">{SIbI'Ha':adv}</column>
       <column name="see_also">{qen:adv}, {nom:adv}, {tugh:excl}, {lIb:v}</column>
@@ -9309,6 +10333,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9318,6 +10343,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9325,6 +10351,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9338,6 +10365,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">Быстро!</column>
       <column name="definition_zh_HK">快啲啦！</column>
       <column name="definition_pt">Se apresse!</column>
+      <column name="definition_fi">Kiirehdi!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha':excl}, {tugh:adv}</column>
@@ -9348,6 +10376,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9357,6 +10386,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9364,6 +10394,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -9377,6 +10408,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">быть опозоренным</column>
       <column name="definition_zh_HK">慚愧、可恥</column>
       <column name="definition_pt">Estar envergonhado</column>
+      <column name="definition_fi">olla nolo, nolostunut, olla häpeissään</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIl:v}, {web:v:1}, {Hem:v}</column>
@@ -9387,6 +10419,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
       <column name="components"></column>
       <column name="examples">
@@ -9397,6 +10430,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9404,6 +10438,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9417,6 +10452,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">маневр (военное выражение)</column>
       <column name="definition_zh_HK">機動（軍事術語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">manobra (termo militar)</column>
+      <column name="definition_fi">sotilasmanööveri?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qeq:n}, {per yuD:n}, {Qu':n}, {tonSaw':n}</column>
@@ -9427,6 +10463,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9437,6 +10474,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">manoeuvre, manoeuver, exercise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9444,6 +10482,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9457,6 +10496,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">стыдить</column>
       <column name="definition_zh_HK">恥辱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">envergonhar</column>
+      <column name="definition_fi">saattaa häpeään, tuottaa häpeää jollekulle, häpäistä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIch:v}</column>
@@ -9467,6 +10507,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tuH:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -9476,6 +10517,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9483,6 +10525,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9496,6 +10539,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">быть горячим</column>
       <column name="definition_zh_HK">熱</column>
       <column name="definition_pt">ser quente</column>
+      <column name="definition_fi">olla kuuma</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bIr:v}, {Qey':v}</column>
       <column name="see_also">{tuj:n}, {Hat:n}, {ghun:v:2}, {pub:v}, {buj:v}</column>
@@ -9506,6 +10550,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It was clarified during the Q &amp; A session at {qep'a' 27 (2020):src} that the temperature words really are about temperature and not about effect or perception, so that clothing, for example, is not said to be "hot" or "cold" in Klingon.</column>
       <column name="components"></column>
       <column name="examples">
@@ -9517,6 +10562,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9524,6 +10570,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -9537,6 +10584,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">жар</column>
       <column name="definition_zh_HK">熱</column>
       <column name="definition_pt">calor</column>
+      <column name="definition_fi">lämpö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuj:v}, {Hat:n}, {SImyon:n}</column>
@@ -9547,6 +10595,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9562,6 +10611,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9569,6 +10619,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.76-77:src}</column>
     </table>
     <table name="mem">
@@ -9582,6 +10633,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">отвод тепла [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">散熱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">exaustão de calor</column>
+      <column name="definition_fi">lämmönpoistaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peng baHjan tuj ghImwI':n}</column>
@@ -9592,6 +10644,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tuj:n}, {ghImwI':n}</column>
       <column name="examples"></column>
@@ -9601,6 +10654,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9608,6 +10662,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -9621,6 +10676,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">термошовный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">熱縫合 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sutura térmica</column>
+      <column name="definition_fi">lämpöliitin?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaqwI':n}</column>
@@ -9631,6 +10687,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tuj:n}, {muv:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -9640,6 +10697,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9647,6 +10705,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 1.3, Sept. 1992:src}</column>
     </table>
     <table name="mem">
@@ -9660,6 +10719,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">инфракрасное, инфракрасное излучение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">紅外線輻射</column>
       <column name="definition_pt">infravermelho, radiação infravermelha</column>
+      <column name="definition_fi">infrapuna, infrapunasäteily</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9670,6 +10730,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tuj:n}, {'otlh:n}</column>
       <column name="examples"></column>
@@ -9679,6 +10740,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9686,6 +10748,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -9699,6 +10762,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">Кровь воина кипит, пока огонь не остыл. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">在火炎熱之前，戰士的血液沸騰了。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O sangue de um guerreiro ferve antes que o fogo esteja quente.</column>
+      <column name="definition_fi">Soturin veri kiehuu ennen kuin tuli on kuuma.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9709,6 +10773,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tuj:v}, {-pa':v}, {qul:n}, {pub:v}, {SuvwI':n}, {'Iw:n}</column>
       <column name="examples"></column>
@@ -9718,6 +10783,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9725,6 +10791,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.32:src}</column>
     </table>
     <table name="mem">
@@ -9738,6 +10805,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">Двигатель перегревается.</column>
       <column name="definition_zh_HK">發動機過熱。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O motor está super aquecido.</column>
+      <column name="definition_fi">Moottori ylikuumenee.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9748,6 +10816,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/pS5XfZGmy34} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/pS5XfZGmy34} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/pS5XfZGmy34} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/pS5XfZGmy34} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9757,6 +10826,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9764,6 +10834,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -9777,6 +10848,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">надеяться</column>
       <column name="definition_zh_HK">希望</column>
       <column name="definition_pt">esperança</column>
+      <column name="definition_fi">toivoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIl:v}</column>
@@ -9787,6 +10859,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru">Этот глагол может принимать {'e':n:pro} в качестве своего объекта.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este verbo pode usar {'e':n:pro} como seu objeto.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi voi ottaa objektiksi {'e':n:pro}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9800,6 +10873,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9807,6 +10881,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {msn 1997.07.01:src} (reprinted in {HQ 7.2, p.8, Jun. 1998:src})</column>
     </table>
     <table name="mem">
@@ -9820,6 +10895,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">агентство</column>
       <column name="definition_zh_HK">機構 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agência</column>
+      <column name="definition_fi">virasto, osasto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9830,6 +10906,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -9841,6 +10918,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9848,6 +10926,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9861,6 +10940,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">быть мягким</column>
       <column name="definition_zh_HK">柔軟 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser suave</column>
+      <column name="definition_fi">olla pehmeä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{let:v}</column>
       <column name="see_also">{reghuluS 'Iwghargh:n}</column>
@@ -9871,6 +10951,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9880,6 +10961,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9887,6 +10969,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9900,6 +10983,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">обескураживать</column>
       <column name="definition_zh_HK">不鼓勵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desencorajar</column>
+      <column name="definition_fi">lannistaa, koettaa saada joku luopumaan (jostain)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tungHa':v}</column>
       <column name="see_also"></column>
@@ -9910,6 +10994,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9919,6 +11004,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9926,6 +11012,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -9939,6 +11026,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">поощрять</column>
       <column name="definition_zh_HK">鼓勵、支持</column>
       <column name="definition_pt">encorajar</column>
+      <column name="definition_fi">kannustaa, rohkaista jotakuta</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tung:v}</column>
       <column name="see_also">{ruch:v}</column>
@@ -9949,6 +11037,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這可以應用於音樂。[2, p.71] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser aplicado à música.[2, p.71] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan soveltaa musiikkiin.[2, p.71] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tung:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -9958,6 +11047,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9965,6 +11055,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -9978,6 +11069,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">бетон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">混凝土</column>
       <column name="definition_pt">concreto</column>
+      <column name="definition_fi">betoni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9988,6 +11080,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Tung-Yen Lin was a pioneer in standardising the use of prestressed concrete.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9997,6 +11090,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10004,6 +11098,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -10017,6 +11112,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">минута</column>
       <column name="definition_zh_HK">分鐘</column>
       <column name="definition_pt">minuto (de tempo)</column>
+      <column name="definition_fi">minuutti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lup:n}, {rep:n}</column>
@@ -10027,6 +11123,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10036,6 +11133,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10043,6 +11141,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10056,6 +11155,7 @@ A inclinação para baixo é indicada por um ângulo negativo (consulte {taH:v:2
       <column name="definition_ru">племя, дом, прародина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">家族</column>
       <column name="definition_pt">tribo, casa, unidade ancestral</column>
+      <column name="definition_fi">huone, heimo, perhe</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qorDu':n}, {joH:n}, {tuqnIgh:n}, {chuQun:n}, {chuD:n}</column>
@@ -10072,6 +11172,13 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Sanoa "Kahlor of the Molor House", sanotaan yksinkertaisesti {qeylor, molor tuq:sen:nolink} "Kahlor, House of Molor". Ollakseen muodollisempi voidaan lisätä isän nimi, kuten julkaisussa {qeylor, qeylIn puqloD, molor tuq:sen:nolink} "Kahlor, Kahlinin poika, (Molorin talon)".
+
+Toinen muodollinen ja hieman arkaainen tapa ilmaista jäsenyyttä talossa on käyttää verbiä {tay':v}:
+▶ {tay' qeylor molor tuq je:sen:nolink} "Kahlor on Molorin talosta"
+▶ {matay' jIH molor tuq je:sen:nolink} "Olen Molorin talossa"
+▶ {Sutay' SoH molor tuq je:sen:nolink} "Olet Molorin talossa"
+Tämä rakenne näyttää liittyvän sananlaskuun {reH tay' ghot tuqDaj je.:sen}[2][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10084,6 +11191,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10091,6 +11199,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.09.01:src}</column>
     </table>
     <table name="mem">
@@ -10104,6 +11213,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="definition_ru">фамильный герб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">家徽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">brasão</column>
+      <column name="definition_fi">sukuvaakuna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuq:n}, {Degh:n:1}</column>
@@ -10114,6 +11224,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tuq:n}, {Degh:n:1}</column>
       <column name="examples"></column>
@@ -10123,6 +11234,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10130,6 +11242,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10143,6 +11256,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="definition_ru">Великобритания</column>
       <column name="definition_zh_HK">聯合王國</column>
       <column name="definition_pt">Reino Unido</column>
+      <column name="definition_fi">Yhdistynyt kuningaskunta</column>
       <column name="synonyms">{wo' tay':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{'amerI'qa' SepjIjQa':n}, {yuQjIjQa':n}, {'Inglan:n}, {SIqotlan:n}</column>
@@ -10153,6 +11267,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tuq:n}, {jIj:v}, {Qa':n:2,hyp}</column>
       <column name="examples"></column>
@@ -10162,6 +11277,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">England, Britain</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10169,6 +11285,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -10182,6 +11299,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="definition_ru">член дома [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一個房子的成員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">membro de uma casa</column>
+      <column name="definition_fi">huoneen jäsen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuq:n}, {qorDu':n}, {muv:v}</column>
@@ -10192,6 +11310,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="notes_ru">Смотрите в {tuq:n} объяснение, как выразить членство в палате. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關如何表達眾議院成員身份的說明，請參見{tuq:n}下的內容。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {tuq:n} para obter uma explicação de como expressar associação em uma Casa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso kohdasta {tuq:n} selitys siitä, miten ilmaista jäsenyys talossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10201,6 +11320,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10208,6 +11328,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -10221,6 +11342,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="definition_ru">лоб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">額頭</column>
       <column name="definition_pt">testa</column>
+      <column name="definition_fi">otsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quch:n}</column>
@@ -10231,6 +11353,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10240,6 +11363,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10247,6 +11371,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -10260,6 +11385,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="definition_ru">носить (одежду)</column>
       <column name="definition_zh_HK">穿衣服） [AUTOTRANSLATED]</column>
       <column name="definition_pt">vestir (roupas)</column>
+      <column name="definition_fi">pitää (vaatetta päällä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuQmoH:v}, {tuQHa'moH:v}</column>
@@ -10270,6 +11396,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10279,6 +11406,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10286,6 +11414,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10299,6 +11428,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="definition_ru">сито ума (Клингонский психический зонд)</column>
       <column name="definition_zh_HK">心靈篩子（Klingon psychic probe） [AUTOTRANSLATED]</column>
       <column name="definition_pt">peneira mental (sonda psíquica klingon)</column>
+      <column name="definition_fi">eräs laite, mieliseula (klingonien psyykkinen luotain)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10309,6 +11439,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="notes_ru">Это устройство, которое может читать содержимое мозга субъекта.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種可以讀取受試者大腦內容的設備。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um dispositivo que pode ler o conteúdo do cérebro de um sujeito.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on laite, joka pystyy lukemaan kohteen aivojen sisällön.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10318,6 +11449,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10325,6 +11457,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TOS - Errand of Mercy:src}</column>
     </table>
     <table name="mem">
@@ -10338,6 +11471,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="definition_ru">снять (одежду)</column>
       <column name="definition_zh_HK">脫衣服 [AUTOTRANSLATED]</column>
       <column name="definition_pt">despir</column>
+      <column name="definition_fi">riisua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tuQmoH:v}</column>
       <column name="see_also">{teq:v}</column>
@@ -10348,6 +11482,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="notes_ru">Посмотрите {qawmoH:v} для примера того, как использовать глагол как этот. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關如何使用此類動詞的示例，請參見{qawmoH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja {qawmoH:v} para um exemplo de como usar um verbo como este. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {qawmoH:v} esimerkki siitä, miten tämän kaltaista verbiä käytetään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tuQ:v}, {-Ha':v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -10357,6 +11492,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10364,6 +11500,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10377,6 +11514,7 @@ This construction seems to be related to the proverb {reH tay' ghot tuqDaj je.:s
       <column name="definition_ru">надевать (одежду)</column>
       <column name="definition_zh_HK">穿上衣服） [AUTOTRANSLATED]</column>
       <column name="definition_pt">vestir (roupas)</column>
+      <column name="definition_fi">pukea (vaate päälleen)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tuQHa'moH:v}</column>
       <column name="see_also"></column>
@@ -10397,6 +11535,9 @@ Slanguttrycket {qogh tuQmoHHa':sen}, bokstavligen "att ta av sig bältet", betyd
       <column name="notes_pt">Veja {qawmoH:v} para um exemplo de como usar um verbo como este.
 
 A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", significa "não ouvir" .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {qawmoH:v} esimerkki siitä, miten tämän kaltaista verbiä käytetään.
+
+Slangilauseke {qogh tuQmoHHa':sen}, kirjaimellisesti "ottaa pois vyönsä", tarkoittaa "ei kuulla".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tuQ:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -10406,6 +11547,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10413,6 +11555,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 2.4, p.17, Dec. 1993:src}</column>
     </table>
     <table name="mem">
@@ -10426,6 +11569,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="definition_ru">выполнять, выполнять (миссия), выполнять (обязанности) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">執行、執行（任務）、執行（職責） [AUTOTRANSLATED]</column>
       <column name="definition_pt">realizar, conduzir (uma missão), executar (deveres)</column>
+      <column name="definition_fi">suorittaa (tehtävä, velvollisuus tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qu':n}</column>
@@ -10436,6 +11580,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10447,6 +11592,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10454,6 +11600,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Smithsonian GO FLIGHT app:src}, [2] {Saarbrücken qepHom'a' 2016:src}, [3] {Pop Culture Hero Coalition announcement:src} ({KLI mailing list 2016.11.30:src})</column>
     </table>
     <table name="mem">
@@ -10467,6 +11614,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="definition_ru">сервер (компьютер) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">伺服器（電腦）</column>
       <column name="definition_pt">servidor (computador)</column>
+      <column name="definition_fi">palvelin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10477,6 +11625,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="notes_ru">Если контекст не ясен, будет использоваться {De'wI' turwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果上下文不清楚，將使用{De'wI' turwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se o contexto não estiver claro, {De'wI' turwI':n} seria usado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos konteksti ei ole selkeä, käytetään {De'wI' turwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tur:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -10486,6 +11635,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10493,6 +11643,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -10506,6 +11657,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="definition_ru">моча [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">尿</column>
       <column name="definition_pt">urina</column>
+      <column name="definition_fi">virtsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{taQbang:n:2}, {ghIm:v}, {vuj:v}, {puch:n}</column>
@@ -10516,6 +11668,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">From Latin "micturation", maybe also a reference to the colour of tumeric.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10525,6 +11678,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pee</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10532,6 +11686,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -10545,6 +11700,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="definition_ru">мочевой пузырь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">膀胱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bexiga urinária</column>
+      <column name="definition_fi">virtsarakko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10555,6 +11711,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{turmIq:n}, {'enDeq:n}</column>
       <column name="examples"></column>
@@ -10564,6 +11721,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10571,6 +11729,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -10584,6 +11743,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="definition_ru">кашель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">咳嗽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tossir</column>
+      <column name="definition_fi">yskiä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10594,6 +11754,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">From Latin "tussire".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10603,6 +11764,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10610,6 +11772,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -10623,6 +11786,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="definition_ru">колонна</column>
       <column name="definition_zh_HK">柱</column>
       <column name="definition_pt">coluna</column>
+      <column name="definition_fi">pilari, pylväs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tut:n:2}</column>
@@ -10633,6 +11797,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10648,6 +11813,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pillar, post</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10655,6 +11821,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.159:src}</column>
     </table>
     <table name="mem">
@@ -10668,6 +11835,7 @@ A expressão de gíria {qogh tuQmoHHa':sen}, literalmente "tirar o cinto", signi
       <column name="definition_ru">призма (геометрия) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">柱體</column>
       <column name="definition_pt">prisma (geometria)</column>
+      <column name="definition_fi">prisma, särmiö (geometria)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tut:n:1}, {mey':n}, {yergh:n}</column>
@@ -10692,6 +11860,9 @@ Ett prisma med en tre-sidig bas är en {ra'Duch tut:n@@ra'Duch:n, tut:n:2}, och 
       <column name="notes_pt">Observe que isso se refere à figura geométrica, e não a um objeto de vidro usado para refratar a luz.
 
 Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e assim por diante. Um cilindro é um {gho tut:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä viittaa geometriseen kuvioon eikä lasiesineeseen, jota käytetään valon taittamiseen.
+
+Kolmen puolen pohjalla oleva prisma on {ra'Duch tut:n@@ra'Duch:n, tut:n:2} ja niin edelleen. Sylinteri on {gho tut:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10701,6 +11872,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10708,6 +11880,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -10721,6 +11894,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="definition_ru">лифт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">𨋢、罐籠、升降機</column>
       <column name="definition_pt">elevador</column>
+      <column name="definition_fi">hissi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10731,6 +11905,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="notes_ru">Это буквально «колонный автомобиль» и относится к кабине, а не ко всей системе. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這實際上是“列式車輛”，是指駕駛室，而不是整個系統。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é literalmente "veículo de coluna" e refere-se à cabine, não a todo o sistema. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kirjaimellisesti "pylväsajoneuvo" ja viittaa ohjaamoon, ei koko järjestelmään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tut:n:1}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -10740,6 +11915,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">turbolift</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10747,6 +11923,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -10760,6 +11937,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="definition_ru">иметь татуировку [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有紋身、紋身 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter uma tatuagem, ser tatuado</column>
+      <column name="definition_fi">olla tatuoitu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIr tutlh:n}, {tutlhmoH:v}</column>
@@ -10770,6 +11948,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10779,6 +11958,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <!-- Reported by Robyn Stewart, on Facebook: https://www.facebook.com/groups/LearnKlingon/permalink/1474580219316856/ -->
@@ -10787,6 +11967,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Facebook "Learn Klingon" group 2017.10.07:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -10800,6 +11981,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="definition_ru">тату [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">黥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tatuagem</column>
+      <column name="definition_fi">tatuoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIr tutlh:n}</column>
@@ -10810,6 +11992,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tutlh:v:1}, {-moH:v}</column>
       <column name="examples"></column>
@@ -10819,6 +12002,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <!-- Reported by Robyn Stewart, on Facebook: https://www.facebook.com/groups/LearnKlingon/permalink/1474580219316856/ -->
@@ -10827,6 +12011,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Facebook "Learn Klingon" group 2017.10.07:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -10840,6 +12025,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="definition_ru">быть официальным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">正式</column>
       <column name="definition_pt">ser oficial</column>
+      <column name="definition_fi">olla virallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10850,6 +12036,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Maltz was asked about "canon", but didn't give an answer.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10859,6 +12046,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">canon</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10866,6 +12054,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -10879,6 +12068,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="definition_ru">быть терпеливым</column>
       <column name="definition_zh_HK">耐心</column>
       <column name="definition_pt">ser paciente</column>
+      <column name="definition_fi">olla kärsivällinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{boH:v}</column>
       <column name="see_also">{loS:v}</column>
@@ -10889,6 +12079,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {vut:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10898,6 +12089,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10905,6 +12097,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -10918,6 +12111,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="definition_ru">вертел [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吐口水</column>
       <column name="definition_pt">cuspir</column>
+      <column name="definition_fi">sylkeä (nestettä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIS:v}, {tIl:v}, {tlhepQe':n}, {qo'qaD:n}</column>
@@ -10928,6 +12122,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="notes_ru">Если вы выплевываете жидкость, то {bItuy':sen:nolink}, а если вы выплевываете твердые частицы, то {bItlhIS:sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果吐出液體，則為{bItuy':sen:nolink}，但如果吐出固體，則為{bItlhIS:sen:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se você cuspir líquido, {bItuy':sen:nolink}, mas se cuspir sólidos, {bItlhIS:sen:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos sylkette ulos nestettä, sitten {bItuy':sen:nolink}, mutta jos sylkette kiinteät aineet, sitten {bItlhIS:sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Cantonese Chinese for "spit" (吐).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10937,6 +12132,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10944,6 +12140,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -10957,6 +12154,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="definition_ru">обнаружить, находить, наблюдать, замечать</column>
       <column name="definition_zh_HK">發現、觀察、注意</column>
       <column name="definition_pt">descobrir, encontrar, observar, notar</column>
+      <column name="definition_fi">löytää, havaita, huomata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sam:v}, {bej:v:1}, {tu'lu':v}</column>
@@ -10967,6 +12165,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10990,6 +12189,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10997,6 +12197,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -11010,6 +12211,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="definition_ru">что-то бесполезное [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">冇用嘅嘢</column>
       <column name="definition_pt">algo inútil</column>
+      <column name="definition_fi">hyödytön (asia)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{potlh:n}</column>
       <column name="see_also">{lo'laHbe':v}</column>
@@ -11020,6 +12222,7 @@ Um prisma com base de três lados é um {ra'Duch tut:n@@ra'Duch:n, tut:n:2} e as
       <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/dhcRzrNc_P0} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/dhcRzrNc_P0} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/dhcRzrNc_P0} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/dhcRzrNc_P0} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the episode {DS9 - Blood Oath:src}, Kor asks Kang (regarding Jadzia Dax): "Why do you dismiss her like some useless t'ooho'mIrah?" This was adapted by Okrand in {KGT:src} and used in {KCD:src} (see the example sentence).[3]
 
 The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed in {HQ 5.1:src}. As this list was just a preview containing no additional information (many of the words would subsequently officially appear in {KGT:src}), {HQ 5.1:src} has been left out of the list of sources for these words. There are two minor differences with {KGT:src}, one of which was that {tu'HomI'raH:n:nolink} was simply transliterated as "T'oohomIrah" (spelled that way, but not otherwise defined or explained).[4] (See {gha'tlhIq:n} for the other one.)</column>
@@ -11032,6 +12235,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">burden, T'oohomIrah</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11039,6 +12243,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KCD:src}, [3] {DS9 - Blood Oath:src}, [4] {HQ 5.1, Mar. 1996 p.20:src}</column>
     </table>
     <table name="mem">
@@ -11053,6 +12258,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="definition_ru">teacup (older or upper-class word) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">茶杯（較舊或較高級的單詞） [AUTOTRANSLATED]</column>
       <column name="definition_pt">xícara de chá (palavra mais antiga ou de classe alta)</column>
+      <column name="definition_fi">teekuppi (ylätyylinen sana)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11063,6 +12269,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="notes_ru">Это слово высшего класса для {Dargh HIvje':n}. Это архаичное слово, которое раньше означало только металлическую чашу. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{Dargh HIvje':n}的上位詞。這是一個古老的詞，過去僅表示金屬杯。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra de classe alta para {Dargh HIvje':n}. É uma palavra arcaica que costumava significar apenas copo de metal. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ylemmän luokan sana sanalle {Dargh HIvje':n}. Se on arkaainen sana, joka tarkoitti aiemmin vain metallikuppia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11072,6 +12279,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11079,6 +12287,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -11093,6 +12302,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="definition_ru">есть, наблудается</column>
       <column name="definition_zh_HK">有……的</column>
       <column name="definition_pt">existe algo</column>
+      <column name="definition_fi">olla olemassa (jossakin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11103,6 +12313,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="notes_ru">Это глагол {tu':v} с суффиксом {-lu':v}, комбинация которого часто переводится как «есть» на английском языке.[1] Обратите внимание, что используется префикс единственного числа от третьего лица, даже если объект является множественным (когда можно ожидать префикс {lu-:v:pref}, т.е. {lutu'lu':sen:nolink}) .[1; 3; 4] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on verbi {tu':v}, jonka pääte on {-lu':v}, jonka yhdistelmä käännetään usein englanniksi "on" -toimintona. {lu-:v:pref}, eli {lutu'lu':sen:nolink}) .[1; 3; 4][1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tu':v}, {-lu':v}</column>
       <column name="examples">
@@ -11119,6 +12330,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11126,6 +12338,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}, [3] {KGT p.127,168-172:src}, [4] {KLI mailing list 2014.09.03:src}</column>
     </table>
     <table name="mem">
@@ -11139,6 +12352,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="definition_ru">носок</column>
       <column name="definition_zh_HK">襪（單數）</column>
       <column name="definition_pt">meia</column>
+      <column name="definition_fi">sukka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11149,6 +12363,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Sock it to me" was a frequent catchphrase on the sketch comedy television show "Laugh-In".</column>
       <column name="components">{paSlogh:n}</column>
       <column name="examples"></column>
@@ -11158,6 +12373,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11165,6 +12381,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.01.22:src}</column>
     </table>
     <table name="mem">
@@ -11178,6 +12395,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="definition_ru">форма, форма, внешний вид, конфигурация [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">形式、形狀、外觀、構型</column>
       <column name="definition_pt">forma, aparência, configuração</column>
+      <column name="definition_fi">muoto, ulkonäkö, asetelma, teema</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11188,6 +12406,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="notes_ru">Это также может быть использовано для «темы» применительно к приложению.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也可以用於應用到應用程序的“主題”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode ser usado para um "tema", conforme aplicado a um aplicativo.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää myös "teemaan" sovelluksena sovellettuna.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{ngutlh tu'qom:n}</column>
@@ -11197,6 +12416,7 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">theme</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11204,5 +12424,6 @@ The KLI got a list of vocabulary used in {KCD:src} in advance, which was printed
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}, [2] {KLI mailing list 2018.02.17:src}</column>
     </table>

--- a/mem-16-t.xml
+++ b/mem-16-t.xml
@@ -694,42 +694,42 @@ Watch a performance of these lines by {Brian Rivera:url:http://www.imdb.com/name
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
-      <column name="notes_fi">Tämä on kuuluisa linja {Hamlet:n:name}: ltä.
+      <column name="notes_fi">Tämä on kuuluisa lausahdus {Hamlet:n:name}ista.
 
-Koko III, kohtaus I, yksinäinen saarnaus menee seuraavasti:
+Koko yksinpuhelu näytöksestä III kohtauksesta I:
 ▶ {taH pagh taHbe'.:sen:nolink} {DaH mu'tlheghvam vIqelnIS.@@DaH:adv, mu'tlhegh:n, -vam:n, vI-:v, qel:v:1, -nIS:v}
-   {quv'a ', yabDaq San vaQ cha, pu' je SIQDI '? @@ quv: v, -'a': v, yab: n, -Daq: n, San: n, vaQ: v, cha: n , pu ': n: 1, je: conj, SIQ: v, -DI': v}
-   DONOTTRANSLATE 5
-   {'ej, Suvmo', rInmoHDI '? Hegh. Qong - Qong neH -}
-   DONOTTRANSLATE 7
-   {cho'nISbogh porghDaj rInmoHlaH net Har.}
-   {yIn mevbogh mIwvam'e' wIruchqangbej.}
-   DONOTTRANSLATE 10
-   DONOTTRANSLATE 11
-   DONOTTRANSLATE 12
-   DONOTTRANSLATE 13
-   {SIQmoHmo' qechvam. Qugh yIn nI'moH 'oH.}
-   {reH vaq 'ej qIpqu' bov; mayHa'taH HI';}
-   DONOTTRANSLATE 16
-   DONOTTRANSLATE 17
-   DONOTTRANSLATE 18
-   {qatlh Hochvam lajqang vay '? wa 'taj neH lo'DI',}
-   {Qu'Daj Qatlh qIllaH ghaH! tep qengqang 'Iv?}
-   DONOTTRANSLATE 21
-   {mISbe'chugh neHtaHghach, ghaH ghIjmo' DuHvam -}
-   {Hegh tlha' vay' - Hegh tlha' qo''e' tu'bogh pagh.}
-   {not chegh lengwI'ma', qo'vetlh veHmey 'elDI'.}
-   {vaj Seng DIghajbogh, lajtaHmeH qaq law';}
-   {latlh DISovbe'bogh, ghoSchoHmeH qaq puS.}
-   {vaj nuch DIDa 'e' raDlaw' ghobmaj, qelDI'.}
-   {'ej, pIvmo', wovqu'taHvIS wuqbogh qab,}
-   {'oH ropmoH rIntaH Sotbogh qech ghom Hurgh.}
-   {'ej Qu'mey potlh DItulbogh qIl je qechvam.}
-   31
-   {toH be', qa''a'pu'vaD bItlhobtaHvIS,}
-   {jIyempu' 'e' yIQIjchoH je.}[2]
+    {quv'a', yabDaq San vaQ cha, pu' je SIQDI'?@@quv:v, -'a':v, yab:n, -Daq:n, San:n, vaQ:v, cha:n, pu':n:1, je:conj, SIQ:v, -DI':v}
+    {pagh, Seng bIQ'a'Hey SuvmeH nuHmey SuqDI',@@pagh:conj, Seng:n, bIQ'a':n, -Hey:n, Suv:v, -meH:v, nuH:n:1, -mey:n, Suq:v, -DI':v}
+    {'ej, Suvmo', rInmoHDI'? Hegh. Qong - Qong neH -}
+    {'ej QongDI', tIq 'oy', wa'SanID Daw''e' je}
+    {cho'nISbogh porghDaj rInmoHlaH net Har.}
+    {yIn mevbogh mIwvam'e' wIruchqangbej.}
+    {Hegh. Qong. QongDI' chaq naj. toH, waQlaw' ghu'vam!}
+    {HeghDaq maQongtaHvIS, tugh vay' wInajlaH,}
+    {volchaHmajvo' jubbe'wI' bep wIwoDDI';}
+    {'e' wIqelDI', maHeDnIS. Qugh DISIQnIS,}
+    {SIQmoHmo' qechvam. Qugh yIn nI'moH 'oH.}
+    {reH vaq 'ej qIpqu' bov; mayHa'taH HI';}
+    {Dochchu' HemwI'; ruv mImlu'; tIchrup patlh;}
+    {'oy'moH muSHa'ghach 'Il vuvHa'lu'bogh;}
+    {quvwI'pu' tuv quvHa'moH quvHa'wI'pu';}
+    {qatlh Hochvam lajqang vay'? wa' taj neH lo'DI',}
+    {Qu'Daj Qatlh qIllaH ghaH! tep qengqang 'Iv?}
+    {Doy'moHmo' yInDaj, bepmeH bechqang 'Iv,}
+    {mISbe'chugh neHtaHghach, ghaH ghIjmo' DuHvam -}
+    {Hegh tlha' vay' - Hegh tlha' qo''e' tu'bogh pagh.}
+    {not chegh lengwI'ma', qo'vetlh veHmey 'elDI'.}
+    {vaj Seng DIghajbogh, lajtaHmeH qaq law';}
+    {latlh DISovbe'bogh, ghoSchoHmeH qaq puS.}
+    {vaj nuch DIDa 'e' raDlaw' ghobmaj, qelDI'.}
+    {'ej, pIvmo', wovqu'taHvIS wuqbogh qab,}
+    {'oH ropmoH rIntaH Sotbogh qech ghom Hurgh.}
+    {'ej Qu'mey potlh DItulbogh qIl je qechvam.}
+    {vIDHa'choH nab. baQa'! 'ovelya 'IH!}
+    {toH be', qa''a'pu'vaD bItlhobtaHvIS,}
+    {jIyempu' 'e' yIQIjchoH je.}[2]
 
-Katso näiden linjojen esitys artistilta {Brian Rivera:url:http://www.imdb.com/name/nm2092459/}: {YouTube video:url:http://youtu.be/CiRMGYQfXrs}{quv'a', yabDaq San vaQ cha, pu' je SIQDI'?@@quv:v, -'a':v, yab:n, -Daq:n, San:n, vaQ:v, cha:n, pu':n:1, je:conj, SIQ:v, -DI':v}{pagh, Seng bIQ'a'Hey SuvmeH nuHmey SuqDI',@@pagh:conj, Seng:n, bIQ'a':n, -Hey:n, Suv:v, -meH:v, nuH:n:1, -mey:n, Suq:v, -DI':v}{'ej, Suvmo', rInmoHDI'? Hegh. Qong - Qong neH -}{'ej QongDI', tIq 'oy', wa'SanID Daw''e' je}{Hegh. Qong. QongDI' chaq naj. toH, waQlaw' ghu'vam!}{HeghDaq maQongtaHvIS, tugh vay' wInajlaH,}{volchaHmajvo' jubbe'wI' bep wIwoDDI';}{'e' wIqelDI', maHeDnIS. Qugh DISIQnIS,}{Dochchu' HemwI'; ruv mImlu'; tIchrup patlh;}{'oy'moH muSHa'ghach 'Il vuvHa'lu'bogh;}{quvwI'pu' tuv quvHa'moH quvHa'wI'pu';}{qatlh Hochvam lajqang vay'? wa' taj neH lo'DI',}{Qu'Daj Qatlh qIllaH ghaH! tep qengqang 'Iv?}{Doy'moHmo' yInDaj, bepmeH bechqang 'Iv,}{vIDHa'choH nab. baQa'! 'ovelya 'IH!} [AUTOTRANSLATED]</column>
+Katso tämä {Brian Rivera:url:http://www.imdb.com/name/nm2092459/}n esittämänä: {YouTube video:url:http://youtu.be/CiRMGYQfXrs}</column>
       <column name="hidden_notes">These lines have been translated from the original Klingon by Nick Nicholas and Andrew Strader.</column>
       <column name="components">{taH:v:1}, {pagh:conj}, {taH:v:1}, {-be':v}</column>
       <column name="examples"></column>
@@ -10074,7 +10074,7 @@ Nousu alaspäin ilmaistaan ​​negatiivisella kulmalla (katso {taH:v:2}). [AUT
       <column name="notes_ru">Это значит невольно мигать. Сленговым способом сказать, что это {mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}. Например, {mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1} означает «Я моргаю». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著不由自主地眨眼。 this語是{mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}。例如，{mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1}表示“我眨眼”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa piscar involuntariamente. Uma forma de gíria para dizer isso é {mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}. Por exemplo, {mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1} significa "Eu pisco". [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Tämä tarkoittaa vilkkua tahattomasti. Slangitapa sanoa tämä on {mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}. Esimerkiksi {mInDu '(wIj) vIyIv: sen @@ mIn: n, -Du': n, -wIj: n, vI-: v, yIv: v: 1} tarkoittaa "vilkkuu".{mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa vilkkua tahattomasti. Slangitapa sanoa tämä on {mInDu' yIv:sen@@mIn:n, -Du':n, yIv:v:1}. Esimerkiksi {mInDu'(wIj) vIyIv:sen@@mIn:n, -Du':n, -wIj:n, vI-:v, yIv:v:1} tarkoittaa "vilkkuu". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It was stated during the Q &amp; A session that this does not generally take an object. It is used for eyes, not lights.</column>
       <column name="components"></column>
       <column name="examples"></column>

--- a/mem-17-tlh.xml
+++ b/mem-17-tlh.xml
@@ -1187,7 +1187,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Uma expressão de gíria para pontuação é {ghewmey:n}. {tlhavqop:n:nolink} é inerentemente plural, mas pode-se dizer {tlhavqop ngutlh(mey):n@@tlhavqop:n, ngutlh:n, -mey:n} "sinais de pontuação".[1] [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Välimerkkien slangilauseke on {ghewmey:n}. {tlhavqop:n:nolink} on luonnostaan ​​monikkomuoto, mutta voidaan sanoa {tlhavqop ngutlh (mey): n @@ tlhavqop: n, ngutlh: n, -mey: n} "välimerkit (merkit)".{tlhavqop ngutlh(mey):n@@tlhavqop:n, ngutlh:n, -mey:n}[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Välimerkkien slangilauseke on {ghewmey:n}. {tlhavqop:n:nolink} on luonnostaan ​​monikkomuoto, mutta voidaan sanoa {tlhavqop ngutlh(mey):n@@tlhavqop:n, ngutlh:n, -mey:n} "välimerkit (merkit)".[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>

--- a/mem-17-tlh.xml
+++ b/mem-17-tlh.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {tlh:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{tlh:sen:nolink}</column>
       <column name="definition_pt">a consoante {tlh:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {tlh:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">быть свободным</column>
       <column name="definition_zh_HK">自由、獨立</column>
       <column name="definition_pt">ser livre, independente</column>
+      <column name="definition_fi">olla vapaa, riippumaton, itsenäinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngem Ha'DIbaH:n}, {tlhab:n}, {tlhay':v}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">свобода</column>
       <column name="definition_zh_HK">自由、獨立</column>
       <column name="definition_pt">liberdade, independência</column>
+      <column name="definition_fi">vapaus, riippumattomuus, itsenäisyys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhab:v}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {batlh:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">секта, фракция [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">派、派系 [AUTOTRANSLATED]</column>
       <column name="definition_pt">seita, facção</column>
+      <column name="definition_fi">lahko, ryhmittymä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghom:n}, {boq:n:1}, {DIvI':n}, {qev:n}, {qev:v}</column>
@@ -136,6 +149,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -145,6 +159,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -152,6 +167,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 4.4, Dec. 1995:src}</column>
     </table>
     <table name="mem">
@@ -165,6 +181,7 @@
       <column name="definition_ru">жаргон, арго [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">行話、argot [AUTOTRANSLATED]</column>
       <column name="definition_pt">jargão, árgon</column>
+      <column name="definition_fi">ammattikieli, slangi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -175,6 +192,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhach:n}, {mu':n}, {-mey:n}</column>
       <column name="examples"></column>
@@ -184,6 +202,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -191,6 +210,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -204,6 +224,7 @@
       <column name="definition_ru">жир, животный жир [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">脂肪、動物脂肪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gordura, gordura animal</column>
+      <column name="definition_fi">rasva, eläinrasva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pI':v}, {ror:v}, {'Im:v}</column>
@@ -214,6 +235,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It "clog"s your arteries.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -223,6 +245,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -230,6 +253,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -243,6 +267,7 @@
       <column name="definition_ru">фри, картофель фри [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">炸薯條</column>
       <column name="definition_pt">batata frita</column>
+      <column name="definition_fi">ranskanperuna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -253,6 +278,7 @@
       <column name="notes_ru">Это использовалось во множественном числе ({tlhagh patat 'oQqar naQHommey:n:nolink}), чтобы перевести «картофель фри» (как в «картофель фри»). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它用於復數形式（{tlhagh patat 'oQqar naQHommey:n:nolink}）來翻譯“炸薯條”（如“炸薯條”）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso foi usado no plural ({tlhagh patat 'oQqar naQHommey:n:nolink}) para traduzir "batatas fritas" (como em "batatas fritas"). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytettiin monikkomuodossa ({tlhagh patat 'oQqar naQHommey:n:nolink}) kääntämään "perunat" (kuten "ranskalaiset"). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhagh:n}, {patat 'oQqar:n}, {naQ:n:1}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -262,6 +288,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fries, French fries</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -269,6 +296,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -282,6 +310,7 @@
       <column name="definition_ru">Throgni [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Throgni [AUTOTRANSLATED]</column>
       <column name="definition_pt">Throgni</column>
+      <column name="definition_fi">eräs kasvi, throgni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -292,6 +321,7 @@
       <column name="notes_ru">Это тип растения, которое растет на {Qo'noS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種在{Qo'noS:n}上生長的植物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de planta que cresce com {Qo'noS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen kasvi, joka kasvaa {Qo'noS:n}-levyllä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -301,6 +331,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -308,6 +339,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -321,6 +353,7 @@
       <column name="definition_ru">процесс, парад, марш [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">過程遊行遊行 [AUTOTRANSLATED]</column>
       <column name="definition_pt">desfile, marcha</column>
+      <column name="definition_fi">edetä kulkueessa tai paraatissa, marssia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boghoy:n}</column>
@@ -331,6 +364,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -340,6 +374,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -347,6 +382,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -360,6 +396,7 @@
       <column name="definition_ru">сила тяжести</column>
       <column name="definition_zh_HK">重力</column>
       <column name="definition_pt">gravidade</column>
+      <column name="definition_fi">painovoima</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wa'lay:n}, {tlham:n:2}</column>
@@ -370,6 +407,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Clam" down.</column>
       <column name="components"></column>
       <column name="examples">
@@ -380,6 +418,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -387,6 +426,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -400,6 +440,7 @@
       <column name="definition_ru">гравитационное поле [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">重力場</column>
       <column name="definition_pt">campo gravitacional</column>
+      <column name="definition_fi">painovoimakenttä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoSchem:n}, {peQchem:n}, {pIvchem:n}, {Surchem:n}</column>
@@ -410,6 +451,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlham:n:1}, {chem:n:hyp}</column>
       <column name="examples"></column>
@@ -419,6 +461,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -426,6 +469,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -439,6 +483,7 @@
       <column name="definition_ru">order, structure (societal) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">秩序、結構（社會） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ordem, estrutura (societária)</column>
+      <column name="definition_fi">(yhteiskunnallinen) järjestys, rakenne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qutluch patlh:n}, {tlham:n:1}</column>
@@ -449,6 +494,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -458,6 +504,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -465,6 +512,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -478,6 +526,7 @@
       <column name="definition_ru">горка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滑動</column>
       <column name="definition_pt">escorregar</column>
+      <column name="definition_fi">liukua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -488,6 +537,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -497,6 +547,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -504,6 +555,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -517,6 +569,7 @@
       <column name="definition_ru">копать землю [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">挖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">escavação</column>
+      <column name="definition_fi">kaivaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{molHa':v}, {ghaw:v}, {ghevjur:n}, {lam:n}</column>
@@ -527,6 +580,7 @@
       <column name="notes_ru">Объектом является грязь или почва или поле или дорога, а не яма, для которой см. {ghaw:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">物體是泥土，土壤，田野或道路，而不是孔，有關這些物體，請參見{ghaw:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é sujeira ou solo ou um campo ou uma estrada, não um buraco, para o qual veja {ghaw:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on lika tai maaperä, pelto tai tie, ei reikä, josta katso {ghaw:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -536,6 +590,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -543,6 +598,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -556,6 +612,7 @@
       <column name="definition_ru">взять</column>
       <column name="definition_zh_HK">採取 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pegar</column>
+      <column name="definition_fi">ottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nob:v}</column>
       <column name="see_also"></column>
@@ -566,6 +623,7 @@
       <column name="notes_ru">При использовании с суффиксом {-qa':v} результат имеет смысл «извлекать». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與後綴{-qa':v}一起使用時，結果具有“檢索”的感覺。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando usado com o sufixo {-qa':v}, o resultado tem o sentido de "recuperar". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun sitä käytetään loppuliitteen {-qa':v} kanssa, tuloksella on tunne "noutaa". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -577,6 +635,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">retrieve</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -584,6 +643,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -597,6 +657,7 @@
       <column name="definition_ru">монстр [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">怪物、怪獸</column>
       <column name="definition_pt">monstro</column>
+      <column name="definition_fi">hirviö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yInbogh lom:n}, {'Iw remwI':n}</column>
@@ -607,6 +668,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The song "Monster Mash" was released on Garpax Records. (Note that this is {tlhapragh:n:nolink} written backwards in "xifan hol".)</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -616,6 +678,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -623,6 +686,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - The Butcher's Knife Cares Not for the Lamb's Cry:src}</column>
     </table>
     <table name="mem">
@@ -636,6 +700,7 @@
       <column name="definition_ru">хронометр</column>
       <column name="definition_zh_HK">時計、時鐘</column>
       <column name="definition_pt">cronômetro</column>
+      <column name="definition_fi">kello, kronometri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -646,6 +711,7 @@
       <column name="notes_ru">В {TNK:src} это слово использовалось как «часы». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{TNK:src}中，該詞用於“時鐘”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em {TNK:src}, essa palavra foi usada para "relógio". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{TNK:src}: ssä tätä sanaa käytettiin "kelloon". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It almost sounds like "clock".</column>
       <column name="components"></column>
       <column name="examples">
@@ -656,6 +722,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">clock, watch, wristwatch</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -663,6 +730,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -676,6 +744,7 @@
       <column name="definition_ru">Мой хронометр остановился.</column>
       <column name="definition_zh_HK">我的天文台已經停了。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Meu cronômetro parou.</column>
+      <column name="definition_fi">Kelloni on pysähtynyt.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -686,6 +755,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhaq:n}, {-wIj:n}, {chu':v:2}, {-Ha':v}, {-lu':v}, {-pu':v}</column>
       <column name="examples"></column>
@@ -695,6 +765,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -702,6 +773,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -715,6 +787,7 @@
       <column name="definition_ru">быть забавным</column>
       <column name="definition_zh_HK">好笑</column>
       <column name="definition_pt">ser engraçado</column>
+      <column name="definition_fi">olla hauska, huvittava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hagh:v}, {qID:v}</column>
@@ -725,6 +798,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -734,6 +808,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -741,6 +816,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -754,6 +830,7 @@
       <column name="definition_ru">быть аллергиком, иметь аллергию на [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">對...過敏 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser alérgico, ser alérgico a</column>
+      <column name="definition_fi">olla allerginen jollekin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suntay':n}, {'aw':v}, {Soj:n:1}, {chuy:v}, {lun:v}, {tlhaw:v}</column>
@@ -764,6 +841,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Claritin is a brand of allergy medicine.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -773,6 +851,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -780,6 +859,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -794,6 +874,7 @@
       <column name="definition_ru">разведчик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">偵察兵（船） [AUTOTRANSLATED]</column>
       <column name="definition_pt">batedor (navio)</column>
+      <column name="definition_fi">partioalus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bI'rel tlharghDuj:n}</column>
@@ -804,6 +885,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This may have been named for the explorer William Clark (of the Lewis and Clark Expedition fame).</column>
       <column name="components">{tlhargh:n:hyp}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -813,6 +895,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -820,6 +903,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -833,6 +917,7 @@
       <column name="definition_ru">звено в цепи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鏈中的鏈接 [AUTOTRANSLATED]</column>
       <column name="definition_pt">link em uma cadeia</column>
+      <column name="definition_fi">lenkki (ketjussa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIr:n:1}</column>
@@ -843,6 +928,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Clarence Williams III played the character Linc Hayes on the cop show "The Mod Squad".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -852,6 +938,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -859,6 +946,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -872,6 +960,7 @@
       <column name="definition_ru">вагон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有軌電車 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vagão de trem</column>
+      <column name="definition_fi">junavaunu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lupwI' mIr:n}, {tIHmey:n}</column>
@@ -882,6 +971,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlharwIl:n}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -891,6 +981,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">train car</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -898,6 +989,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>
     <table name="mem">
@@ -911,6 +1003,7 @@
       <column name="definition_ru">бой, битва (относительно незначительный бой) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥、戰鬥（相對較小的戰鬥） [AUTOTRANSLATED]</column>
       <column name="definition_pt">lutar, batalhar (luta relativamente menor)</column>
+      <column name="definition_fi">taistella (suhteellisen vähäisessä taistelussa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suv:v}, {may':n}</column>
@@ -921,6 +1014,7 @@
       <column name="notes_ru">В порядке возрастания жестокости глаголы, используемые для описания военных столкновений: {Qor:v}, {tlhaS:v:nolink}, {vay:v}, {lul:v}, {Hargh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Armeijan nousevassa järjestyksessä sotilaallisia yhteenottoja kuvaavia verbejä ovat: {Qor:v}, {tlhaS:v:nolink}, {vay:v}, {lul:v}, {Hargh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Clash".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -930,6 +1024,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -937,6 +1032,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -950,6 +1046,7 @@
       <column name="definition_ru">сетка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rede</column>
+      <column name="definition_fi">ruudukko, taulukko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wa'chaw:n}, {war:n}, {wev:n}, {pu'jIn:n}, {wIy:n}</column>
@@ -960,6 +1057,7 @@
       <column name="notes_ru">Это слово можно использовать для сетки на электронной таблице, а также для линий сетки на карте. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該詞可用於電子表格上的網格以及地圖上的網格線。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra pode ser usada para a grade em uma planilha e também para as linhas de grade em um mapa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää laskentataulukon ruudukkoon ja myös kartan ruudukkoihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -969,6 +1067,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -976,6 +1075,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -989,6 +1089,7 @@
       <column name="definition_ru">тип еды, радость [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物類型、gladstone [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de comida, gladst</column>
+      <column name="definition_fi">eräs ruokalaji, gladst</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -999,6 +1100,7 @@
       <column name="notes_ru">Это еда из коричневых листьев, лучше всего подается без соуса. Смотрите {'uSu':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是用棕葉製成的食物，最好不加醬料食用。參見{'uSu':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É um alimento feito de folhas marrons, melhor servido sem molho. Consulte {'uSu':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ruskeaista lehdistä valmistettu ruoka, jota tarjoillaan parhaiten ilman kastiketta. Katso {'uSu':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The writers of {DS9 - Melora:src} made up the word "gladst", which contains sounds not possible in standard Klingon. This word is Okrand's backfit.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1008,6 +1110,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1015,6 +1118,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1028,6 +1132,7 @@
       <column name="definition_ru">соус для удовольствия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">歡樂醬 [AUTOTRANSLATED]</column>
       <column name="definition_pt">molho para gladst</column>
+      <column name="definition_fi">eräs kastike gladstille</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uSu':n}, {Se'tu':n}</column>
@@ -1038,6 +1143,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhatlh:n}, {vIychorgh:n}</column>
       <column name="examples"></column>
@@ -1047,6 +1153,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1054,6 +1161,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1068,6 +1176,7 @@
       <column name="definition_ru">пунктуация [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">標點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pontuação</column>
+      <column name="definition_fi">välimerkit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1078,6 +1187,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Uma expressão de gíria para pontuação é {ghewmey:n}. {tlhavqop:n:nolink} é inerentemente plural, mas pode-se dizer {tlhavqop ngutlh(mey):n@@tlhavqop:n, ngutlh:n, -mey:n} "sinais de pontuação".[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Välimerkkien slangilauseke on {ghewmey:n}. {tlhavqop:n:nolink} on luonnostaan ​​monikkomuoto, mutta voidaan sanoa {tlhavqop ngutlh (mey): n @@ tlhavqop: n, ngutlh: n, -mey: n} "välimerkit (merkit)".{tlhavqop ngutlh(mey):n@@tlhavqop:n, ngutlh:n, -mey:n}[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1087,6 +1197,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1094,6 +1205,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1107,6 +1219,7 @@
       <column name="definition_ru">быть воспаленным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發炎 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser inflamado</column>
+      <column name="definition_fi">olla tulehtunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIyeStaS:n}, {tlhar:v}, {lun:v}</column>
@@ -1117,6 +1230,7 @@
       <column name="notes_ru">Это медицинский термин. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是醫學術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo médico. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lääketieteellinen termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1126,6 +1240,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1133,6 +1248,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1146,6 +1262,7 @@
       <column name="definition_ru">удар (ударный инструмент) кулаком [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用拳頭擊打（打擊樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">bater (instrumento de percussão) com punho</column>
+      <column name="definition_fi">lyödä (lyömäsoitinta) nyrkillä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ro':n}, {qIp:v}, {'In:n}, {chu':v:3}</column>
@@ -1156,6 +1273,7 @@
       <column name="notes_ru">Сравните с {moq:v} и {weq:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與{moq:v}和{weq:v}比較。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Compare com {moq:v} e {weq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vertaa {moq:v}- ja {weq:v}-tiedostoihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Clout".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1165,6 +1283,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">punch</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1172,6 +1291,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1185,6 +1305,7 @@
       <column name="definition_ru">Клавдий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克勞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Claudius</column>
+      <column name="definition_fi">Claudius</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -1195,6 +1316,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1204,6 +1326,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1211,6 +1334,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -1224,6 +1348,7 @@
       <column name="definition_ru">рукав [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">袖</column>
       <column name="definition_pt">manga (de roupa)</column>
+      <column name="definition_fi">hiha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIvbeH:n:0}</column>
@@ -1234,6 +1359,7 @@
       <column name="notes_ru">Как правило, это сделано из {veDDIrmey:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常是由{veDDIrmey:n:nolink}製成的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso geralmente é feito com {veDDIrmey:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tehdään yleensä {veDDIrmey:n:nolink}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1243,6 +1369,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1250,6 +1377,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1263,6 +1391,7 @@
       <column name="definition_ru">быть ручным, быть прирученным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">馴服、被馴服 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser manso, ser domesticado</column>
+      <column name="definition_fi">olla kesy, olla kesytetty</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhab:v}</column>
       <column name="see_also">{Saj:n}, {Ha'DIbaH:n:1}</column>
@@ -1273,6 +1402,7 @@
       <column name="notes_ru">Это относится к животным, живущим в доме.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指生活在房屋中的動物。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere aos animais que vivem em uma casa.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa eläimiä, jotka asuvat talossa[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1282,6 +1412,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1289,6 +1420,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -1302,6 +1434,7 @@
       <column name="definition_ru">следить</column>
       <column name="definition_zh_HK">追逐、跟隨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">perseguir, seguir</column>
+      <column name="definition_fi">jahdata, seurata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoch:v}, {jun:v}, {ghoS:v:1}, {tlhej:v}</column>
@@ -1312,6 +1445,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1321,6 +1455,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1328,6 +1463,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1341,6 +1477,7 @@
       <column name="definition_ru">Клаа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">「卡拉」</column>
       <column name="definition_pt">Klaa</column>
+      <column name="definition_fi">Klaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIqSIS:n:name}</column>
@@ -1351,6 +1488,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">The Chinese transliteration comes from the subtitles of {Star Trek V:src}.[2]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This actually appeared as {tlh'a':sen:nolink}, but this is a known typo.[1]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1360,6 +1498,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1367,6 +1506,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.11, Dec. 1999:src}, [2] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1380,6 +1520,7 @@
       <column name="definition_ru">Клавек [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Klavek [AUTOTRANSLATED]</column>
       <column name="definition_pt">Klavek</column>
+      <column name="definition_fi">Klavek</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1390,6 +1531,7 @@
       <column name="notes_ru">Одиннадцатый том Клавека является частью {paq'batlh:n} и рассказывает историю спуска {qeylIS'e' lIjlaHbe'bogh vay':n:name} в {ghe'tor:n}, чтобы спасти его брата.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">O Décimo Primeiro Tomo de Klavek faz parte do {paq'batlh:n} e conta a história da descida de {qeylIS'e' lIjlaHbe'bogh vay':n:name} ao {ghe'tor:n} para resgatar seu irmão.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klavekin yhdestoista Tome on osa {paq'batlh:n}-elokuvaa ja kertoo tarinan {qeylIS'e' lIjlaHbe'bogh vay':n:name}: n laskeutumisesta {ghe'tor:n}: ksi pelastaakseen veljensä.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1399,6 +1541,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1406,6 +1549,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {VOY - Barge of the Dead:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1419,6 +1563,7 @@
       <column name="definition_ru">отходить</column>
       <column name="definition_zh_HK">離開</column>
       <column name="definition_pt">partir (ir)</column>
+      <column name="definition_fi">lähteä jostakin (matkalle)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{paw:v}</column>
       <column name="see_also">{leng:n}, {ghoch:n}</column>
@@ -1429,6 +1574,7 @@
       <column name="notes_ru">Как правило, {tlheD:v:nolink} подразумевает отправку в путешествие с целью или местом назначения, в то время как {mej:v} означает просто покинуть свое текущее местоположение. В обоих случаях объект - это место, откуда вы уезжаете или отправляетесь из него.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">通常，{tlheD:v:nolink}意味著出發時要牢記目標或目的地，而{mej:v}只是指離開當前位置。在這兩種情況下，對像都是您要離開或離開的地方.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Geralmente, {tlheD:v:nolink} implica iniciar uma viagem, com uma meta ou destino em mente, enquanto {mej:v} se refere simplesmente a deixar a localização atual. Em ambos os casos, o objeto é o lugar de onde você está saindo ou saindo.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yleensä {tlheD:v:nolink} tarkoittaa matkalle lähtöä tavoitetta tai määränpäätä ajatellen, kun taas {mej:v} viittaa yksinkertaisesti nykyisen sijaintinsa jättämiseen. Molemmissa tapauksissa objekti on paikka, josta poistut tai jolta lähdet.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1438,6 +1584,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1445,6 +1592,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1458,6 +1606,7 @@
       <column name="definition_ru">строка, веревка</column>
       <column name="definition_zh_HK">線、繩</column>
       <column name="definition_pt">linha corda, cabo</column>
+      <column name="definition_fi">naru, köysi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIrgh:n}, {yamtaw:n}</column>
@@ -1468,6 +1617,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1477,6 +1627,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1484,6 +1635,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1497,6 +1649,7 @@
       <column name="definition_ru">брашпиль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">轆轤</column>
       <column name="definition_pt">guindaste</column>
+      <column name="definition_fi">vintturi, vinssi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daqrab:n}</column>
@@ -1507,6 +1660,7 @@
       <column name="notes_ru">Это буквально означает «веревочный твистер / ротатор». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">字面意思是“絞線/轉子”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "trava-cabos / rotador". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "köyden kääntäjä / rotaattori". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhegh:n}, {jIrmoH:v:2}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1516,6 +1670,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">winch</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1523,6 +1678,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -1536,6 +1692,7 @@
       <column name="definition_ru">spell (magic) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">法術（魔法） [AUTOTRANSLATED]</column>
       <column name="definition_pt">feitiço (magia)</column>
+      <column name="definition_fi">loitsu, taika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{reS:v}</column>
@@ -1546,6 +1703,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1555,6 +1713,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1562,6 +1721,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -1575,6 +1735,7 @@
       <column name="definition_ru">сопровождать</column>
       <column name="definition_zh_HK">陪</column>
       <column name="definition_pt">acompanhar</column>
+      <column name="definition_fi">olla jonkun mukana/seurana/kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlha':v}, {Dor:v:1}, {nItebHa':adv}</column>
@@ -1585,6 +1746,7 @@
       <column name="notes_ru">Слово «с» (в смысле «сопровождается») обычно переводится фразой с использованием этого глагола.[2; 4] Использование этого глагола не ограничивается понятием идти куда-то с кем-то.[4] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">單詞“ with”（在“伴隨”的意義上）通常由使用該動詞的短語翻譯。[2; 4]此動詞的使用不限於與某人一起去某個地方的概念。[4] [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra "com" (no sentido de "acompanhado por") é geralmente traduzida por uma frase usando este verbo.[2; 4] O uso deste verbo não se restringe à noção de ir a algum lugar com alguém.[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sana "kanssa" (merkityksessä "mukana") käännetään yleensä lauseella, joka käyttää tätä verbiä.[2; 4] Tämän verbin käyttö ei rajoitu käsitteeseen mennä jonnekin jonkun kanssa.[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the E-K word list of {TKD:src}, this was erroneously tagged as a noun.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1600,6 +1762,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">with</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1607,6 +1770,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 2.4, p.18, Dec. 1993:src}, [3] {TKW:src}, [4] {s.k 1999.01.04:src}</column>
     </table>
     <table name="mem">
@@ -1620,6 +1784,7 @@
       <column name="definition_ru">шишка, йокель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">布朗克，約克 [AUTOTRANSLATED]</column>
       <column name="definition_pt">caipira, yokel</column>
+      <column name="definition_fi">juntti, maalaistollo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1630,6 +1795,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1639,6 +1805,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1646,6 +1813,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1659,6 +1827,7 @@
       <column name="definition_ru">Thranx [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">thranx [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de planta, thranx</column>
+      <column name="definition_fi">eräs kasvi, thranx</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1669,6 +1838,7 @@
       <column name="notes_ru">Это тип растения. В {paq'batlh:src} упоминается, что {ngeng HeH:n} {qul ngeng:n} внутри {QIStaq:n} имеет такую ​​среду, враждебную к жизни, что даже {tlheng'IQ:n:nolink} там не будет расти. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是植物的一種。在{paq'batlh:src}中，提到了{QIStaq:n}內部的{qul ngeng:n}的{ngeng HeH:n}具有對生活充滿敵意的環境，即使{tlheng'IQ:n:nolink}也不會在那裡生長。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de planta. No {paq'batlh:src}, é mencionado que o {ngeng HeH:n} do {qul ngeng:n} dentro do {QIStaq:n} possui um ambiente tão hostil à vida que nem mesmo o {tlheng'IQ:n:nolink} cresceria ali. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen kasvi. {paq'batlh:src}: ssä mainitaan, että {qul ngeng:n}: n {ngeng HeH:n}: lla {QIStaq:n}: ssä on ympäristö, joka on niin vihamielinen elämään, ettei edes {tlheng'IQ:n:nolink} kasvaisi siellä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">According to the novel {Kahless:src}, this plant flowers only every eight years.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1678,6 +1848,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1685,6 +1856,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.80-81:src}</column>
     </table>
     <table name="mem">
@@ -1698,6 +1870,7 @@
       <column name="definition_ru">быть подвешенным, болтаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">懸而未決 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser suspenso, ser pendurado</column>
+      <column name="definition_fi">olla riippuva, roikkuva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HuS:v}</column>
@@ -1708,6 +1881,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1717,6 +1891,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1724,6 +1899,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -1737,6 +1913,7 @@
       <column name="definition_ru">слюна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">口水</column>
       <column name="definition_pt">saliva</column>
+      <column name="definition_fi">sylki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIl:v}, {bol:v:1}, {tuy':v}, {nuj:n}, {bIQ:n}</column>
@@ -1747,6 +1924,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1756,6 +1934,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">spit</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1763,6 +1942,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1776,6 +1956,7 @@
       <column name="definition_ru">быть комом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">笨拙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser irregular</column>
+      <column name="definition_fi">olla paakkuinen, kokkareinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghegh:v}, {Hab:v}, {neS:v}</column>
@@ -1786,6 +1967,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to a character named "Clar"ence Rutherford, who is nicknamed "Lumpy", from the television show "Leave It to Beaver". See {warjun:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1795,6 +1977,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1802,6 +1985,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1815,6 +1999,7 @@
       <column name="definition_ru">риф [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">礁 [AUTOTRANSLATED]</column>
       <column name="definition_pt">recife</column>
+      <column name="definition_fi">riutta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oqe':n}, {bIQ'a':n}</column>
@@ -1825,6 +2010,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1834,6 +2020,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1841,6 +2028,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1854,6 +2042,7 @@
       <column name="definition_ru">прогрессировать</column>
       <column name="definition_zh_HK">進展</column>
       <column name="definition_pt">progredir</column>
+      <column name="definition_fi">edistyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ser:n}</column>
@@ -1864,6 +2053,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1873,6 +2063,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1880,6 +2071,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1893,6 +2085,7 @@
       <column name="definition_ru">тип копья (брошенный с помощью специального инструмента) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">矛的類型（借助特殊工具拋出） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de lança (atirada com auxílio de uma ferramenta especial)</column>
+      <column name="definition_fi">eräs keihästyyppi (joka heitetään erityisellä työkalulla)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQjej:n}, {chetvI':n:2}, {wob:v}, {chuH:v:1}</column>
@@ -1903,6 +2096,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1912,6 +2106,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dart, arrow</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1919,6 +2114,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1932,6 +2128,7 @@
       <column name="definition_ru">пространство-время [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">時空 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tempo-espaço</column>
+      <column name="definition_fi">avaruusaika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh:n}, {poH:n}, {qIr'a':n}, {roDSer:n}, {'evnagh:n}</column>
@@ -1942,6 +2139,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{tlhey'at qIr'a':n}</column>
@@ -1951,6 +2149,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1958,6 +2157,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1971,6 +2171,7 @@
       <column name="definition_ru">пространственно-временной континуум [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">時空連續體 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espaço-tempo continuo</column>
+      <column name="definition_fi">avaruusaikajatkumo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1981,6 +2182,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhey'at:n}, {qIr'a':n}</column>
       <column name="examples"></column>
@@ -1990,6 +2192,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1997,6 +2200,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2010,6 +2214,7 @@
       <column name="definition_ru">повернуть</column>
       <column name="definition_zh_HK">轉</column>
       <column name="definition_pt">virar</column>
+      <column name="definition_fi">kääntää, kiertää (kääntyä?)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuvtlhe':n}</column>
@@ -2020,6 +2225,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2029,6 +2235,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2036,6 +2243,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2049,6 +2257,7 @@
       <column name="definition_ru">быть некомпетентным</column>
       <column name="definition_zh_HK">無能為力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser incompetente</column>
+      <column name="definition_fi">olla epäpätevä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{po':v}</column>
       <column name="see_also">{toppa':n}</column>
@@ -2059,6 +2268,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2068,6 +2278,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2075,6 +2286,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2088,6 +2300,7 @@
       <column name="definition_ru">дым</column>
       <column name="definition_zh_HK">煙</column>
       <column name="definition_pt">fumaça</column>
+      <column name="definition_fi">savu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qul:n}, {meQ:v}, {tlhoD:v}, {mIrSam:n}, {toba'qo:n}</column>
@@ -2098,6 +2311,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Jos haluat sanoa "tupakoida" (kuten hengittää nikotiinia), käytä {tlhIch pur:sen@@tlhIch:n, pur:v}.[2] Voit tupakoida muunlaisia ​​kasveja myös sanomalla {por pur:sen}.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2107,6 +2321,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2114,6 +2329,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}, [3] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2127,6 +2343,7 @@
       <column name="definition_ru">тип животного, тригак [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《trigak》動物類型</column>
       <column name="definition_pt">tipo de animal, trigak</column>
+      <column name="definition_fi">eräs eläin, trigak</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2137,6 +2354,7 @@
       <column name="notes_ru">Согласно глоссарию {A Burning House:src}, это хищное животное с острыми зубами, которое оно обнажает перед атакой. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據{A Burning House:src}的詞彙表，這是一種掠食性動物，具有鋒利的牙齒，在攻擊前會裸露。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o glossário do {A Burning House:src}, este é um animal predador com dentes afiados que descobre antes de atacar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{A Burning House:src}-sanaston mukaan tämä on saalistajaeläin, jolla on terävät hampaat, joita se paljastaa ennen hyökkäystä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2146,6 +2364,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2153,6 +2372,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2166,6 +2386,7 @@
       <column name="definition_ru">вы, вас</column>
       <column name="definition_zh_HK">你們</column>
       <column name="definition_pt">vocês</column>
+      <column name="definition_fi">te</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-raj:n}, {-ra':n}</column>
@@ -2187,6 +2408,18 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on monikko {SoH:n:pro}.
+
+Verbien etuliitteet, kun aihe {tlhIH:n:nolink} on:
+▶ {tlhIH:n:nolink}: {pagh:n:1h} = {Su-:v:pref}
+▶ {tlhIH:n:nolink}: {jIH:n:1h} = {tu-:v:pref}
+▶ {tlhIH:n:nolink}: {maH:n:1h} = {che-:v:pref}
+▶ {tlhIH:n:nolink}: {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n} = {bo-:v:pref}
+
+Verbien etuliitteet, kun {tlhIH:n:nolink} on objekti:
+▶ {jIH:n:1h}: {tlhIH:n:nolink} = {Sa-:v:pref}
+▶ {maH:n:1h}: {tlhIH:n:nolink} = {re-:v:pref}
+▶ {ghaH:n} / {'oH:n} / {chaH:n} / {bIH:n}: {tlhIH:n:nolink} = {lI-:v:pref} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2196,6 +2429,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">you plural, you all, y'all, yall, yinz</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2203,6 +2437,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2216,6 +2451,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="definition_ru">извиняться</column>
       <column name="definition_zh_HK">道歉</column>
       <column name="definition_pt">pedir desculpas</column>
+      <column name="definition_fi">pyytää anteeksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QoS:v}</column>
@@ -2226,6 +2462,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2236,6 +2473,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2243,6 +2481,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {paq'batlh p.128-129:src}</column>
     </table>
     <table name="mem">
@@ -2256,6 +2495,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="definition_ru">добывать</column>
       <column name="definition_zh_HK">開採</column>
       <column name="definition_pt">minerar</column>
+      <column name="definition_fi">louhia, kaivaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIlHal:n}</column>
@@ -2266,6 +2506,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是指開採資源（請參閱{jo:n}），例如礦物（請參閱{tlhIl:n}），而不是部署炸藥（請參閱{jorwI':n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à extração de recursos (consulte {jo:n}), como minerais (consulte {tlhIl:n}), e não à implantação de explosivos (consulte {jorwI':n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2275,6 +2516,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2282,6 +2524,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2295,6 +2538,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="definition_ru">минерал</column>
       <column name="definition_zh_HK">礦物</column>
       <column name="definition_pt">mineral</column>
+      <column name="definition_fi">mineraali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIl:v}, {naghboch:n}, {toplIn:n}, {parchech:n}</column>
@@ -2305,6 +2549,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2314,6 +2559,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2321,6 +2567,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2334,6 +2581,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="definition_ru">шахта</column>
       <column name="definition_zh_HK">礦</column>
       <column name="definition_pt">mina</column>
+      <column name="definition_fi">kaivos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoS waw':n}</column>
@@ -2344,6 +2592,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="notes_ru">Это относится к месту, где добываются минералы ({tlhIl:n}) ({tlhIl:v}), а не к взрывчатым веществам, находящимся вблизи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Refere-se a um local onde os minerais ({tlhIl:n}) são extraídos ({tlhIl:v}) e não a um explosivo de proximidade. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In the {Haynes BoP Manual:src}, this word was incorrectly used to refer to proximity explosives. (It was also misspelled as {tlhHl:sen:nolink}, perhaps deliberately in an attempt to make it look like a different word.)</column>
       <column name="components">{tlhIl:n}, {Hal:n}</column>
       <column name="examples"></column>
@@ -2353,6 +2602,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2360,6 +2610,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2373,6 +2624,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="definition_ru">шахтер</column>
       <column name="definition_zh_HK">礦工</column>
       <column name="definition_pt">mineiro</column>
+      <column name="definition_fi">kaivostyöläinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2383,6 +2635,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIl:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2392,6 +2645,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2399,6 +2653,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2412,6 +2667,7 @@ Verb prefixes when {tlhIH:n:nolink} is the object:
       <column name="definition_ru">ковер, коврик, одеяло [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地毯、地毯、毯子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tapete, cobertor</column>
+      <column name="definition_fi">matto, ryijy, peite; viltti, peitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{veDDIr:n}, {QongDaq:n}, {paSrIq:n}</column>
@@ -2450,6 +2706,11 @@ Slutligen kan {tlhIm:n:nolink} också användas för en filt, även om Klingons 
 A palavra {tlhIm:n:nolink} também é usada para decoração de parede em tecido. Um {tlhIm:n:nolink} tem que abranger alguma coisa. Um tecido exibido na extremidade de um poste seria um {joqwI':n}.
 
 Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Klingons geralmente não usem cobertores. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbi maton asettamisesta on {vel:v}. Verbi {mutlh:v}, kun sitä levitetään matolle, tarkoittaa sen kokoamista.
+
+Sanaa {tlhIm:n:nolink} käytetään myös kankaan seinään ripustamiseen. {tlhIm:n:nolink}: n on peitettävä jotain. Sauvan päässä näkyvä kangas olisi {joqwI':n}.
+
+Lopuksi, {tlhIm:n:nolink}: ta voidaan käyttää myös huopana, vaikka klingonit eivät yleensä käytä huopia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A "gelim" is a type of Persian carpet.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2459,6 +2720,7 @@ Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Kli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2466,6 +2728,7 @@ Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Kli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.09:src}</column>
     </table>
     <table name="mem">
@@ -2479,6 +2742,7 @@ Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Kli
       <column name="definition_ru">тип питания, зильмкач [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物類型、zilm'kach [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de alimento, zilm'kach</column>
+      <column name="definition_fi">eräs ruokalaji, zilm'kach</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2489,6 +2753,7 @@ Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Kli
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">According to {A Good Day to Die:src}, this is made from something orange.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2498,6 +2763,7 @@ Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Kli
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2505,6 +2771,7 @@ Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Kli
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2518,6 +2785,7 @@ Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Kli
       <column name="definition_ru">быть конкретным, индивидуальным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">特別是個人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser particular, individual</column>
+      <column name="definition_fi">olla tietty, nimenomainen, olla oma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2528,6 +2796,7 @@ Finalmente, {tlhIm:n:nolink} também pode ser usado como cobertor, embora os Kli
       <column name="notes_ru">Это не означает просто «отдельный, отдельный», а скорее что-то вроде «быть приписанным к чему-то или кому-то» или «быть однозначно связанным с чем-то или кем-то». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這並不意味著簡單地“單一，分離”，而是諸如“可歸於某物或某人”或“與某物或某物唯一地關聯”之類的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não significa simplesmente "único, separado", mas algo como "ser atribuível a algo ou alguém" ou "ser associado exclusivamente a algo ou alguém". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei tarkoita yksinkertaisesti "yksittäistä, erillistä", vaan pikemminkin jotain "johtuvan jostakin tai toisesta" tai "olla ainutlaatuisesti yhteydessä johonkin tai johonkin". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">When asked whether the word {qangtlhIn:n} is related, MO said he did not know of any relationship.
 
 In many languages, the endonym for its speakers means something like "our own people".</column>
@@ -2541,6 +2810,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">own</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2548,6 +2818,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -2561,6 +2832,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="definition_ru">Клин Жа, популярная настольная игра [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">klin zha、一款受歡迎的棋盤遊戲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">klin zha, um jobo de tabuleiro popular</column>
+      <column name="definition_fi">eräs suosittu lautapeli, klin zha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tonSaw':n}, {'echlet:n}, {Dup:n}</column>
@@ -2571,6 +2843,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="notes_ru">Это стратегическая игра, которую сравнивают с шахматами. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種與國際象棋相比的戰略遊戲。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um jogo de estratégia que foi comparado ao xadrez. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on strategiapeli, jota on verrattu shakkiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2580,6 +2853,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">klinzha, chess</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2587,6 +2861,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {A Final Reflection:src}, [3] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2600,6 +2875,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="definition_ru">Клингский район [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林區</column>
       <column name="definition_pt">distrito Kling</column>
+      <column name="definition_fi">Klingin vyöhyke</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{veng wa'DIch:n}</column>
@@ -2610,6 +2886,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2620,6 +2897,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2627,6 +2905,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2640,6 +2919,7 @@ In many languages, the endonym for its speakers means something like "our own pe
       <column name="definition_ru">Клингонец</column>
       <column name="definition_zh_HK">克林崗人</column>
       <column name="definition_pt">Klingon (pessoa)</column>
+      <column name="definition_fi">klingoni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan Hol:n}, {Qo'noS:n}</column>
@@ -2664,6 +2944,9 @@ Det finns ett formspråk, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTR
       <column name="notes_pt">Observe que isso se refere a uma pessoa Klingon ou ao povo Klingon, mas não à língua Klingon (para a qual veja {tlhIngan Hol:n}). Em Klingon, ao contrário do Padrão da Federação, o nome de um idioma não é simplesmente o nome das pessoas que o falam, mas deve ser um identificador seguido pela palavra {Hol:n}.
 
 Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä viittaa klingonilaiseen henkilöön tai klingonilaisiin, mutta ei klingonikieleen (josta ks. {tlhIngan Hol:n}). Klingonissa, toisin kuin Federation Standardissa, kielen nimi ei ole vain sitä puhuvien ihmisten nimi, vaan sen on oltava tunniste, jota seuraa sana {Hol:n}.
+
+On idioomi, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The TKD entry says only "Klingon". The "(person)" annotation has been added to distinguish this entry from "Klingon (language)", and to make it consistent with the entry for "Vulcan (person)", etc.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2675,6 +2958,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2682,6 +2966,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2695,6 +2980,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Клингонский язык</column>
       <column name="definition_zh_HK">克林崗文、克林崗語</column>
       <column name="definition_pt">Klingon (língua)</column>
+      <column name="definition_fi">klingonin kieli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan:n}, {Hol:n}</column>
@@ -2705,6 +2991,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru">Это сокращение от {tlhIngan wo' Hol:n:nolink}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{tlhIngan wo' Hol:n:nolink}.[3]的縮寫 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é abreviação de {tlhIngan wo' Hol:n:nolink}.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhyt sanalle {tlhIngan wo' Hol:n:nolink}.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This term doesn't actually appear in the word lists in {TKD:src}, but is used in the list of useful expressions.</column>
       <column name="components">{tlhIngan:n}, {Hol:n}</column>
       <column name="examples"></column>
@@ -2714,6 +3001,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2721,6 +3009,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.10:src}, [3] {KLI mailing list 2012.04.01:src}</column>
     </table>
     <table name="mem">
@@ -2734,6 +3023,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Говоришь по-клингонски?</column>
       <column name="definition_zh_HK">你說克林崗語嗎？</column>
       <column name="definition_pt">Você fala klingon?</column>
+      <column name="definition_fi">Puhutko klingonia?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -2747,6 +3037,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/YtWZNvQl6mc} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/YtWZNvQl6mc} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YtWZNvQl6mc} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/YtWZNvQl6mc} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {Hol:n}, {Da-:v}, {jatlh:v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -2756,6 +3047,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2763,6 +3055,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -2776,6 +3069,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Я не говорю по-клингонски.</column>
       <column name="definition_zh_HK">我不說克林崗語。</column>
       <column name="definition_pt">Eu não falo klingon.</column>
+      <column name="definition_fi">En puhu klingonia.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan Hol Dajatlh'a'?:sen}</column>
@@ -2786,6 +3080,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {Hol:n}, {vI-:v}, {jatlh:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -2795,6 +3090,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">I do not speak Klingon.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2802,6 +3098,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -2815,6 +3112,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Я не могу говорить по-клингонски.</column>
       <column name="definition_zh_HK">我不會說克林崗語。</column>
       <column name="definition_pt">Eu não posso falar klingon.</column>
+      <column name="definition_fi">En osaa puhua klingonia.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan Hol Dajatlh'a'?:sen}</column>
@@ -2825,6 +3123,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {Hol:n}, {vI-:v}, {jatlh:v}, {-laH:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -2834,6 +3133,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">I can't speak Klingon.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2841,6 +3141,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -2854,6 +3155,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Клингонский языковой институт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗語言學院</column>
       <column name="definition_pt">Instituto da Língua Klingon</column>
+      <column name="definition_fi">Klingonin kielen laitos, KLI</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yejHaD:n}, {qep'a':n}</column>
@@ -2864,6 +3166,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru">Пожалуйста, посетите веб-сайт KLI в {www.kli.org:url:http://www.kli.org/} для получения дополнительной информации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關更多信息，請訪問KLI網站{www.kli.org:url:http://www.kli.org/}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Por favor, visite o site da KLI em {www.kli.org:url:http://www.kli.org/} para obter mais informações. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Käy KLI: n verkkosivustolla osoitteessa {www.kli.org:url:http://www.kli.org/} saadaksesi lisätietoja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan Hol:n}, {yejHaD:n}</column>
       <column name="examples"></column>
@@ -2873,6 +3176,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2880,6 +3184,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2893,6 +3198,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Клингонская Оборонительная Сила</column>
       <column name="definition_zh_HK">克林崗防軍</column>
       <column name="definition_pt">Força de Defesa Klingon</column>
+      <column name="definition_fi">Klingonien puolustusvoimat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2903,6 +3209,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru">Официальный {QI':n} империи клингонов, управляемый {ra'ghomquv:n}. Он подразделяется на {yo':n} и {nawlogh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗帝國的官方{QI':n}，由{ra'ghomquv:n}經營。它分為{yo':n}和{nawlogh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O {QI':n} oficial do Império Klingon, dirigido pelo {ra'ghomquv:n}. Está subdividido em {yo':n} e {nawlogh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin imperiumin virallinen {QI':n}, jota johtaa {ra'ghomquv:n}. Se on jaettu osiin {yo':n} ja {nawlogh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {Hub:n}, {beq:n}</column>
       <column name="examples"></column>
@@ -2912,6 +3219,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2919,6 +3227,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2932,6 +3241,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Я клингонец/клингонка.</column>
       <column name="definition_zh_HK">我是克林崗人。</column>
       <column name="definition_pt">Eu sou um klingon.</column>
+      <column name="definition_fi">Olen klingoni.</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhIngan jIHbe'.:sen}</column>
       <column name="see_also">{tlhIngan maH!:sen}, {tlhIngan maH! taHjaj!:sen}</column>
@@ -2942,6 +3252,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {jIH:n:1}</column>
       <column name="examples"></column>
@@ -2951,6 +3262,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2958,6 +3270,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -2971,6 +3284,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Я не клингон. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我不是克林崗人。</column>
       <column name="definition_pt">Eu não sou um Klingon.</column>
+      <column name="definition_fi">En ole klingoni.</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhIngan jIH.:sen}</column>
       <column name="see_also"></column>
@@ -2981,6 +3295,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {jIH:n:1}, {-be':v}</column>
       <column name="examples"></column>
@@ -2990,6 +3305,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2997,6 +3313,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -3010,6 +3327,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Мы клингонцы!</column>
       <column name="definition_zh_HK">我們是克林崗人！</column>
       <column name="definition_pt">Nós somos Klingons!</column>
+      <column name="definition_fi">Olemme klingoneita!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan jIH.:sen}</column>
@@ -3020,6 +3338,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {maH:n:1h}</column>
       <column name="examples"></column>
@@ -3029,6 +3348,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3036,6 +3356,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.3:src}</column>
     </table>
     <table name="mem">
@@ -3049,6 +3370,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Клингоны убивают в своих целях. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗人為了自己的目的而殺掉。</column>
       <column name="definition_pt">Os klingons matam para seus próprios propósitos.</column>
+      <column name="definition_fi">Klingonit tappavat omien tarkoitustensa vuoksi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3059,6 +3381,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3068,6 +3391,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3075,6 +3399,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.165:src}</column>
     </table>
     <table name="mem">
@@ -3088,6 +3413,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Вы клингон? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你是克林崗人嗎？</column>
       <column name="definition_pt">Você é um Klingon?</column>
+      <column name="definition_fi">Oletko klingoni?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3098,6 +3424,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3107,6 +3434,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3114,6 +3442,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -3127,6 +3456,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">When you insult a Klingon's honor, prepare for trouble. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">當你侮辱克林崗恩的榮譽時，請為災難做好準備。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quando você insultar a honra de um Klingon, prepare-se para o problema.</column>
+      <column name="definition_fi">Loukattuasi klingonin kunniaa odota ongelmia.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3137,6 +3467,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {quv:n}, {Da-:v}, {tIch:v}, {-DI':v}, {Seng:n}, {yI-:v}, {ghuH:v}</column>
       <column name="examples"></column>
@@ -3146,6 +3477,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">When you insult a Klingon's honour, prepare for trouble.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3153,6 +3485,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.56:src}</column>
     </table>
     <table name="mem">
@@ -3166,6 +3499,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Клингонская Империя</column>
       <column name="definition_zh_HK">克林崗帝國</column>
       <column name="definition_pt">Império Klingon</column>
+      <column name="definition_fi">Klingonien keisarikunta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3176,6 +3510,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">克林崗帝國使用的語言稱為{tlhIngan wo' Hol:n:nolink}，簡稱{tlhIngan Hol:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {wo':n}</column>
       <column name="examples"></column>
@@ -3185,6 +3520,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3192,6 +3528,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3205,6 +3542,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">тушеное мясо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">燉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ensopado</column>
+      <column name="definition_fi">muhennos, pata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qev:v}, {qagh tlhIq:n}, {chatlh:n:1}</column>
@@ -3215,6 +3553,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a private joke referring to a specific person.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3224,6 +3563,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3231,6 +3571,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3244,6 +3585,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">выплюнуть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吐出</column>
       <column name="definition_pt">cuspir</column>
+      <column name="definition_fi">sylkeä pois (esine)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIv:v:1}, {tuy':v}</column>
@@ -3254,6 +3596,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru">Если вы выплевываете жидкость, то {bItuy':sen:nolink}, а если вы выплевываете твердые частицы, то {bItlhIS:sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果吐出液體，則為{bItuy':sen:nolink}，但如果吐出固體，則為{bItlhIS:sen:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se você cuspir líquido, {bItuy':sen:nolink}, mas se cuspir sólidos, {bItlhIS:sen:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos sylkette ulos nestettä, sitten {bItuy':sen:nolink}, mutta jos sylkette kiintoaineet, sitten {bItlhIS:sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3263,6 +3606,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3270,6 +3614,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -3283,6 +3628,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">быть непокорным</column>
       <column name="definition_zh_HK">是不服從的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser insubordinado</column>
+      <column name="definition_fi">olla tottelematon, niskoitteleva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lob:v}, {lobHa':v}</column>
@@ -3293,6 +3639,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3302,6 +3649,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3309,6 +3657,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3322,6 +3671,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">Клеопатра</column>
       <column name="definition_zh_HK">克莉奧佩特拉</column>
       <column name="definition_pt">Cleópatra</column>
+      <column name="definition_fi">Kleopatra</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'antonI':n:name}</column>
@@ -3332,6 +3682,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="notes_ru">Это имя из пьесы {wIlyam SeQpIr:n:name} {'antonI' tlhI'yopatra' je:sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{wIlyam SeQpIr:n:name}的戲劇{'antonI' tlhI'yopatra' je:sen:nolink}的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on nimi {wIlyam SeQpIr:n:name}: n näytelmästä {'antonI' tlhI'yopatra' je:sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3341,6 +3692,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3348,6 +3700,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.110:src}</column>
     </table>
     <table name="mem">
@@ -3361,6 +3714,7 @@ Existe um idioma, {Hem; tlhIngan rur@@Hem:v, tlhIngan:n, rur:v}. [AUTOTRANSLATED
       <column name="definition_ru">просить</column>
       <column name="definition_zh_HK">請求</column>
       <column name="definition_pt">pedir, perguntar, implorar</column>
+      <column name="definition_fi">pyytää jotakin, vaatia, anoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghel:v}, {yu':v}, {jang:v}, {qoy':v}, {poQ:v}</column>
@@ -3381,6 +3735,7 @@ Syftet med detta verb är personen som begäran görs eller {'e':n:pro} med hän
       <column name="notes_pt">Este verbo é usado para fazer uma solicitação, enquanto {ghel:v} é usado para fazer uma pergunta.[3]
 
 O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro} referindo-se à ação solicitada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3398,6 +3753,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3405,6 +3761,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKDA:src}, [3] {HQ 7.4, p.3-4, Dec. 1998:src}, [4] {PK:src}, [5] {paq'batlh p.112-113:src}</column>
     </table>
     <table name="mem">
@@ -3419,6 +3776,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="definition_ru">противоречить</column>
       <column name="definition_zh_HK">頂撞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">contradizer</column>
+      <column name="definition_fi">olla ristiriidassa jonkin kanssa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghoH:v}, {ngach:v}, {tem:v}</column>
@@ -3429,6 +3787,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3438,6 +3797,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3445,6 +3805,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3458,6 +3819,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="definition_ru">быть немного неясным, отфильтрованным, нечетким, нечетким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有點模糊、過濾、污跡、模糊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser um pouco obscurecida, filtrada, manchada, não claro</column>
+      <column name="definition_fi">olla jokseenkin hämärtynyt, suodattunut, tummentunut, sumea, epäselvä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eng:n}, {vI'laS:n}, {tlhIch:n}</column>
@@ -3468,6 +3830,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Cloud".</column>
       <column name="components"></column>
       <column name="examples">
@@ -3478,6 +3841,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cloudy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3485,6 +3849,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -3498,6 +3863,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="definition_ru">брак</column>
       <column name="definition_zh_HK">婚姻</column>
       <column name="definition_pt">casamento</column>
+      <column name="definition_fi">avioliitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Saw:v}, {nay:v}, {be'nal:n}, {loDnal:n}, {ngoS:v}, {tlhogh:v}, {qelHay'ya:n}</column>
@@ -3508,6 +3874,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3517,6 +3884,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3524,6 +3892,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3537,6 +3906,7 @@ O objeto deste verbo é a pessoa de quem a solicitação é feita, ou {'e':n:pro
       <column name="definition_ru">жениться, жениться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結婚</column>
       <column name="definition_pt">casar com, casar</column>
+      <column name="definition_fi">mennä naimisiin, naida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhogh:n}</column>
@@ -3561,6 +3931,9 @@ Man kan säga antingen {B tlhogh A:sen:nolink} för "{A:sen:nolink} gifter sig m
       <column name="notes_pt">Por muito tempo, essa palavra foi considerada estranha ou arcaica, mas é ouvida com frequência cada vez maior. Ao contrário de {Saw:v} e {nay:v}, pode ser usado por qualquer um dos parceiros, independentemente do sexo ou gênero.
 
 Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolink}" ou {tlhoghchuq A B je:sen:nolink} "{A:sen:nolink} e {B:sen:nolink} casam-se". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa pidettiin pitkään viehättävänä tai arkaaisena, mutta sitä kuulla yhä useammin. Toisin kuin {Saw:v} ja {nay:v}, kumpikin kumppani voi käyttää sitä sukupuolesta tai sukupuolesta riippumatta.
+
+Voidaan sanoa joko {B tlhogh A:sen:nolink} "{A:sen:nolink} naimisiin {B:sen:nolink}" tai {tlhoghchuq A B je:sen:nolink} "{A:sen:nolink} ja {B:sen:nolink} naimisiin toistensa kanssa". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3570,6 +3943,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3577,6 +3951,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2017.07.13:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3590,6 +3965,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">жениться, провести брачную церемонию [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">舉行婚禮</column>
       <column name="definition_pt">casar, realizar uma cerimônia de casamento</column>
+      <column name="definition_fi">vihkiä, suorittaa vihkimisseremonia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3600,6 +3976,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru">Объект этого глагола во множественном числе. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個動詞的賓語是複數。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto deste verbo é plural. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde on monikko. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhogh:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -3609,6 +3986,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3616,6 +3994,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3629,6 +4008,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">сознавать</column>
       <column name="definition_zh_HK">實現</column>
       <column name="definition_pt">realizar</column>
+      <column name="definition_fi">tajuta, ymmärtää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaj:v}, {ghov:v}</column>
@@ -3639,6 +4019,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3654,6 +4035,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3661,6 +4043,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -3674,6 +4057,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">быть сырым</column>
       <column name="definition_zh_HK">未加工的</column>
       <column name="definition_pt">ser cru, não processado</column>
+      <column name="definition_fi">olla raaka, käsittelemätön</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Soj tlhol:n}</column>
@@ -3684,6 +4068,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3693,6 +4078,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3700,6 +4086,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3713,6 +4100,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">смеркаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">黃昏</column>
       <column name="definition_pt">crepúsculo, anoitecer</column>
+      <column name="definition_fi">iltahämärä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jajlo':n}</column>
       <column name="see_also">{choS:n}, {ram:n}</column>
@@ -3723,6 +4111,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3732,6 +4121,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3739,6 +4129,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -3752,6 +4143,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">заход солнца [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">日落</column>
       <column name="definition_pt">pôr do sol</column>
+      <column name="definition_fi">auringonlasku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3762,6 +4154,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru">Это относится к визуальному явлению на небе, а не к техническому моменту заката. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指天空中的視覺現象，而不是日落的技術瞬間。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao fenômeno visual no céu, não ao momento técnico do pôr do sol. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa taivaan visuaaliseen ilmiöön, ei auringonlaskun tekniseen hetkeen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhom:n}, {chum:v}</column>
       <column name="examples"></column>
@@ -3771,6 +4164,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3778,6 +4172,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -3791,6 +4186,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">тип еды [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">食物種類</column>
       <column name="definition_pt">tipo de comida</column>
+      <column name="definition_fi">eräs ruokalaji</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3801,6 +4197,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru">Это делается путем покрытия блока {tlhagh:n} {ngat:n:2} и {tIr:n}, затем {mIQ:n}. [1, p.93] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso é feito revestindo um bloco de {tlhagh:n} com {ngat:n:2} e {tIr:n} e depois {mIQ:n}.[1, p.93] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tehdään päällystämällä {tlhagh:n}-lohko {ngat:n:2}: lla ja {tIr:n}: lla, sitten {mIQ:n}: llä.[1, p.93] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Thrombus".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3810,6 +4207,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3817,6 +4215,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3830,6 +4229,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">ноздря</column>
       <column name="definition_zh_HK">鼻哥窿</column>
       <column name="definition_pt">narina</column>
+      <column name="definition_fi">sierain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIch:n}</column>
@@ -3840,6 +4240,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3849,6 +4250,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3856,6 +4258,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3870,6 +4273,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">вид животного, клонгат [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《klongat》動物類型</column>
       <column name="definition_pt">tipo de animal, klongat</column>
+      <column name="definition_fi">eräs eläin, klongat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3880,6 +4284,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{A Burning House:src}-sanaston mukaan tämä on paljon suurempi kuin {targh:n}, sitä on vaikeampaa hillitä, ja sitä käytetään joskus ratsupetona. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3889,6 +4294,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3896,6 +4302,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -3909,6 +4316,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">торговаться, вести меновую торговлю</column>
       <column name="definition_zh_HK">易貨、討價還價 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trocar, barganhar</column>
+      <column name="definition_fi">käydä vaihtokauppaa, neuvotella, hieroa kauppoja, tinkiä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{je':v:1}, {malja':n}, {Huq:v}</column>
@@ -3919,6 +4327,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3928,6 +4337,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3935,6 +4345,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3948,6 +4359,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">спереди, площадь перед [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">前面、前方</column>
       <column name="definition_pt">frente, área na frente de</column>
+      <column name="definition_fi">edessä, alue edessä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'em:n}</column>
       <column name="see_also">{tlhop:n:2}, {bIng:n}, {Dung:n}, {joj:n}, {retlh:n}, {poS:n}, {nIH:n}</column>
@@ -3958,6 +4370,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru">Для передней части объекта см. {'et:n:2h}. Смотрите также {lurgh:n} для других слов, связанных с пространственными направлениями. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關對象的前部，請參閱{'et:n:2h}。另請參見{lurgh:n}以獲取與空間方向有關的其他詞語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para a seção frontal de um objeto, consulte {'et:n:2h}. Veja também {lurgh:n} para outras palavras relacionadas às direções espaciais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso kohteen etuosa kohdasta {'et:n:2h}. Katso myös sanat {lurgh:n}, jotka liittyvät spatiaalisiin suuntiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3967,6 +4380,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3974,6 +4388,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3987,6 +4402,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">публичная зона [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">公共區域 [AUTOTRANSLATED]</column>
       <column name="definition_pt">área publica</column>
+      <column name="definition_fi">yleinen alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhop:n:1}, {ghom:v}</column>
@@ -3997,6 +4413,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru">Это просто расширение {tlhop:n:1} в определенном контексте. Идея состоит в том, что общественная зона будет находиться перед каким-то барьером, используемым для удержания публики, в то время как частная зона будет на другой стороне. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是{tlhop:n:1}在特定上下文中的擴展。這個想法是，公共區域將位於用來阻止公眾進入的障礙物的前面，而私人區域將位於另一側。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é apenas uma extensão do {tlhop:n:1} em um contexto específico. A idéia é que uma área pública esteja na frente de alguma barreira usada para manter o público fora, enquanto a área privada estará do outro lado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain {tlhop:n:1}: n laajennus tietyssä kontekstissa. Ajatuksena on, että julkinen alue olisi jonkin esteen edessä, jota käytetään pitämään julkinen poissa, kun taas yksityinen alue olisi toisella puolella. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4006,6 +4423,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4013,6 +4431,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4026,6 +4445,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="definition_ru">одолжение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">寵愛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">favor</column>
+      <column name="definition_fi">palvelus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4036,6 +4456,7 @@ Pode-se dizer {B tlhogh A:sen:nolink} para "{A:sen:nolink} casa com {B:sen:nolin
       <column name="notes_ru">Обычно это объект глагола типа {tur:v}. Получатель услуги отмечен знаком {-vaD:n:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">通常，這是{tur:v}之類的動詞的賓語。優惠的接受者標有{-vaD:n:suff}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Geralmente, esse é o objeto de um verbo como {tur:v}. O destinatário do favor está marcado com {-vaD:n:suff}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleensä verbin, kuten {tur:v}, kohde. Palveluksen vastaanottaja on merkitty {-vaD:n:suff}-merkinnällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"One good turn deserves another ({latlh qotlh:sen@@latlh:n, qotlh:v:2})".
 
 The request that resulted in this word specified that a favor is "an act done out of goodwill rather than from justice or renumeration", so the word may be narrower in scope than all possible meanings of the English word "favor".</column>
@@ -4047,6 +4468,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">favour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4054,6 +4476,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4067,6 +4490,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="definition_ru">конгломерация</column>
       <column name="definition_zh_HK">聚集 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conglomeração</column>
+      <column name="definition_fi">kasauma, rykelmä?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boq:n:1}, {ghom:n}, {Sar:n}</column>
@@ -4077,6 +4501,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Flock".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4086,6 +4511,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4093,6 +4519,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <!-- {tlhoqo':n} KLI slang for "misanthrope, jerk, idiot". -->
@@ -4107,6 +4534,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="definition_ru">быть острым (имея в виду еду) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">辛辣（指食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser picante (referente a alimentos)</column>
+      <column name="definition_fi">olla pistevä, kirpeä, väkevä (ruoasta)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhorghHa':v}</column>
       <column name="see_also">{'ey:v}, {mum:v}</column>
@@ -4117,6 +4545,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4126,6 +4555,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4133,6 +4563,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4146,6 +4577,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="definition_ru">быть мягким (имея в виду еду) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">平淡無奇（指食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser branda (referindo-se a comida)</column>
+      <column name="definition_fi">olla mieto, mauton (ruoasta)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhorgh:v}</column>
       <column name="see_also">{jot:v:2}</column>
@@ -4156,6 +4588,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhorgh:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -4165,6 +4598,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4172,6 +4606,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4185,6 +4620,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="definition_ru">почти, почти, практически, не совсем; едва [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">幾乎、不完全、僅僅</column>
       <column name="definition_pt">quase, virtualmente, não exatamente; mal</column>
+      <column name="definition_fi">lähes, melkein, käytännössä, ei aivan (myönteisissä lauseissa); tuskin (kielteisissä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhoSHa':adv:hyp}</column>
       <column name="see_also">{loQ:adv}, {tlhoy:adv}</column>
@@ -4195,6 +4631,7 @@ The request that resulted in this word specified that a favor is "an act done ou
       <column name="notes_ru">При использовании с отрицательным глаголом это имеет значение «едва».[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與否定動詞一起使用時，其含義為“幾乎”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando usado com um verbo negativo, isso tem o significado de "mal".[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Negatiivisella verbillä käytettynä tällä on merkitys "tuskin" .[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Close".
 
 This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "barely" meaning was added at {qep'a' 25 (2018):src}.</column>
@@ -4206,6 +4643,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4213,6 +4651,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4226,6 +4665,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="definition_ru">земля на воде (как птица) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">水面上登陸（像鳥一樣）</column>
       <column name="definition_pt">pousar na água (como um pássaro)</column>
+      <column name="definition_fi">laskeutua veteen (kuin lintu)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngun:v}, {Saq:v}</column>
@@ -4236,6 +4676,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="notes_ru">Если птица садится на дерево, используется глагол {ngun:v}, а если на земле, то {Saq:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果有鳥落在樹上，則使用動詞{ngun:v}；如果在土地上，則使用動詞{Saq:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se um pássaro pousar em uma árvore, o verbo {ngun:v} será usado e, se estiver em terra, então {Saq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos lintu laskeutuu puuhun, käytetään verbiä {ngun:v} ja jos maassa, niin {Saq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4245,6 +4686,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4252,6 +4694,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4265,6 +4708,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="definition_ru">хрипеть</column>
       <column name="definition_zh_HK">哮</column>
       <column name="definition_pt">chiado</column>
+      <column name="definition_fi">vinkua, pihistä</column>
       <column name="synonyms">{jev:v:2}</column>
       <column name="antonyms"></column>
       <column name="see_also">{wuD:v}, {pur:v}, {rech:v}, {tlhuH:v:1}, {chuy:v}</column>
@@ -4275,6 +4719,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4284,6 +4729,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4291,6 +4737,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4304,6 +4751,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="definition_ru">чрезмерно, чрезмерно, чрезмерно, слишком много [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">過度</column>
       <column name="definition_pt">excessivamente, em grau excessivo, muito intensivo</column>
+      <column name="definition_fi">liian, liiallisesti, kohtuuttomasti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhoyHa':adv:hyp}</column>
       <column name="see_also">{'Iq:v}, {loQ:adv}, {tlhoS:adv}</column>
@@ -4314,6 +4762,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Cloy".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4323,6 +4772,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4330,6 +4780,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -4344,6 +4795,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="definition_ru">стена, внутренняя стена, внутренняя поверхность наружной стены, территориальная стена [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">牆、內牆、外牆的內牆、領土牆 [AUTOTRANSLATED]</column>
       <column name="definition_pt">parede, parede interior, face interior da parede exterior, parede territorial</column>
+      <column name="definition_fi">seinä, sisäseinä, ulkoseinän sisäpuoli, alueellinen seinä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa' reD:n}, {reD:n:1}</column>
@@ -4354,6 +4806,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="notes_ru">Также относится к полам / потолкам, см. {tlhoy' SaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">也指地板/天花板，請參閱{tlhoy' SaS:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Também se refere a pisos / tetos, consulte {tlhoy' SaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{chevwI' tlhoy':n}, {pIn tlhoy':n}</column>
@@ -4363,6 +4816,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4370,6 +4824,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -4383,6 +4838,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="definition_ru">потолок / пол между этажами [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">故事之間的天花板/地板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">teto / piso entre andares</column>
+      <column name="definition_fi">lattia/katto kerrosten välillä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{beb:n}</column>
@@ -4393,6 +4849,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhoy':n}, {SaS:v:1}</column>
       <column name="examples"></column>
@@ -4402,6 +4859,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4409,6 +4867,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -4422,6 +4881,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="definition_ru">благодарность</column>
       <column name="definition_zh_HK">感激</column>
       <column name="definition_pt">apreciação, gratidão</column>
+      <column name="definition_fi">arvostus, kiitollisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlho':v}</column>
@@ -4432,6 +4892,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4441,6 +4902,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4448,6 +4910,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -4461,6 +4924,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="definition_ru">благодарить</column>
       <column name="definition_zh_HK">謝</column>
       <column name="definition_pt">agradecer</column>
+      <column name="definition_fi">kiittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlho':n}</column>
@@ -4471,6 +4935,7 @@ This was defined as "almost, nearly, virtually, not quite" in {KGT:src}. The "ba
       <column name="notes_ru">Обратите внимание, что хотя в клингоне можно сказать «Спасибо» ({qatlho'}), это то, что клингоны обычно не говорят. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，雖然可以在克林崗語中說“謝謝”（{qatlho'}），但這是克林貢語通常不會說的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que, embora seja possível dizer "obrigado" ({qatlho'}) em Klingon, isso é algo que os Klingons normalmente não diriam. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että vaikka Klingonissa on mahdollista sanoa "Kiitos" ({qatlho'}), Klingons ei yleensä sano sitä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TNG - The Mind's Eye:src}, Captain Jean-Luc Picard ({janluq pIqarD:n:name}) said {qatlho':sen:nolink} to Kell after the latter paid him a compliment. Kell responded with an odd look.[2]
 
 At {qep'a' loSDIch:src}, MO explained that he never intended {qatlho':sen:nolink} to mean "thanks" (in the way English speakers use that expression).</column>
@@ -4482,6 +4947,7 @@ At {qep'a' loSDIch:src}, MO explained that he never intended {qatlho':sen:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">thank you, thanks</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4489,6 +4955,7 @@ At {qep'a' loSDIch:src}, MO explained that he never intended {qatlho':sen:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {TNG - The Mind's Eye:src}, [3] {KLI mailing list 2011.11.07:src}</column>
     </table>
     <table name="mem">
@@ -4502,6 +4969,7 @@ At {qep'a' loSDIch:src}, MO explained that he never intended {qatlho':sen:nolink
       <column name="definition_ru">Единица объема (прибл. одна кварта / литр), клорн [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">體積單位（約1夸脫/升）、klorn [AUTOTRANSLATED]</column>
       <column name="definition_pt">unidade de volume (aprox. um quarto / litro), klorn</column>
+      <column name="definition_fi">eräs tilavuusyksikkö, klorn (n. yksi litra)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{muq:v}</column>
@@ -4512,6 +4980,7 @@ At {qep'a' loSDIch:src}, MO explained that he never intended {qatlho':sen:nolink
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The newsgroup message says only that one {tlho'ren:n:nolink} "seems to be in the quart/liter range."[1]
 
 The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</column>
@@ -4523,6 +4992,7 @@ The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">quart, liter, litre</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4530,6 +5000,7 @@ The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {msn 1997.10.22:src}, [2] {DS9 - Blood Oath:src}</column>
     </table>
     <table name="mem">
@@ -4543,6 +5014,7 @@ The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</col
       <column name="definition_ru">кульминация (литературный термин) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">高潮（文學術語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">clímax (termo literário)</column>
+      <column name="definition_fi">huippukohta, huipentuma, kliimaksi (tarinassa tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4553,6 +5025,7 @@ The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</col
       <column name="notes_ru">Это относится к высоте действия в повествовании. (Он не используется для оргазма.)[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指敘述中的動作高度。 （它不用於高潮。）[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à altura da ação em uma narrativa. (Não é usado para orgasmo.)[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kerronnan toiminnan korkeuteen. (Sitä ei käytetä orgasmiin.) [1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4562,6 +5035,7 @@ The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4569,6 +5043,7 @@ The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4582,6 +5057,7 @@ The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</col
       <column name="definition_ru">исчерпывать</column>
       <column name="definition_zh_HK">排氣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esgotar</column>
+      <column name="definition_fi">kuluttaa loppuun</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghImwI':n}</column>
@@ -4592,6 +5068,7 @@ The spelling of "klorn" comes from the script to {DS9 - Blood Oath:src}.[2]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It is unclear if this means "to tire someone out" (see {Doy':v}), "to use something up completely" (see {natlh:v:1}), or (as in English) both.
 
 Some people believe that this word means "to expel exhaust", based on its similarity to {tlhuH:v:1}, and that {ghImwI':n} was a mistake for {tlhuchwI':n:nolink}. See the KLI Round Table in {HQ 11.2, p.10, Jun. 2002:src}. However, further information on {ghIm:v} since then have confirmed that {ghImwI':n:nolink} is correct.</column>
@@ -4603,6 +5080,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4610,6 +5088,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4623,6 +5102,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">emit (energy, radiation, etc.) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發射（能量、輻射等） [AUTOTRANSLATED]</column>
       <column name="definition_pt">emitir (energia, radiação, etc.)</column>
+      <column name="definition_fi">säteillä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{woj:n}, {rIS:v}, {butnat:n}</column>
@@ -4633,6 +5113,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4643,6 +5124,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">radiate</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4650,6 +5132,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 32:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -4663,6 +5146,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">дыхание</column>
       <column name="definition_zh_HK">呼吸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">respiração</column>
+      <column name="definition_fi">hengitys, hengenveto?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tagh:n}, {tlhuH:v:1}</column>
@@ -4673,6 +5157,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4682,6 +5167,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4689,6 +5175,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4702,6 +5189,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">дышать</column>
       <column name="definition_zh_HK">呼吸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">respirar</column>
+      <column name="definition_fi">hengittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tagh:n}, {jev:v:2}, {tlhov:v}, {pur:v}, {rech:v}, {tlhuH:n}, {tlhuH:v:2}</column>
@@ -4712,6 +5200,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4721,6 +5210,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4728,6 +5218,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4741,6 +5232,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">быть воодушевленным, быть стимулированным, быть бодрым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">感到興奮、受到激勵、充滿活力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser animado, ser estimulado, ser revigorado</column>
+      <column name="definition_fi">olla riemastunut, innostunut, virkistynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhuH:v:1}, {Sey:v}</column>
@@ -4751,6 +5243,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4760,6 +5253,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4767,6 +5261,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4780,6 +5275,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">шептать</column>
       <column name="definition_zh_HK">耳語</column>
       <column name="definition_pt">sussurrar</column>
+      <column name="definition_fi">kuiskata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tam:v:1}</column>
@@ -4790,6 +5286,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4799,6 +5296,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4806,6 +5304,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4819,6 +5318,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">хвостик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">尾巴</column>
       <column name="definition_pt">calda</column>
+      <column name="definition_fi">häntä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4829,6 +5329,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4838,6 +5339,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4845,6 +5347,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4858,6 +5361,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">поймать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">抓住 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pegar (ex. uma bola)</column>
+      <column name="definition_fi">ottaa koppi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jaD:v}</column>
       <column name="see_also">{jon:v}</column>
@@ -4868,6 +5372,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru">Это значит захватывать в воздухе, как ловить бейсбол. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著在空中抓球，就像打棒球一樣。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa agarrar no ar, como pegar uma bola de beisebol. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4877,6 +5382,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4884,6 +5390,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4898,6 +5405,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">быть чучелом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">塞滿 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser recheado</column>
+      <column name="definition_fi">olla täytetty</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4908,6 +5416,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru">Разница между {tlhutmoH:v@@tlhut:v, -moH:v} и {ghoD:v} заключается в том, что для последнего контейнер используется для хранения или хранения того, что вы помещаете в него, например пината, тогда как {tlhut:v:nolink} используется для заполнения чего-либо, имеющего определенную форму или внешний вид, например с таксидермией и чучелами животных. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">A diferença entre {tlhutmoH:v@@tlhut:v, -moH:v} e {ghoD:v} é que, para o último, o contêiner é usado para armazenar ou armazenar o que você está colocando nele, como uma pinata, enquanto {tlhut:v:nolink} é usado para preencher algo com uma determinada forma ou aparência, como com taxidermia e animais empalhados. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ero {tlhutmoH:v@@tlhut:v, -moH:v}: n ja {ghoD:v}: n välillä on, että jälkimmäiselle säiliötä käytetään säilyttämään tai tallentamaan siihen asetettavia tietoja, kuten pinata, kun taas {tlhut:v:nolink}: ta käytetään täyttämään jotain, jolla on tietty muoto tai ulkonäkö, kuten taksidermian ja pehmolelujen kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4917,6 +5426,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4924,6 +5434,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -4937,6 +5448,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">пить</column>
       <column name="definition_zh_HK">飲、喝</column>
       <column name="definition_pt">beber</column>
+      <column name="definition_fi">juoda</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oj:v}, {ghup:v}, {'ep:v:1}, {Sop:v}</column>
@@ -4947,6 +5459,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4956,6 +5469,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4963,6 +5477,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4976,6 +5491,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">Пить поддельный эль лучше, чем пить воду. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">飲假酒比飲水好。</column>
       <column name="definition_pt">Beber cerveja falsa é melhor do que beber água.</column>
+      <column name="definition_fi">On parempi juoda väärennettyä olutta kuin vettä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4986,6 +5502,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhutlh:v}, {-meH:v}, {HIq:n}, {ngeb:v}, {qaq:v}, {... law':sen}, {bIQ:n}, {qaq:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -4995,6 +5512,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5002,6 +5520,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.35:src}</column>
     </table>
     <table name="mem">
@@ -5015,6 +5534,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">быть искушенным</column>
       <column name="definition_zh_HK">被誘惑、被勾引</column>
       <column name="definition_pt">ser tentado</column>
+      <column name="definition_fi">olla kiusauksessa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5025,6 +5545,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5034,6 +5555,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5041,6 +5563,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5054,6 +5577,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="definition_ru">искушать</column>
       <column name="definition_zh_HK">勾引</column>
       <column name="definition_pt">tentar</column>
+      <column name="definition_fi">houkutella, viekoitella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngel:v}</column>
@@ -5064,6 +5588,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhu':v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -5073,6 +5598,7 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5080,5 +5606,6 @@ Some people believe that this word means "to expel exhaust", based on its simila
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>

--- a/mem-18-v.xml
+++ b/mem-18-v.xml
@@ -5121,7 +5121,7 @@ Katso idioomaattinen ilmaisu, jota käytetään käskemään jotakuta liikkumaan
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">A sugestão foi feita em {qep'a' 16 (2009):src} de que um {vIlHom:n:nolink} poderia ser uma única crista em um {Quch:n}. [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Ehdotus tehtiin kohdassa {qep'a '16 (2009): src}, että {vIlHom:n:nolink} voisi olla yksi harjanne {Quch:n}: ssa.{qep'a' 16 (2009):src} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ehdotus tehtiin kohdassa {qep'a' 16 (2009):src}, että {vIlHom:n:nolink} voisi olla yksi harjanne {Quch:n}: ssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vIl:v:1} or {vIl:n:2,hyp,nolink}, {Hom:n:1}</column>
       <column name="examples"></column>

--- a/mem-18-v.xml
+++ b/mem-18-v.xml
@@ -2068,7 +2068,7 @@ Toisin kuin {pIl:v}, tämä viittaa itse motivaatioon. [AUTOTRANSLATED]</column>
       <column name="definition_ru">бой, битва (средний уровень свирепости) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥、戰鬥（中級兇猛） [AUTOTRANSLATED]</column>
       <column name="definition_pt">lutar, batalhar (ferocidade de nível médio)</column>
-      <column name="definition_fi">taistella (keskitason raakuus)</column>
+      <column name="definition_fi">taistella (keskisuuressa taistelussa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suv:v}, {may':n}</column>

--- a/mem-18-v.xml
+++ b/mem-18-v.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {v:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{v:sen:nolink}</column>
       <column name="definition_pt">a consoante {v:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {v:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">общое ругательство</column>
       <column name="definition_zh_HK">一般粗口</column>
       <column name="definition_pt">invectivo geral</column>
+      <column name="definition_fi">eräs kirosana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Это сокращенная форма {Qu'vatlh:excl}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{Qu'vatlh:excl}的簡化形式。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma forma abreviada de {Qu'vatlh:excl}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhennetty {Qu'vatlh:excl}-muoto. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This might be a retrofit for a line misspoken by Patrick Stewart in {TNG - The Mind's Eye:src}. The script says {Qu'vatlh:excl:nolink}, but he says {va:excl:nolink} instead.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">более того, более того, даже [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">而且、甚至</column>
       <column name="definition_pt">além do mais, até mesmo</column>
+      <column name="definition_fi">jopa, lisäksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -97,6 +106,7 @@
       <column name="notes_ru">Это используется, чтобы сказать, что что-то неожиданное, удивительное или противоречивое, а не просто дополнительное. Для этого можно использовать {je:adv}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">過去常說某些事情是意料之外的，令人驚訝的或違反直覺的，而不僅僅是其他。為此，可以使用{je:adv}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para dizer que algo é inesperado, surpreendente ou contra-intuitivo, não apenas adicional. Para isso, usaria {je:adv}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään sanomaan, että jokin on odottamatonta, yllättävää tai vasta-intuitiivista, ei vain muuta. Tätä varten käytettäisiin {je:adv}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -108,6 +118,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -115,6 +126,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -128,6 +140,7 @@
       <column name="definition_ru">Даже мой тарг не узнает. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">甚至我的《targ》也不會知道。</column>
       <column name="definition_pt">Até o meu targ não saberá.</column>
+      <column name="definition_fi">Edes targini ei tiedä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -138,6 +151,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was the winning secrecy proverb entry, submitted by Jack Bradley ({DeSDu':n:name,nolink}), in the proverbs competition at {qep'a' 25 (2018):src}.</column>
       <column name="components">{vabDot:adv}, {Sov:v}, {-be':v}, {targh:n}, {-wIj:n}</column>
       <column name="examples"></column>
@@ -147,6 +161,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">secrecy proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -154,6 +169,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -167,6 +183,7 @@
       <column name="definition_ru">быть гибким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">變通 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser flexível</column>
+      <column name="definition_fi">olla joustava, ketterä?</column>
       <column name="synonyms">{roS:v:3,hyp}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -177,6 +194,7 @@
       <column name="notes_ru">Есть выражение {vaDjaj yaDDu'lIj:sen:nolink} «пусть ваши пальцы будут гибкими», значение которого неясно, но которое может быть желанием удачи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{vaDjaj yaDDu'lIj:sen:nolink}有一個表達形式，“也許您的腳趾靈活”，其含義尚不清楚，但可能是希望自己有個好運。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe uma expressão, {vaDjaj yaDDu'lIj:sen:nolink} "que seus dedos sejam flexíveis", cujo significado não é claro, mas que pode ser um desejo de boa sorte. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On olemassa ilmaisu, {vaDjaj yaDDu'lIj:sen:nolink} "olkoon varpaasi joustavat", jonka merkitys on epäselvä, mutta joka saattaa olla toivoa onnea. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -186,6 +204,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -193,6 +212,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -206,6 +226,7 @@
       <column name="definition_ru">пять</column>
       <column name="definition_zh_HK">五</column>
       <column name="definition_pt">cinco</column>
+      <column name="definition_fi">viisi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vagh:n:2} (musical tone)</column>
@@ -216,6 +237,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -225,6 +247,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -232,6 +255,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -245,6 +269,7 @@
           <column name="definition_ru">пятый</column>
           <column name="definition_zh_HK">第五</column>
           <column name="definition_pt">quinto</column>
+      <column name="definition_fi">viides</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{vagh:n:1} (number)</column>
@@ -255,6 +280,7 @@
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{vagh:n:1,num}, {-DIch:n:num,suff}</column>
           <column name="examples"></column>
@@ -264,6 +290,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">5th</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -271,6 +298,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -284,6 +312,7 @@
           <column name="definition_ru">50 [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">五十 [AUTOTRANSLATED]</column>
           <column name="definition_pt">cinquenta</column>
+      <column name="definition_fi">viisikymmentä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -294,6 +323,7 @@
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{vagh:n:1,num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -303,6 +333,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -310,6 +341,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -323,6 +355,7 @@
       <column name="definition_ru">пятый тон неатонической музыкальной гаммы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">第五音非音階音階 [AUTOTRANSLATED]</column>
       <column name="definition_pt">quinto tom de escala musical não-atônica</column>
+      <column name="definition_fi">nonatoonisen musiikkiasteikon viides sävel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vagh:n:1} (number)</column>
@@ -333,6 +366,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin musiikkiasteikon sävyt (katso {yutlhegh:n}) ovat: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}, {vagh:n:2,nolink}, {jav:n:2}, {Soch:n:2}, {chorgh:n:2}, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DOT{yu:n:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -342,6 +376,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -349,6 +384,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -362,6 +398,7 @@
       <column name="definition_ru">пятиугольник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">五角形</column>
       <column name="definition_pt">Pentágono</column>
+      <column name="definition_fi">viisikulmio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mey':n}</column>
@@ -372,6 +409,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vagh:n:1,num}, {reD:n:2}, {mey':n}</column>
       <column name="examples">{vagh reD mey' HoS:n@@vagh reD mey':n, HoS:v} "regular pentagon"[2]</column>
@@ -381,6 +419,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -388,6 +427,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -401,6 +441,7 @@
       <column name="definition_ru">кобура, ножны</column>
       <column name="definition_zh_HK">皮套、護套、刀套</column>
       <column name="definition_pt">coldre, bainha, estojo de faca</column>
+      <column name="definition_fi">pistoolikotelo, tuppi, huotra</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QIq:v}, {Qem:v}, {taj:n}, {HIch:n}, {nav vaH:n}, {vev:v}, {buq:n}</column>
@@ -411,6 +452,7 @@
       <column name="notes_ru">На самом деле это может быть использовано для всего, что действует как прикрытие для чего-то, что кто-то вкладывает внутрь него.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">實際上，它可以用於任何用作掩蓋其中內容的東西。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Na verdade, isso pode ser usado para qualquer coisa que funcione como uma cobertura para algo que alguém coloca dentro dela.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan tosiasiallisesti käyttää mihin tahansa, joka toimii suojana jollekin, joka laitetaan sen sisälle.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -420,6 +462,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cover</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -427,6 +470,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -440,6 +484,7 @@
       <column name="definition_ru">лава [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">岩漿</column>
       <column name="definition_pt">lava</column>
+      <column name="definition_fi">laava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qulHuD:n}, {qajunpaQ:n}, {QIStaq:n}, {qul ngeng:n}</column>
@@ -450,6 +495,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -459,6 +505,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">magma</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -466,6 +513,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -479,6 +527,7 @@
       <column name="definition_ru">потому, тогда, вот, так</column>
       <column name="definition_zh_HK">因此、那麼、那樣的話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">então, também, nesse caso</column>
+      <column name="definition_fi">niin, siis, siten, joten, sitten, siinä tapauksessa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIq:adv}</column>
@@ -489,6 +538,7 @@
       <column name="notes_ru">Обратите внимание, что это не союз, а наречие. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，這不是連詞，而是狀語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que isso não é uma conjunção, mas um adverbial. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -498,6 +548,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -505,6 +556,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -518,6 +570,7 @@
       <column name="definition_ru">воин (абстрактное понятие)</column>
       <column name="definition_zh_HK">戰士精神</column>
       <column name="definition_pt">guerreiro (em geral)</column>
+      <column name="definition_fi">soturi, soturius</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaj Duj:n}</column>
@@ -528,6 +581,7 @@
       <column name="notes_ru">Это слово относится к понятию воина (например, «дух воина» и т. Д.). Чтобы обратиться к человеку, который является воином, используйте {SuvwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞指的是戰士的概念​​（例如“戰士精神”，等等）。要引用戰士，請使用{SuvwI':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se refere ao conceito de guerreiro (por exemplo, "espírito guerreiro" e assim por diante). Para se referir a uma pessoa que é um guerreiro, use {SuvwI':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -539,6 +593,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -546,6 +601,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {KGT p.50:src}</column>
     </table>
     <table name="mem">
@@ -559,6 +615,7 @@
       <column name="definition_ru">сила характера [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">性格的力量 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Força de caráter</column>
+      <column name="definition_fi">luonteen vahvuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaj Duj chIj:sen:idiom}</column>
@@ -569,6 +626,7 @@
       <column name="notes_ru">Это идиоматическое выражение буквально означает «корабль воина» или «инстинкты воина» из-за гомофонии между {Duj:n:1} и {Duj:n:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">由於{Duj:n:1}和{Duj:n:2}之間的諧音，這種慣用語的字面意思是“戰士的船”或“戰士的直覺”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa literalmente "navio guerreiro" ou "instinto guerreiro", devido à homofonia entre {Duj:n:1} e {Duj:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "sotalaivaa" tai "soturivaistoja" {Duj:n:1}: n ja {Duj:n:2}: n välisen homofonian vuoksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vaj:n}, {Duj:n:0}</column>
       <column name="examples">
@@ -579,6 +637,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -586,6 +645,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.113:src}</column>
     </table>
     <table name="mem">
@@ -599,6 +659,7 @@
       <column name="definition_ru">иметь силу характера [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">具有品格的力量 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter força de caráter</column>
+      <column name="definition_fi">olla luonteeltaan vahva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaj Duj:n}</column>
@@ -609,6 +670,7 @@
       <column name="notes_ru">Это идиоматическое выражение буквально означает «управлять кораблем воина». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個慣用語的字面意思是“駕駛勇士船”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa literalmente "navegar em um navio guerreiro". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "navigoida soturi-aluksella". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vaj Duj:n}, {chIj:v}</column>
       <column name="examples">
@@ -619,6 +681,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -626,6 +689,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.113:src}</column>
     </table>
     <table name="mem">
@@ -640,6 +704,7 @@
       <column name="definition_ru">быть умным</column>
       <column name="definition_zh_HK">聰明</column>
       <column name="definition_pt">ser inteligente, esperto</column>
+      <column name="definition_fi">olla fiksu, älykäs</column>
       <column name="synonyms"></column>
       <column name="antonyms">{QIp:v}</column>
       <column name="see_also">{Huy':n}, {chul:v}</column>
@@ -650,6 +715,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Val"edictorian.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -659,6 +725,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -666,6 +733,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -679,6 +747,7 @@
       <column name="definition_ru">радужная оболочка глаза [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">虹膜（眼睛） [AUTOTRANSLATED]</column>
       <column name="definition_pt">íris (do olho)</column>
+      <column name="definition_fi">(silmän) iiris</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIn:n}, {lur:n}</column>
@@ -689,6 +758,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was revealed during the Hokey-Pokey.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -698,6 +768,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -705,6 +776,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -718,6 +790,7 @@
       <column name="definition_ru">Валкрис</column>
       <column name="definition_zh_HK">「瓦克莉絲」</column>
       <column name="definition_pt">Valkris</column>
+      <column name="definition_fi">Valkris</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -728,6 +801,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">The Chinese transliteration comes from the subtitles of {Star Trek III:src}.</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -737,6 +811,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -744,6 +819,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -757,6 +833,7 @@
       <column name="definition_ru">протон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">質子</column>
       <column name="definition_pt">próton</column>
+      <column name="definition_fi">protoni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeySel:n}, {yomIj:n}, {tem:n}, {tat:n}, {ruS:v}</column>
@@ -767,6 +844,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -776,6 +854,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -783,6 +862,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -796,6 +876,7 @@
       <column name="definition_ru">отдать честь</column>
       <column name="definition_zh_HK">禮炮 [AUTOTRANSLATED]</column>
       <column name="definition_pt">saudação</column>
+      <column name="definition_fi">tervehtiä, tehdä kunniaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{van:n}, {van:v:2}</column>
@@ -806,6 +887,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The 2009 {Star Trek:src} movie has a deleted scene with the line: {tIjwI'ghom bovanrupbe'chugh, vaj reQaw'.:sen:nolink}</column>
       <column name="components"></column>
       <column name="examples">
@@ -816,6 +898,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -823,6 +906,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -836,6 +920,7 @@
       <column name="definition_ru">конец (событие, путешествие, битва, спектакль, опера, история, песня и т. д.) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結束（事件，航程、戰鬥、遊戲、歌劇、故事、歌曲等） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fim (um evento, viagem, batalha, peça, ópera, história, música etc.)</column>
+      <column name="definition_fi">lopettaa (tapahtuma, matka, taistelu, näytelmä, ooppera, tarina, laulu tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bertlham:n}, {Dor:v:2}, {ghang:v}, {rIn:v}, {'o'megh:n}, {van:v:1}</column>
@@ -846,6 +931,7 @@
       <column name="notes_ru">Предметом этого глагола является человек, вызывающий конец события. Объект - это событие, которое закончено. Если событие было преждевременно завершено, используйте {ghang:v}. Чтобы описать окончание периода времени, используйте {Dor:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">O assunto desse verbo é a pessoa que está causando o término de um evento. O objeto é o evento que terminou. Se o evento foi prematuramente encerrado, use {ghang:v}. Para descrever o final de um período, use {Dor:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin aihe on henkilö, joka aiheuttaa tapahtuman päättymisen. Kohde on tapahtuma, joka on päättynyt. Jos tapahtuma lopetettiin ennenaikaisesti, käytä sen sijaan {ghang:v}. Käytä ajanjakson päättymistä kuvaamalla {Dor:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -855,6 +941,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -862,6 +949,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -875,6 +963,7 @@
       <column name="definition_ru">салют, дань</column>
       <column name="definition_zh_HK">敬禮、致敬 [AUTOTRANSLATED]</column>
       <column name="definition_pt">saldação, tributo</column>
+      <column name="definition_fi">tervehdys, kunnianosoitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{van:v:1}, {van'a':n}</column>
@@ -885,6 +974,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -894,6 +984,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -901,6 +992,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -914,6 +1006,7 @@
       <column name="definition_ru">Вандрос И.В. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Vandros IV [AUTOTRANSLATED]</column>
       <column name="definition_pt">Vandros IV</column>
+      <column name="definition_fi">Vandros IV</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -924,6 +1017,7 @@
       <column name="notes_ru">Планета в гамма-квадранте. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">伽瑪象限中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta no quadrante gama. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Gamma-kvadrantissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -933,6 +1027,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -940,6 +1035,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -953,6 +1049,7 @@
       <column name="definition_ru">премия</column>
       <column name="definition_zh_HK">獎</column>
       <column name="definition_pt">recompensa</column>
+      <column name="definition_fi">palkinto</column>
       <column name="synonyms">{pop:n}</column>
       <column name="antonyms">{bIj:n}</column>
       <column name="see_also">{tev:n}, {Hoy':v}, {SIQwI':n}</column>
@@ -963,6 +1060,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{van:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -972,6 +1070,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -979,6 +1078,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -992,6 +1092,7 @@
       <column name="definition_ru">Гимн</column>
       <column name="definition_zh_HK">國歌、戰歌</column>
       <column name="definition_pt">hino</column>
+      <column name="definition_fi">hymni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:n}</column>
@@ -1002,6 +1103,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{van:n}, {bom:n}</column>
       <column name="examples">
@@ -1013,6 +1115,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1020,6 +1123,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1033,6 +1137,7 @@
       <column name="definition_ru">monument, memorial (sculpture) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">紀念碑、紀念館（雕塑） [AUTOTRANSLATED]</column>
       <column name="definition_pt">monumento, memorial (escultura)</column>
+      <column name="definition_fi">monumentti, muistomerkki (veistos)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1043,6 +1148,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{van:n}, {Hew:n}</column>
       <column name="examples"></column>
@@ -1052,6 +1158,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1059,6 +1166,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1072,6 +1180,7 @@
       <column name="definition_ru">памятник, мемориал (здание) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">紀念碑、紀念館（建築物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">monumento, memorial (construção)</column>
+      <column name="definition_fi">monumentti, muistomerkki (rakennus)</column>
       <column name="synonyms">{lat:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1082,6 +1191,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{van:n}, {qach:n}</column>
       <column name="examples"></column>
@@ -1091,6 +1201,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1098,6 +1209,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1111,6 +1223,7 @@
       <column name="definition_ru">действовать</column>
       <column name="definition_zh_HK">採取行動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agir, tomar uma ação</column>
+      <column name="definition_fi">toimia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1121,6 +1234,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1131,6 +1245,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1138,6 +1253,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1151,6 +1267,7 @@
       <column name="definition_ru">The family of a Klingon warrior is responsible for his actions, and he is responsible for theirs. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗戰士的家人對他的行為負責，他負責他們的行為。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A família de um guerreiro klingon é responsável por suas ações, e ele é responsável pelas delas.</column>
+      <column name="definition_fi">Klingonisoturin perhe on vastuussa hänen teoistaan, ja hän on vastuussa heidän teoistaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1161,6 +1278,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vang:v}, {-DI':v}, {tlhIngan:n}, {SuvwI':n}, {ngoy':v}, {qorDu':n}, {-Daj:n}, {vang:v}, {-DI':v}, {qorDu':n}, {-Daj:n}, {ngoy':v}, {tlhIngan:n}, {SuvwI':n}</column>
       <column name="examples"></column>
@@ -1170,6 +1288,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1177,6 +1296,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.155:src}</column>
     </table>
     <table name="mem">
@@ -1190,6 +1310,7 @@
       <column name="definition_ru">насмехаться</column>
       <column name="definition_zh_HK">嘲笑</column>
       <column name="definition_pt">zombar</column>
+      <column name="definition_fi">pilkata</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yI':v}</column>
       <column name="see_also">{nuS:v}, {tIch:v}</column>
@@ -1200,6 +1321,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1210,6 +1332,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">taunt</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1217,6 +1340,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {paq'batlh p.140-141:src}</column>
     </table>
     <table name="mem">
@@ -1230,6 +1354,7 @@
       <column name="definition_ru">Vaq'aj II [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Vaq'aj II [AUTOTRANSLATED]</column>
       <column name="definition_pt">Vaq'aj II</column>
+      <column name="definition_fi">Vaq'aj II</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1240,6 +1365,7 @@
       <column name="notes_ru">Это планета в империи клингонов, в которой наряду с клингонами сохранились родные языки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是克林崗帝國的一個星球，當地語言與克林崗並存。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um planeta no Império Klingon, no qual línguas nativas sobreviveram ao lado de Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Klingonin imperiumin planeetta, jolla äidinkielet ovat säilyneet Klingonin rinnalla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src}, and in English, but the original Klingon name is obvious.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1249,6 +1375,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1256,6 +1383,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.18:src}</column>
     </table>
     <table name="mem">
@@ -1269,6 +1397,7 @@
       <column name="definition_ru">быть агрессивным, быть эффективным, быть бодрым</column>
       <column name="definition_zh_HK">要有進取心、要有效、要有活力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser agressivo, ser eficaz, ser vigoroso</column>
+      <column name="definition_fi">olla aggressiivinen, voimakas, tarmokas, tehokas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ral:v}</column>
@@ -1279,6 +1408,7 @@
       <column name="notes_ru">Это слово первоначально использовалось при описании оружия, но теперь также применяется к людям. У этого есть сильно положительный смысл в сленге.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞最初用於描述武器，但現在也適用於人們。它在語中具有強烈的積極含義。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra foi originalmente usada na descrição de armas, mas agora também é aplicada às pessoas. Tem conotações fortemente positivas na gíria.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytettiin alun perin kuvaamaan aseita, mutta sitä käytetään nyt myös ihmisissä. Sillä on vahvasti positiivisia merkityksiä slangissa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1288,6 +1418,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1295,6 +1426,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.67:src}</column>
     </table>
     <table name="mem">
@@ -1308,6 +1440,7 @@
       <column name="definition_ru">быть скупым, быть скупым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鄙吝、吝嗇、吝惜</column>
       <column name="definition_pt">ser mesquinho</column>
+      <column name="definition_fi">olla saita, pihi, kitsas</column>
       <column name="synonyms"></column>
       <column name="antonyms">{varHa':v}</column>
       <column name="see_also">{mut:v}, {qur:v}</column>
@@ -1318,6 +1451,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1327,6 +1461,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1334,6 +1469,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
         <table name="mem">
@@ -1347,6 +1483,7 @@
           <column name="definition_ru">быть щедрым [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">慷慨 [AUTOTRANSLATED]</column>
           <column name="definition_pt">ser generoso</column>
+      <column name="definition_fi">olla antelias</column>
           <column name="synonyms"></column>
           <column name="antonyms">{var:v}</column>
           <column name="see_also"></column>
@@ -1357,6 +1494,7 @@
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{var:v}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -1366,6 +1504,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1373,6 +1512,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
     <table name="mem">
@@ -1387,6 +1527,7 @@
       <column name="definition_ru">Перевертыш, Основатель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">創始者，創始人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Changeling, Fundador</column>
+      <column name="definition_fi">eräs laji, muuttuvainen, perustaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1397,6 +1538,7 @@
       <column name="notes_ru">Это относится к представителю расы оборотней, который возглавляет Доминион ({ngup'a':n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指領導Dominion（{ngup'a':n}）的變身者種族中的一員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um membro da raça de cambiaformas que lidera o Domínio ({ngup'a':n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa Dominionia johtavan muodonmuuttajaryhmän jäseneen ({ngup'a':n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This appears to be based on a verb {vargh:v:nolink}, but such a verb hasn't been defined.</column>
       <column name="components">{vargh:v:hyp,nolink}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1406,6 +1548,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1413,6 +1556,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1426,6 +1570,7 @@
       <column name="definition_ru">зал</column>
       <column name="definition_zh_HK">大廳、會堂、禮堂</column>
       <column name="definition_pt">salão, salão de montagem</column>
+      <column name="definition_fi">sali, kokoushuone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vaS'a':n}, {ghom:v}</column>
@@ -1436,6 +1581,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Vast".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1445,6 +1591,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1452,6 +1599,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1465,6 +1613,7 @@
       <column name="definition_ru">великий зал</column>
       <column name="definition_zh_HK">克林崗人民大會堂</column>
       <column name="definition_pt">Grande Salão</column>
+      <column name="definition_fi">Suuri sali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1475,6 +1624,7 @@
       <column name="notes_ru">Это место правительства клингонов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是克林崗政府的所在地。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a sede do governo Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Klingonin hallituksen kotipaikka. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vaS:n}, {-'a':n}</column>
       <column name="examples">
@@ -1488,6 +1638,7 @@
 "В родном мире, есть великий зал, где лидеры Клингонского высшего совета встречаются, чтобы определить политику, задать курс и решить судьбу империи. Сейчас председательствует Гаурон, лидер Высшего совета, назначенный капитаном Жаном-Люком Пикардом, который был Арбитром посвящения."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1495,6 +1646,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {SkyBox 25:src}</column>
     </table>
     <table name="mem">
@@ -1508,6 +1660,7 @@
       <column name="definition_ru">быть широким, широким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">廣闊、廣泛</column>
       <column name="definition_pt">ser amplo</column>
+      <column name="definition_fi">olla leveä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lang:v}</column>
       <column name="see_also">{juch:v}, {ror:v}, {pI':v}</column>
@@ -1518,6 +1671,7 @@
       <column name="notes_ru">Это относится к расстоянию из стороны в сторону и не имеет метафорического значения, такого как «широкая тема» или «широкий диапазон мнений», и при этом оно не используется для определения «в полной мере», такого как «широко раскрытые глаза». открыто". [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指左右距離，不具有“廣泛話題”或“廣泛觀點”之類的隱喻含義，也沒有用於“全貌”之類的含義。打開”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à distância de um lado para o outro e não possui significados metafóricos, como "tópico amplo" ou "ampla gama de opiniões", nem é usado para o sentido de "em toda a extensão", como "olhos arregalados" abrir". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa sivusuunnassa olevaan etäisyyteen, eikä sillä ole metaforisia merkityksiä, kuten "laaja aihe" tai "laaja mielipidevalikoima", eikä sitä käytetä "koko laajuuden" merkitykseen, kuten "silmät leveät". avata". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Vast".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1527,6 +1681,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1534,6 +1689,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1547,6 +1703,7 @@
       <column name="definition_ru">сто</column>
       <column name="definition_zh_HK">百</column>
       <column name="definition_pt">cem</column>
+      <column name="definition_fi">sata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maH:n:2,num}, {SaD:n:num}, {SanID:n:num}</column>
@@ -1557,6 +1714,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1566,6 +1724,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1573,6 +1732,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1586,6 +1746,7 @@
       <column name="definition_ru">процент</column>
       <column name="definition_zh_HK">百分</column>
       <column name="definition_pt">por cento</column>
+      <column name="definition_fi">prosentti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vatlh:n:num}, {vI':n:2}</column>
@@ -1596,6 +1757,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1606,6 +1768,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1613,6 +1776,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1626,6 +1790,7 @@
       <column name="definition_ru">века [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">世紀</column>
       <column name="definition_pt">século</column>
+      <column name="definition_fi">vuosisata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SaD DIS poH:n}, {netlh DIS poH:n}</column>
@@ -1636,6 +1801,7 @@
       <column name="notes_ru">Чтобы указать «столетия назад» или «столетия спустя», {ret:n} и {pIq:n} используются вместо {poH:n} соответственно.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了表示“幾個世紀以前”或“從現在開始幾個世紀”，分別使用{ret:n}和{pIq:n}代替{poH:n}。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para indicar "séculos atrás" ou "séculos a partir de agora", {ret:n} e {pIq:n} são usados ​​no lugar de {poH:n}, respectivamente.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ilmaisemaan "vuosisatoja sitten" tai "vuosisatoja nyt" käytetään {ret:n} ja {pIq:n} vastaavasti {poH:n}: n sijasta.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The sentence from {SkyBox 15:src} has the {wa'DIch:n} in the wrong place. Also, the second occurrence of {vatlh DIS poH:n} is missing a space.</column>
       <column name="components">{vatlh:n:num}, {DIS:n:2}, {poH:n}</column>
       <column name="examples">
@@ -1649,6 +1815,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1656,6 +1823,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 15:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src}), [3] {HQ 8.3, p.3, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1669,6 +1837,7 @@
       <column name="definition_ru">катушка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">盤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bobina</column>
+      <column name="definition_fi">kiertyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IqngIl:n}</column>
@@ -1679,6 +1848,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1688,6 +1858,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1695,6 +1866,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1708,6 +1880,7 @@
       <column name="definition_ru">отец</column>
       <column name="definition_zh_HK">父親</column>
       <column name="definition_pt">pai</column>
+      <column name="definition_fi">isä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoS:n}, {vavoy:n}, {'emrIgh:n}, {qaytu':n}</column>
@@ -1718,6 +1891,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Os irmãos de um {vav:n:nolink} são {tennuS:n} e {'e'mam:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{vav:n:nolink}: n sisarukset ovat {tennuS:n} ja {'e'mam:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The joke with {vav:n:nolink} and {SoS:n:nolink} is that in most human languages, the words for "father" and "mother" contain simple labial sounds (typically either "b" or "p" for father, and "m" for mother), whereas the fricatives {v:sen:nolink} and {S:sen:nolink} are difficult sounds for human infants to make.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1727,6 +1901,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1734,6 +1909,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -1747,6 +1923,7 @@
           <column name="definition_ru">папа [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">爸 [AUTOTRANSLATED]</column>
           <column name="definition_pt">papai</column>
+      <column name="definition_fi">isi (hellittelynimi)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{SoSoy:n}</column>
@@ -1757,6 +1934,7 @@
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{vav:n}, {-oy:n}</column>
           <column name="examples"></column>
@@ -1766,6 +1944,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1773,6 +1952,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Star Trek VI:src}</column>
         </table>
     <table name="mem">
@@ -1786,6 +1966,7 @@
       <column name="definition_ru">дед</column>
       <column name="definition_zh_HK">祖父 [AUTOTRANSLATED]</column>
       <column name="definition_pt">avô</column>
+      <column name="definition_fi">isoisä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoSnI':n}, {'emrIgh:n}</column>
@@ -1796,6 +1977,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1805,6 +1987,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1812,6 +1995,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1825,6 +2009,7 @@
       <column name="definition_ru">быть амбициозным, решительным, мотивированным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雄心勃勃、堅定、有動力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser ambicioso, determinado, motivado</column>
+      <column name="definition_fi">olla kunnianhimoinen, päättäväinen, motivoitunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1849,6 +2034,9 @@ Till skillnad från {pIl:v} avser detta självmotivering. [AUTOTRANSLATED]</colu
       <column name="notes_pt">Observe que isso pode se referir a uma pessoa ambiciosa, mas não a uma tarefa ambiciosa.
 
 Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä voi viitata kunnianhimoiseen henkilöön, mutta ei kunnianhimoiseen tehtävään.
+
+Toisin kuin {pIl:v}, tämä viittaa itse motivaatioon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A determined person is one who "vow"s to do something.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1858,6 +2046,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1865,6 +2054,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1878,6 +2068,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">бой, битва (средний уровень свирепости) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥、戰鬥（中級兇猛） [AUTOTRANSLATED]</column>
       <column name="definition_pt">lutar, batalhar (ferocidade de nível médio)</column>
+      <column name="definition_fi">taistella (keskitason raakuus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suv:v}, {may':n}</column>
@@ -1888,6 +2079,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru">В порядке возрастания жестокости глаголы, используемые для описания военных столкновений: {Qor:v}, {tlhaS:v}, {vay:v:nolink}, {lul:v}, {Hargh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Em ordem crescente de ferocidade, os verbos usados ​​para descrever confrontos militares são: {Qor:v}, {tlhaS:v}, {vay:v:nolink}, {lul:v}, {Hargh:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Vie".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1897,6 +2089,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1904,6 +2097,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1917,6 +2111,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">равнобедренный треугольник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">等腰三角形</column>
       <column name="definition_pt">Triângulo isósceles</column>
+      <column name="definition_fi">tasakylkinen kolmio</column>
       <column name="synonyms">{ra'Duch quv:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{ra'Duch:n}, {ra'Duch tIQ:n}</column>
@@ -1927,6 +2122,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1936,6 +2132,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1943,6 +2140,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -1956,6 +2154,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">кто-нибудь, кто-то, что-нибудь, что-то</column>
       <column name="definition_zh_HK">某人、某事、任何人、任何事物、某人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alguém, algo, qualquer coisa</column>
+      <column name="definition_fi">joku, jokin (myönteisissä lauseissa); kukaan, mikään (kielteisissä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Doch:n}, {vogh:n}</column>
@@ -1966,6 +2165,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru">Чтобы выразить неопределенный предмет, см. {-lu':v:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">要表達不確定的主題，請參閱{-lu':v:suff}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para expressar um assunto indefinido, consulte {-lu':v:suff}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat ilmaista määrittelemättömän aiheen, katso {-lu':v:suff}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1975,6 +2175,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1982,6 +2183,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -1995,6 +2197,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">Завоевать то, что вы хотите. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">征服你想要的東西。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Conquiste o que você deseja.</column>
+      <column name="definition_fi">Valloita mitä haluat.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2005,6 +2208,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2014,6 +2218,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2021,6 +2226,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.149:src}</column>
     </table>
     <table name="mem">
@@ -2034,6 +2240,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">Страх это сила. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">恐懼就是力量。</column>
       <column name="definition_pt">Medo é poder.</column>
+      <column name="definition_fi">Jos pelkäät jotakin, olet voimakas. (Pelko on voimaa.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2044,6 +2251,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2053,6 +2261,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2060,6 +2269,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.109:src}</column>
     </table>
     <table name="mem">
@@ -2073,6 +2283,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">Запомни запах. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">記住氣味。</column>
       <column name="definition_pt">Lembre-se do aroma.</column>
+      <column name="definition_fi">Jos haistat jotakin, muista se. (Muista haju.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2083,6 +2294,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru">Это означает «Учитесь на своем опыте». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著“從您的經驗中學習”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "Aprenda com suas experiências". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "oppia kokemuksistasi". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2092,6 +2304,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2099,6 +2312,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.157:src}</column>
     </table>
     <table name="mem">
@@ -2112,6 +2326,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">пятка (стопы) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">腳跟</column>
       <column name="definition_pt">calcanhar (de pé)</column>
+      <column name="definition_fi">kantapää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qam:n}</column>
@@ -2122,6 +2337,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2131,6 +2347,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2138,6 +2355,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 13.1, p.9, Mar. 2004:src}</column>
     </table>
     <table name="mem">
@@ -2152,6 +2370,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">be next (in a series, sequence) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">接下來（在一系列、序列中） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser o próximo (em uma série, sequência)</column>
+      <column name="definition_fi">olla seuraava</column>
       <column name="synonyms"></column>
       <column name="antonyms">{vorgh:v}</column>
       <column name="see_also">{nung:v}, {ghIq:adv}, {Deq:v}</column>
@@ -2162,6 +2381,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru">Чтобы обратиться к следующему дню, месяцу или году, рассмотрите возможность использования {leS:n}, {waQ:n} и {nem:n} соответственно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Para se referir ao dia, mês ou ano seguinte, considere usar {leS:n}, {waQ:n} e {nem:n}, respectivamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat viitata seuraavaan päivään, kuukauteen tai vuoteen, harkitse {leS:n}-, {waQ:n}- ja {nem:n}-vastaavien käyttöä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">While {nungbogh:v:nolink} precedes a noun, {veb:v:nolink} comes after one.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2175,6 +2395,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">after, next</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2182,6 +2403,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 32:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -2195,6 +2417,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">крест, пролет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">交叉、跨度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cruzar</column>
+      <column name="definition_fi">ristetä, ylittää, mennä ristiin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIq:v}, {neq:v}, {me'cheD:n}, {QI:n}</column>
@@ -2205,6 +2428,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru">Это означает, что он должен проходить или пересекать в стационарном смысле, например, мост через реку, пересечение двумя пальцами или полоса, нарисованная поперек дороги. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著要以固定的方式跨度或交叉，例如跨河的橋樑，兩個手指交叉或在道路上塗有條紋。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa atravessar ou atravessar em sentido estacionário, como por exemplo uma ponte atravessando um rio, dois dedos cruzando ou uma faixa pintada na estrada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa venyttämistä tai ylittämistä paikallaan, kuten esimerkiksi jokea ylittävä silta, kahden sormen ylitys tai tien yli maalattu raita. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Reverse of {chev:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2214,6 +2438,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2221,6 +2446,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2234,6 +2460,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">мех [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">體毛（動物）</column>
       <column name="definition_pt">pele (de animais), pelugem</column>
+      <column name="definition_fi">turkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIr:n}, {veDDIr:n}, {jIb:n}</column>
@@ -2244,6 +2471,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2253,6 +2481,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2260,6 +2489,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2273,6 +2503,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">шкура (кожа с мехом еще прилагается) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">毛皮</column>
       <column name="definition_pt">pele (pele com pelo ainda preso)</column>
+      <column name="definition_fi">vuota, turkis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIm:n}, {veD:n}, {DIr:n}</column>
@@ -2283,6 +2514,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru">Во множественном числе этого слова {veDDIrmey:n:nolink}, а не {veDDIrDu':n:nolink}.[1; 2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個單詞的複數是{veDDIrmey:n:nolink}而不是{veDDIrDu':n:nolink}.[1; 2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O plural desta palavra é {veDDIrmey:n:nolink} em vez de {veDDIrDu':n:nolink}.[1; 2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän sanan monikko on {veDDIrmey:n:nolink} eikä {veDDIrDu':n:nolink}.[1; 2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{veD:n}, {DIr:n}</column>
       <column name="examples"></column>
@@ -2292,6 +2524,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2299,6 +2532,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.58:src}, [2] {s.k 1998.03.23:src}</column>
     </table>
     <table name="mem">
@@ -2312,6 +2546,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">пройти (открытая дверь, туннель и т. д.) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">經過（開著的門、隧道等） [AUTOTRANSLATED]</column>
       <column name="definition_pt">passar (uma porta aberta, um túnel, etc.)</column>
+      <column name="definition_fi">mennä/käydä/kulkea läpi (ovesta, tunnelista tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chob:n}, {'och:n}, {lojmIt:n}, {tol:v}, {'aw:v}</column>
@@ -2322,6 +2557,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru">Этот глагол означает только пройти через какое-то отверстие, а не «пройти» (в смысле «пройти» через лес) .[1] Объект - это вещь, через которую проходили. {-Daq:n:suff} не нужен.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞僅意味著經過某種開口，而不意味著“經過”（在“經過”森林的意義上）。[1]對像是正在經歷的事物。 {-Daq:n:suff}是不必要的。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo significa apenas passar por algum tipo de abertura, e não "atravessar" (no sentido de "atravessar" uma floresta) .[1] O objeto é a coisa que está sendo atravessada. {-Daq:n:suff} é desnecessário.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi tarkoittaa vain käydä läpi jonkinlaisen aukon eikä "kulkea" (siinä mielessä, että "käydä läpi" metsän). {-Daq:n:suff} on tarpeeton.[2][1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2340,6 +2576,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2347,6 +2584,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 6.3, p.5-8, Sept. 1997:src}, [2] {HQ 7.4, Dec. 1998:src}, [3] {Klingon Monopoly:src}, [4] {paq'batlh:src}, [5] {KLI mailing list 2013.07.29:src}</column>
     </table>
     <table name="mem">
@@ -2360,6 +2598,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">граница</column>
       <column name="definition_zh_HK">邊界、邊境</column>
       <column name="definition_pt">fronteira</column>
+      <column name="definition_fi">raja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeH:n}, {vuS:v}, {ghangwI':n}</column>
@@ -2370,6 +2609,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2380,6 +2620,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">border, frontier, barrier</column>
       <column name="search_tags_de">Rand, Abgrenzung, Barriere</column>
       <column name="search_tags_fa"></column>
@@ -2387,6 +2628,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2400,6 +2642,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">великий барьер</column>
       <column name="definition_zh_HK">大屏障</column>
       <column name="definition_pt">Grande Barreira</column>
+      <column name="definition_fi">Suuri este</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2410,6 +2653,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">This translation was used in the subtitles to {Star Trek V:src}.</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{veH:n}, {tIn:v}</column>
       <column name="examples"></column>
@@ -2419,6 +2663,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2426,6 +2671,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -2439,6 +2685,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">«Космос: последний рубеж» [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">“太空：最後的邊疆” [AUTOTRANSLATED]</column>
       <column name="definition_pt">"Espaço: a fronteira final"</column>
+      <column name="definition_fi">"Avaruus: viimeiset käymättömät korpimaat"</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2450,6 +2697,8 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SkyBox 99:src}:n teksti kuuluu:
+▶ {loS... qIb HeHDaq, 'u' SepmeyDaq Sovbe'lu'bogh lenglu'meH He ghoSlu'bogh retlhDaq 'oHtaH. HaDlu'meH, QuSlu'meH, SuDlu'meH lojmIt Da logh Hop Hut tengchaH. vaj loghDaq lenglaHtaH Humanpu'. veH Qav 'oH logh'e'.:sen:nolink}</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2459,6 +2708,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">space the final frontier</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2466,6 +2716,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 99:src}</column>
     </table>
     <table name="mem">
@@ -2479,6 +2730,7 @@ Em contraste com {pIl:v}, isso se refere à automotivação. [AUTOTRANSLATED]</c
       <column name="definition_ru">чехол, пальто, маска [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">封面、外套、面具 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cobrir, mascarar</column>
+      <column name="definition_fi">peittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tetyub:n}</column>
@@ -2503,6 +2755,9 @@ Detta verb används för att beskriva läggningen av en matta. Den som lägger e
       <column name="notes_pt">O sujeito faz a cobertura, enquanto o objeto é coberto.
 
 Este verbo é usado para descrever a colocação de um tapete. A pessoa que coloca um tapete é chamada de {velwI':n:nolink} (apesar do fato de que a gramática sugere que {velwI':n:nolink} se refere ao próprio tapete). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde tekee peitteen, kun esine on peitetty.
+
+Tätä verbiä käytetään kuvaamaan maton asettamista. Henkilöä, joka asettaa maton, kutsutaan {velwI':n:nolink}: ksi (huolimatta siitä, että kielioppi viittaa siihen, että {velwI':n:nolink} viittaa itse mattoon). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Veil".</column>
       <column name="components"></column>
       <column name="examples">
@@ -2514,6 +2769,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">carpet</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2521,6 +2777,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.09:src}</column>
     </table>
     <table name="mem">
@@ -2534,6 +2791,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="definition_ru">копия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">複製品 [AUTOTRANSLATED]</column>
       <column name="definition_pt">réplica</column>
+      <column name="definition_fi">jäljennös (museossa tms.)?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIw:n}, {qa'meH:n}, {ngeb:v}</column>
@@ -2544,6 +2802,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="notes_ru">В {Klingon Monopoly:src} «Реплика тростника канцлера» упоминается как {Qang naQ velqa':n:nolink}.[1] Модели динозавров в натуральную величину, которые можно увидеть в музее, также можно назвать {velqa':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{Klingon Monopoly:src}中，“校長的甘蔗複製品”被稱為{Qang naQ velqa':n:nolink}.[1]恐龍的真人大小模型，例如在博物館中看到的恐龍，也可能被稱為{velqa':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">No {Klingon Monopoly:src}, a "Réplica do Chanceler's Cane" é denominada {Qang naQ velqa':n:nolink}.[1] Os modelos em tamanho real de dinossauros, como se pode ver em um museu, também podem ser chamados de {velqa':n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohdassa {Klingon Monopoly:src} "kanslerin keppi-kopioon" viitataan nimellä {Qang naQ velqa':n:nolink}.[1] Dinosaurusten kokoisia malleja, joita museossa voi nähdä, voidaan kutsua myös nimellä {velqa':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Revell" is a company which makes model kits ({-qa':v} means "again", or "re-").</column>
       <column name="components"></column>
       <column name="examples">{jorchan velqa':n}</column>
@@ -2553,6 +2812,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">clone, copy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2560,6 +2820,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2573,6 +2834,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="definition_ru">хром [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鉻</column>
       <column name="definition_pt">cromo</column>
+      <column name="definition_fi">kromi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}</column>
@@ -2583,6 +2845,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="notes_ru">Это относится к элементарному хрому, тогда как {qo'rIn:n} относится к солям хрома, таким как соли, используемые при дублении кожи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指元素鉻，而{qo'rIn:n}是指鉻鹽，如皮革鞣製中所使用的那些。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao cromo elementar, enquanto que o {qo'rIn:n} se refere a sais de cromo, como os usados ​​no curtimento de couro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa alkukromiin, kun taas {qo'rIn:n} viittaa kromisuoloihin, kuten ne, joita käytetään nahan parkituksessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This appears to be a combination of {vel:v} and {So':v:1}. Chromium is often used to coat things.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2592,6 +2855,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2599,6 +2863,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2612,6 +2877,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="definition_ru">нержавеющая сталь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不銹鋼</column>
       <column name="definition_pt">aço inoxidável</column>
+      <column name="definition_fi">ruostumaton teräs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}, {ghav 'uSqan:n}</column>
@@ -2622,6 +2888,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{velSo':n}, {'uSqan:n}</column>
       <column name="examples"></column>
@@ -2631,6 +2898,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2638,6 +2906,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2651,6 +2920,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="definition_ru">проснуться</column>
       <column name="definition_zh_HK">醒來、停止睡覺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acordar, parar de dormir</column>
+      <column name="definition_fi">herätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qong:v}, {Hu':v}, {vemmoH:v}</column>
@@ -2661,6 +2931,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2670,6 +2941,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2677,6 +2949,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2690,6 +2963,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="definition_ru">разбудить</column>
       <column name="definition_zh_HK">喚醒（某人）了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acordar (alguém)</column>
+      <column name="definition_fi">herättää joku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2700,6 +2974,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vem:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -2709,6 +2984,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2716,6 +2992,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2729,6 +3006,7 @@ Este verbo é usado para descrever a colocação de um tapete. A pessoa que colo
       <column name="definition_ru">печать, отметка, дорожки, след, изображение, рисунок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">打印、標記、軌道、跟踪、圖像、模式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">imprimir, marca, faixas, rastreamento, imagem, padrão</column>
+      <column name="definition_fi">jälki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2781,6 +3059,13 @@ Esta palavra é contrastada com {Su'nIm:n}, que se refere ao padrão que faz o {
 Observe que uma imagem produzida intencionalmente, semelhante a um selo, é uma {yang:n}.
 
 Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado em vez de {nItlh:n} (ou {yaD:n:1}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kosketuksesta jäljelle jääneeseen jälkeeseen tai merkkeihin, kuten sormenjäljen (renkaan kuvan), renkaan jälkiin tai kuvaan likaantumisesta, joka syntyy sen päälle astumisesta.
+
+Tätä sanaa verrataan {Su'nIm:n}: een, joka viittaa kuvioon, joka tekee {vem:n:nolink}: n. Mutta {Su'nIm:n:nolink}: ta käytetään vain, kun se on jotain hyvin yksityiskohtaista, mikä jättää {vem:n:nolink}: n. Vertaa esimerkiksi {nItlh Su'nIm:n}: n "sormenjälkeä" (harjanteet sormenpäässä) {nItlh Su'nIm vem:n}: n "sormenjälkeen" (merkki, joka on jätetty taakse koskettamisen jälkeen).
+
+Huomaa, että tarkoituksella tuotettu leimamainen kuva on {yang:n}.
+
+Seuraavissa esimerkeissä voidaan käyttää tiettyä sormen tai varpaan nimeä {nItlh:n}: n (tai {yaD:n:1}) sijaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2794,6 +3079,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2801,6 +3087,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2814,6 +3101,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="definition_ru">вид птицы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma espécie de pássaro</column>
+      <column name="definition_fi">eräs lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2824,6 +3112,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="notes_ru">Это птица, которая питается почти исключительно змеиным червем, из которого сделан {qagh:n}. Клингоны не особенно любят эту птицу. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這隻鳥幾乎只以製成{qagh:n}的蛇蠕蟲為食。克林崗人並不特別喜歡這隻鳥。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um pássaro que se alimenta quase exclusivamente do verme da serpente do qual o {qagh:n} é feito. Os klingons não gostam particularmente deste pássaro. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lintu, joka ruokkii melkein yksinomaan käärmematoa, josta {qagh:n} on valmistettu. Klingonit eivät ole erityisen kiinnostuneita tästä linnusta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">An early bird, i.e., a bird which wakes up ({vem:v}) early ({'eq:v}), catches the worm.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2833,6 +3122,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2840,6 +3130,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2853,6 +3144,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="definition_ru">быть ботаником [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">書呆子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser nerd</column>
+      <column name="definition_fi">olla nörtti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngom:v}, {venwI':n}</column>
@@ -2863,6 +3155,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="notes_ru">Это слово описывает кого-то, кто действительно во что-то (или несколько вещей), кто участвует в действиях, связанных с этим, и делает это очень серьезно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞描述的是一個真正從事某件事（或許多事情）的人，他參與與之相關的活動，並且做事非常認真。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra descreve alguém que realmente gosta de algo (ou várias coisas), que participa de atividades associadas a ele e o faz muito a sério. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana kuvaa henkilöä, joka on todella kiinnostunut jostakin (tai monista asioista), joka osallistuu siihen liittyvään toimintaan ja tekee niin hyvin vakavasti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A reference to "The Nerdy Venoms" podcast, on which Okrand had been invited as a guest at the time.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2872,6 +3165,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2879,6 +3173,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Festival of the Spoken Nerd DVD:src}</column>
     </table>
     <table name="mem">
@@ -2892,6 +3187,7 @@ Nos exemplos a seguir, o nome específico do dedo ou dedo do pé pode ser usado 
       <column name="definition_ru">Умник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">書呆子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nerd</column>
+      <column name="definition_fi">nörtti</column>
       <column name="synonyms">{qatru':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{ngomwI':n}, {ven:v}</column>
@@ -2916,6 +3212,9 @@ En vanligare term för detta är {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa palavra descreve alguém que realmente gosta de alguma coisa (ou de várias coisas), que participa de atividades associadas a isso e o faz muito a sério.
 
 Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana kuvaa henkilöä, joka on todella kiinnostunut jostakin (tai monista asioista), joka osallistuu siihen liittyvään toimintaan ja tekee niin hyvin vakavasti.
+
+Yleisempi termi tälle on {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{ven:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2925,6 +3224,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2932,6 +3232,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Festival of the Spoken Nerd DVD:src}</column>
     </table>
     <table name="mem">
@@ -2945,6 +3246,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">город</column>
       <column name="definition_zh_HK">城市</column>
       <column name="definition_pt">cidade</column>
+      <column name="definition_fi">kaupunki</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hatlh:n}</column>
       <column name="see_also">{Sep:n}, {yoS:n}</column>
@@ -2957,6 +3259,9 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{Qo'noS:n}:n tunnettuja kaupunkeja on:
+▶ {veng wa'DIch:n}
+▶ {ruq'e'vet:n}</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2966,6 +3271,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">urban</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2973,6 +3279,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2986,6 +3293,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Первый Город; столица {Qo'noS:n} [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">第一城（克洛诺斯的首都）</column>
       <column name="definition_pt">Primeira cidade; capital de {Qo'noS:n}</column>
+      <column name="definition_fi">Ensimmäinen kaupunki, {Qo'noS:n}:n pääkaupunki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIng yoS:n}</column>
@@ -2996,6 +3304,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} and not in the glossary.</column>
       <column name="components">{veng:n}, {wa'DIch:n:num}</column>
       <column name="examples"></column>
@@ -3005,6 +3314,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3012,6 +3322,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3025,6 +3336,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Первый Городской район [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">第一城州</column>
       <column name="definition_pt">região da Primeira Cidade</column>
+      <column name="definition_fi">Ensimmäisen kaupungin alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3035,6 +3347,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} and not in the glossary.</column>
       <column name="components">{veng wa'DIch:n}, {Sep:n}</column>
       <column name="examples"></column>
@@ -3044,6 +3357,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3051,6 +3365,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3064,6 +3379,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">деревня</column>
       <column name="definition_zh_HK">村</column>
       <column name="definition_pt">Vila</column>
+      <column name="definition_fi">kylä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3074,6 +3390,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{veng:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -3083,6 +3400,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3090,6 +3408,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3103,6 +3422,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">объявление, уведомление, объявление и т. д. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">公告、通知等</column>
       <column name="definition_pt">proclamação, notificação, anúncio e similares</column>
+      <column name="definition_fi">julistus, ilmoitus, tiedote, kuulutus tms.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maq:v}, {ruSvep:n}</column>
@@ -3113,6 +3433,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3122,6 +3443,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3129,6 +3451,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3142,6 +3465,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">чёрт, фэкилар</column>
       <column name="definition_zh_HK">魔鬼、惡魔、Fek'lhr [AUTOTRANSLATED]</column>
       <column name="definition_pt">diabo, demônio, Fek'lhr</column>
+      <column name="definition_fi">paholainen, demoni, Fek'lhr</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3152,6 +3476,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Существует идиома {qej; veqlargh rur@@qej:v, veqlargh:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{qej; veqlargh rur@@qej:v, veqlargh:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {qej; veqlargh rur@@qej:v, veqlargh:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {qej; veqlargh rur@@qej:v, veqlargh:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3162,6 +3487,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3169,6 +3495,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {TKW:src}, [3] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -3182,6 +3509,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Вы обращаете внимание на свой Fek'lhr, а я обращаю внимание на мой. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你注意你的Fek'lhr，我會關注我的。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você presta atenção ao seu Fek'lhr e eu prestarei atenção ao meu.</column>
+      <column name="definition_fi">Keskity omaan Fek'lhriisi ja minä keskityn omaani.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3192,6 +3520,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3201,6 +3530,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3208,6 +3538,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.197:src}</column>
     </table>
     <table name="mem">
@@ -3221,6 +3552,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">мусор</column>
       <column name="definition_zh_HK">垃圾</column>
       <column name="definition_pt">lixo</column>
+      <column name="definition_fi">roska, jäte</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DI:n}</column>
@@ -3231,6 +3563,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/PBM4fiXLc-U} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/PBM4fiXLc-U} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/PBM4fiXLc-U} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/PBM4fiXLc-U} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3240,6 +3573,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">trash</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3247,6 +3581,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3260,6 +3595,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Мусорный судно</column>
       <column name="definition_zh_HK">垃圾船</column>
       <column name="definition_pt">embarcação de lixo</column>
+      <column name="definition_fi">roska-alus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{veQ:n}, {Duj:n:1}</column>
@@ -3270,6 +3606,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{veQ:n}, {Duj:n:1}</column>
       <column name="examples">
@@ -3280,6 +3617,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3287,6 +3625,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3300,6 +3639,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Твой корабль - это мусорный судно.</column>
       <column name="definition_zh_HK">你的船是垃圾船。</column>
       <column name="definition_pt">Seu navio é uma embarcação de lixo.</column>
+      <column name="definition_fi">Aluksesi on roska-alus.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3310,6 +3650,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{veQDuj:n}, {'oH:n}, {Duj:n:1}, {-lIj:n}, {-'e':n}</column>
       <column name="examples"></column>
@@ -3319,6 +3660,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3326,6 +3668,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -3339,6 +3682,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть спиральным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">螺旋型</column>
       <column name="definition_pt">ser espiral</column>
+      <column name="definition_fi">olla kierteinen, spiraalinmuotoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI'rab:n}, {ver:v:2}</column>
@@ -3349,6 +3693,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это слово может использоваться, чтобы говорить о ветре ({SuS:n}). Например, {ver SuS'a':sen@@ver:v:1, SuS:n, -'a':n} означает «случается торнадо». {ver SuS:sen@@ver:v:1, SuS:n} или {ver SuSHom:sen@@ver:v:1, SuS:n, -Hom:n}, скорее всего, относятся к вихрю. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞可以用來談論風（{SuS:n}）。例如，{ver SuS'a':sen@@ver:v:1, SuS:n, -'a':n}表示“發生龍捲風”。 {ver SuS:sen@@ver:v:1, SuS:n}或{ver SuSHom:sen@@ver:v:1, SuS:n, -Hom:n}最有可能是指旋風。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää puhumaan tuulesta ({SuS:n}). Esimerkiksi {ver SuS'a':sen@@ver:v:1, SuS:n, -'a':n} tarkoittaa "tapahtuu tornado". {ver SuS:sen@@ver:v:1, SuS:n} tai {ver SuSHom:sen@@ver:v:1, SuS:n, -Hom:n} viittaisivat todennäköisesti pyörremyrskyyn. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3358,6 +3703,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3365,6 +3711,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3378,6 +3725,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть головокружительным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頭暈</column>
       <column name="definition_pt">ficar tonto</column>
+      <column name="definition_fi">olla pyörryksissä, huimata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vul:v}, {ver:v:1}</column>
@@ -3388,6 +3736,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Vertigo".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3397,6 +3746,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3404,6 +3754,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3417,6 +3768,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">заклепка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鉚釘</column>
       <column name="definition_pt">rebite</column>
+      <column name="definition_fi">niitti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hut'In vIl:n}</column>
@@ -3427,6 +3779,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Frog"s make the sound "rivet".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3436,6 +3789,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">screw, nail</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3443,6 +3797,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3456,6 +3811,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Франциско [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">弗朗西斯科 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Francisco</column>
+      <column name="definition_fi">Francisco</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -3466,6 +3822,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3475,6 +3832,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3482,6 +3840,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -3495,6 +3854,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Ференги</column>
       <column name="definition_zh_HK">佛瑞吉人</column>
       <column name="definition_pt">Ferengi</column>
+      <column name="definition_fi">ferengi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{verenganar:n}, {verengan Ha'DIbaH:n}</column>
@@ -3505,6 +3865,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Ференги известны своей жадностью, что отражено в сравнении {qur; verengan rur@@qur:v, verengan:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">Ferengis以貪婪著稱，在比較{qur; verengan rur@@qur:v, verengan:n, rur:v}中可以看出。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os Ferengis são conhecidos por sua ganância, como refletido na comparação {qur; verengan rur@@qur:v, verengan:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ferengit tunnetaan ahneudestaan, mikä näkyy vertailussa {qur; verengan rur@@qur:v, verengan:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{verenganar:n}, {ngan:n}</column>
       <column name="examples">
@@ -3515,6 +3876,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3522,6 +3884,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3536,6 +3899,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Ференгинар [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Ferenginar [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ferenginar</column>
+      <column name="definition_fi">Ferenginaari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{verengan:n}</column>
@@ -3546,6 +3910,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это название Дома Ференги, основной планеты в Альянсе Ференги. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是Ferengi聯盟的主要星球Ferengi Homeworld的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome do Ferengi Homeworld, o planeta principal da Aliança Ferengi. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on nimi Ferengi Homeworldille, joka on Ferengi-allianssin ensisijainen planeetta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3555,6 +3920,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3562,6 +3928,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3575,6 +3942,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">Собака ференги, оскорбление [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Ferengi狗、一種侮辱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Cão Ferengi, um insulto</column>
+      <column name="definition_fi">eräs haukkuma, ferengikoira</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3585,6 +3953,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/8MLXFbHYZOk} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/8MLXFbHYZOk} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/8MLXFbHYZOk} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/8MLXFbHYZOk} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{verengan:n}, {Ha'DIbaH:n:2}</column>
       <column name="examples"></column>
@@ -3594,6 +3963,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3601,6 +3971,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -3614,6 +3985,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">док</column>
       <column name="definition_zh_HK">碼頭、停車場、機場</column>
       <column name="definition_pt">doca, porto (porto, aeroporto, porto espacial)</column>
+      <column name="definition_fi">satama, telakka (merisatama, lentokenttä, avaruussatama jne.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vergh:v}, {'otHel:n}</column>
@@ -3624,6 +3996,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к месту со структурой, к которой прикрепляют сосуд, например, к пирсу.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指具有將船隻連接到碼頭的結構的地方。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um local com uma estrutura para anexar uma embarcação, como um píer.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa paikkaan, jossa on rakenne, johon alus voidaan kiinnittää, kuten laituri.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined only as "dock" in {TKD:src}. The definition was expanded at {qep'a' 25 (2018):src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3633,6 +4006,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">parking</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3640,6 +4014,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -3653,6 +4028,7 @@ Um termo mais comum para isso é {qatru':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">стыковаться</column>
       <column name="definition_zh_HK">碼頭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atracar, ancorar</column>
+      <column name="definition_fi">telakoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vergh:n}, {tengchaH:n}</column>
@@ -3677,6 +4053,9 @@ I {Klingon Monopoly:src} översätts "Free Parking" till {vergh 'ach DIlnISbe':s
       <column name="notes_pt">O objeto é o veículo que está ancorado.[3]
 
 Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'ach DIlnISbe':sen:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on telakoitu ajoneuvo.[3]
+
+{Klingon Monopoly:src}-ohjelmassa "ilmainen pysäköinti" käännetään nimellä {vergh 'ach DIlnISbe':sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3687,6 +4066,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">park, parking</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3694,6 +4074,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}, [3] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -3707,6 +4088,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">война, война [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰爭（概念）</column>
       <column name="definition_pt">guerra, batalha</column>
+      <column name="definition_fi">sota, sodankäynti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIq:n}, {Qoj:v}</column>
@@ -3717,6 +4099,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru">Сравните это с {noH:n}, который относится к определенной войне. [1, p.47] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與此形成鮮明對比的是{noH:n}，後者是指一場特定的戰爭。[1, p.47] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Compare isso com {noH:n}, que se refere a uma guerra específica.[1, p.47] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kontrasti tämä kohdalla {noH:n}, joka viittaa tiettyyn sotaan[1, p.47] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3727,6 +4110,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3734,6 +4118,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3747,6 +4132,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">военный корабль</column>
       <column name="definition_zh_HK">軍艦</column>
       <column name="definition_pt">navio de guerra</column>
+      <column name="definition_fi">sota-alus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3757,6 +4143,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{veS:n}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -3766,6 +4153,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3773,6 +4161,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3786,6 +4175,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">вестай (ранг) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">vestai（排名） [AUTOTRANSLATED]</column>
       <column name="definition_pt">vestai (rank)</column>
+      <column name="definition_fi">vestai (arvo)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3796,6 +4186,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru">От низшего к высшему эти ранги: {tay:n:3}, {Sutay:n}, {veStay:n:nolink}, {Santay:n}, {'Iptay:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從最低到最高，這些排名是：{tay:n:3}、{Sutay:n}、{veStay:n:nolink}、{Santay:n}、{'Iptay:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Do menor para o mais alto, essas classificações são: {tay:n:3}, {Sutay:n}, {veStay:n:nolink}, {Santay:n}, {'Iptay:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Alimmasta korkeimpaan nämä rivit ovat: {tay:n:3}, {Sutay:n}, {veStay:n:nolink}, {Santay:n}, {'Iptay:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a rank from John M. Ford's 1984 novel "The Final Reflection". These ranks are used by many Klingon fan clubs, despite not appearing in canon (i.e., in any TV episode or movie).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3805,6 +4196,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3812,6 +4204,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -3825,6 +4218,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">таракан</column>
       <column name="definition_zh_HK">曱甴、蟑螂</column>
       <column name="definition_pt">barata</column>
+      <column name="definition_fi">torakka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghew:n}, {'I' ghew:n}</column>
@@ -3835,6 +4229,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Marc Okrand decided to put this word into {TKD:src} because he thought that if any animal survives into the future, it would surely be the cockroach.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3844,6 +4239,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3851,6 +4247,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2019.09.26:src}</column>
     </table>
     <table name="mem">
@@ -3865,6 +4262,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">вставьте, вставьте штифт (прикрепите или закрепите штифтом) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">插入、放入、銷（用別針固定或固定） [AUTOTRANSLATED]</column>
       <column name="definition_pt">inserir, colocar, prender (prender ou amarrar com um prendedor)</column>
+      <column name="definition_fi">pistää, panna sisään; kiinnittää nuppineulalla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'on vevwI':n}, {'emvI':n}, {vaH:n}</column>
@@ -3875,6 +4273,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru">Это один из возможных глаголов для использования с {watrIn:n}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是與{watrIn:n}.[3]一起使用的可能動詞 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um verbo possível para usar com {watrIn:n}.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined as "insert, put in" in 2015.[1] It was expanded to include "pin, attach or fasten with a pin" in 2016.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3884,6 +4283,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3891,6 +4291,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}, [2] {Saarbrücken qepHom'a' 2016:src}, [3] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -3904,6 +4305,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">упаковка, упаковка, набор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">包裝、包裝、套裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pacote, conjunto</column>
+      <column name="definition_fi">paketti, pakkaus, sarja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chovnatlh:n}, {'aplo':n}</column>
@@ -3914,6 +4316,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In the "Limited Edition" example, since {veymey:n:nolink} is plural, the correct grammar should have {luchenmoHlu'pu':v:nolink}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3927,6 +4330,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">copy, edition, deck</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3934,6 +4338,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -3947,6 +4352,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">быть комфортным, быть в изобилии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要舒服、要充足 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser confortável, ser abundante</column>
+      <column name="definition_fi">olla riittävä, olla runsas</column>
       <column name="synonyms"></column>
       <column name="antonyms">{vey'Ha':v}</column>
       <column name="see_also">{'Iq:v}</column>
@@ -3957,6 +4363,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru">Это похоже на {yap:v}, но {vey':v:nolink} подразумевает, что его более чем достаточно / достаточно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on samanlainen kuin {yap:v}, mutta {vey':v:nolink} tarkoittaa olevan enemmän kuin riittävä / riittävä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3966,6 +4373,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3973,6 +4381,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3986,6 +4395,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">быть неудобным, быть скудным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不舒服、微薄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desconfortável, ser escasso</column>
+      <column name="definition_fi">olla riittämätön, olla niukka</column>
       <column name="synonyms"></column>
       <column name="antonyms">{vey':v}</column>
       <column name="see_also"></column>
@@ -3996,6 +4406,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru">Это означает, что более чем недостаточно или недостаточно (см. {yap:v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不僅意味著不足或不足（請參閱{yap:v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa mais do que não ser suficiente ou ser insuficiente (consulte {yap:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa enemmän kuin ei riitä tai riittämätön (katso {yap:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vey':v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -4005,6 +4416,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4012,6 +4424,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -4025,6 +4438,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">путешествовать с целью, по определенной причине; путешествовать на миссии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">出於特定原因有目的地旅行;旅行團 [AUTOTRANSLATED]</column>
       <column name="definition_pt">viajar com um propósito, por um motivo específico; viajar em missão</column>
+      <column name="definition_fi">matkustaa tarkoituksella tai tehtävällä, tietystä syystä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{leng:v}</column>
@@ -4035,6 +4449,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4045,6 +4460,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4052,6 +4468,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -4065,6 +4482,7 @@ Em {Klingon Monopoly:src}, "Estacionamento gratuito" é traduzido como {vergh 'a
       <column name="definition_ru">я-его/её/их</column>
       <column name="definition_zh_HK">我：他、它、他們、它們</column>
       <column name="definition_pt">Eu-ele/ela/eles</column>
+      <column name="definition_fi">minä-häntä/sitä/heitä/niitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mu-:v:pref}</column>
       <column name="see_also">{wI-:v:pref}, {DI-:v:pref}, {jI-:v:pref}</column>
@@ -4077,6 +4495,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4086,6 +4505,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">I-him, I-her, I-it, I-them</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4093,6 +4513,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4106,6 +4527,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">двигаться во времени к будущему [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">走向時間走向未來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">avançar no tempo em direção ao futuro</column>
+      <column name="definition_fi">liikkua ajassa eteenpäin (kohti tulevaisuutta)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{vIbHa':v}</column>
       <column name="see_also">{vIb:v:2}, {poH qut:n}</column>
@@ -4116,6 +4538,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4127,6 +4550,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">time-travel, time travel</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4134,6 +4558,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4147,6 +4572,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">propagate (not in reference to plants) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傳播（不參考植物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">propagar, difundir</column>
+      <column name="definition_fi">kulkea väliaineessa ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIb:v:1}</column>
@@ -4157,6 +4583,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined parenthetically in the definition of {vIb:v:1,nolink}. The note that this is not used in reference to plants implies that this means "to be transmitted, as through a medium", and not "to breed".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4166,6 +4593,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4173,6 +4601,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4186,6 +4615,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">двигаться во времени в прошлое [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">從時間走向過去 [AUTOTRANSLATED]</column>
       <column name="definition_pt">avançar através do tempo em direção ao passado</column>
+      <column name="definition_fi">liikkua ajassa taaksepäin (kohti menneisyyttä)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{vIb:v:1}</column>
       <column name="see_also">{poH qut:n}</column>
@@ -4196,6 +4626,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vIb:v:1}, {-Ha':v}</column>
       <column name="examples">
@@ -4207,6 +4638,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4214,6 +4646,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4227,6 +4660,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">быть воюющим</column>
       <column name="definition_zh_HK">好戰的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser beligerante</column>
+      <column name="definition_fi">olla sotiva, sotaa käyvä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4237,6 +4671,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4246,6 +4681,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4253,6 +4689,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -4266,6 +4703,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">дефлектор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">障 [AUTOTRANSLATED]</column>
       <column name="definition_pt">deflector</column>
+      <column name="definition_fi">jakolevy ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wab:n}, {SIp:n}</column>
@@ -4276,6 +4714,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это устройство, которое регулирует поток газа, звука и т. Д. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是調節氣體，聲音等流量的設備。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um dispositivo que regula o fluxo de gás, som etc. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on laite, joka säätelee kaasun, äänen jne. Virtausta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4285,6 +4724,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">filter, regulator</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4292,6 +4732,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -4305,6 +4746,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">тип животного, в'гро (как кошка) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、v'gro（像貓一樣） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, v'gro (como um gato)</column>
+      <column name="definition_fi">erös kissan kaltainen eläin, v'gro</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tI'qa' vIghro':n}, {ghISnar:n}, {'Imyagh:excl}, {Huy:v:1}, {Saj:n}</column>
@@ -4315,6 +4757,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Figaro" is the name of the cat in Disney's Pinocchio. This word isn't named directly for that, but via an actual cat named "Figaro".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4324,6 +4767,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cat, feline, kitten</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4331,6 +4775,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4344,6 +4789,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">быть в движении</column>
       <column name="definition_zh_HK">移動、動起來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">se mover, estar em movimento</column>
+      <column name="definition_fi">liikkua, olla liikkeessä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mev:v}</column>
@@ -4368,6 +4814,9 @@ För {taD:v} för ett idiomatiskt uttryck som används för att säga någon att
       <column name="notes_pt">Este verbo é intransitivo. Para dizer que alguém ou algo move alguém ou alguma outra coisa, use {vIHmoH:v:nolink}.[2]
 
 Para obter uma expressão idiomática usada para dizer a alguém para não se mover, consulte {taD:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä verbi on intransitiivinen. Käytä {vIHmoH:v:nolink}.[2] sanomaan, että joku tai joku liikuttaa ketään tai jotain muuta.
+
+Katso idioomaattinen ilmaisu, jota käytetään käskemään jotakuta liikkumaan, katso {taD:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4377,6 +4826,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4384,6 +4834,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {HQ 7.4, p.3, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -4397,6 +4848,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">обруч движется [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">箍正在移動 [AUTOTRANSLATED]</column>
       <column name="definition_pt">o aro está em movimento</column>
+      <column name="definition_fi">vanne on liikkeessä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pav:v}, {nom:adv}
@@ -4409,6 +4861,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это идиоматическое выражение означает, что началась деятельность конечной (хотя, возможно, неопределенной) длины. Это происходит от {qa'vaQ:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語表示已經開始進行有限（儘管可能不確定）長度的活動。它源自{qa'vaQ:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa expressão idiomática significa que uma atividade de comprimento finito (embora talvez indeterminado) foi iniciada. É originário de {qa'vaQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa, että rajallisen (vaikka ehkä määrittelemättömän) pituuden toiminta on alkanut. Se on peräisin {qa'vaQ:n}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vIH:v}, {-taH:v}, {gho:n}</column>
       <column name="examples">
@@ -4419,6 +4872,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4426,6 +4880,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.111:src}</column>
     </table>
     <table name="mem">
@@ -4439,6 +4894,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">толкатель</column>
       <column name="definition_zh_HK">火箭推進器（單數）</column>
       <column name="definition_pt">propulsor</column>
+      <column name="definition_fi">(työntö)moottori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{laQ:v}</column>
@@ -4449,6 +4905,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{chuyDaH:n:inhpl}</column>
       <column name="examples"></column>
@@ -4458,6 +4915,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4465,6 +4923,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4478,6 +4937,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">быть зачарованным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">是（前額） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser rugoso (a testa)</column>
+      <column name="definition_fi">olla harjantainen (otsasta)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hab:v}</column>
       <column name="see_also">{Quch:n}, {Hut'In vIl:n}</column>
@@ -4488,6 +4948,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">See {Hut'In vIl:n} for the pun behind {vIl:v:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4497,6 +4958,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4504,6 +4966,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 13.1, p.10, Mar. 2004:src}</column>
     </table>
     <table name="mem">
@@ -4517,6 +4980,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">быть крутым (как в шикарном) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">很酷（如別緻） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser legal</column>
+      <column name="definition_fi">olla viileä, siisti, cooli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qu':v:2}</column>
@@ -4527,6 +4991,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4536,6 +5001,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4543,6 +5009,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -4556,6 +5023,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">кто-то или что-то, кто только там; кто-то, кто рядом, когда ты [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">某人或某物就在那裡;你身邊的人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alguém ou algo que está lá; alguém que está por perto quando você está</column>
+      <column name="definition_fi">joku tai jokin, joka on läsnä kun itse on läsnä?; hidaste, töyssy</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4567,6 +5035,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">When this word was defined at {qep'a' 16 (2009):src}, a description of an object which was recognised as a "speed bump" was given as an example of a {vIl:n:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4576,6 +5045,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4583,6 +5053,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 16 (2009):src}</column>
     </table>
     <table name="mem">
@@ -4596,6 +5067,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">последователь, ученик, поклонник, поклонник, миньон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">追隨者、門徒、粉絲、崇拜者、奴才 [AUTOTRANSLATED]</column>
       <column name="definition_pt">seguidor, discípulo, adepto, admirador, lacaio</column>
+      <column name="definition_fi">seuraaja, opetuslapsi, fani, ihailija, kätyri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4606,6 +5078,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Pun: "filet mignon".</column>
       <column name="components">{vIl:n}, {le':v}</column>
       <column name="examples"></column>
@@ -4615,6 +5088,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4622,6 +5096,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 16 (2009):src}</column>
     </table>
     <table name="mem">
@@ -4635,6 +5110,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">гребень лба [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">前額脊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cume da testa</column>
+      <column name="definition_fi">otsaharjanne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghul:n}</column>
@@ -4645,6 +5121,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">A sugestão foi feita em {qep'a' 16 (2009):src} de que um {vIlHom:n:nolink} poderia ser uma única crista em um {Quch:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ehdotus tehtiin kohdassa {qep'a '16 (2009): src}, että {vIlHom:n:nolink} voisi olla yksi harjanne {Quch:n}: ssa.{qep'a' 16 (2009):src} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vIl:v:1} or {vIl:n:2,hyp,nolink}, {Hom:n:1}</column>
       <column name="examples"></column>
@@ -4654,6 +5131,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4661,6 +5139,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 16 (2009):src}</column>
     </table>
     <table name="mem">
@@ -4674,6 +5153,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">вид птицы, попугай [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種鳥、鸚鵡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma espécie de pássaro, papagaio</column>
+      <column name="definition_fi">eräs papukaijaa muistuttava lintu (joka osaa jäljitellä puhetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qaryoq:n}, {qaryoq'a':n}</column>
@@ -4684,6 +5164,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是一隻能模仿說話的鳥。有些人使用{-pu':n:suff}將這個詞複數，但大多數人使用{-mey:n:suff}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um pássaro capaz de imitar a fala. Algumas pessoas pluralizam essa palavra com {-pu':n:suff}, mas a maioria usa {-mey:n:suff}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lintu, joka kykenee matkimaan puhetta. Jotkut ihmiset moninkertaistavat tämän sanan sanalla {-pu':n:suff}, mutta useimmat käyttävät sanaa {-mey:n:suff}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Captain Flint, Long John Silver's parrot in "Treasure Island".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4693,6 +5174,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4700,6 +5182,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4713,6 +5196,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">{lor:n:0} или {tey':n:0}; двоюродный брат, племянник / племянница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">{lor:n:0}或{tey':n:0};堂兄、侄子/侄女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">{lor:n:0} ou {tey':n:0}; primo, sobrinho / sobrinha</column>
+      <column name="definition_fi">{lor:n:0} tai {tey':n:0}; serkku, veljentytär, tyttärentytär, veljenpoika, tyttärenpoika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lor:n:0}, {tey':n:0}, {yur:n}</column>
@@ -4723,6 +5207,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">В единственном числе, как правило, {tey':n:nolink} или {lor:n:nolink} является предпочтительным, если индивидуум не упоминается как член группы, которая, вероятно, включает в себя {tey':n:nolink} и / или {lor:n:nolink}. Форма множественного числа {vInpu':n:nolink} используется для группы, которая включает в себя {tey':n:nolink} и / или {lor:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">No singular, normalmente {tey':n:nolink} ou {lor:n:nolink} é preferido, a menos que o indivíduo esteja sendo referido como membro de um grupo que provavelmente inclui {tey':n:nolink} e / ou {lor:n:nolink}. A forma plural {vInpu':n:nolink} é usada para um grupo que inclui {tey':n:nolink} e / ou {lor:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksittäisessä muodossa suositellaan tyypillisesti {tey':n:nolink} tai {lor:n:nolink}, ellei yksilöä kutsuta ryhmän jäseneksi, joka todennäköisesti sisältää sekä {tey':n:nolink} että {lor:n:nolink}. Monikkomuotoa {vInpu':n:nolink} käytetään ryhmälle, joka sisältää {tey':n:nolink} ja / tai {lor:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A reference to the movie "My Cousin Vinny".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4732,6 +5217,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4739,6 +5225,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -4752,6 +5239,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">печь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">爐</column>
       <column name="definition_pt">forno, fornalha</column>
+      <column name="definition_fi">uuni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mItlh:v}, {Qu:v}, {baS laSvargh:n}, {QumeH ngaSwI':n}</column>
@@ -4762,6 +5250,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4771,6 +5260,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4778,6 +5268,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4791,6 +5282,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">соотечественник, член сообщества, когорта, согражданин [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">同胞、社區成員、同夥、同胞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">compatriota, membro da comunidade, coorte, concidadão</column>
+      <column name="definition_fi">maanmies, yhteisön jäsen, kohortti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuD:n}, {nugh:n}</column>
@@ -4801,6 +5293,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The example sentence is a lip-match for {'ej DochmeywIj vItlhapqa'meH}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4811,6 +5304,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4818,6 +5312,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -4831,6 +5326,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">бобы финовы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《finova》豆</column>
       <column name="definition_pt">feijão (s) finova</column>
+      <column name="definition_fi">eräs elintarvike, finova-papu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qurgh:n}</column>
@@ -4841,6 +5337,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4850,6 +5347,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4857,6 +5355,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -4870,6 +5369,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">скулить</column>
       <column name="definition_zh_HK">抱怨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lamento</column>
+      <column name="definition_fi">ulista, vinkua, inistä, kitistä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bep:v}, {boj:v}</column>
@@ -4880,6 +5380,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4889,6 +5390,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4896,6 +5398,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4909,6 +5412,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">битва, бой (аннотация) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰鬥（概念）</column>
       <column name="definition_pt">batalha, combate (abstrato)</column>
+      <column name="definition_fi">taistelu, kamppailu (käsitteenä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{veS:n}, {Qoj:v}</column>
@@ -4919,6 +5423,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это слово относится к абстрактной концепции боя. Конкретная битва {may':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞指的是戰鬥的抽象概念。具體的戰鬥是{may':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra refere-se ao conceito abstrato de combate. Uma batalha específica é um {may':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana viittaa taistelun abstraktiin käsitteeseen. Erityinen taistelu on {may':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The TV show "Combat!" starred Vic Morrow.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4928,6 +5433,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4935,6 +5441,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4948,6 +5455,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">артефакт, произведение искусства [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">神器、藝術品 [AUTOTRANSLATED]</column>
       <column name="definition_pt">artefato, obra de arte</column>
+      <column name="definition_fi">artefakti, taideteos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jan:n:1}, {SommI':n}, {mutlh:v}</column>
@@ -4958,6 +5466,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Этот термин является более общим, чем визуальное произведение искусства. Он охватывает это, но также и артефакт (не в археологическом смысле), ремесло, штуковину, гаджет, устройство, машину, устройство и т. Д. То есть относится к чему-то произведенному или изготовленному. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該術語比視覺藝術品更為籠統。它涵蓋了這些內容，還涵蓋了人工製品（不是考古意義上的），手工藝品，小發明，小工具，設備，機器，設備等。也就是說，它是指已製造或製造的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo é mais geral do que uma obra de arte visual. Ele abrange isso, mas também um artefato (não no sentido arqueológico), artesanato, aparelhos, engenhocas, engenhocas, máquinas, dispositivos, etc. Ou seja, refere-se a algo fabricado ou fabricado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä termi on yleisempi kuin visuaalinen taideteos. Se kattaa sen, mutta myös esineistön (ei arkeologisessa mielessä), käsityön, gizmo, gadgetin, muunnoksen, koneen, laitteen jne. Toisin sanoen se viittaa johonkin valmistettuun tai valmistettuun. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Fake rock".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4967,6 +5476,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gizmo, gadget, contraption, artefact</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4974,6 +5484,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4987,6 +5498,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">Vixis [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《Vixis》</column>
       <column name="definition_pt">Vixis</column>
+      <column name="definition_fi">Vixis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlha'a:n:name}</column>
@@ -4997,6 +5509,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5006,6 +5519,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5013,6 +5527,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.197:src}</column>
     </table>
     <table name="mem">
@@ -5026,6 +5541,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">задыхаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">窒息 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sufocar</column>
+      <column name="definition_fi">tukehtua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{voQ:v}</column>
@@ -5036,6 +5552,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это значит быть лишенным воздуха. Для «утопить», перед глаголом {bIQDaq:sen@@bIQ:n, -Daq:n} или тому подобное. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著被剝奪空氣。對於“淹沒”，在動詞前加上{bIQDaq:sen@@bIQ:n, -Daq:n}等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa ser privado de ar. Para "afogar-se", preceda o verbo com {bIQDaq:sen@@bIQ:n, -Daq:n} ou algo semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa ilman riistämistä. Sana "hukkua" edeltää verbiä {bIQDaq:sen@@bIQ:n, -Daq:n} tai vastaavalla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was confirmed not to take an object.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5045,6 +5562,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">drown</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5052,6 +5570,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5065,6 +5584,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">задушить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">扼殺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sufocar</column>
+      <column name="definition_fi">tukahduttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5075,6 +5595,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это означает, что кто-то / что-то лишается воздуха. Для «утопить», перед глаголом {bIQDaq:sen@@bIQ:n, -Daq:n} или тому подобное. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著使某人/某物沒有空氣。對於“淹沒”，在動詞前加上{bIQDaq:sen@@bIQ:n, -Daq:n}等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa fazer com que alguém / algo seja privado de ar. Para "afogar-se", preceda o verbo com {bIQDaq:sen@@bIQ:n, -Daq:n} ou algo semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa, että joku / joku menettää ilman. Sana "hukkua" edeltää verbiä {bIQDaq:sen@@bIQ:n, -Daq:n} tai vastaavalla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vIQ:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -5084,6 +5605,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">drown</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5091,6 +5613,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5104,6 +5627,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">разрывать (вверх), рубить, рвать (вверх), ранить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">撕裂（向上），斜線，撕裂（向上），煤氣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rasgar, cortar</column>
+      <column name="definition_fi">repiä (palasiksi)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pe':v}, {rIv:v}</column>
@@ -5114,6 +5638,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Например, это будет использовано для копирования фотографии пополам. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">例如，這將用於將照片撕成兩半。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Por exemplo, isso seria usado para rasgar uma foto ao meio. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään esimerkiksi kuvan repimiseen kahtia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5123,6 +5648,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5130,6 +5656,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -5143,6 +5670,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">Все оружие под моим контролем! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">所有武器由我控制。</column>
       <column name="definition_pt">Todas as armas sob meu controle!</column>
+      <column name="definition_fi">Siirrä kaikki aseet hallintaani!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5153,6 +5681,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vI-:v}, {SeH:v}, {-meH:v}, {Hoch:n}, {nuH:n:1}, {-mey:n}, {Qay:v}</column>
       <column name="examples"></column>
@@ -5162,6 +5691,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5169,6 +5699,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -5182,6 +5713,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">говорить правду</column>
       <column name="definition_zh_HK">講真話、說實話</column>
       <column name="definition_pt">dizer a verdade</column>
+      <column name="definition_fi">kertoa totuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIt:n}, {nep:v}, {teH:v}, {'Ip:v}, {lugh:v}</column>
@@ -5192,6 +5724,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">From the Latin "veritus".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5201,6 +5734,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5208,6 +5742,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5221,6 +5756,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">правда</column>
       <column name="definition_zh_HK">真相</column>
       <column name="definition_pt">verdade</column>
+      <column name="definition_fi">totuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIt:v}, {teH:v}</column>
@@ -5231,6 +5767,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">From the Latin "veritus".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5240,6 +5777,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5247,6 +5785,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5260,6 +5799,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">Я это не делал(а).</column>
       <column name="definition_zh_HK">我沒有這樣做。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu não fiz isso.</column>
+      <column name="definition_fi">En tehnyt sitä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5270,6 +5810,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5279,6 +5820,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5286,6 +5828,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -5300,6 +5843,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">проверка правды, поединок правды [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">真相測試、真相決鬥</column>
       <column name="definition_pt">teste da verdade, duelo da verdade</column>
+      <column name="definition_fi">totuustesti, totuuskaksintaistelu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIt:n}, {Hay':v}</column>
@@ -5310,6 +5854,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It's not specified whether this is a noun or a verb, but it's likely to be a noun, even though {Hay':n:nolink,hyp} is not known to exist as a noun.</column>
       <column name="components">{vIt:v} or {vIt:n}, {Hay':v} or {Hay':n:nolink,hyp}</column>
       <column name="examples"></column>
@@ -5319,6 +5864,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5326,6 +5872,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -5339,6 +5886,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">пословица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">諺語、俗話</column>
       <column name="definition_pt">provérbio</column>
+      <column name="definition_fi">sanonta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5349,6 +5897,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vIt:n}, {tlhegh:n}</column>
       <column name="examples"></column>
@@ -5358,6 +5907,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5365,6 +5915,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 5.1, Mar. 1996 p.10:src}</column>
     </table>
     <table name="mem">
@@ -5378,6 +5929,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">быть высоким, отличным (по количеству, размеру, интенсивности) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">很高、很棒（數量、大小、強度） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser alto, grande (em quantidade, tamanho, intensidade)</column>
+      <column name="definition_fi">olla korkea (nopeus tms.), olla suuri (määrällisesti, kooltaan, voimakkuudeltaan)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iq:v}</column>
@@ -5388,6 +5940,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это используется для вещей, которые измеримы или измеримы, но не обязательно исчисляются. Для счетных вещей обычно используется {law':v}, но {vItlh:v:nolink} будет использоваться, если число будет больше, чем обычно, или больше, чем раньше, или больше, чем ожидалось.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">用於可測量或可量化但不一定可計數的事物。對於可數事物，通常將使用{law':v}，但是如果該數字大於正常或大於之前或大於預期，則將使用{vItlh:v:nolink}。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para coisas que são mensuráveis ​​ou quantificáveis, mas não necessariamente contáveis. Para itens contáveis, {law':v} normalmente seria usado, mas {vItlh:v:nolink} seria usado se o número fosse maior que o normal ou maior que antes ou maior que o esperado.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään asioihin, jotka ovat mitattavissa tai mitattavissa, mutta eivät välttämättä laskettavissa. Laskettavissa oleviin asioihin käytettäisiin normaalisti {law':v}, mutta {vItlh:v:nolink} käytettäisiin, jos lukumäärä on normaalia suurempi tai suurempi kuin ennen tai suurempi kuin odotettiin.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5400,6 +5953,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5407,6 +5961,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Smithsonian GO FLIGHT app:src}, [2] {Saarbrücken qepHom'a' 2016:src}, [3] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -5420,6 +5975,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">сок, сок растения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">果汁、植物的汁液</column>
       <column name="definition_pt">suco, seiva de uma planta</column>
+      <column name="definition_fi">(hedelmän tms.) mehu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rebmugh;n}</column>
@@ -5430,6 +5986,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это любая жидкость из растения. На некоторых региональных диалектах это слово используется для обозначения любых жидких сопутствующих продуктов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是來自工廠的任何液體。在某些地區性方言中，該詞用於任何伴隨食物的液體。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é qualquer líquido de uma planta. Em alguns dialetos regionais, essa palavra é usada para qualquer alimento líquido que o acompanhe. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on mitä tahansa laitoksen nestettä. Joissakin alueellisissa murteissa tätä sanaa käytetään kaikkiin nestemäisiin ruokiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"V8" is a juice blend made from tomato juice mixed with the juices of various vegetables.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5439,6 +5996,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5446,6 +6004,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5459,6 +6018,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">накапливать</column>
       <column name="definition_zh_HK">積累 [AUTOTRANSLATED]</column>
       <column name="definition_pt">acumular</column>
+      <column name="definition_fi">kerääntyä, kasaantua</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chen:v}</column>
@@ -5469,6 +6029,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Ушная сера (см. {Serrum:n}), как говорят, делает это в ухе.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">據說耳垢（請參見{Serrum:n}）可以在耳朵中做到這一點。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Diz-se que a cera de ouvido (consulte {Serrum:n}) faz isso na orelha.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Korvanvahan (katso {Serrum:n}) sanotaan tekevän tämän korvalla.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5478,6 +6039,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5485,6 +6047,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 12.4, p.9, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -5498,6 +6061,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">меткая стрельба</column>
       <column name="definition_zh_HK">槍法</column>
       <column name="definition_pt">atiradores de elite, atirador desportivo</column>
+      <column name="definition_fi">tarkka-ampuminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baH:v}, {bach:v}</column>
@@ -5508,6 +6072,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5518,6 +6083,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5525,6 +6091,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -5538,6 +6105,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">десятичная точка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小數點</column>
       <column name="definition_pt">ponto decimal</column>
+      <column name="definition_fi">desimaalierotin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vatlhvI':n}, {DoD:n}</column>
@@ -5548,6 +6116,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5558,6 +6127,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5565,6 +6135,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5578,6 +6149,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">косвенное дополнение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">間接賓語 [AUTOTRANSLATED]</column>
       <column name="definition_pt">objeto indireto</column>
+      <column name="definition_fi">epäsuora objekti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ovmay:n}, {SeSor:n}, {-vaD:n:suff}</column>
@@ -5588,6 +6160,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это грамматический термин. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個語法術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo gramatical. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kieliopin termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5597,6 +6170,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5604,6 +6178,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5617,6 +6192,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">волна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">浪潮</column>
       <column name="definition_pt">maré</column>
+      <column name="definition_fi">vuorovesi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIQ'a':n}, {yu'egh:n}</column>
@@ -5627,6 +6203,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Tide brand of laundry detergent is also sold under the mark Vizir. (Note that {vI'Ir:n:nolink} written in "xifan hol" is "vizir".)</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5636,6 +6213,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5643,6 +6221,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5656,6 +6235,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">туман, туман [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">霧</column>
       <column name="definition_pt">neblina</column>
+      <column name="definition_fi">sumu, usva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIS:v}, {'eng:n}, {tlhoD:v}</column>
@@ -5666,6 +6246,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to Phileas Fogg, the protagonist of the Jules Verne novel "Around the World in Eighty Days".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5675,6 +6256,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5682,6 +6264,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5695,6 +6278,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">сверло, отверстие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鑽、鑽孔 [AUTOTRANSLATED]</column>
       <column name="definition_pt">furar</column>
+      <column name="definition_fi">porata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hut'In vIl:n}</column>
@@ -5705,6 +6289,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5714,6 +6299,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5721,6 +6307,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5734,6 +6321,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">{voDmeH jan:n}</column>
       <column name="definition_zh_HK">{voDmeH jan:n}</column>
       <column name="definition_pt">{voDmeH jan:n}</column>
+      <column name="definition_fi">{voDmeH jan:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5744,6 +6332,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это сокращенная версия {voDmeH jan:n}, которую часто слышат. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是經常聽到的{voDmeH jan:n}的簡化版本。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma versão abreviada do {voDmeH jan:n}, que é frequentemente ouvida. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhennetty versio {voDmeH jan:n}: stä, joka kuuluu usein. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{voD:v}, {jan:n:1}</column>
       <column name="examples"></column>
@@ -5753,6 +6342,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5760,6 +6350,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5773,6 +6364,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">drill (device) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鑽頭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">furadeira</column>
+      <column name="definition_fi">pora</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5783,6 +6375,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="notes_ru">Это относится ко всему устройству, а не только к буровому долоту. Это часто сокращается до {voD jan:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指整個設備，而不僅僅是鑽頭。通常將其縮短為{voD jan:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a todo o dispositivo, não apenas à broca. Isso geralmente é reduzido para {voD jan:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa koko laitteeseen, ei vain poranterään. Tämä lyhennetään usein muotoon {voD jan:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is defined as "drill". The word "device" was added to disambiguate this from (and to be consistent in appearance with) {qeq:n} "drill (military)".</column>
       <column name="components">{voD:v}, {-meH:v}, {jan:n:1}</column>
       <column name="examples"></column>
@@ -5792,6 +6385,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5799,6 +6393,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5812,6 +6407,7 @@ Para obter uma expressão idiomática usada para dizer a alguém para não se mo
       <column name="definition_ru">паукообразное существо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蜘蛛般的生物</column>
       <column name="definition_pt">criatura tipo aranha</column>
+      <column name="definition_fi">eräs hämähäkin kaltainen eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5836,6 +6432,9 @@ En stor spindel på jorden skulle vara en {tera' voDchuch:n@@tera':n, voDchuch:n
       <column name="notes_pt">Esta é uma criatura parecida com uma aranha com nove pernas, mas às vezes sete ou oito (e não menos que sete, a menos que esteja ferida).
 
 Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas uma pequena aranha não seria um {voDchuch:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on hämähäkkimäinen olento, jolla on yhdeksän jalkaa, mutta joskus seitsemän tai kahdeksan (ja vähintään seitsemän, ellei se ole loukkaantunut).
+
+Suuri hämähäkki maan päällä olisi {tera' voDchuch:n@@tera':n, voDchuch:n}, mutta pieni hämähäkki ei olisi {voDchuch:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{voD:v} "bore" + {chuch:n} "ice" = Boris. "Boris the Spider" is a song by The Who.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5845,6 +6444,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">arachnid</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5852,6 +6452,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5865,6 +6466,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">император</column>
       <column name="definition_zh_HK">皇帝</column>
       <column name="definition_pt">imperador</column>
+      <column name="definition_fi">keisari</column>
       <column name="synonyms">{ta':n:2}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5875,6 +6477,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5884,6 +6487,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5891,6 +6495,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5904,6 +6509,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">мясо императора [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">皇帝的肉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">carne do imperador</column>
+      <column name="definition_fi">keisarin liha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5914,6 +6520,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Это относится к мясу, приготовленному {HaH:v:2}. Слово для конкретного мяса заменяет слово {Ha'DIbaH:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指{HaH:v:2}準備的肉。特定肉類的單詞代替了{Ha'DIbaH:n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à carne preparada pelo {HaH:v:2}. A palavra para a carne específica substitui a palavra {Ha'DIbaH:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa lihaan, jonka on valmistanut {HaH:v:2}. Erityisen lihan sana korvaa sanan {Ha'DIbaH:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{voDleH:n}, {Ha'DIbaH:n:1}</column>
       <column name="examples"></column>
@@ -5923,6 +6530,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5930,6 +6538,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.91:src}</column>
     </table>
     <table name="mem">
@@ -5943,6 +6552,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">где-нибудь, где-то</column>
       <column name="definition_zh_HK">某處 [AUTOTRANSLATED]</column>
       <column name="definition_pt">em algum lugar</column>
+      <column name="definition_fi">jossakin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vay':n}, {Dat:n}, {naDev:n}, {pa':n:2}</column>
@@ -5953,6 +6563,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">При использовании в качестве локатива за этим словом не следует суффикс локатора {-Daq:n:suff}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">用作位置詞時，此詞後不帶位置後綴{-Daq:n:suff}.[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä sanaa ei käytetä paikannimena, vaan sitä seuraa lokonatiivi-pääte {-Daq:n:suff}.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5964,6 +6575,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">anywhere, nowhere</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5971,6 +6583,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}, [3] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -5984,6 +6597,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">выкуп</column>
       <column name="definition_zh_HK">贖金 [AUTOTRANSLATED]</column>
       <column name="definition_pt">resgate</column>
+      <column name="definition_fi">lunnaat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quch:v}, {vub:n}, {wel:v}</column>
@@ -5994,6 +6608,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Это слово может быть объектом {wel:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該詞可以是{wel:v}的對象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra pode ser o objeto de {wel:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana voi olla {wel:v}-objektin kohde. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6004,6 +6619,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mortgage</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6011,6 +6627,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6024,6 +6641,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">залоговая стоимость [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">抵押價值 [AUTOTRANSLATED]</column>
       <column name="definition_pt">valor da hipoteca</column>
+      <column name="definition_fi">asuntolainan arvo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{voHDajbo':n}, {qav'ap:n}, {wel:v}</column>
@@ -6034,6 +6652,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Это слово используется в {Klingon Monopoly:src}, чтобы обозначить, сколько {QaS:n:1h} игрок получает за заклад планеты в банк. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{Klingon Monopoly:src}中使用了這個詞來表示玩家將一顆行星抵押給銀行而獲得多少{QaS:n:1h}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{voHDajbo':n}, {qav'ap:n}</column>
       <column name="examples"></column>
@@ -6043,6 +6662,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6050,6 +6670,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6063,6 +6684,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">панель, панель, лист (не для кровати) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">窗格、面板、床單（不適用於床） [AUTOTRANSLATED]</column>
       <column name="definition_pt">painel, quadro, tela</column>
+      <column name="definition_fi">paneeli, levy, laatta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rItlh:n}, {DIj:v:2}, {ngoH:v:2}, {nagh beQ:n}</column>
@@ -6073,6 +6695,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Это термин, связанный с произведениями искусства. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個與藝術品有關的術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo relacionado a obras de arte. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on taideteokseen liittyvä termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{rItlh vol:n}</column>
@@ -6082,6 +6705,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6089,6 +6713,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6102,6 +6727,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">плечо</column>
       <column name="definition_zh_HK">膊頭、肩膀</column>
       <column name="definition_pt">ombro</column>
+      <column name="definition_fi">olkapää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DeS:n:1}, {mong:n}, {ro:n}, {wIlle':n}</column>
@@ -6112,6 +6738,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6121,6 +6748,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6128,6 +6756,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6141,6 +6770,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">Вольтиманд [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Voltimand [AUTOTRANSLATED]</column>
       <column name="definition_pt">Voltimand</column>
+      <column name="definition_fi">Voltimand</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -6151,6 +6781,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6160,6 +6791,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6167,6 +6799,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -6180,6 +6813,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">ловушка, ловушка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陷阱、誘捕 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fazer armadilha, entrar</column>
+      <column name="definition_fi">pyydystää, saada ansaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6190,6 +6824,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to Captain "von Trapp" from The Sound of Music, who was played by Christopher Plummer, who of course was also General Chang ({cheng:n:name}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6199,6 +6834,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6206,6 +6842,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6219,6 +6856,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">полностью потерпеть неудачу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">徹底失敗了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falhar completamente</column>
+      <column name="definition_fi">epäonnistua täysin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{luj:v}</column>
@@ -6229,6 +6867,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Этот жаргонный термин не используется применительно к играм, но применяется только к более серьезным вопросам. [1, p.165] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個語不用於遊戲，而僅用於更嚴重的事情。[1, p.165] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo de gíria não é usado em referência a jogos, mas é aplicado apenas a assuntos mais sérios.[1, p.165] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä slangitermiä ei käytetä pelien yhteydessä, vaan sitä käytetään vain vakavammissa asioissa.[1, p.165] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Note that in the example, the prefix {bI-:v} is used rather than {Da-:v}. This might indicate that the apparent {-lu':v} suffix is a fossilized form and isn't truly the suffix.</column>
       <column name="components">{von:v}, {-lu':v}</column>
       <column name="examples">
@@ -6239,6 +6878,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6246,6 +6886,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6259,6 +6900,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">гипнотировать</column>
       <column name="definition_zh_HK">催眠 [AUTOTRANSLATED]</column>
       <column name="definition_pt">hipnotizar</column>
+      <column name="definition_fi">hypnotisoida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6269,6 +6911,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6278,6 +6921,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hypnotise</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6285,6 +6929,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6298,6 +6943,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">доверять</column>
       <column name="definition_zh_HK">信任、有信心、相信</column>
       <column name="definition_pt">Confiar, ter fé em</column>
+      <column name="definition_fi">luottaa, uskoa johonkuhun</column>
       <column name="synonyms"></column>
       <column name="antonyms">{voqHa':v}</column>
       <column name="see_also">{Har:v}, {Hovmey Davan.:sen}</column>
@@ -6308,6 +6954,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6321,6 +6968,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6328,6 +6976,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6341,6 +6990,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">недоверие</column>
       <column name="definition_zh_HK">懷疑</column>
       <column name="definition_pt">desconfiar</column>
+      <column name="definition_fi">ei luottaa, epäillä, tuntea epäluottamusta jotakin kohtaan</column>
       <column name="synonyms"></column>
       <column name="antonyms">{voq:v}</column>
       <column name="see_also">{pIH:v:2}</column>
@@ -6351,6 +7001,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{voq:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -6360,6 +7011,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6367,6 +7019,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6380,6 +7033,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">Voq [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">「福」</column>
       <column name="definition_pt">Voq</column>
+      <column name="definition_fi">Voq</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choH'a':n}</column>
@@ -6390,6 +7044,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Вок был изгоем, который называл себя «сыном никого» ({pagh puqloD:n@@pagh:n:1, puqloD:n}). Он является последователем {tIquvma:n:name} и получил роль {Sech qengwI':n} после смерти {rej'aq:n:name}. Он альбинос, цвет кожи которого был описан как {Dem:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">沃克（Voq）是一個流浪者，自稱“無子”（{pagh puqloD:n@@pagh:n:1, puqloD:n}）。他是{tIquvma:n:name}的追隨者，並在{rej'aq:n:name}去世後被賦予{Sech qengwI':n}的角色。他是一名白化病患者，其膚色被描述為{Dem:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Voq era um pária que se referia a si mesmo como "filho de ninguém" ({pagh puqloD:n@@pagh:n:1, puqloD:n}). Ele é um seguidor de {tIquvma:n:name} e recebeu o papel de {Sech qengwI':n} após a morte de {rej'aq:n:name}. Ele é um albino, cuja cor da pele foi descrita como {Dem:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Voq oli syrjäytetty henkilö, joka kutsui itseään "kenenkään pojaksi" ({pagh puqloD:n@@pagh:n:1, puqloD:n}). Hän on {tIquvma:n:name}: n seuraaja, ja hänelle annettiin {Sech qengwI':n}: n rooli {rej'aq:n:name}: n kuoleman jälkeen. Hän on albino, jonka ihonväri kuvattiin nimellä {Dem:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6399,6 +7054,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6406,6 +7062,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - The Vulcan Hello:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -6419,6 +7076,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">душить</column>
       <column name="definition_zh_HK">嗆 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sufocar</column>
+      <column name="definition_fi">tukehtua, kuristua, saada jotain kurkkuun</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIQ:v}</column>
@@ -6429,6 +7087,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Based on the similarity to {vIQ:v:nolink}, this appears not to take an object.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6438,6 +7097,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6445,6 +7105,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6458,6 +7119,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">азот [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">氮氣</column>
       <column name="definition_pt">nitrogênio</column>
+      <column name="definition_fi">typpi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIp:n}, {tamler:n}</column>
@@ -6468,6 +7130,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Это слово состоит из глагола {voQ:v} (или гомофоничного, но неизвестного существительного) и {SIp:n}, поэтому оно означает что-то вроде «удушающего газа». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä sana näyttää koostuvan verbistä {voQ:v} (tai homofonisesta, mutta tuntemattomasta substantiivista) ja {SIp:n}, joten se tarkoittaa jotain "tukehtumiskaasua". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{voQ:v} or {voQ:n:nolink,hyp}, {SIp:n}</column>
       <column name="examples"></column>
@@ -6477,6 +7140,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6484,6 +7148,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6497,6 +7162,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">исцелять</column>
       <column name="definition_zh_HK">治愈</column>
       <column name="definition_pt">curar</column>
+      <column name="definition_fi">parantaa, hoitaa (sairaus, haava tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hergh:n}, {Qel:n:1h}, {ngej:v}, {rop:v}, {rop:n}</column>
@@ -6507,6 +7173,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6517,6 +7184,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6524,6 +7192,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -6537,6 +7206,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">Ворча (судно) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Vor'cha（船隻） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Vor'cha (embarcação)</column>
+      <column name="definition_fi">eräs alustyyppi, Vor'cha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Duj:n:1}</column>
@@ -6547,6 +7217,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Непонятно, почему Стандарт Федерации исказил написание этого слова, перемещая {qaghwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">不清楚為什麼聯邦標准通過移動{qaghwI':n}來破壞該單詞的拼寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não está claro por que o Federation Standard corrompeu a ortografia desta palavra movendo o {qaghwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On epäselvää, miksi Federation Standard turmeli tämän sanan oikeinkirjoituksen siirtämällä {qaghwI':n}-sanaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6556,6 +7227,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6563,6 +7235,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -6576,6 +7249,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">быть предыдущим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">先前</column>
       <column name="definition_pt">ser anterior</column>
+      <column name="definition_fi">olla edellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{veb:v}</column>
       <column name="see_also">{nung:v}, {ret:v}</column>
@@ -6586,6 +7260,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru">Можно также использовать {nungbogh:v@@nung:v, -bogh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一個人也可以使用{nungbogh:v@@nung:v, -bogh:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Pode-se também usar {nungbogh:v@@nung:v, -bogh:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Voidaan käyttää myös {nungbogh:v@@nung:v, -bogh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6595,6 +7270,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6602,6 +7278,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -6615,6 +7292,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">Фортинбрас [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">福丁布拉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Fortinbras</column>
+      <column name="definition_fi">Fortinbras</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -6625,6 +7303,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6634,6 +7313,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6641,6 +7321,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -6654,6 +7335,7 @@ Uma grande aranha na Terra seria um {tera' voDchuch:n@@tera':n, voDchuch:n}, mas
       <column name="definition_ru">Воспегский район [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《Vospeg》州</column>
       <column name="definition_pt">Região de Vospeg</column>
+      <column name="definition_fi">Vospegin alue</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sep Hol Sar:n}</column>
@@ -6671,6 +7353,14 @@ This region has some vocabulary differences from {ta' Hol:n}. Terms which have a
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on alue lounaaseen {veng wa'DIch:n}:sta.
+
+Tällä alueella on sanastoeroja {ta' Hol:n}:iin. Termeillä, joilla on erilainen merkitys tällä alueella kuin {ta' Hol:n}:ssa, on:
+▶ {cheSvel:n:2}
+▶ {ghaw':n:2}
+▶ {wep:n:2}
+▶ {yIvbeH:n:2}
+▶ {'IghvaH chej chatlh:n}</column>
       <column name="hidden_notes">This word appears only in the body of {KGT:src} and not in the glossary.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6680,6 +7370,7 @@ This region has some vocabulary differences from {ta' Hol:n}. Terms which have a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6687,6 +7378,7 @@ This region has some vocabulary differences from {ta' Hol:n}. Terms which have a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -6700,6 +7392,7 @@ This region has some vocabulary differences from {ta' Hol:n}. Terms which have a
       <column name="definition_ru">схватка, борьба, драка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">格鬥搏鬥摔跤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">luta, brigar</column>
+      <column name="definition_fi">kamppailla, painia, tapella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6710,6 +7403,7 @@ This region has some vocabulary differences from {ta' Hol:n}. Terms which have a
       <column name="notes_ru">Для «снасти» в сочетании с {pummoH:v@@pum:v:2, -moH:v} «причина падения (вниз)». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於“釣具”，請與{pummoH:v@@pum:v:2, -moH:v}“導致跌倒”結合使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para "tackle", combine com {pummoH:v@@pum:v:2, -moH:v} "faça cair (para baixo)". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yhdistä "taklaukseen" {pummoH:v@@pum:v:2, -moH:v}: n kanssa "syyn pudota (alas)" kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The requested word was "tackle", defined as "seize and knock to the ground".
 
 It was stated during the Q &amp; A session that the primary meaning of this word is physical (i.e., it does not mean "wrestling" with a problem). The object is the person being grappled, but MO would have to think about whether it can be a body part.</column>
@@ -6721,6 +7415,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tackle</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6728,6 +7423,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6741,6 +7437,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">железа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">腺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">glândula</column>
+      <column name="definition_fi">rauhanen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6751,6 +7448,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6760,6 +7458,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6767,6 +7466,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6780,6 +7480,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">привожить в движение</column>
       <column name="definition_zh_HK">推進</column>
       <column name="definition_pt">impulsionar</column>
+      <column name="definition_fi">työntää (eteenpäin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuv:v}, {jaD:v}, {woD:v:1}, {rapmar:n}</column>
@@ -6790,6 +7491,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6803,6 +7505,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">throw</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6810,6 +7513,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.76-77:src}</column>
     </table>
     <table name="mem">
@@ -6823,6 +7527,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">Вояджер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">航海家 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Voyager</column>
+      <column name="definition_fi">Voyager</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hov leng:n}</column>
@@ -6833,6 +7538,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru">Это название корабля Федерации.</column>
       <column name="notes_zh_HK">這是聯邦星艦的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma nave estelar da Federação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on federaation tähtialuksen nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6842,6 +7548,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6849,6 +7556,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Kauderwelsch Klingonisch:src}</column>
     </table>
     <table name="mem">
@@ -6862,6 +7570,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">заложник</column>
       <column name="definition_zh_HK">人質</column>
       <column name="definition_pt">refém</column>
+      <column name="definition_fi">panttivanki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quch:v}, {voHDajbo':n}</column>
@@ -6872,6 +7581,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6881,6 +7591,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6888,6 +7599,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6901,6 +7613,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">Трусы берут заложников. Клингонов нет. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">懦夫劫持人質。克林崗人沒有。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Covardes fazem reféns. Klingons não.</column>
+      <column name="definition_fi">Pelkurit ottavat panttivankeja. Klingonit eivät.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6911,6 +7624,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6920,6 +7634,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6927,6 +7642,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.97:src}</column>
     </table>
     <table name="mem">
@@ -6940,6 +7656,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">мнение</column>
       <column name="definition_zh_HK">意見</column>
       <column name="definition_pt">opinião</column>
+      <column name="definition_fi">mielipide</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qech:n}, {ngoD:n}</column>
@@ -6950,6 +7667,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -6965,6 +7683,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6972,6 +7691,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.136-137:src}</column>
     </table>
     <table name="mem">
@@ -6985,6 +7705,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">изгнать, изгнать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">驅逐、彈射 [AUTOTRANSLATED]</column>
       <column name="definition_pt">expulsar, ejetar</column>
+      <column name="definition_fi">työntää ulos, karkottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIm:v}, {ruq:v}, {puch:n}</column>
@@ -6995,6 +7716,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru">Этот глагол может использоваться с {turmIq:n}, {qeQ:n} и {taQbang:n:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞可與{turmIq:n}，{qeQ:n}和{taQbang:n:2}一起使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo pode ser usado com {turmIq:n}, {qeQ:n} e {taQbang:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä voidaan käyttää {turmIq:n}-, {qeQ:n}- ja {taQbang:n:2}-ohjelmien kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7004,6 +7726,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7011,6 +7734,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -7024,6 +7748,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">быть без созания</column>
       <column name="definition_zh_HK">無意識 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ficar inconsciente</column>
+      <column name="definition_fi">olla tajuton</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ver:v:2}</column>
@@ -7034,6 +7759,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7044,6 +7770,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">faint</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7051,6 +7778,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7064,6 +7792,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">Klingons do not faint. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗人不會暈倒。</column>
       <column name="definition_pt">Klingons não desmaiam.</column>
+      <column name="definition_fi">Klingonit eivät pyörry.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7074,6 +7803,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7083,6 +7813,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7090,6 +7821,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.40:src}</column>
     </table>
     <table name="mem">
@@ -7103,6 +7835,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="definition_ru">Вулкан (планета)</column>
       <column name="definition_zh_HK">「瓦肯」星</column>
       <column name="definition_pt">Vulcano (planeta)</column>
+      <column name="definition_fi">Vulkanus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vulqangan:n}</column>
@@ -7113,6 +7846,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="notes_ru">Планета в Федерации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">聯邦中的一顆行星。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta na Federação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta federaatiossa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7122,6 +7856,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7129,6 +7864,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
         <table name="mem">
@@ -7142,6 +7878,7 @@ It was stated during the Q &amp; A session that the primary meaning of this word
           <column name="definition_ru">Вулканец</column>
           <column name="definition_zh_HK">「瓦肯」人</column>
           <column name="definition_pt">Vulcano (pessoa)</column>
+      <column name="definition_fi">vulkanuslainen</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{vulqan:n}</column>
@@ -7156,6 +7893,11 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
           <column name="notes_ru"></column>
           <column name="notes_zh_HK">This transliteration is used in the subtitles of {Star Trek V:src} among other places.</column>
           <column name="notes_pt"></column>
+      <column name="notes_fi">Vulcania kutsutaan joskus myös englanniksi vulcaniansiksi.[2]
+
+Huomaa, että tämä on {vulqangan:n:nolink} eikä {vulqanngan:n:nolink} ({n:sen:nolink} {vulqan:n:nolink}: n lopussa hylätään).
+
+On olemassa klingonin idioomi {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, joka on tarkoitettu ironisesti. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{vulqan:n}, {ngan:n}</column>
           <column name="examples"></column>
@@ -7165,6 +7907,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">vulqanngan</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -7172,6 +7915,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}, [2] {TOS - Errand of Mercy:src}</column>
         </table>
     <table name="mem">
@@ -7185,6 +7929,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">работать, трудиться</column>
       <column name="definition_zh_HK">工作、辛勞</column>
       <column name="definition_pt">trabalhar, labutar</column>
+      <column name="definition_fi">tehdä työtä, työskennellä, uurastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baj:v}, {Qap:v:1}, {Qu':n}, {ghIgh:n:2}</column>
@@ -7195,6 +7940,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7204,6 +7950,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7211,6 +7958,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7224,6 +7972,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">презренный или презренный человек, подонок, ублюдок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">卑鄙或卑鄙的人、卑鄙小人、私生子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pessoa desprezível, bastardo</column>
+      <column name="definition_fi">eräs haukkumasana, halveksittava henkilö, kusipää, paskiainen, mäntti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{petaQ:excl}</column>
@@ -7234,6 +7983,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The first part of the example sentence was a lip-match for {mughojmoH parmaqqaywI':sen@@mu-:v, ghojmoH:v, parmaqqay:n, -wI':n}. The second part was a lip-match for {'ej jIHvo' nIHDI' jIbup:sen@@'ej:conj, jIH:n:1h, -vo':n, nIH:v, -DI':v, jI-:v, bup:v}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -7244,6 +7994,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7251,6 +8002,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -7264,6 +8016,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">заказ (в ресторане, по каталогу и т. д.) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">訂單（在餐館、目錄等） [AUTOTRANSLATED]</column>
       <column name="definition_pt">pedido (em um restaurante, de um catálogo etc.)</column>
+      <column name="definition_fi">tilata (ravintolassa, luettelosta tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{je':v:1}, {jab:v}, {Qe':n}, {HIDjolev:n}, {mem:n}, {ra':v:1}</column>
@@ -7274,6 +8027,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7283,6 +8037,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7290,6 +8045,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7303,6 +8059,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">циклон, ураган [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">龍捲風、颱風</column>
       <column name="definition_pt">um ciclone ou furacão se inciam</column>
+      <column name="definition_fi">sykloni, hurrikaani, pyörremyrsky, hirmumyrsky</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cheq:v}, {SuS:n}, {jev:v:1}, {muD Dotlh:n}</column>
@@ -7313,6 +8070,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru">Обратите внимание, что это глагол в клингоне. В клингоне говорят «это ураганы», подобно тому, как говорят «по-английски идет дождь». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，這是克林崗語中的動詞。在克林崗，有人說“颶風”，類似於用英語說“下雨”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Note que este é um verbo em Klingon. Em Klingon, diz-se "faz furacões", semelhante a como diz-se "chove" em inglês. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä on verbi klingonissa. Klingonissa sanotaan "se hurrikaanit", samalla tavalla kuin sanotaan "sataa" englanniksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Cantonese Chinese for "wind" (風).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7322,6 +8080,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">typhoon</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7329,6 +8088,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -7342,6 +8102,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">жалеть</column>
       <column name="definition_zh_HK">可憐</column>
       <column name="definition_pt">pena</column>
+      <column name="definition_fi">sääliä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pung:n}, {QoS:v}, {'IQ:v}, {'It:v}</column>
@@ -7352,6 +8113,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7362,6 +8124,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7369,6 +8132,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7382,6 +8146,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">очаворывать</column>
       <column name="definition_zh_HK">吸引 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fascinar</column>
+      <column name="definition_fi">kiehtoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daj:v:1}</column>
@@ -7392,6 +8157,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7407,6 +8173,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7414,6 +8181,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.140-141:src}</column>
     </table>
     <table name="mem">
@@ -7427,6 +8195,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">быть современным, современным, современным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">現代、最新、最先進</column>
       <column name="definition_pt">ser moderno, atualizado, de última geração</column>
+      <column name="definition_fi">olla moderni, ajan tasalla, uusinta uutta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7437,6 +8206,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7446,6 +8216,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7453,6 +8224,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -7466,6 +8238,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">ограничивать</column>
       <column name="definition_zh_HK">限制 [AUTOTRANSLATED]</column>
       <column name="definition_pt">limite</column>
+      <column name="definition_fi">rajoittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yap:v}, {HeH:n}, {veH:n}, {'aqroS:n:2}</column>
@@ -7476,6 +8249,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7485,6 +8259,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">restrict</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7492,6 +8267,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7505,6 +8281,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">готовить еду, готовить напиток</column>
       <column name="definition_zh_HK">做飯、準備食物、做一個飲料 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cozinhar, preparar alimentos, fazer uma bebida</column>
+      <column name="definition_fi">kokata, valmistaa/tehdä ruokaa tai juomaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Soj:n:1}, {jab:v}, {qerjIq:n}</column>
@@ -7515,6 +8292,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The definition in {TKD:src} is just "cook". On {KGT p.83:src}, this is expanded to include the preparation of any food, including beverages. Reverse of {tuv:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7524,6 +8302,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7531,6 +8310,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7544,6 +8324,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">горшок с плоским дном для приготовления пищи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用於食物準備的平底鍋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">panela de fundo plano para preparação de alimentos</column>
+      <column name="definition_fi">tasapohjainen kattila ruoanvalmistukseen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7554,6 +8335,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru">Это иногда сокращается до {vut'un:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有時將其縮短為{vut'un:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Às vezes, isso é encurtado para {vut'un:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lyhennetään joskus {vut'un:n}-muotoon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vut:v}, {-meH:v}, {'un:n}</column>
       <column name="examples"></column>
@@ -7563,6 +8345,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7570,6 +8353,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7583,6 +8367,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">камбуз, кухня</column>
       <column name="definition_zh_HK">廚房</column>
       <column name="definition_pt">galeria</column>
+      <column name="definition_fi">(aluksen tms.) keittiö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7593,6 +8378,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru">Это относится к месту, где готовится еда. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指準備食物的地方。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um local onde a comida é preparada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa paikkaan, jossa ruokaa valmistetaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{vut:v} or {vut:n:hyp,nolink}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -7602,6 +8388,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">kitchen, cooking room</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7609,6 +8396,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7622,6 +8410,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">Повар</column>
       <column name="definition_zh_HK">廚師</column>
       <column name="definition_pt">chefe de cozinha</column>
+      <column name="definition_fi">kokki, keittäjä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jabwI':n}, {tebwI':n}</column>
@@ -7632,6 +8421,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vut:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -7641,6 +8431,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7648,6 +8439,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7661,6 +8453,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">шеф повар [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">主廚 [AUTOTRANSLATED]</column>
       <column name="definition_pt">chefe de cozinha</column>
+      <column name="definition_fi">pääkokki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7671,6 +8464,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vutwI':n}, {quv:v}</column>
       <column name="examples"></column>
@@ -7680,6 +8474,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7687,6 +8482,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7700,6 +8496,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">горшок с плоским дном для приготовления пищи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用於食物準備的平底鍋</column>
       <column name="definition_pt">panela de fundo plano para preparação de alimentos</column>
+      <column name="definition_fi">tasapohjainen kattila ruoanvalmistukseen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7710,6 +8507,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru">Это сокращение от {vutmeH 'un:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{vutmeH 'un:n}的縮寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é abreviação de {vutmeH 'un:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lyhyt sanalle {vutmeH 'un:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7719,6 +8517,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7726,6 +8525,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -7739,6 +8539,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">уважать</column>
       <column name="definition_zh_HK">尊重</column>
       <column name="definition_pt">respeitar</column>
+      <column name="definition_fi">kunnioittaa, arvostaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIch:v}, {Ho':v}, {naD:v}, {quvmoH:v}</column>
@@ -7749,6 +8550,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7759,6 +8561,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7766,6 +8569,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7779,6 +8583,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">быть полезным, поддерживающим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有助、有利</column>
       <column name="definition_pt">ser útil, apoiar, suportar</column>
+      <column name="definition_fi">olla avulias, tukea antava</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QaH:v}, {boQ:v}</column>
@@ -7789,6 +8594,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -7799,6 +8605,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7806,6 +8613,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -7819,6 +8627,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">управлять</column>
       <column name="definition_zh_HK">管理</column>
       <column name="definition_pt">gerenciar, administrar</column>
+      <column name="definition_fi">hallita (matalalla tasolla), johtaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vu'wI':n}</column>
@@ -7829,6 +8638,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7838,6 +8648,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7845,6 +8656,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -7858,6 +8670,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="definition_ru">управлятель</column>
       <column name="definition_zh_HK">經理</column>
       <column name="definition_pt">gerente</column>
+      <column name="definition_fi">johtaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7868,6 +8681,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vu':v}, {-wI':v}</column>
       <column name="examples">
@@ -7878,6 +8692,7 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7885,5 +8700,6 @@ There is a Klingon idiom, {nong; vulqangan rur@@nong:v, vulqangan:n, rur:v}, whi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>

--- a/mem-19-w.xml
+++ b/mem-19-w.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {w:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{w:sen:nolink}</column>
       <column name="definition_pt">a consoante {w:sen:nolink}</column>
+      <column name="definition_fi">konsonatti {w:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">звук, шум [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聲音、噪音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">som, barulho</column>
+      <column name="definition_fi">ääni, melu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghogh:n}, {chuS:v}, {vID'Ir:n}, {'arlogh Qoylu'pu'?:sen}, {ya'rIS:n}, {Ham:v}, {pun:v}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Смотрите в {QIch wab Ho'DoS:n} названия согласных и гласных клингонов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關克林崗輔音和元音的名稱，請參見{QIch wab Ho'DoS:n}下的內容。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {QIch wab Ho'DoS:n} os nomes das consoantes e vogais klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {QIch wab Ho'DoS:n}-kohdasta Klingonin konsonanttien ja vokaalien nimet. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -68,6 +74,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">vowel, consonant</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -75,6 +82,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.02.02:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -88,6 +96,7 @@
       <column name="definition_ru">радио [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">無線電 [AUTOTRANSLATED]</column>
       <column name="definition_pt">radio</column>
+      <column name="definition_fi">radio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wab labwI':n}, {Se':n}, {rI'Se':n}, {chaDvay':n}</column>
@@ -98,6 +107,7 @@
       <column name="notes_ru">Это относится к устройству, которое получает (но не отправляет) аудиосигнал. Для устройства, используемого для двусторонней связи, см. {Se' HablI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指接收（但不發送）音頻信號的設備。有關用於雙向通訊的設備，請參閱{Se' HablI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um dispositivo que recebe (mas não envia) um sinal de áudio. Para o dispositivo usado para comunicação bidirecional, consulte {Se' HablI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa laitteeseen, joka vastaanottaa (mutta ei lähetä) äänisignaalia. Katso kaksisuuntaiseen viestintään käytettävä laite kohdasta {Se' HablI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wab:n}, {Hev:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -107,6 +117,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -114,6 +125,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -127,6 +139,7 @@
       <column name="definition_ru">радиопередатчик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">無線電發射器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transmissor de rádio</column>
+      <column name="definition_fi">radiolähetin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wab HevwI':n}, {Se':n}, {rI'Se':n}, {chaDvay':n}</column>
@@ -137,6 +150,7 @@
       <column name="notes_ru">Это используется для вещания, радиослужбы и т. Д. Оно также может использоваться для устройства, которое выполняет передачу. Если необходимо провести различие, устройство {wab labwI' jan:n@@wab labwI':n, jan:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它用於廣播公司，無線電服務等。它也可以用於進行傳輸的設備。如果必須進行區分，則該設備為{wab labwI' jan:n@@wab labwI':n, jan:n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É usado para uma emissora, serviço de rádio, etc. Também pode ser usado para o dispositivo que transmite. Se for necessário fazer uma distinção, o dispositivo é {wab labwI' jan:n@@wab labwI':n, jan:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään lähetystoiminnan harjoittajalle, radiopalvelulle jne. Sitä voidaan käyttää myös laitteelle, joka lähettää lähetyksen. Jos on tehtävä ero, laite on {wab labwI' jan:n@@wab labwI':n, jan:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wab:n}, {lab:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -146,6 +160,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -153,6 +168,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -166,6 +182,7 @@
       <column name="definition_ru">гласная буква [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">元音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vogal</column>
+      <column name="definition_fi">vokaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wab poD:n}</column>
@@ -176,6 +193,7 @@
       <column name="notes_ru">Это относится к звукам, а не к буквам или глифам. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指聲音，而不是字母或字形。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a sons, não a letras ou glifos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa ääniä, ei kirjaimia tai kuvioita. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wab:n}, {naQ:v}</column>
       <column name="examples"></column>
@@ -185,6 +203,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -192,6 +211,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -205,6 +225,7 @@
       <column name="definition_ru">согласный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">輔音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">consoante</column>
+      <column name="definition_fi">konsonantti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wab naQ:n}</column>
@@ -215,6 +236,7 @@
       <column name="notes_ru">Это относится к звукам, а не к буквам или глифам. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指聲音，而不是字母或字形。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a sons, não a letras ou glifos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa ääniä, ei kirjaimia tai kuvioita. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wab:n}, {poD:v}</column>
       <column name="examples"></column>
@@ -224,6 +246,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -231,6 +254,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -244,6 +268,7 @@
       <column name="definition_ru">кассета [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">錄音帶</column>
       <column name="definition_pt">cassete</column>
+      <column name="definition_fi">kasetti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -254,6 +279,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wab:n}, {qoSta':n}, {'aplo':n}</column>
       <column name="examples"></column>
@@ -263,6 +289,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -270,6 +297,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -283,6 +311,7 @@
       <column name="definition_ru">аудио, звукозапись [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">音頻、錄音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">áudio, gravação de som</column>
+      <column name="definition_fi">äänitallenne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaSta ta:n}</column>
@@ -293,6 +322,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wab:n}, {ta:n}</column>
       <column name="examples"></column>
@@ -302,6 +332,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -309,6 +340,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.25:src}</column>
     </table>
     <table name="mem">
@@ -322,6 +354,7 @@
       <column name="definition_ru">Мах [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">馬赫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mach (unidade)</column>
+      <column name="definition_fi">Mach (yksikkö)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -332,6 +365,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Oikeinkirjoitusmenetelmänä {wab Do:n:nolink} "äänen nopeus" kirjoitetaan kahtena sanana. Kun sitä käytetään mittausterminä ("Mach"), se kirjoitetaan yhtenä sanana ({wabDo:n:nolink}). Äännys (ja tältä osin merkitys) on sama.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wab:n}, {Do:n}</column>
       <column name="examples">
@@ -342,6 +376,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -349,6 +384,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Smithsonian GO FLIGHT app:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -362,6 +398,7 @@
       <column name="definition_ru">быть дорогим [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">貴</column>
       <column name="definition_pt">ser caro</column>
+      <column name="definition_fi">olla kallis</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qutlh:v}</column>
       <column name="see_also"></column>
@@ -372,6 +409,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -381,6 +419,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -388,6 +427,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}, [2] {msn 1997.07.13:src}, [3] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -401,6 +441,7 @@
       <column name="definition_ru">пробовать, тестировать, использовать экспериментально</column>
       <column name="definition_zh_HK">試用</column>
       <column name="definition_pt">experimentar, testar, usar experimentalmente</column>
+      <column name="definition_fi">kokeilla, testata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngong:v}, {chov:v}, {nuD:v}, {tob:v}, {Daj:v:2}</column>
@@ -411,6 +452,7 @@
       <column name="notes_ru">Это более общий смысл {waH:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{waH:v:2}的更一般含義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um significado mais geral de {waH:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {waH:v:2}: n yleisempi merkitys. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -420,6 +462,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -427,6 +470,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.07.13:src}</column>
     </table>
     <table name="mem">
@@ -440,6 +484,7 @@
       <column name="definition_ru">попробовать, попробовать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">品嚐、嘗試（食物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">provar, experimentar (comida)</column>
+      <column name="definition_fi">maistaa, kokeilla (ruokaa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mum:v}</column>
@@ -464,6 +509,9 @@ Förväxla inte detta med {mum:v}, vilket betyder "smak" i den meningen att man 
       <column name="notes_pt">Este é um significado especializado de {waH:v:1}. Significa experimentar a comida para ver se ela foi preparada corretamente ou para determinar se alguém gosta dela.[2]
 
 Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sabores. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {waH:v:1}: n erityinen merkitys. Se tarkoittaa kokeilla ruokaa nähdäksesi, onko se valmistettu oikein, tai selvittää, pidetäänkö siitä.
+
+Älä sekoita tätä {mum:v}: een, joka tarkoittaa "makua" makujen havaitsemisessa.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -473,6 +521,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -480,6 +529,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.07.13:src}</column>
     </table>
     <table name="mem">
@@ -493,6 +543,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">вибрировать, быть в состоянии вибрации [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">顫動</column>
       <column name="definition_pt">vibrar, estar em um estado de vibração</column>
+      <column name="definition_fi">väristä, värähdellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIrgh:n}, {yu'egh:n}, {jel:v}</column>
@@ -503,6 +554,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это означает, что нужно двигаться быстро, повторяющимся образом, как гитарная струна. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著要像吉他弦那樣快速重複地移動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa mover-se de uma maneira rápida e repetitiva, como uma corda de violão. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa liikkumista nopeasti toistuvalla tavalla, kuten kitaran kieli. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -512,6 +564,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -519,6 +572,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -532,6 +586,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">охотиться на</column>
       <column name="definition_zh_HK">打獵</column>
       <column name="definition_pt">caçar</column>
+      <column name="definition_fi">metsästää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chon:n}, {gheD:n}, {wamwI':n}, {ghab:v}</column>
@@ -542,6 +597,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это также используется для рыбалки.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也用於捕魚。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é usado para a pesca.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Hunt the Wumpus" was an early computer game.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -551,6 +607,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fish, fishing, hunting</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -558,6 +615,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -571,6 +629,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">wam, тип змея [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">wam、蛇的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de serpente</column>
+      <column name="definition_fi">eräs käärmeen kaltainen eläin, wam</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghargh:n}</column>
@@ -581,6 +640,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -590,6 +650,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -597,6 +658,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -610,6 +672,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">охотник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">獵人</column>
       <column name="definition_pt">caçador</column>
+      <column name="definition_fi">metsästäjä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -620,6 +683,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wam:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -629,6 +693,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -636,6 +701,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -649,6 +715,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">мясо охотника [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">獵人的肉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">carne de caçador</column>
+      <column name="definition_fi">metsästäjän liha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -659,6 +726,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это мясо, приготовленное с использованием {ngat:n:2}. Слово, обозначающее конкретное мясо, заменяет слово {Ha'DIbaH:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是用{ngat:n:2}準備的肉。特定肉類的單詞代替了{Ha'DIbaH:n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a carne preparada com {ngat:n:2}. A palavra para a carne específica substitui a palavra {Ha'DIbaH:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on liha, joka on valmistettu {ngat:n:2}: llä. Erityisen lihan sana korvaa sanan {Ha'DIbaH:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wamwI':n}, {Ha'DIbaH:n:1}</column>
       <column name="examples"></column>
@@ -668,6 +736,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -675,6 +744,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.90:src}</column>
     </table>
     <table name="mem">
@@ -688,6 +758,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">be straight (not crooked) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">直（不彎）</column>
       <column name="definition_pt">ser reto (não torto)</column>
+      <column name="definition_fi">olla suora</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wanHa':v}, {job:v}, {'ob:v}</column>
       <column name="see_also">{SIH:v}</column>
@@ -698,6 +769,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sounds like the Chinese word for "crooked" (彎). </column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -707,6 +779,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -714,6 +787,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
         <table name="mem">
@@ -727,6 +801,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">быть кривым, быть согнутым [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">彎、彎曲</column>
           <column name="definition_pt">ser torto, ser dobrado</column>
+      <column name="definition_fi">olla vino, taipunut</column>
           <column name="synonyms"></column>
           <column name="antonyms">{wan:v}</column>
           <column name="see_also">{SIH:v}, {job:v}</column>
@@ -737,6 +812,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">There is an Indo-European root "wanha" with exactly this meaning.</column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -746,6 +822,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -753,6 +830,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
         </table>
     <table name="mem">
@@ -766,6 +844,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">явление, событие, вхождение, еффект</column>
       <column name="definition_zh_HK">現象、事件、發生、影響 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fenômeno, evento, ocorrência, efeito</column>
+      <column name="definition_fi">ilmiö, tapahtuma, esiintymä, vaikutus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -776,6 +855,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Чтобы выразить природные явления, название эффекта сопровождается словом {wanI':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了表達自然現象，效果的名稱後跟單詞{wanI':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para expressar fenômenos naturais, o nome do efeito é seguido pela palavra {wanI':n:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Luonnonilmiöiden ilmaisemiseksi vaikutuksen nimen perässä on sana {wanI':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word was defined in {TKD:src} as "phenomenon, event, occurrence". The definition "effect" was added in the booklet for the {Saarbrücken qepHom'a' 2016:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -786,6 +866,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">experience</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -793,6 +874,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -806,6 +888,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">частота, коэффициент встречаемости [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頻率、發生率 [AUTOTRANSLATED]</column>
       <column name="definition_pt">frequência, índice de ocorrência</column>
+      <column name="definition_fi">esiintymistiheys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -816,6 +899,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wanI':n}, {SubmaH:n}</column>
       <column name="examples"></column>
@@ -825,6 +909,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -832,6 +917,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -845,6 +931,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">подмигивать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">眨眼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">piscar o olho</column>
+      <column name="definition_fi">iskeä silmää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -855,6 +942,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это добровольное движение, чтобы закрыть и открыть один глаз. Для непроизвольного мигания используйте {tu:v}. Для подергивания используйте {jergh:v} "spasm". [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是關閉和睜開一隻眼睛的自願運動。對於非自願眨眼，請使用{tu:v}。對於抽搐，請使用{jergh:v}“痙攣”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um movimento voluntário para fechar e abrir um olho. Para um piscar involuntário, use {tu:v}. Para contração, use {jergh:v} "espasmo". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vapaaehtoinen liike yhden silmän sulkemiseksi ja avaamiseksi. Käytä tahattomaa vilkkumista käyttämällä {tu:v}. Käytä nykimiseen {jergh:v} "kouristusta". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -864,6 +952,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -871,6 +960,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -884,6 +974,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">башмак</column>
       <column name="definition_zh_HK">鞋</column>
       <column name="definition_pt">sapato</column>
+      <column name="definition_fi">kenkä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paSlogh:n}, {qam:n}</column>
@@ -894,6 +985,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">You can certainly "wack" someone with it, or "walk" in it.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -903,6 +995,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -910,6 +1003,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -923,6 +1017,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">вид птицы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma espécie de pássaro</column>
+      <column name="definition_fi">eräs pitkänokkainen lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nu'SIylan:n}</column>
@@ -933,6 +1028,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это птица с очень длинным клювом. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一隻喙很長的鳥。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um pássaro com bico muito longo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lintu, jolla on hyvin pitkä nokka. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Kiwi is a brand of shoe polish ({waq:n} "shoe", {boch:v} "be shiny"), and also a kind of bird with a very long beak.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -942,6 +1038,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -949,6 +1046,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -962,6 +1060,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">преграждать</column>
       <column name="definition_zh_HK">阻礙 [AUTOTRANSLATED]</column>
       <column name="definition_pt">obstruir</column>
+      <column name="definition_fi">estää, olla tiellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bot:v}, {Huv:v:1}</column>
@@ -972,6 +1071,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -981,6 +1081,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -988,6 +1089,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1001,6 +1103,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">через несколько месяцев [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">（幾個）月後</column>
       <column name="definition_pt">meses a partir de agora</column>
+      <column name="definition_fi">... kuukauden päästä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wen:n}</column>
       <column name="see_also">{jar:n}, {pIq:n}</column>
@@ -1011,6 +1114,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Wax" and "wane".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1020,6 +1124,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1027,6 +1132,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.3, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1040,6 +1146,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">столбец (в таблице или электронной таблице) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">列（在表格或電子表格中） [AUTOTRANSLATED]</column>
       <column name="definition_pt">coluna (em uma tabela ou planilha)</column>
+      <column name="definition_fi">sarake</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wev:n}</column>
       <column name="see_also">{wa'chaw:n}, {tlhat:n}</column>
@@ -1050,6 +1157,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">From the term "warp and weft" in weaving. See also {wev:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1059,6 +1167,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1066,6 +1175,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -1079,6 +1189,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">тип ножа (используется для приготовления пищи) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刀的類型（用於食物準備） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de faca (usada para preparação de alimentos)</column>
+      <column name="definition_fi">eräs ruoanlaittoon käytetty veitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIjwI':n}</column>
@@ -1089,6 +1200,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это большой, острый и квадратный клинок, почти как {'obmaQ:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它很大，很鋒利，並且直角鋸齒，幾乎像一塊{'obmaQ:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É grande, afiado e de lâmina quadrada, quase como um {'obmaQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on suuri, terävä ja neliömäinen, melkein kuin {'obmaQ:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Ward and June Cleaver, from the television show "Leave It to Beaver". See {tlher:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1098,6 +1210,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">cleaver</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1105,6 +1218,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1118,6 +1232,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">ошибаться, ошибаться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不對頭、唔係路</column>
       <column name="definition_pt">ser errado, distorcido</column>
+      <column name="definition_fi">olla väärässä, vinossa, pielessä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1128,6 +1243,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Обратите внимание, что это означает «быть не в порядке, ошибаться» (что-то пошло не так или не получилось согласно плану), в отличие от {muj:v} «быть неверным, фактически неверным». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，這意味著“不對，就算錯了”（出了一些問題或沒有按計劃進行），而不是{muj:v}“不正確，實際上是錯誤的”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que isso significa "esteja errado, errado" (algo deu errado ou não deu certo de acordo com o plano), em oposição a {muj:v} "esteja incorreto, factualmente errado". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä tarkoittaa "ole väärässä, väärässä" (jokin on mennyt pieleen tai ei sujunut suunnitelmien mukaan), toisin kuin {muj:v} "ole väärä, tosiasiallisesti väärä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1137,6 +1253,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">amiss</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1144,6 +1261,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1157,6 +1275,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">смазка (общий термин) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">潤滑劑（總稱） [AUTOTRANSLATED]</column>
       <column name="definition_pt">lubricante (termo genérico)</column>
+      <column name="definition_fi">voiteluaine</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngIS:n}</column>
@@ -1167,6 +1286,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это относится к смазке в целом, а не к конкретному типу смазки. Глагол {lo':v} может использоваться для нанесения смазки или, в зависимости от того, как он применяется, могут использоваться {lIch:v}, {ngoH:v:1}, {vev:v}, {ghay:v} или, возможно, {QIn:v}. Слово {'onroS:n} также может быть включено.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常是指潤滑劑，而不是特定類型的潤滑劑。動詞{lo':v}可用於施加潤滑劑，或取決於其施加方式，可使用{lIch:v}，{ngoH:v:1}，{vev:v}，{ghay:v}或{QIn:v}。單詞{'onroS:n}也可能包括在內。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere ao lubrificante em geral, e não a um tipo específico de lubrificante. O verbo {lo':v} pode ser usado para aplicar lubrificante ou, dependendo de como ele é aplicado, {lIch:v}, {ngoH:v:1}, {vev:v}, {ghay:v} ou talvez {QIn:v} possa ser usado. A palavra {'onroS:n} também pode ser incluída.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa voiteluaineeseen yleensä eikä tiettyyn tyyppiseen voiteluaineeseen. Verbiä {lo':v} voidaan käyttää voiteluaineen levittämiseen tai sen käyttötavasta riippuen voidaan käyttää {lIch:v}, {ngoH:v:1}, {vev:v}, {ghay:v} tai ehkä {QIn:v}. Saatetaan myös sisällyttää sana {'onroS:n}[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1176,6 +1296,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1183,6 +1304,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -1196,6 +1318,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">быть чистым</column>
       <column name="definition_zh_HK">是純潔的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser puro</column>
+      <column name="definition_fi">olla puhdas, sekoittumaton</column>
       <column name="synonyms">{nIt:v}</column>
       <column name="antonyms">{qal:v}</column>
       <column name="see_also">{Say':v}</column>
@@ -1206,6 +1329,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1227,6 +1351,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1234,6 +1359,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.118-121:src}</column>
     </table>
     <table name="mem">
@@ -1247,6 +1373,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">делить</column>
       <column name="definition_zh_HK">劃分</column>
       <column name="definition_pt">dividir</column>
+      <column name="definition_fi">jakaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIm:v}</column>
@@ -1257,6 +1384,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Для математической операции деления, см. {boqHa''egh:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關除法的數學運算，請參見{boqHa''egh:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para a operação matemática da divisão, consulte {boqHa''egh:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso jakamisen matemaattinen toiminta kohdasta {boqHa''egh:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1266,6 +1394,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1273,6 +1402,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1286,6 +1416,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">база (военная)</column>
       <column name="definition_zh_HK">基地（軍事）</column>
       <column name="definition_pt">base (termo militar)</column>
+      <column name="definition_fi">sotilastukikohta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{raQ:n}, {HoS waw':n}, {jem'IH:n}</column>
@@ -1296,6 +1427,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1305,6 +1437,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">facility</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1312,6 +1445,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1325,6 +1459,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">быть полосатым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">條紋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser listrado</column>
+      <column name="definition_fi">olla raidallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ejvoH:n}, {yegh:v}</column>
@@ -1335,6 +1470,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"The White Stripes" was an American rock band.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1344,6 +1480,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1351,6 +1488,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1364,6 +1502,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">парировать, отклонять выпад [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">招架、偏轉弓步 [AUTOTRANSLATED]</column>
       <column name="definition_pt">parrear, afasta-te de um golpe</column>
+      <column name="definition_fi">torjua pisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jop:v:1}, {baQ:v:1}, {chaQ:v}, {lev:v}, {ngol:v}, {jIrmoH:v:1}, {DIj:v:1}, {mong'em:n}</column>
@@ -1374,6 +1513,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это также используется для аргументов (см. {jop 'ej way':sen}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也用於參數（請參閱{jop 'ej way':sen}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é usado para argumentos (consulte {jop 'ej way':sen}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään myös argumentteihin (katso {jop 'ej way':sen}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1383,6 +1523,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1390,6 +1531,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1403,6 +1545,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">хаос [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">混沌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">caos</column>
+      <column name="definition_fi">kaaos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIH:v:1}, {web:v:2}</column>
@@ -1413,6 +1556,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это относится к ситуации дезорганизации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指混亂的情況。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a uma situação de desorganização. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa epäjärjestykseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Wire". Perhaps a reference to the mess of cables often connecting certain groups of devices.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1422,6 +1566,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1429,6 +1574,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1442,6 +1588,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">один</column>
       <column name="definition_zh_HK">一</column>
       <column name="definition_pt">um</column>
+      <column name="definition_fi">yksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha':n:num}, {maH:n:2,num}</column>
@@ -1452,6 +1599,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1461,6 +1609,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1468,6 +1617,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -1481,6 +1631,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">первый</column>
           <column name="definition_zh_HK">第一</column>
           <column name="definition_pt">primeiro</column>
+      <column name="definition_fi">ensimmäinen</column>
           <column name="synonyms"></column>
           <column name="antonyms">{Qav:v}, {HochDIch:n}</column>
           <column name="see_also">{ghubDaQ:n}, {paghDIch:n}</column>
@@ -1491,6 +1642,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru">В {Klingon Monopoly:src} {Quj wa'DIch:n:nolink} используется для обозначения оригинальной монопольной игры. Таким образом, {wa'DIch:n:nolink} можно использовать для «оригинала» в смысле «первого» (см. Предложение в {qa':v}). [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi">Kohdassa {Klingon Monopoly:src} {Quj wa'DIch:n:nolink} käytetään viittaamaan alkuperäiseen Monopoly-peliin. Joten {wa'DIch:n:nolink}: ta voidaan käyttää "alkuperäiseksi" merkityksessä "ensimmäinen" (katso lause {qa':v}: ssä). [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n:num}, {-DIch:n:num,suff}</column>
           <column name="examples">
@@ -1502,6 +1654,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">original, 1st</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1509,6 +1662,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -1522,6 +1676,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">вчера</column>
           <column name="definition_zh_HK">尋日、琴日、昨天</column>
           <column name="definition_pt">ontem</column>
+      <column name="definition_fi">eilinen, eilen</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1532,6 +1687,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n:num}, {Hu':n}</column>
           <column name="examples"></column>
@@ -1541,6 +1697,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1548,6 +1705,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -1561,6 +1719,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">завтра</column>
           <column name="definition_zh_HK">聽日、明天</column>
           <column name="definition_pt">amanhã</column>
+      <column name="definition_fi">huomen, huomenna</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1571,6 +1730,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n:num}, {leS:n}</column>
           <column name="examples"></column>
@@ -1580,6 +1740,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1587,6 +1748,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -1600,6 +1762,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">один раз</column>
           <column name="definition_zh_HK">一次</column>
           <column name="definition_pt">uma vez</column>
+      <column name="definition_fi">kerran</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1610,6 +1773,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n:num}, {-logh:n:num,suff}</column>
           <column name="examples"></column>
@@ -1619,6 +1783,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1626,6 +1791,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -1639,6 +1805,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">десять</column>
           <column name="definition_zh_HK">十</column>
           <column name="definition_pt">dez</column>
+      <column name="definition_fi">kymmenen</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1649,6 +1816,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n:num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -1658,6 +1826,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1665,6 +1834,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -1678,6 +1848,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">десятый</column>
           <column name="definition_zh_HK">第十</column>
           <column name="definition_pt">décimo</column>
+      <column name="definition_fi">kymmenes</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1688,6 +1859,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa'maH:n:num}, {-DIch:n:num,suff}</column>
           <column name="examples"></column>
@@ -1697,6 +1869,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">10th</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1704,6 +1877,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -1717,6 +1891,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">Мы преуспеваем вместе в большом целом. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">我們在更大的整體上共同取得成功。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Conseguimos juntos um todo maior.</column>
+      <column name="definition_fi">Onnistumme yhdessä suurempana kokonaisuutena.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1727,6 +1902,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n:num}, {Dol:n}, {nIv:v}, {-Daq:n}, {ma-:v}, {tay':v}, {-DI':v}, {ma-:v}, {Qap:v:1}</column>
           <column name="examples"></column>
@@ -1736,6 +1912,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1743,6 +1920,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.209:src}</column>
         </table>
         <table name="mem">
@@ -1756,6 +1934,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">Сосредоточьтесь на одной цели. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">只關註一個目標。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Concentre-se apenas em um alvo.</column>
+      <column name="definition_fi">Keskity vain yhteen kohteeseen.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1766,6 +1945,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n:num}, {DoS:n}, {neH:adv}, {yI-:v}, {buS:v}</column>
           <column name="examples"></column>
@@ -1775,6 +1955,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1782,6 +1963,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.81:src}</column>
         </table>
         <table name="mem">
@@ -1795,6 +1977,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">We agree. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">我們同意。</column>
           <column name="definition_pt">Nós concordamos.</column>
+      <column name="definition_fi">Olemme samaa mieltä.</column>
           <column name="synonyms"></column>
           <column name="antonyms">{cha' DoSmey DIqIp.:sen}</column>
           <column name="see_also">{Qoch:v}, {Qochbe':v}</column>
@@ -1805,6 +1988,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru">Это буквально означает «мы попали в одну цель». Это может быть сокращено до просто {DoS wIqIp.:sen:nolink} [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這字面意思是“我們擊中了一個目標”。可以縮短為{DoS wIqIp.:sen:nolink} [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso significa literalmente "atingimos um alvo". Pode ser reduzido para apenas {DoS wIqIp.:sen:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "osuimme yhteen kohteeseen". Se voidaan lyhentää vain {DoS wIqIp.:sen:nolink}-muotoon [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n}, {DoS:n}, {wI-:v}, {qIp:v}</column>
           <column name="examples"></column>
@@ -1814,6 +1998,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1821,6 +2006,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.105:src}</column>
         </table>
         <table name="mem">
@@ -1834,6 +2020,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">Сын клингона - это человек, который в первый день может держать клинок. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">克林崗的兒子是他可以先拿刀片的那一天。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">O filho de um klingon é um homem no dia em que pode segurar uma lâmina pela primeira vez.</column>
+      <column name="definition_fi">Kun klingonin poika ensimmäisen kerran pitelee terää, hänestä tulee mies.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1844,6 +2031,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n}, {jaj:n}, {'etlh:n}, {'uch:v:1}, {-choH:v}, {-laH:v}, {tlhIngan:n}, {puqloD:n}, {jaj:n}, {-vetlh:n}, {loD:n}, {nen:v}, {moj:v}</column>
           <column name="examples"></column>
@@ -1853,6 +2041,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1860,6 +2049,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.177:src}</column>
         </table>
         <table name="mem">
@@ -1873,6 +2063,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">На одну миссию есть один лидер. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">一個任務只有一個領導者。</column>
           <column name="definition_pt">Para uma missão, há um líder.</column>
+      <column name="definition_fi">Yhdessä tehtävässä on yksi johtaja.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1883,6 +2074,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n}, {Qu':n}, {-vaD:n}, {wa':n}, {DevwI':n}, {tu'lu':v}</column>
           <column name="examples"></column>
@@ -1892,6 +2084,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1899,6 +2092,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.66:src}</column>
         </table>
         <table name="mem">
@@ -1912,6 +2106,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">Моноцикл [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">獨輪車 [AUTOTRANSLATED]</column>
           <column name="definition_pt">monociclo</column>
+      <column name="definition_fi">yksipyörä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{qam Do Duj:n}</column>
@@ -1922,6 +2117,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n}, {rutlh:n}, {qam Do Duj:n}</column>
           <column name="examples"></column>
@@ -1931,6 +2127,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1938,6 +2135,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
         </table>
         <table name="mem">
@@ -1951,6 +2149,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">The execution of but one warrior brings shame to all. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">只有一個戰士的執行給所有人帶來了恥辱。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">A execução de apenas um guerreiro traz vergonha a todos.</column>
+      <column name="definition_fi">Vain yhden soturin teloitus tuo häpeää kaikille.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1961,6 +2160,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -1970,6 +2170,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1977,6 +2178,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.136:src}</column>
         </table>
         <table name="mem">
@@ -1990,6 +2192,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">Это сложно. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">這很複雜。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Isso é complicado.</column>
+      <column name="definition_fi">Se on monimutkaista.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{wa'maH wej.:sen}</column>
@@ -2000,6 +2203,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru">Мальц сказал, что если в школе ученик ответил на вопрос учителя, сказав это, ученик, вероятно, подвергнется дисциплине (если это не был правильный ответ). Он не уточнил дальше.[1] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">馬爾茨說，如果在學校裡學生通過這樣回答老師的問題，那麼學生很可能會受到紀律處分（除非這實際上是正確的答案）。他沒有進一步闡述。[1] [AUTOTRANSLATED]</column>
           <column name="notes_pt">Maltz disse que se, na escola, um aluno responder à pergunta de um professor dizendo isso, é provável que ele seja disciplinado (a menos que essa seja realmente a resposta correta). Ele não deu mais detalhes.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maltz sanoi, että jos opiskelija vastasi koulussa opettajan kysymykseen sanomalla tämän, opiskelija todennäköisesti kurinalainen (ellei se oikeastaan ​​ollut oikea vastaus). Hän ei tarkentanut asiaa tarkemmin[1] [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -2009,6 +2213,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2016,6 +2221,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
         </table>
         <table name="mem">
@@ -2029,6 +2235,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">долго [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">很長時間 [AUTOTRANSLATED]</column>
           <column name="definition_pt">a muito tempo</column>
+      <column name="definition_fi">hyvin pitkä aika</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2039,6 +2246,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru">Это идиоматическое выражение относится к событию в жизни {qeylIS'e' lIjlaHbe'bogh vay':n:name}, когда он сражался со своим братом {moratlh:n:name} в течение двенадцати дней и двенадцати ночей (как описано в {paq'batlh:src}). Выражение означает не только то, что длина события большая, но и то, что это важное событие, достойное того, чтобы отнимать столько времени. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaus viittaa tapahtumaan {qeylIS'e' lIjlaHbe'bogh vay':n:name}-elämässä, kun hän taisteli veljensä {moratlh:n:name}: n kanssa kaksitoista päivää ja kaksitoista yötä (kuten {paq'batlh:src} kertoi). Lauseke tarkoittaa paitsi sitä, että tapahtuman pituus on pitkä, myös sitä, että tapahtuma on tärkeä ja ansaitsee viedä niin paljon aikaa. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -2048,6 +2256,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">twelve days and twelve nights</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2055,6 +2264,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KGT p.121:src}</column>
         </table>
         <table name="mem">
@@ -2068,6 +2278,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">Это сложно. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">這很複雜。 [AUTOTRANSLATED]</column>
           <column name="definition_pt">É complicado.</column>
+      <column name="definition_fi">Se on monimutkaista.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{wa' wa' wa'.:sen}</column>
@@ -2078,6 +2289,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru">Клингоны считают число 13 особенным из-за того, как они привыкли считать. Десятичное число 12 раньше выражалось как 3 × 3 + 3, а затем система усложнялась. Эта связь сохранилась даже после того, как клингоны перешли на десятичную систему счисления. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">克林崗人認為13的數字很特殊，因為它們的計數方式。十進制數字12過去常常表示為3×3 + 3，然後系統變得複雜了。即使在克林崗族切換到十進制數字系統後，這種聯繫仍然存在。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Os klingons consideram o número 13 especial por causa do modo como costumavam contar. O número decimal 12 costumava ser expresso como 3 × 3 + 3, e então o sistema ficou complicado. Essa associação permaneceu mesmo depois que os klingons passaram para o sistema de números decimais. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonit pitävät lukua 13 erityisenä sen vuoksi, miten he laskivat. Desimaaliluku 12 ilmaistiin aikanaan 3 × 3 + 3, ja sitten järjestelmä muuttui monimutkaiseksi. Tämä yhdistys säilyi silloinkin, kun Klingons siirtyi desimaalijärjestelmään. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{wa':n:num}, {maH:n:2,num}, {wej:n:num}</column>
           <column name="examples">
@@ -2088,6 +2300,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2095,6 +2308,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
         </table>
     <table name="mem">
@@ -2108,6 +2322,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">таблица, таблица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">電子表格、表格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">planilha, tabela</column>
+      <column name="definition_fi">taulukko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhat:n}, {war:n}, {wev:n}, {yu'muD:n}, {qawHaq:n}</column>
@@ -2118,6 +2333,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Lotus 1-2-3" ({wa':n}, {cha':n}, {wej:n}) was a popular spreadsheet program.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2127,6 +2343,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2134,6 +2351,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2147,6 +2365,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">масса (физическая концепция) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">質量（物理概念） [AUTOTRANSLATED]</column>
       <column name="definition_pt">massa (conceito de física)</column>
+      <column name="definition_fi">massa (fysiikka)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Surma':n}, {ngI':v}, {tlham:n:1}</column>
@@ -2157,6 +2376,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это отличается от веса объекта, который зависит от гравитации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這與物體的重量不同，後者取決於重力。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é diferente do peso de um objeto, que depende da gravitação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä eroaa kohteen painosta, joka riippuu painovoimasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The kilogram was originally defined to be the mass of 1 L ({wa':n:num}, {lay:n:1}) of water.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2166,6 +2386,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2173,6 +2394,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2186,6 +2408,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">Wa'Joh'a' [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Wa'Joh'a“ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Wa'Joh'a'</column>
+      <column name="definition_fi">Wa'Joh'a '</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qun:n}</column>
@@ -2196,6 +2419,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">根據{The Klingon Art of War:src}，這是第一個克林崗神的名字。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{The Klingon Art of War:src}: n mukaan tämä on ensimmäisen klingonijumalan nimi.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2205,6 +2429,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2212,6 +2437,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {The Klingon Art of War:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2225,6 +2451,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">быть опальным</column>
       <column name="definition_zh_HK">丟醜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desgraçado</column>
+      <column name="definition_fi">joutua epäsuosioon</column>
       <column name="synonyms">{mIl:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{tuH:v}</column>
@@ -2235,6 +2462,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2244,6 +2472,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2251,6 +2480,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2264,6 +2494,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">быть хаотичным, дезорганизованным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">混亂無序 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser caótico, desorganizado</column>
+      <column name="definition_fi">olla kaaottinen, järjestymätön</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{way'ar:n}</column>
@@ -2274,6 +2505,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это сленговое значение {web:v:1} применительно к ситуации, миссии или тому подобному. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{web:v:1}是to語，適用於情節或任務等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um significado de gíria de {web:v:1} aplicado a uma situação, missão ou algo semelhante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {web:v:1}: n slangi-merkitys tilanteessa, tehtävässä tai vastaavassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Possibly a reference to the (World Wide) Web.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2283,6 +2515,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2290,6 +2523,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2303,6 +2537,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">подавать ферментированную пищу на пике [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">在高峰期供應發酵食品 [AUTOTRANSLATED]</column>
       <column name="definition_pt">servir comida fermentada no tempo certo</column>
+      <column name="definition_fi">tarjoilla käynyttä ruokaa parhaimmillaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2313,6 +2548,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это еда, смешанная с {'atlhqam:n}, ферментированная и подаваемая.[1, p.92] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是與{'atlhqam:n}混合，發酵並食用的食物。[1, p.92] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um alimento misturado com {'atlhqam:n}, fermentado e servido.[1, p.92] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ruoka, joka on sekoitettu {'atlhqam:n}: n kanssa, fermentoitu ja tarjoiltu[1, p.92] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2322,6 +2558,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2329,6 +2566,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2342,6 +2580,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">органичивать</column>
       <column name="definition_zh_HK">局限 [AUTOTRANSLATED]</column>
       <column name="definition_pt">limitar</column>
+      <column name="definition_fi">eristää joku tai jokin (jonnekin)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIghHa':n}, {Sev:v}, {ngaS:v}</column>
@@ -2352,6 +2591,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2361,6 +2601,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2368,6 +2609,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2381,6 +2623,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">собершать набег</column>
       <column name="definition_zh_HK">襲擊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Incursão</column>
+      <column name="definition_fi">tehdä ylläkköhyökkäys jonnekin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIv:v}</column>
@@ -2391,6 +2634,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это слово похоже на {yot:v}, но имеет оттенок неожиданности или скорости.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞就像{yot:v}，但是具有驚喜或速度的含義。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é como {yot:v}, mas com a conotação de surpresa ou velocidade.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on kuin {yot:v}, mutta siinä on yllätyksen tai nopeuden merkitys.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2400,6 +2644,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2407,6 +2652,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi">yllätyshyökkäys</column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.48:src}</column>
     </table>
     <table name="mem">
@@ -2420,6 +2666,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">ещё нет</column>
       <column name="definition_zh_HK">還沒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ainda não</column>
+      <column name="definition_fi">ei vielä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wejHa':adv:hyp}</column>
       <column name="see_also">{tagha':adv}, {not:adv}</column>
@@ -2430,6 +2677,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2439,6 +2687,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2446,6 +2695,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2459,6 +2709,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">три</column>
       <column name="definition_zh_HK">三</column>
       <column name="definition_pt">três</column>
+      <column name="definition_fi">kolme</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2469,6 +2720,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2478,6 +2730,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2485,6 +2738,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -2498,6 +2752,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">третий</column>
           <column name="definition_zh_HK">第三</column>
           <column name="definition_pt">terceiro</column>
+      <column name="definition_fi">kolmas</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2508,6 +2763,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wej:n:num}, {-DIch:n:num,suff}</column>
           <column name="examples"></column>
@@ -2517,6 +2773,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">3rd</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2524,6 +2781,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
         <table name="mem">
@@ -2537,6 +2795,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="definition_ru">тридцать [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">三十 [AUTOTRANSLATED]</column>
           <column name="definition_pt">trinta</column>
+      <column name="definition_fi">kolmekymmentä</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2547,6 +2806,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wej:n:num}, {maH:n:2,num}</column>
           <column name="examples"></column>
@@ -2556,6 +2816,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2563,6 +2824,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source"></column>
         </table>
     <table name="mem">
@@ -2576,6 +2838,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">нитрат (химический термин) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">硝酸鹽（化學術語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">nitrato (termo químico)</column>
+      <column name="definition_fi">nitraatti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2586,6 +2849,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">NO3 = {wej:adv} + {-be':v}</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2595,6 +2859,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2602,6 +2867,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2615,6 +2881,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">вкус, вкус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">味道</column>
       <column name="definition_pt">sabor, gosto</column>
+      <column name="definition_fi">maku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ey:v}, {tlhorgh:v}, {mum:v}</column>
@@ -2625,6 +2892,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Baskin Robbins has 31 flavours.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2634,6 +2902,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">flavour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2641,6 +2910,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>
     <table name="mem">
@@ -2654,6 +2924,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">Воин сражается до смерти. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一個戰士為死亡而戰。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Um guerreiro luta até a morte.</column>
+      <column name="definition_fi">Soturi taistelee kuolemaan asti.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2664,6 +2935,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2673,6 +2945,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2680,6 +2953,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.88:src}</column>
     </table>
     <table name="mem">
@@ -2693,6 +2967,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">прелестный (только иронично)</column>
       <column name="definition_zh_HK">迷人（諷刺性地使用） [AUTOTRANSLATED]</column>
       <column name="definition_pt">encantador (usado apenas ironicamente)</column>
+      <column name="definition_fi">viehättävää (käytetään vain ironisesti)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2703,6 +2978,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Third time's a charm.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2712,6 +2988,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2719,6 +2996,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2732,6 +3010,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">задолжать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">欠、爭</column>
       <column name="definition_pt">dever</column>
+      <column name="definition_fi">olla velkaa jollekulle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghogh'ot:n}</column>
@@ -2742,6 +3021,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Объектом может быть либо вещь, которая должна, либо человек, которому что-то должен. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">所欠的東西或所欠的人都可以成為對象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ou a coisa devida, ou a pessoa a quem algo é devido, pode ser o objeto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In English slang, to "welch" is to fail to pay a debt or to fulfill an obligation.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2755,6 +3035,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2762,6 +3043,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, [2] {Klingon Monopoly:src}, [3] {KLI mailing list 2012.06.30:src}</column>
     </table>
     <table name="mem">
@@ -2775,6 +3057,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">звук сделан {targh:n} [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">{targh:n}發出的聲音</column>
       <column name="definition_pt">som produzido por um {targh:n}</column>
+      <column name="definition_fi">{targh:n}in ääntelyä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghugh:v}</column>
@@ -2785,6 +3068,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Стереотипный {targh:n:nolink} издает звук, традиционно воспроизводимый как {welwelwel:sen:nolink} (где количество повторений является переменным). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">O {targh:n:nolink} estereotipado emite um som convencionalmente {welwelwel:sen:nolink} (onde o número de repetições é variável). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Stereotyyppinen {targh:n:nolink} tuottaa tavanomaisesti renderoidun äänen {welwelwel:sen:nolink} (jossa toistojen määrä vaihtelee). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{wel:v} is "owe" so {welwelwel:excl:nolink} is "oweoweowe". "Wowowow" is one way to transliterate the sound a dog makes in English.
 
 "Well Well Well" is a song by John Lennon in which he screams the song's title. "Well, well, well" is also a stereotypical phrase associated with British police officers in film.</column>
@@ -2796,6 +3080,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">wuff, wau</column>
       <column name="search_tags_fa"></column>
@@ -2803,6 +3088,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -2816,6 +3102,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">нарушать</column>
       <column name="definition_zh_HK">違反 [AUTOTRANSLATED]</column>
       <column name="definition_pt">violar</column>
+      <column name="definition_fi">rikkoa, loukata (sopimusta tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIv:v}, {HeQ:v}, {lob:v}, {wogh:v}, {wem:n}</column>
@@ -2826,6 +3113,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2835,6 +3123,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2842,6 +3131,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2855,6 +3145,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">нарушение</column>
       <column name="definition_zh_HK">違反 [AUTOTRANSLATED]</column>
       <column name="definition_pt">violação</column>
+      <column name="definition_fi">rikkomus, (sopimuksen tms.) loukkaus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wem:v}</column>
@@ -2865,6 +3156,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2874,6 +3166,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2881,6 +3174,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2894,6 +3188,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">несколько месяцев назад [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">（幾個）月前</column>
       <column name="definition_pt">meses atrás</column>
+      <column name="definition_fi">... kuukautta sitten</column>
       <column name="synonyms"></column>
       <column name="antonyms">{waQ:n}</column>
       <column name="see_also">{jar:n}, {ret:n}</column>
@@ -2904,6 +3199,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Wax" and "wane".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2913,6 +3209,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2920,6 +3217,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.3, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -2933,6 +3231,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">куртка, пальто</column>
       <column name="definition_zh_HK">上衣、外套、夾克</column>
       <column name="definition_pt">casaco</column>
+      <column name="definition_fi">takki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cheSvel:n:2}</column>
@@ -2943,6 +3242,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2952,6 +3252,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2959,6 +3260,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -2972,6 +3274,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">рубашка с рукавами [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">袖子襯衫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">camisa com mangas</column>
+      <column name="definition_fi">hihallinen paita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wep:n:1}, {yIvbeH:n:2}, {tlhay:n:2h}</column>
@@ -2982,6 +3285,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это слово имеет это значение на диалекте {voSpegh Sep:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞在{voSpegh Sep:n}方言中具有此含義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra tem esse significado no dialeto {voSpegh Sep:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä sanalla on tämä merkitys {voSpegh Sep:n}-murteessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2991,6 +3295,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2998,6 +3303,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3011,6 +3317,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">удар (ударный инструмент) ладонью [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用掌心擊打（打擊樂器） [AUTOTRANSLATED]</column>
       <column name="definition_pt">golpear (instrumento de percussão) com a palma da mão</column>
+      <column name="definition_fi">lyödä (lyömäsoitinta) kämmenellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toch:n}, {qIp:v}, {'In:n}, {chu':v:3}</column>
@@ -3021,6 +3328,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Сравните с {moq:v} и {tlhaw':v}. Для удара чего-то ладонью в не-музыкальном контексте, подумайте о {yo:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">與{moq:v}和{tlhaw':v}比較。對於在非音樂環境中用手掌敲打東西的情況，請考慮{yo:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Compare com {moq:v} e {tlhaw':v}. Para bater em algo com a palma da mão em um contexto não musical, considere {yo:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Vertaa {moq:v}- ja {tlhaw':v}-tiedostoihin. Jos haluat lyödä jotain kämmenellä ei-musiikillisessa kontekstissa, ota huomioon {yo:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Whack".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3030,6 +3338,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3037,6 +3346,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3050,6 +3360,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">свеча</column>
       <column name="definition_zh_HK">蠟燭</column>
       <column name="definition_pt">vela</column>
+      <column name="definition_fi">kynttilä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sech:n}, {wovmoHbogh jan:n}, {wovmoHwI':n}, {req:n}, {SuS:v}</column>
@@ -3060,6 +3371,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Wax" or "wick".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3069,6 +3381,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3076,6 +3389,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -3089,6 +3403,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">Всемирная паутина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">萬維網</column>
       <column name="definition_pt">Rede mundial de computadores</column>
+      <column name="definition_fi">World Wide Web (osa Internetiä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Internet:n}</column>
@@ -3099,6 +3414,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это самое близкое, что есть у клингонов во «всемирной паутине». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是Klingons與“萬維網”最接近的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a coisa mais próxima que os klingons têm da "World Wide Web". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lähinnä asiaa, jonka Klingonsilla on "World Wide Webiin". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"The whole ball of wax".</column>
       <column name="components">{weQ:n}, {moQ:n}, {naQ:v}</column>
       <column name="examples"></column>
@@ -3108,6 +3424,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Internet</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3115,6 +3432,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom 2012:src}</column>
     </table>
     <table name="mem">
@@ -3128,6 +3446,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">быть морщинистым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">起皺、皺起來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser vincado, ser enrugado</column>
+      <column name="definition_fi">olla rypistynyt, kurttuinen, ruttuinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Damu':n}, {wol:v}</column>
@@ -3138,6 +3457,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3147,6 +3467,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3154,6 +3475,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3167,6 +3489,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">складка, морщина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">皺摺、皺紋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vinco, rugas</column>
+      <column name="definition_fi">rypistää, rutata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Damu':n}, {wolmoH:v}</column>
@@ -3177,6 +3500,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wer:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -3186,6 +3510,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3193,6 +3518,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -3206,6 +3532,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">потерять, подвергнуться сокращению, пострадать от сокращения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">失去、減少、減少 [AUTOTRANSLATED]</column>
       <column name="definition_pt">perder, sofrer uma redução de, sofrer uma redução de</column>
+      <column name="definition_fi">menettää, kärsiä jonkin vähentymisestä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIl:v}, {'anmoH:v}</column>
@@ -3216,6 +3543,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это используется для выражения таких вещей, как «мы потеряли много солдат» или «он потерял много крови». Чтобы сказать, что кто-то умер, просто используйте {Hegh:v}. Например, «она потеряла мужа» будет просто {Heghpu' loDnalDaj:sen@@Hegh:v, -pu':v, loDnal:n, -Daj:n}. Для «мы потеряли много воинов» в том смысле, что они погибли, используйте {Heghpu' SuvwI'pu'ma':sen@@Hegh:v, -pu':v, SuvwI':n, -pu':n, -ma':n}. Можно сказать {SuvwI'pu' DIweSpu':sen@@SuvwI':n, -pu':n, DI-:v, weS:v, -pu':v}, но это подразумевает, что воины потеряны в том смысле, что они пропали или пропали без вести, или серьезно ранены и не ожидают возвращения (или возвращения в ближайшее время), но не обязательно мертвы.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於表達“我們失去了很多士兵”或“他失去了很多鮮血”之類的東西。要說有人死了，只需使用{Hegh:v}。例如，“她失去了丈夫”就是{Heghpu' loDnalDaj:sen@@Hegh:v, -pu':v, loDnal:n, -Daj:n}。對於“我們失去了很多勇士”，就用他們死亡，使用{Heghpu' SuvwI'pu'ma':sen@@Hegh:v, -pu':v, SuvwI':n, -pu':n, -ma':n}。可以說{SuvwI'pu' DIweSpu':sen@@SuvwI':n, -pu':n, DI-:v, weS:v, -pu':v}，但這意味著戰士在失去或失踪，受到嚴重傷害且無法返回（或希望很快返回）的意義上迷失了，但不一定死亡。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ele é usado para expressar coisas como "perdemos muitos soldados" ou "ele perdeu muito sangue". Para dizer que alguém morreu, basta usar {Hegh:v}. Por exemplo, "ela perdeu o marido" seria apenas {Heghpu' loDnalDaj:sen@@Hegh:v, -pu':v, loDnal:n, -Daj:n}. Para "perdemos muitos guerreiros" no sentido de que morreram, use {Heghpu' SuvwI'pu'ma':sen@@Hegh:v, -pu':v, SuvwI':n, -pu':n, -ma':n}. Pode-se dizer {SuvwI'pu' DIweSpu':sen@@SuvwI':n, -pu':n, DI-:v, weS:v, -pu':v}, mas isso implica que os guerreiros estão perdidos no sentido de que se foram ou estão desaparecidos, ou gravemente feridos e não se espera que retornem (ou retornem em breve), mas não necessariamente mortos.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään ilmaisemaan esimerkiksi "olemme menettäneet paljon sotilaita" tai "hän on menettänyt paljon verta". Käytä sanaa {Hegh:v} sanomalla, että joku on kuollut. Esimerkiksi "hän menetti miehensä" olisi vain {Heghpu' loDnalDaj:sen@@Hegh:v, -pu':v, loDnal:n, -Daj:n}. Sillä "olemme menettäneet paljon sotureita" siinä mielessä, että he kuolivat, käytä {Heghpu' SuvwI'pu'ma':sen@@Hegh:v, -pu':v, SuvwI':n, -pu':n, -ma':n}. Voidaan sanoa {SuvwI'pu' DIweSpu':sen@@SuvwI':n, -pu':n, DI-:v, weS:v, -pu':v}, mutta se tarkoittaa, että soturit ovat kadonneet siinä mielessä, että he ovat kadonneet tai kadonneita tai vakavasti loukkaantuneita eikä heidän odoteta palavan (tai palaavan pian milloin tahansa), mutta eivät välttämättä kuolleita.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3225,6 +3553,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3232,6 +3561,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Lethe:src}</column>
     </table>
     <table name="mem">
@@ -3245,6 +3575,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">ткань, сукно, текстиль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">布料織物布料 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tecido</column>
+      <column name="definition_fi">kangas, tekstiili</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sut:n}, {paSrIq:n}</column>
@@ -3255,6 +3586,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">Это может использоваться для текстиля или ткани в одежде, простынях, полотенцах и т. Д., Но обычно не для ковров или ковриков (за исключением тонких).[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它可以用於衣物，床單，毛巾等中的紡織品或織物，但通常不適用於地毯或地毯（稀薄的地毯除外）。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para tecidos ou tecidos em roupas, lençóis, toalhas e assim por diante, mas geralmente não para tapetes ou tapetes (exceto os finos).[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää vaatteiden tekstiileihin tai kankaisiin, lakanoihin, pyyhkeisiin ja niin edelleen, mutta yleensä ei mattoihin (paitsi ohuisiin).[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3264,6 +3596,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3271,6 +3604,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3284,6 +3618,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">воздушный шар [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">熱氣球 [AUTOTRANSLATED]</column>
       <column name="definition_pt">balão de ar quente</column>
+      <column name="definition_fi">kuumailmapallo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hurgh Duj:n}</column>
@@ -3294,6 +3629,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="notes_ru">{weSjech ba'Suq:n@@weSjech:n, ba'Suq:n} - особый вид воздушного шара. Как только корзина ({'unwat:n}, или в данном случае {'unwat'a':n@@'unwat:n, -'a':n}) присоединена к ней, все это можно назвать {weSjech ba'Suq Duj:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Um {weSjech ba'Suq:n@@weSjech:n, ba'Suq:n} é um tipo específico de balão. Depois que uma cesta (um {'unwat:n} ou, neste caso, um {'unwat'a':n@@'unwat:n, -'a':n}) for anexada, tudo poderá ser chamado de {weSjech ba'Suq Duj:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{weSjech ba'Suq:n@@weSjech:n, ba'Suq:n} on erityinen ilmapallo. Kun kori ({'unwat:n} tai tässä tapauksessa {'unwat'a':n@@'unwat:n, -'a':n}) on kiinnitetty siihen, koko asiaa voidaan kutsua {weSjech ba'Suq Duj:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{weSjech:n}, {ba'Suq:n}, {Duj:n:1}</column>
       <column name="examples"></column>
@@ -3303,6 +3639,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3310,6 +3647,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -3323,6 +3661,7 @@ Não confunda isso com {mum:v}, que significa "gosto" no sentido de perceber sab
       <column name="definition_ru">строка (в таблице или электронной таблице) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">行（在表格或電子表格中） [AUTOTRANSLATED]</column>
       <column name="definition_pt">linha (em uma tabela ou planilha de cálculo)</column>
+      <column name="definition_fi">rivi (taulukossa)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{war:n}</column>
       <column name="see_also">{wa'chaw:n}, {tlhat:n}, {lanSoy:n}, {wIyqap:n}</column>
@@ -3347,6 +3686,9 @@ Ordet {mIr:n:1} kan användas som slangtermer för detta, om saker är tydliga. 
       <column name="notes_pt">Além de ser usado para uma linha em uma grade (como em uma planilha ou outra representação gráfica), isso também pode ser usado para coisas físicas se a configuração geral for (ou puder ser) semelhante a uma grade e houver (ou possa haver) outros linhas, não apenas uma. Por exemplo, isso seria usado para fileiras de milho ou fileiras de árvores crescendo em um campo em uma fazenda. Ele ainda pode ser usado se houver apenas uma linha em uma situação em que normalmente há mais (ou não seria surpreendente se houvesse mais). Se não estiver claro em uma situação se mais de uma linha é esperada ou típica, {wIyqap:n:nolink} é provavelmente a escolha certa.
 
 A palavra {mIr:n:1} pode ser usada como uma gíria para isso, se as coisas estiverem claras. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen lisäksi, että sitä käytetään ruudukon rivillä (kuten laskentataulukossa tai muussa graafisessa esityksessä), sitä voidaan käyttää myös fyysisiin asioihin, jos kokonaiskonfiguraatio on (tai saattaa olla) ruudukkomainen ja jos on (tai saattaa olla) muita rivit, ei vain yksi. Tätä käytetään esimerkiksi maatilan pellolla kasvavilla maissi- tai puuriveillä. Sitä voidaan silti käyttää, jos tilanteessa on vain yksi rivi, jossa tyypillisesti on enemmän (tai ei olisi yllättävää, jos niitä olisi enemmän). Jos tilanteessa on epäselvää, onko odotettavissa useampi kuin yksi rivi vai tyypillinen, {wIyqap:n:nolink} on todennäköisesti oikea valinta.
+
+Sanaa {mIr:n:1} voidaan käyttää slangiterminä tähän, jos asiat ovat selvät. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">From the term "warp and weft" in weaving. See also {war:n}.
 
 This was originally defined as "row (in a table or spreadsheet)" at {Saarbrücken qepHom'a' 2015:src} but was expanded to include physical things later.[2]</column>
@@ -3358,6 +3700,7 @@ This was originally defined as "row (in a table or spreadsheet)" at {Saarbrücke
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3365,6 +3708,7 @@ This was originally defined as "row (in a table or spreadsheet)" at {Saarbrücke
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}, [2] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -3378,6 +3722,7 @@ This was originally defined as "row (in a table or spreadsheet)" at {Saarbrücke
       <column name="definition_ru">эскиз, каракули [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">素描、塗鴉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esboço, rabisco</column>
+      <column name="definition_fi">piirtää, luonnostella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIj:v:2}</column>
@@ -3430,6 +3775,13 @@ Esta palavra não tem a conotação da palavra inglesa "doodle" de que a pessoa 
 Se o resultado do rabisco não for facilmente identificável ou nominável, a "imagem" pode ser chamada de {yay:n:3}.
 
 Embora o implementado usado possa ser qualquer coisa, não é comum usar esse verbo com um {rItlh naQ:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on piirretty kuva. Käsitys on, että se on nopea, ei varovainen.
+
+Tällä sanalla ei ole merkitystä englanninkieliselle sanalle "doodle", jonka mukaan doodlingin tekijä ei kiinnitä huomiota piirustettavaan tai piirrettävään.
+
+Jos doodlingin tulos ei ole helposti tunnistettavissa tai nimettävissä, "kuvaa" voidaan kutsua {yay:n:3}.
+
+Vaikka käytetty toteutus voi olla mitä tahansa, ei ole yleistä käyttää tätä verbiä {rItlh naQ:n}: n kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3440,6 +3792,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3447,6 +3800,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.10.18:src}</column>
     </table>
     <table name="mem">
@@ -3460,6 +3814,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="definition_ru">светиться</column>
       <column name="definition_zh_HK">輝光 [AUTOTRANSLATED]</column>
       <column name="definition_pt">brilhar</column>
+      <column name="definition_fi">hehkua</column>
       <column name="synonyms">{wov:v}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3470,6 +3825,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3479,6 +3835,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3486,6 +3843,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3499,6 +3857,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="definition_ru">рота (воинская часть) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">公司（軍事單位） [AUTOTRANSLATED]</column>
       <column name="definition_pt">companhia (unidade militar)</column>
+      <column name="definition_fi">komppania (sotilasyksikkö)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wey jolpat:n}, {ghotpu' tamey:n}</column>
@@ -3509,6 +3868,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="notes_ru">Это полный комплект корабельного персонала, экипажа и офицеров. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是船舶人員，船員和高級職員的完整補充。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o complemento completo de pessoal, tripulação e oficiais de um navio. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on aluksen täydellinen henkilökunta, miehistö ja upseerit. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3518,6 +3878,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">personnel</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3525,6 +3886,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3538,6 +3900,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="definition_ru">перевозчик персонала [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">人員運輸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transportador de pessoal</column>
+      <column name="definition_fi">henkilösiirrin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tep jolpat:n}</column>
@@ -3548,6 +3911,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wey:n}, {jolpat:n}</column>
       <column name="examples">
@@ -3558,6 +3922,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3565,6 +3930,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -3578,6 +3944,7 @@ Embora o implementado usado possa ser qualquer coisa, não é comum usar esse ve
       <column name="definition_ru">мы-его/её</column>
       <column name="definition_zh_HK">我們：他、它</column>
       <column name="definition_pt">nós-ele/ela</column>
+      <column name="definition_fi">me-häntä/sitä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nu-:v:pref}</column>
       <column name="see_also">{vI-:v:pref}, {ma-:v:pref}, {DI-:v:pref}</column>
@@ -3590,6 +3957,9 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{maH:n:1h}: {ghaH:n} / {'oH:n} = {wI-:v:pref,nolink}
+
+Kun sitä käytetään {-lu':v}: n kanssa, tämä etuliite tarkoittaa "Joku (määrittelemätön aihe) tekee meille jotain". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3599,6 +3969,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">we-him, we-her, we-it</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3606,6 +3977,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3619,6 +3991,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">быть кислым, быть горьким, быть терпким</column>
       <column name="definition_zh_HK">要酸、要苦、要酸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser azedo, ser amargo</column>
+      <column name="definition_fi">olla hapan, kitkerä, karvas, kirpeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{na':v:1}, {na'ran:n}</column>
@@ -3629,6 +4002,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3639,6 +4013,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3646,6 +4021,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {CK:src}</column>
     </table>
     <table name="mem">
@@ -3659,6 +4035,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">миф</column>
       <column name="definition_zh_HK">神話、傳説</column>
       <column name="definition_pt">mito</column>
+      <column name="definition_fi">myytti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3669,6 +4046,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Witch"es are a myth.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3680,6 +4058,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">legend</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3687,6 +4066,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 8:src}</column>
     </table>
     <table name="mem">
@@ -3700,6 +4080,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">бойня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">屠殺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">massacre</column>
+      <column name="definition_fi">surmata, teurastaa (joukoittain)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peq:v}, {HoH:v}</column>
@@ -3710,6 +4091,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это слово означает неизбирательное убийство.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞表示不分青紅皂白的殺戮。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra denota assassinato indiscriminado.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana merkitsee mielivaltaista tappamista.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example sentence is a lip-match for {'ej DochmeywIj vItlhapqa'meH}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3720,6 +4102,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3727,6 +4110,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -3740,6 +4124,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">гений</column>
       <column name="definition_zh_HK">天才</column>
       <column name="definition_pt">gênio</column>
+      <column name="definition_fi">nero</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3750,6 +4135,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Big "wig".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3759,6 +4145,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3766,6 +4153,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3779,6 +4167,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">быть беспощадным</column>
       <column name="definition_zh_HK">冷酷無情 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser impiedoso</column>
+      <column name="definition_fi">olla armoton, säälimätön</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hur'Iqngan:n}, {naS:v}</column>
@@ -3789,6 +4178,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Существует идиома {wIH; Hur'Iqngan rur@@wIH:v, Hur'Iqngan:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{wIH; Hur'Iqngan rur@@wIH:v, Hur'Iqngan:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {wIH; Hur'Iqngan rur@@wIH:v, Hur'Iqngan:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {wIH; Hur'Iqngan rur@@wIH:v, Hur'Iqngan:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Wick"ed.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3798,6 +4188,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3805,6 +4196,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3818,6 +4210,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">ферма</column>
       <column name="definition_zh_HK">種地、種田</column>
       <column name="definition_pt">fazenda</column>
+      <column name="definition_fi">viljellä tai kasvattaa, harjoittaa maataloutta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yob:v}, {Du':n}, {Satlh:n}, {poch:v}, {wIjwI' jan:n}, {qInut:n}</column>
@@ -3828,6 +4221,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3837,6 +4231,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3844,6 +4239,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3857,6 +4253,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">плуг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">犁</column>
       <column name="definition_pt">arado</column>
+      <column name="definition_fi">aura</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3867,6 +4264,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wIj:v}, {-wI':v}, {jan:n:1}</column>
       <column name="examples"></column>
@@ -3876,6 +4274,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">plow</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3883,6 +4282,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.142-143:src}</column>
     </table>
     <table name="mem">
@@ -3896,6 +4296,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">чучело [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">稻草人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espantalho</column>
+      <column name="definition_fi">variksenpelätin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3906,6 +4307,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это заданное выражение, и его нельзя понимать как реального человека, изображающего из себя фермера. Клингоны больше не используют такие вещи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個固定的表達方式，不會被理解為冒充農民的真實人物。克林崗人不再使用這些東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma expressão definida e não seria entendida como uma pessoa real se passando por um agricultor. Os klingons não usam mais essas coisas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on joukko ilmaisua, eikä sitä ymmärretä todellisena maanviljelijänä esiintyvänä henkilönä. Klingonit eivät enää käytä tällaisia ​​asioita. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wIj:v}, {-wI':v}, {ngeb:v}</column>
       <column name="examples"></column>
@@ -3915,6 +4317,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3922,6 +4325,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -3935,6 +4339,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">"мой друг" [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">“我的朋友” [AUTOTRANSLATED]</column>
       <column name="definition_pt">"amigo meu"</column>
+      <column name="definition_fi">"ni ystävä minun"</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jup:n}, {-wI':n}, {-wIj:n}</column>
@@ -3945,6 +4350,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это выражение используется между близкими друзьями в высших социальных слоях. Этого следует избегать, если это возможно, если только его социальное положение не является абсолютно ясным. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是較高社會階層中密友之間的一種表達方式。除非可能，否則應避免這樣做，除非一個人的社會地位絕對明確。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma expressão usada entre amigos íntimos nas classes sociais mais altas. Deve ser evitado, se possível, a menos que a posição social de alguém seja absolutamente clara. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä ilmaisua käytetään läheisten ystävien välillä ylemmissä sosiaaliluokissa. Sitä tulisi välttää, jos mahdollista, ellei ihmisen sosiaalinen asema ole täysin selvä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The real reason {wIj jup:sen:nolink} has this meaning is because some Star Trek writer looked up "my" and "friend" in {TKD:src}, found {-wIj:n} and {jup:n}, and attached them to each other without any regard for grammar or correctness. In standard Klingon, "my friend" (assuming said friend is a being capable of language) is {jupwI':n:nolink} (from {jup:n} and {-wI':n}).</column>
       <column name="components">{-wIj:n}, {jup:n}</column>
       <column name="examples"></column>
@@ -3954,6 +4360,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">friend mine, my friend</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3961,6 +4368,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.40:src}</column>
     </table>
     <table name="mem">
@@ -3974,6 +4382,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">колос [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">穗 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Espinho</column>
+      <column name="definition_fi">piikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hut'In:n}, {DuQwI':n}, {pu':n:2}</column>
@@ -3984,6 +4393,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это относится к отдельному пику, такому как кол. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是獨立的尖峰，例如股票。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a um pico independente, como uma estaca. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa itsenäiseen piikkiin, kuten vaarnaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">On the TV show "Buffy the Vampire Slayer", there is a character nicknamed Spike whose real name is William.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3993,6 +4403,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4000,6 +4411,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.08.13:src}</column>
     </table>
     <table name="mem">
@@ -4013,6 +4425,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">совместный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聯合 [AUTOTRANSLATED]</column>
       <column name="definition_pt">articulação</column>
+      <column name="definition_fi">nivel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DeSqIv:n}, {ngIb:n:1}, {qIv:n}, {volchaH:n}, {yeb:n:1}</column>
@@ -4023,6 +4436,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"I didn't inhale."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4032,6 +4446,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4039,6 +4454,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4052,6 +4468,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">пудинг [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">布丁 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pudim</column>
+      <column name="definition_fi">vanukas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4062,6 +4479,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a double pun: it sounds like "will puke", and also refers to "Pudd'nhead Wilson" ({puqloD:n} means "son"), the name of the eponymous character of a Mark Twain novel.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4071,6 +4489,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4078,6 +4497,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 15 (2008):src}</column>
     </table>
     <table name="mem">
@@ -4091,6 +4511,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">Вильям Шекспир</column>
       <column name="definition_zh_HK">威廉·莎士比亞</column>
       <column name="definition_pt">Wil'yam Shex'pir</column>
+      <column name="definition_fi">Wil'yam Shex'pir</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -4106,6 +4527,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это имя известного клингонского драматурга. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是著名的克林崗劇作家的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um famoso dramaturgo Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kuuluisan Klingonin näytelmäkirjailijan nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4115,6 +4537,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">William Shakespeare</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4122,6 +4545,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -4135,6 +4559,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">математическое уравнение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">數學方程</column>
       <column name="definition_pt">equação matemática</column>
+      <column name="definition_fi">matemaattinen yhtälö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIqtu':n}, {mI'QeD:n}</column>
@@ -4145,6 +4570,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"The Whetstone of Witte" was a famous book on mathematics, in which the equals sign (=) was introduced.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4154,6 +4580,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4161,6 +4588,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4174,6 +4602,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">что-то сломать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">打破（某事） [AUTOTRANSLATED]</column>
       <column name="definition_pt">quebrar (algo)</column>
+      <column name="definition_fi">taittaa tai murtaa (irti)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghor:v}</column>
@@ -4184,6 +4613,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Согласно {KGT p.99:src}, этот глагол может использоваться для описания действия разрыва порции пищи для ее передачи с подающего блюда ({'elpI':n}) на тарелку ({jengva':n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{KGT p.99:src}: n mukaan tätä verbiä voidaan käyttää kuvaamaan toimintaa, joka katkaisee osan ruokaa siirtämällä tarjoilualustalta ({'elpI':n}) lautaselle ({jengva':n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Wilt".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4193,6 +4623,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4200,6 +4631,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4213,6 +4645,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">выбор</column>
       <column name="definition_zh_HK">選擇 [AUTOTRANSLATED]</column>
       <column name="definition_pt">escolha</column>
+      <column name="definition_fi">valinta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wIv:v}</column>
@@ -4223,6 +4656,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Choices "weave" the future.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4232,6 +4666,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4239,6 +4674,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4252,6 +4688,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">выбирать</column>
       <column name="definition_zh_HK">選擇</column>
       <column name="definition_pt">escolher, selecionar</column>
+      <column name="definition_fi">valita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wuq:v}, {maS:v}, {wIv:n}, {lap:v}</column>
@@ -4262,6 +4699,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Этот глагол также используется для нажатия на гиперссылку на компьютере.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此動詞也用於單擊計算機上的超鏈接。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este verbo também é usado para clicar em um hiperlink em um computador.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään myös napsauttamalla hyperlinkkiä tietokoneessa[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4272,6 +4710,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">click</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4279,6 +4718,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4292,6 +4732,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="definition_ru">тактическое отображение</column>
       <column name="definition_zh_HK">戰術展示 [AUTOTRANSLATED]</column>
       <column name="definition_pt">display tático</column>
+      <column name="definition_fi">taktinen näyttö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha':v}, {HaSta:n}, {tlhat:n}</column>
@@ -4302,6 +4743,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="notes_ru">Это относится к абстрактной схеме поля битвы, которая отображается на {jIH:n:2}. Сравните это с {HaSta:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指戰場的抽象示意圖，該示意圖顯示在{jIH:n:2}上。將此與{HaSta:n}進行對比。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um esquema abstrato de um campo de batalha, exibido em um {jIH:n:2}. Compare isso com {HaSta:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa taistelukentän abstraktiin kaavioon, joka näytetään {jIH:n:2}-tiedostossa. Kontrasti tämä {HaSta:n}: lla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The first ever line of Klingon spoken on-screen was {wIy cha':sen@@wIy:n, cha':v}, in {Star Trek I:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4316,6 +4758,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4323,6 +4766,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek I:src}, [3] {SkyBox 3:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src})</column>
     </table>
         <table name="mem">
@@ -4336,6 +4780,7 @@ When used with {-lu':v}, this prefix means "Someone (indefinite subject) does so
           <column name="definition_ru">Покажите тактический дисплей! [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">顯示戰術顯示！ [AUTOTRANSLATED]</column>
           <column name="definition_pt">Mostre a exibição tática!</column>
+      <column name="definition_fi">Näytä taktinen näyttö!</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -4360,6 +4805,9 @@ Den klippta Klingon-formen för detta kommando skulle vara {wIy cha'!:sen@@wIy:n
           <column name="notes_pt">Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/ooFuTPjRtEM}
 
 A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/ooFuTPjRtEM}
+
+Tämän komennon leikattu klingonimuoto olisi {wIy cha'!:sen@@wIy:n, cha':v} [AUTOTRANSLATED]</column>
           <column name="hidden_notes">The first ever line of Klingon spoken on-screen was {wIy cha':sen:nolink}, in {Star Trek I:src}.</column>
           <column name="components">{wIy:n}, {yI-:v}, {cha':v}</column>
           <column name="examples"></column>
@@ -4369,6 +4817,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -4376,6 +4825,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KCD:src}</column>
         </table>
     <table name="mem">
@@ -4389,6 +4839,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">строка или строка (людей или предметов, которые не должны находиться в движении) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一行或一行（預期不會運動的人或事物） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fila ou linha (de pessoas ou coisas que não se espera que estejam em movimento)</column>
+      <column name="definition_fi">rivi tai jono (paikallaan olevia asioita tai ihmisiä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lanSoy:n}, {wev:n}</column>
@@ -4399,6 +4850,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru">Это может быть использовано для построения полиции. Составные части {wIyqap:n:nolink} не должны перемещаться (в отличие от тех, что в {lanSoy:n:nolink}). Это слово используется, даже если люди или вещи сгруппированы вместе. Оно также используется, если есть более одной строки, когда обычно есть только одна, так что в полицейском составе с двумя строками каждая по-прежнему является {wIyqap:n:nolink} (а не {wev:n:nolink}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能用於警察陣容。 {wIyqap:n:nolink}的組成部分不希望移動（與{lanSoy:n:nolink}中的組成部分不同。即使人或物聚集在一起，也使用此詞。如果一行以上，通常只有一行，則也使用此詞，因此，在具有兩行的警察陣容中，每個仍然是{wIyqap:n:nolink}（而不是{wev:n:nolink}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para uma formação policial. Não se espera que os constituintes de um {wIyqap:n:nolink} se movam (em contraste com os de um {lanSoy:n:nolink}). Esta palavra é usada mesmo se as pessoas ou coisas estiverem agrupadas. Também é usada se houver mais de uma linha, quando normalmente há apenas uma, de modo que em uma fila policial com duas linhas, cada uma ainda é uma {wIyqap:n:nolink} (e não uma {wev:n:nolink}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää poliisin kokoonpanossa. {wIyqap:n:nolink}: n ainesosien ei odoteta liikkuvan (toisin kuin {lanSoy:n:nolink}). Tätä sanaa käytetään, vaikka ihmiset tai asiat olisivatkin joukossa. Sitä käytetään myös, jos on enemmän kuin yksi rivi, kun tyypillisesti on vain yksi, joten poliisin kokoonpanossa, jossa on kaksi riviä, kukin on edelleen {wIyqap:n:nolink} (eikä {wev:n:nolink}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4409,6 +4861,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">lineup, line-up</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4416,6 +4869,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -4429,6 +4883,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">вики [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">維基 [AUTOTRANSLATED]</column>
       <column name="definition_pt">wiki</column>
+      <column name="definition_fi">wiki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4439,6 +4894,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru">Это не клингонское слово, а клингонское произношение стандартного слова федерации, относящееся к совместно редактируемому веб-сайту или базе данных. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這不是克林崗語單詞，而是聯邦標准單詞的克林崗語發音，指的是經過協作編輯的網站或數據庫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta não é uma palavra klingon, mas a pronúncia klingon de uma palavra Standard da Federação, referente a um site ou banco de dados editado em colaboração. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei ole klingonilainen sana, vaan federaation standardisanan klingoni-ääntäminen, joka viittaa yhteistyössä muokattuun verkkosivustoon tai tietokantaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4448,6 +4904,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4455,6 +4912,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2017.08.02:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -4468,6 +4926,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">hurl a spear by means of a {chetvI':n:2} [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通過{chetvI':n:2}投擲長矛 [AUTOTRANSLATED]</column>
       <column name="definition_pt">arremessar uma lança por meio de um {chetvI':n:2}</column>
+      <column name="definition_fi">heittää keihäs {chetvI':n:2}:llä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhevjaQ:n}, {chetvI':n:2}, {chuH:v:1}</column>
@@ -4478,6 +4937,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4487,6 +4947,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4494,6 +4955,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4507,6 +4969,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">быть высоким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">高</column>
       <column name="definition_pt">ser alto</column>
+      <column name="definition_fi">olla korkea, (henkilöstä) olla pitkä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{run:v}</column>
       <column name="see_also">{'ab:v}, {jen:v}, {tIq:v}, {'uj:n}</column>
@@ -4517,6 +4980,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4527,6 +4991,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4534,6 +4999,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 13.1, p.9, Mar. 2004:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -4547,6 +5013,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">выбрасывать</column>
       <column name="definition_zh_HK">扔掉、丟棄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">jogar fora, descartar</column>
+      <column name="definition_fi">heittää pois</column>
       <column name="synonyms">{polHa':v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{vo':v}, {jaD:v}, {lon:v}</column>
@@ -4557,6 +5024,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru">Это прискорбно, когда это применяется к еде.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">遺憾的是，將其應用於食品。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">É lamentável quando isso é aplicado aos alimentos.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4566,6 +5034,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4573,6 +5042,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.91:src}</column>
     </table>
     <table name="mem">
@@ -4586,6 +5056,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">быть пустым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">空洞的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser oco</column>
+      <column name="definition_fi">olla ontto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chIm:v}</column>
@@ -4596,6 +5067,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4605,6 +5077,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4612,6 +5085,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4625,6 +5099,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">грешить, делать больше, чем допустимо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">違背、做超過可接受的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transgredir, fazer mais do que é aceitável</column>
+      <column name="definition_fi">rikkoa rajoja, mennä liian pitkälle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wem:v}, {wem:n}, {'Iq:v}, {mIt:v}</column>
@@ -4635,6 +5110,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru">{bIwogh:sen:nolink} можно перевести как «Вы идете слишком далеко». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{bIwogh:sen:nolink}可能會翻譯為“您走得太遠了”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">{bIwogh:sen:nolink} pode ser traduzido como "Você vai longe demais". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{bIwogh:sen:nolink} voidaan kääntää "Sinä menet liian pitkälle". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4644,6 +5120,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">violate, go too far</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4651,6 +5128,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, Sept. 2003:src}</column>
     </table>
     <table name="mem">
@@ -4664,6 +5142,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">подбирать</column>
       <column name="definition_zh_HK">撿起 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pegar</column>
+      <column name="definition_fi">poimia ylös, nostaa, noukkia</column>
       <column name="synonyms"></column>
       <column name="antonyms">{roQ:v}</column>
       <column name="see_also">{chagh:v}, {Hu':v}</column>
@@ -4674,6 +5153,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4683,6 +5163,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4690,6 +5171,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4703,6 +5185,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">радиация</column>
       <column name="definition_zh_HK">輻射 [AUTOTRANSLATED]</column>
       <column name="definition_pt">radiação</column>
+      <column name="definition_fi">säteily</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhuD:v}, {butnat:n}</column>
@@ -4713,6 +5196,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4724,6 +5208,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4731,6 +5216,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {SkyBox 19:src}</column>
     </table>
     <table name="mem">
@@ -4744,6 +5230,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">стерилизовать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">消毒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esterilizar</column>
+      <column name="definition_fi">steriloida</column>
       <column name="synonyms">{Say'qu'moH:v}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4754,6 +5241,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The noun {woj:n} and the verb {Say'qu'moH:v} appeared next to each other in a word list published in {veS QonoS:src} (reprinted in {HQ 1.3, Sept. 1992:src} in Sept. 1992). Will Martin made an error in transcribing the words, and MO subsequently canonised his error, as a joke.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4763,6 +5251,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4770,6 +5259,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4783,6 +5273,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">реактор</column>
       <column name="definition_zh_HK">反應堆 [AUTOTRANSLATED]</column>
       <column name="definition_pt">reator</column>
+      <column name="definition_fi">reaktori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HoS lIngwI':n}, {lIngwI':n}</column>
@@ -4793,6 +5284,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{woj:n}, {choH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -4802,6 +5294,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4809,6 +5302,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -4822,6 +5316,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">быть согнутым, быть сложенным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被摺、被折疊</column>
       <column name="definition_pt">ser dobrado</column>
+      <column name="definition_fi">olla rypistetty, olla taitettu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Damu':n}, {wer:v}</column>
@@ -4832,6 +5327,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4841,6 +5337,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4848,6 +5345,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -4861,6 +5359,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">сгибать, складывать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">摺痕、折疊</column>
       <column name="definition_pt">vinco, dobra</column>
+      <column name="definition_fi">rypistää, taittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Damu':n}, {wermoH:v}</column>
@@ -4871,6 +5370,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wol:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -4880,6 +5380,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4887,6 +5388,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -4900,6 +5402,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">клевать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">啄 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bicar</column>
+      <column name="definition_fi">näykkiä (ruokaa); nokkia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}, {neb:n:1}</column>
@@ -4910,6 +5413,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru">Это слово используется как для еды, так и для нападения путем клевания. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞用於啄食和攻擊。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada para comer e atacar por bicar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään sekä syömiseen että hyökkäyksiin nokkimalla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4919,6 +5423,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4926,6 +5431,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -4939,6 +5445,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">аллея [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">胡同 [AUTOTRANSLATED]</column>
       <column name="definition_pt">beco</column>
+      <column name="definition_fi">kuja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'och:n}, {qach:n}, {taw:n}</column>
@@ -4949,6 +5456,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru">Обычно это узкая дорога или путь между или позади зданий. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常是建築物之間或建築物後的狹窄道路或小路。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Geralmente, é uma estrada ou caminho estreito entre ou atrás dos prédios. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleensä kapea tie tai polku rakennusten välillä tai takana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Dr. Wonmug is a character from the comic strip Alley Oop.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4958,6 +5466,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4965,6 +5474,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -4978,6 +5488,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">идеальный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">理想 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ideal</column>
+      <column name="definition_fi">ihanne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qangtlhIn:n}</column>
@@ -4988,6 +5499,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4997,6 +5509,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5004,6 +5517,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5017,6 +5531,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">подтвердить, обосновать, подтвердить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">確認、證實、證實 [AUTOTRANSLATED]</column>
       <column name="definition_pt">confirmar, fundamentar, corroborar</column>
+      <column name="definition_fi">vahvistaa, todistaa, osoittaa oikeaksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5027,6 +5542,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru">Обратите внимание, что {'ol:v} используется для проверки факта, в то время как {woq:v:nolink} используется для его подтверждения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Observe que {'ol:v} é usado para verificar um fato, enquanto {woq:v:nolink} é usado para confirmá-lo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että {'ol:v} käytetään tosiasian tarkistamiseen, kun taas {woq:v:nolink} käytetään sen vahvistamiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5036,6 +5552,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5043,6 +5560,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Magic to Make the Sanest Man Go Mad:src}</column>
     </table>
     <table name="mem">
@@ -5056,6 +5574,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">власть</column>
       <column name="definition_zh_HK">權威、政治權力 [AUTOTRANSLATED]</column>
       <column name="definition_pt">autoridade, poder político</column>
+      <column name="definition_fi">auktoriteetti, poliittinen valta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cho':v}, {ngup:n:2}, {qo'rob:n}</column>
@@ -5066,6 +5585,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5081,6 +5601,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5088,6 +5609,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.130-131:src}</column>
     </table>
     <table name="mem">
@@ -5101,6 +5623,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">warnog, клингон эль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">warnog、克林崗啤酒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">warnog, Ale Klingon</column>
+      <column name="definition_fi">eräs juoma, warnog, klingonilainen olut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIq:n}</column>
@@ -5111,6 +5634,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"War" nog (like eggnog but with war).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5120,6 +5644,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5127,6 +5652,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5140,6 +5666,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">подбородок</column>
       <column name="definition_zh_HK">下巴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cadeia, sequência</column>
+      <column name="definition_fi">leuka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rol:n}, {qab:n}</column>
@@ -5150,6 +5677,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5159,6 +5687,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5166,6 +5695,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5179,6 +5709,7 @@ A forma Klingon recortada deste comando seria {wIy cha'!:sen@@wIy:n, cha':v} [AU
       <column name="definition_ru">глагол</column>
       <column name="definition_zh_HK">動詞</column>
       <column name="definition_pt">verbo</column>
+      <column name="definition_fi">verbi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIp:n}</column>
@@ -5247,6 +5778,65 @@ See under {moHaq:n} for the verb prefixes.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">There are nine types of verb suffixes in Klingon, in addition to the rovers ({lengwI':n}), which do not have a fixed position relative to the other suffix types.
+
+Päätetyyppi 1: itseään/toisiaan
+▶ {-'egh:v:suff}
+▶ {-chuq:v:suff}
+
+Päätetyyppi 2: tahtominen/valmius
+▶ {-nIS:v:suff}
+▶ {-qang:v:suff}
+▶ {-rup:v:suff}
+▶ {-beH:v:suff}
+▶ {-vIp:v:suff}
+
+Päätetyyppi 3: muutos
+▶ {-choH:v:suff}
+▶ {-qa':v:suff}
+
+Päätetyyppi 4: aiheuttaminen
+▶ {-moH:v:suff}
+
+Päätetyyppi 5: passiivi/kykeneminen
+▶ {-lu':v:suff}
+▶ {-laH:v:suff}
+
+Päätetyyppi 6: täsmennyspäätteet
+▶ {-chu':v:suff}
+▶ {-bej:v:suff}
+▶ {-law':v:suff}
+▶ {-ba':v:suff}
+
+Päätetyyppi 7: aspekti
+▶ {-pu':v:suff}
+▶ {-ta':v:suff}
+▶ {-taH:v:suff}
+▶ {-lI':v:suff}
+
+Päätetyyppi 8: kunniapääte
+▶ {-neS:v:suff}
+
+Päätetyyppi 9: kieliopilliset päätteet
+▶ {-DI':v:suff}
+▶ {-chugh:v:suff}
+▶ {-pa':v:suff}
+▶ {-vIS:v:suff}
+▶ {-bogh:v:suff}
+▶ {-meH:v:suff}
+▶ {-'a':v:suff}
+▶ {-wI':v:suff}
+▶ {-mo':v:suff}
+▶ {-jaj:v:suff}
+▶ {-ghach:v:suff}
+
+Seikkalijat:
+▶ {-be':v:suff}
+▶ {-Qo':v:suff}
+▶ {-Ha':v:suff}
+▶ {-qu':v:suff}
+
+Katso verbietuliitteet artikkelissa {moHaq:n}.</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5257,6 +5847,7 @@ See under {moHaq:n} for the verb prefixes.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5264,6 +5855,7 @@ See under {moHaq:n} for the verb prefixes.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5277,6 +5869,7 @@ See under {moHaq:n} for the verb prefixes.</column>
       <column name="definition_ru">быть свветлым, быть ярким</column>
       <column name="definition_zh_HK">明亮、光亮</column>
       <column name="definition_pt">ser luz, brilhante</column>
+      <column name="definition_fi">olla valoisa, kirkas</column>
       <column name="synonyms">{wew:v}</column>
       <column name="antonyms">{Hurgh:v}</column>
       <column name="see_also">{tamghay:n}, {nguv:v}, {QIb:n}, {ghI'boj:n}, {chIS:v}, {'otlh:n}, {boch:v}</column>
@@ -5315,6 +5908,11 @@ Om ens ögon är "känsliga för ljus" kan de vara känsliga för {wovtaHghach:n
 Este verbo também é usado para descrever um dia ensolarado.[2]
 
 Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n@@wov:v, -taH:v, -ghach:v}.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {wov; ghI'boj Sech rur}.
+
+Tätä verbiä käytetään kuvaamaan myös aurinkoista päivää
+
+Jos ihmisen silmät ovat "herkkiä valolle", ne voivat olla herkkiä {wovtaHghach:n@@wov:v, -taH:v, -ghach:v} -[3]-tiedostolle.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The {wovtaHghach:n:nolink} construction was used by Okrand to explain how to describe Mirror Lorca's condition in {Star Trek Discovery:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5328,6 +5926,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5335,6 +5934,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}, [3] {KLI mailing list 2018.01.26:src}</column>
     </table>
     <table name="mem">
@@ -5348,6 +5948,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">light (device) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">燈（設備） [AUTOTRANSLATED]</column>
       <column name="definition_pt">luz (dispositivo)</column>
+      <column name="definition_fi">valo (laite)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{weQ:n}, {Sech:n}</column>
@@ -5358,6 +5959,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru">Посмотрите рекламный ролик Hallmark, в котором появляется это слово: {YouTube video:url:http://youtu.be/9eM1OSNGLwI} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看出現此詞的Hallmark廣告：{YouTube video:url:http://youtu.be/9eM1OSNGLwI} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista ao comercial da Hallmark em que esta palavra aparece: {YouTube video:url:http://youtu.be/9eM1OSNGLwI} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso Hallmark-mainosta, jossa tämä sana esiintyy: {YouTube video:url:http://youtu.be/9eM1OSNGLwI} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word has appeared in canon only in the formation {wovmoHbogh janHommey:n:nolink}[1; 2], but the noun suffixes have been removed here for ease of reference.</column>
       <column name="components">{wov:v}, {-moH:v}, {-bogh:v}, {jan:n:1}</column>
       <column name="examples">
@@ -5368,6 +5970,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5375,6 +5978,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hallmark commercial:src}, [2] {msn 1997.06.18:src}</column>
     </table>
     <table name="mem">
@@ -5388,6 +5992,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">свет (лампа) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">燈（燈） [AUTOTRANSLATED]</column>
       <column name="definition_pt">luz (lâmpada)</column>
+      <column name="definition_fi">valo (lamppu)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamghay:n}, {QIb:n}, {weQ:n}, {Sech:n}, {wovmoHbogh jan:n}, {telDaq wovmoHwI':n}, {wovmoHwI' moQ:n}</column>
@@ -5398,6 +6003,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wov:v}, {-moH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5407,6 +6013,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">lamp</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5414,6 +6021,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5427,6 +6035,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">лампочка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">燈泡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lâmpada</column>
+      <column name="definition_fi">hehkulamppu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5437,6 +6046,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wovmoHwI':n}, {moQ:n}</column>
       <column name="examples"></column>
@@ -5446,6 +6056,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5453,6 +6064,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5466,6 +6078,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">memory (recollection) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">記憶（回憶） [AUTOTRANSLATED]</column>
       <column name="definition_pt">memória (lembrança)</column>
+      <column name="definition_fi">muisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qaw:v}, {ngonDer:n}</column>
@@ -5476,6 +6089,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru">Это относится к конкретным воспоминаниям или воспоминаниям и отличается от «памяти» в смысле способности запоминать или способности вспомнить, для чего см. {qaw:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指特定的記憶或回憶，在記憶能力或記憶力方面與“記憶”不同，請參見{qaw:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a memórias ou lembranças específicas e é diferente de "memória" no sentido da capacidade de lembrar ou do poder de recordar, para o qual ver {qaw:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tiettyihin muistoihin tai muisteluihin, ja se eroaa "muistista" muistikyvyn tai muistamisen voiman kannalta, josta ks. {qaw:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Light ({wov:v}) on.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5486,6 +6100,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5493,6 +6108,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.06:src}</column>
     </table>
     <table name="mem">
@@ -5506,6 +6122,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">империя</column>
       <column name="definition_zh_HK">帝國</column>
       <column name="definition_pt">Império</column>
+      <column name="definition_fi">valtakunta, keisarikunta, imperiumi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rewbe':n}</column>
@@ -5516,6 +6133,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"World order".</column>
       <column name="components"></column>
       <column name="examples">
@@ -5529,6 +6147,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5536,6 +6155,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 1:src} (reprinted in {HQ 4.1, p.7:src})</column>
     </table>
     <table name="mem">
@@ -5549,6 +6169,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">объединенное Королевство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聯合王國</column>
       <column name="definition_pt">Reino Unido</column>
+      <column name="definition_fi">Yhdistynyt kuningaskunta</column>
       <column name="synonyms">{tuqjIjQa':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{'Inglan:n}, {SIqotlan:n}</column>
@@ -5559,6 +6180,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru">{wo' tay':n:nolink} - более старое имя, чем {tuqjIjQa':n}. Клингоны, давшие стране такое название, возможно, думали о Британской империи.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{wo' tay':n:nolink}比{tuqjIjQa':n}更舊。給這個國家起名字的克林崗人可能在想大英帝國。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">{wo' tay':n:nolink} é um nome mais antigo que {tuqjIjQa':n}. Os Klingons que deram ao país esse nome podem ter pensado no Império Britânico.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{wo' tay':n:nolink} on vanhempi nimi kuin {tuqjIjQa':n}. Klingonit, jotka antoivat maalle tämän nimen, saattoivat ajatella Britannian valtakuntaa[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wo':n}, {tay':v}</column>
       <column name="examples"></column>
@@ -5568,6 +6190,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">England, Britain, British Empire</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5575,6 +6198,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Radio Times Star Trek 30th Anniversary Special Issue:src}, [2] {KLI mailing list 2011.10.29:src}</column>
     </table>
     <table name="mem">
@@ -5588,6 +6212,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">Умереть во время служения Империи - надежда каждого клингона. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">服務帝國時死亡是每個克林崗人的希望。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Morrer enquanto servia ao Império é a esperança de todo Klingon.</column>
+      <column name="definition_fi">Jokainen klingoni toivoo kuolevansa palvellessaan keisarikuntaa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5598,6 +6223,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5607,6 +6233,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5614,6 +6241,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.74:src}</column>
     </table>
     <table name="mem">
@@ -5627,6 +6255,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">Ворф</column>
       <column name="definition_zh_HK">「武夫」</column>
       <column name="definition_pt">Worf</column>
+      <column name="definition_fi">Worf</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QI'tomer:n}, {qeylar:n:name}</column>
@@ -5637,6 +6266,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru">Сын Мога ({mogh:n:name}) и первый офицер клингонов, служивший в Звездном Флоте. Он изображен актером {mayqel Do'rIn:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">莫格（{mogh:n:name}）的兒子，也是首位在星艦隊服役的克林崗軍官。他由演員{mayqel Do'rIn:n:name}飾演。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Moghin poika ({mogh:n:name}) ja ensimmäinen Klingonin upseeri, joka palveli Tähtilaivastossa. Näyttelijä {mayqel Do'rIn:n:name} kuvaa häntä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5646,6 +6276,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5653,6 +6284,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 4.3, Sept. 1995:src}</column>
     </table>
     <table name="mem">
@@ -5666,6 +6298,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">храп [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">打鼾</column>
       <column name="definition_pt">roncar</column>
+      <column name="definition_fi">kuorsata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jev:v:2}, {tlhov:v}</column>
@@ -5676,6 +6309,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru">Дышите шумнее, чем {jev:v:2}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">比{jev:v:2}呼吸得更吵。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Respire mais ruidosamente que o {jev:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hengitä meluisammin kuin {jev:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">An idiomatic way of saying "snore" in English is "saw wood".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5685,6 +6319,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5692,6 +6327,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -5705,6 +6341,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">быть незащищенным, быть уязвимым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不受保護、易受傷害 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desprotegido, ser vulnerável</column>
+      <column name="definition_fi">olla suojaamaton, olla haavoittuva</column>
       <column name="synonyms"></column>
       <column name="antonyms">{QaD:v:2}</column>
       <column name="see_also">{Qan:v}</column>
@@ -5715,6 +6352,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5726,6 +6364,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5733,6 +6372,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -5746,6 +6386,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">разразиться песней [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">爆發成歌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">explodir em música</column>
+      <column name="definition_fi">puhjeta laulamaan</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:v}</column>
@@ -5756,6 +6397,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Whoop!</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5765,6 +6407,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5772,6 +6415,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5785,6 +6429,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">решать</column>
       <column name="definition_zh_HK">決定</column>
       <column name="definition_pt">decidir</column>
+      <column name="definition_fi">päättää jostakin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wuqHa':v}</column>
       <column name="see_also">{wIv:v}, {lap:v}</column>
@@ -5795,6 +6440,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5808,6 +6454,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
 "В родном мире, есть великий зал, где лидеры Клингонского высшего совета встречаются, чтобы определить политику, задать курс и решить судьбу империи. Сейчас председательствует Гаурон, лидер Высшего совета, назначенный капитаном Жаном-Люком Пикардом, который был Арбитром посвящения."[2]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5815,6 +6462,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 25:src}</column>
     </table>
     <table name="mem">
@@ -5828,6 +6476,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">commute (a judicial sentence) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通勤（司法判決） [AUTOTRANSLATED]</column>
       <column name="definition_pt">comutar (uma sentença judicial)</column>
+      <column name="definition_fi">muuntaa tai lieventää (rangaistusta)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wuq:v}</column>
       <column name="see_also"></column>
@@ -5838,6 +6487,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This means to undo a decision. Its only known use in canon is in the example.</column>
       <column name="components">{wuq:v}, {-Ha':v}</column>
       <column name="examples">
@@ -5848,6 +6498,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">revoke, withdraw</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5855,6 +6506,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -5868,6 +6520,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">иметь головную боль</column>
       <column name="definition_zh_HK">頭痛</column>
       <column name="definition_pt">ter uma dor de cabeça</column>
+      <column name="definition_fi">olla päänsärky, särkeä päätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uH:v}, {nuch Hergh:n}</column>
@@ -5878,6 +6531,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The similarity of this to {wuq:v} may be a joke.</column>
       <column name="components"></column>
       <column name="examples">
@@ -5888,6 +6542,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5895,6 +6550,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5908,6 +6564,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">руба</column>
       <column name="definition_zh_HK">嘴唇</column>
       <column name="definition_pt">lábio</column>
+      <column name="definition_fi">huuli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nuj:n}, {Du'ran:n}, {wuS rItlh naQ}</column>
@@ -5918,6 +6575,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5927,6 +6585,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5934,6 +6593,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -5947,6 +6607,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
           <column name="definition_ru">губная помада [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">嘴唇膏</column>
           <column name="definition_pt">batom</column>
+      <column name="definition_fi">huulipuna</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5957,6 +6618,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{wuS:n}, {rItlh naQ:n}</column>
           <column name="examples"></column>
@@ -5966,6 +6628,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5973,6 +6636,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
     <table name="mem">
@@ -5986,6 +6650,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">подполье</column>
       <column name="definition_zh_HK">地下</column>
       <column name="definition_pt">subterrâneo</column>
+      <column name="definition_fi">maanalainen maailma? tuonela?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yav:n}, {puH:n}</column>
@@ -5996,6 +6661,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6005,6 +6671,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6012,6 +6679,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6025,6 +6693,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">подземелье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地下室、地牢</column>
       <column name="definition_pt">masmorra</column>
+      <column name="definition_fi">vankityrmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6035,6 +6704,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru">Это буквально означает «подземная комната». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從字面上看，這僅意味著“地下室”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso literalmente significa apenas "sala subterrânea". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti vain "maanalaista huonetta". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{wutlh:n}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -6044,6 +6714,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6051,6 +6722,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.09:src}</column>
     </table>
     <table name="mem">
@@ -6064,6 +6736,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="definition_ru">полагаться на</column>
       <column name="definition_zh_HK">依靠</column>
       <column name="definition_pt">depender de , contar com</column>
+      <column name="definition_fi">riippua jostain, olla riippuvainen jostain, olla jonkin varassa?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghaq:v}</column>
@@ -6074,6 +6747,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6083,6 +6757,7 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6090,5 +6765,6 @@ Se os olhos são "sensíveis à luz", eles podem ser sensíveis a {wovtaHghach:n
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>

--- a/mem-20-y.xml
+++ b/mem-20-y.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {y:sen:nolink}</column>
       <column name="definition_zh_HK">輔音{y:sen:nolink}</column>
       <column name="definition_pt">a consoante {y:sen:nolink}</column>
+      <column name="definition_fi">konsonantti {y:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">тактический офицер</column>
       <column name="definition_zh_HK">戰術軍官</column>
       <column name="definition_pt">Oficial tático</column>
+      <column name="definition_fi">taktinen upseeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The resemblance to Tasha Yar's name is a coincidence, as the first edition of {TKD:src} came out before {TNG:src} aired.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">тактический компьютер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰術電腦</column>
       <column name="definition_pt">computador tático</column>
+      <column name="definition_fi">taktinen tietokone</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -97,6 +106,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ya:n}, {De'wI':n}</column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">тактическая система [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰術系統</column>
       <column name="definition_pt">sistema tático</column>
+      <column name="definition_fi">taktinen järjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -136,6 +149,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ya:n}, {pat:n}</column>
       <column name="examples"></column>
@@ -145,6 +159,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -152,6 +167,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -165,6 +181,7 @@
       <column name="definition_ru">ум, мозг</column>
       <column name="definition_zh_HK">心神、意識、腦</column>
       <column name="definition_pt">mente, cérebro</column>
+      <column name="definition_fi">mieli, aivot</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -175,6 +192,7 @@
       <column name="notes_ru">Это слово относится как к мозгу, так и к «уму, интеллекту». Для органа, см. {QoghIj:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞既指大腦又指“頭腦，智力”。有關器官，請參見{QoghIj:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se refere ao cérebro e à "mente, intelecto". Para o órgão, consulte {QoghIj:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -185,6 +203,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -192,6 +211,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -205,6 +225,7 @@
       <column name="definition_ru">подсознание [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">潛意識</column>
       <column name="definition_pt">subconsciente</column>
+      <column name="definition_fi">alitajunta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -215,6 +236,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yab:n}, {qoD:n}</column>
       <column name="examples"></column>
@@ -224,6 +246,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -231,6 +254,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -244,6 +268,7 @@
       <column name="definition_ru">ласкать, погладить</column>
       <column name="definition_zh_HK">撫摸</column>
       <column name="definition_pt">acariciar</column>
+      <column name="definition_fi">silittää, haroa, sukia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Saj:n}, {yach:v:2}</column>
@@ -254,6 +279,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta não é uma palavra klingon para "carinho", mas {yachchuq:v@@yach:v:1, -chuq:v} transmite a ideia.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei ole klingonilainen sana "halata", mutta {yachchuq:v@@yach:v:1, -chuq:v} saa idean eteenpäin.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -263,6 +289,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">brush, cuddle</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -270,6 +297,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2018.01.09:src}</column>
     </table>
     <table name="mem">
@@ -283,6 +311,7 @@
       <column name="definition_ru">Струм (струнный инструмент) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">撥動</column>
       <column name="definition_pt">dedilhado (um instrumento de cordas)</column>
+      <column name="definition_fi">soittaa, rämpyttää (kielisoitinta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HurDagh:n}, {pang:v}, {yach:v:1}</column>
@@ -293,6 +322,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -302,6 +332,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -309,6 +340,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -322,6 +354,7 @@
       <column name="definition_ru">палец на ноге</column>
       <column name="definition_zh_HK">腳趾</column>
       <column name="definition_pt">dedo do pé</column>
+      <column name="definition_fi">varvas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qam:n}, {nItlh:n}</column>
@@ -360,6 +393,11 @@ Tån verb används på samma sätt som finger verb, men de hörs inte ofta utanf
 Correspondentemente, os cinco dedos são {marwI':n}, {HomwI':n}, {roSwI':n}, {nanwI':n:2} e {Qay'wI':n}.
 
 Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas não são ouvidos com frequência fora das discussões sobre movimentos ou dança das artes marciais e são normalmente considerados arcaicos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonilla on viisi verbiä, jotka vastaavat kutakin {yaD:n:1,nolink}: {mar:v}, {Hom:v}, {roS:v:2}, {nan:v:2} ja {Qay':v:2}.
+
+Vastaavasti viisi varpaata ovat {marwI':n}, {HomwI':n}, {roSwI':n}, {nanwI':n:2} ja {Qay'wI':n}.
+
+Varpaiden verbejä käytetään samalla tavalla kuin sormen verbejä, mutta niitä ei kuule usein taistelulajien liikkeistä tai tanssista käytävien keskustelujen ulkopuolella, ja niitä pidetään yleensä arkaaisina. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The verbs for the toes come from the nursery rhyme "This Little Piggy".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -369,6 +407,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -376,6 +415,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -389,6 +429,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="definition_ru">меч [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">劍</column>
       <column name="definition_pt">espada</column>
+      <column name="definition_fi">miekka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -399,6 +440,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="notes_ru">Это сленговое слово возникло из-за сходства {yan:n} и {yaD:n:1} в диалекте {Qotmagh Sep:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個語源自{Qotmagh Sep:n}方言中{yan:n}和{yaD:n:1}的相似性。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra de gíria originou-se da semelhança de {yan:n} e {yaD:n:1} no dialeto {Qotmagh Sep:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä slangisana on peräisin {yan:n}- ja {yaD:n:1}-samankaltaisuudesta {Qotmagh Sep:n}-murteessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -408,6 +450,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -415,6 +458,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -428,6 +472,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="definition_ru">подросток, подросток, подросток, молодежь, молодые взрослые [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">青少年，少年，青少年，青年，年輕成人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">adolescente, jovem, adulto jovem</column>
+      <column name="definition_fi">teini, kasvu- tai murrosikäinen, nuori, nuori aikuinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puq:n}, {nen:v}</column>
@@ -438,6 +483,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="notes_ru">Несленговый термин - {HojnIy:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">非-語術語是{HojnIy:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O termo que não é gíria é {HojnIy:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Slangiton termi on {HojnIy:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -447,6 +493,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -454,6 +501,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -467,6 +515,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="definition_ru">Ядера Прайм [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Yadera Prime [AUTOTRANSLATED]</column>
       <column name="definition_pt">Yadera Prime</column>
+      <column name="definition_fi">Yadera I</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -477,6 +526,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="notes_ru">Планета в Гамма-квадранте, часть Доминиона. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">伽瑪象限中的一顆行星，是自治領的一部分。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um planeta no Quadrante Gama, uma parte do Domínio. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Planeetta Gamma-kvadrantissa, osa Dominionia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -486,6 +536,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -493,6 +544,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -506,6 +558,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="definition_ru">организм</column>
       <column name="definition_zh_HK">生物</column>
       <column name="definition_pt">organismo</column>
+      <column name="definition_fi">organismi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dep:n}, {mut:n}</column>
@@ -516,6 +569,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -525,6 +579,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">creature, lifeform, being</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -532,6 +587,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -545,6 +601,7 @@ Os verbos do dedo do pé são usados ​​da mesma forma que os dos dedos, mas 
       <column name="definition_ru">место службы</column>
       <column name="definition_zh_HK">工作站</column>
       <column name="definition_pt">estação de serviço, estação</column>
+      <column name="definition_fi">työpiste, sijoituspaikka, vartioasema</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qu':n}, {Qu' poH:n}</column>
@@ -569,6 +626,9 @@ Varje plats som specifikt är avsedd för utförande av en specifik uppgift elle
       <column name="notes_pt">Refere-se a qualquer lugar onde se trabalha, e não se limita ao uso militar.[2]
 
 Qualquer local designado especificamente para o desempenho de uma tarefa ou tarefas específicas é um {yaH:n:nolink}. Por exemplo, um palco é o {yaH:n:nolink} para a execução de peças ou música, um campo de futebol é o {yaH:n:nolink} para um jogo de futebol, um laboratório ({Qulpa':n}) é o {yaH:n:nolink} de um cientista. Se o contexto não for suficiente para esclarecer a que tipo de {yaH:n:nolink} alguém está se referindo, pode-se dizer coisas como {much yaH:n}, {QoQ yaH:n@@QoQ:n, yaH:n}, {tamlerQeD yaH:n@@tamlerQeD:n, yaH:n} e assim por diante.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa mihin tahansa paikkaan, jossa joku työskentelee, eikä rajoitu vain sotilaalliseen käyttöön
+
+Mikä tahansa paikka, joka on nimenomaisesti tarkoitettu tietyn tehtävän tai tehtävien suorittamiseen, on {yaH:n:nolink}. Esimerkiksi vaihe on {yaH:n:nolink} näytelmien tai musiikin esittämiselle, jalkapallokenttä on {yaH:n:nolink} jalkapallopelille, laboratorio ({Qulpa':n}) on tutkijan {yaH:n:nolink}. Jos asiayhteys ei riitä sen selvittämiseen, mihin {yaH:n:nolink}: ään viitataan, voidaan sanoa esimerkiksi {much yaH:n}, {QoQ yaH:n@@QoQ:n, yaH:n}, [2]0 ja niin edelleen.{tamlerQeD yaH:n@@tamlerQeD:n, yaH:n}[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -582,6 +642,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">workplace, office, stage, field, laboratory</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -589,6 +650,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}, [3] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -602,6 +664,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="definition_ru">быть убратым куда-то</column>
       <column name="definition_zh_HK">帶走、拿走</column>
       <column name="definition_pt">ser levado embora</column>
+      <column name="definition_fi">olla pois otettu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nge':v}, {lel:v}</column>
@@ -612,6 +675,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -621,6 +685,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -628,6 +693,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -641,6 +707,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="definition_ru">понимать</column>
       <column name="definition_zh_HK">明白</column>
       <column name="definition_pt">compreender, entender</column>
+      <column name="definition_fi">ymmärtää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yajHa':v}</column>
       <column name="see_also">{tlhoj:v}</column>
@@ -651,6 +718,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -660,6 +728,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -667,6 +736,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -680,6 +750,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="definition_ru">неверно истолковывать</column>
       <column name="definition_zh_HK">曲解 [AUTOTRANSLATED]</column>
       <column name="definition_pt">interpretar mal</column>
+      <column name="definition_fi">ymmärtää väärin, tulkita väärin</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yaj:v}</column>
       <column name="see_also"></column>
@@ -690,6 +761,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yaj:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -699,6 +771,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -706,6 +779,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -719,6 +793,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="definition_ru">Понятно? Вы понимаете?</column>
       <column name="definition_zh_HK">明白嗎？你明白嗎？</column>
       <column name="definition_pt">Entendido? Você entendeu?</column>
+      <column name="definition_fi">Ymmärrätkö?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yajchu':sen}</column>
@@ -729,6 +804,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="notes_ru">Это в обрезанном клингоне. В стандартном клингоне "понимаешь?" (говорит с одним человеком) будет {bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是在修剪過的克林崗語中。在標準的克林貢語中，“您了解嗎？” （與一個人交談）將是{bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso está no Klingon cortado. No Klingon padrão, "você entende?" (falando com uma pessoa) seria {bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on leikattu Klingon. Tavallisessa Klingon-muodossa "ymmärrätkö?" (puhuminen yhdelle henkilölle) olisi {bIyaj'a '?: sen: nolink}{bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yaj:v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -738,6 +814,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -745,6 +822,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -758,6 +836,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="definition_ru">Understood clearly. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">非常明白。</column>
       <column name="definition_pt">Compreendeu claramente.</column>
+      <column name="definition_fi">Ymmärretty hyvin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -768,6 +847,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="notes_ru">Это можно сказать в ответ на {yaj'a'?:sen} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能是對{yaj'a'?:sen}的回應 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser dito em resposta ao {yaj'a'?:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voidaan sanoa vastauksena {yaj'a '?: Sen}{yaj'a'?:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yaj:v}, {-chu':v}</column>
       <column name="examples"></column>
@@ -777,6 +857,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -784,6 +865,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -797,6 +879,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="definition_ru">линия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">直線</column>
       <column name="definition_pt">linha</column>
+      <column name="definition_fi">viiva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhegh:n}</column>
@@ -807,6 +890,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="notes_ru">Это относится к линии, например, на линованной бумаге или нарисованной на дороге. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是一條線，例如在橫格紙上或塗在道路上的線。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma linha como papel forrado ou pintado na estrada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa viivaan, kuten esimerkiksi vuorattuun paperiin tai maalattuna tielle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"What's My Line" ({watmay:sen:nolink}) was a TV show.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -816,6 +900,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -823,6 +908,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -836,6 +922,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="definition_ru">неровная линия, зигзагообразная линия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鋸齒線</column>
       <column name="definition_pt">linha recortada, linha em ziguezague</column>
+      <column name="definition_fi">rosoinen viiva, siksak-viiva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -846,6 +933,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yamtaw:n}, {job:v}</column>
       <column name="examples"></column>
@@ -855,6 +943,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -862,6 +951,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -875,6 +965,7 @@ Qualquer local designado especificamente para o desempenho de uma tarefa ou tare
       <column name="definition_ru">меч [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">劍</column>
       <column name="definition_pt">espada</column>
+      <column name="definition_fi">miekka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIqleH:n}, {'etlh:n}, {yaD:n:2}, {yan:v}</column>
@@ -899,6 +990,9 @@ Detta ord används också som slang för en "båge" som används för att spela 
       <column name="notes_pt">Esta é uma arma com lâminas longas.
 
 Esta palavra também é usada como gíria para um "arco", que é usado para tocar o {ngItHel:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on ase, jolla on pitkät terät.
+
+Tätä sanaa käytetään myös slangina "jouselle", jota käytetään pelaamaan {ngItHel:n}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Cantonese Chinese for "blade" (刃).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -908,6 +1002,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -915,6 +1010,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -929,6 +1025,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="definition_ru">Братство Меча, Ян-Ислет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">劍之兄弟會</column>
       <column name="definition_pt">Irmandade da espada, Yan-Isleth</column>
+      <column name="definition_fi">Miekan veljeskunta, Yan-Isleth</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qang:n}</column>
@@ -939,6 +1036,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="notes_ru">Члены {yan 'ISletlh:n:nolink} являются личными телохранителями канцлера. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{yan 'ISletlh:n:nolink}的成員是總理的私人保鏢。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os membros do {yan 'ISletlh:n:nolink} são os guarda-costas pessoais do Chanceler. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{yan 'ISletlh:n:nolink}: n jäsenet ovat liittokanslerin henkilökohtaisia ​​henkivartijoita. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Yan-Isleth was mentioned in {DS9 - Apocalypse Rising:src}. It appears in the glossary to the novel {A Burning House:src} spelled as {yanISletlh:sen:nolink}.</column>
       <column name="components">{yan:n}, {'ISletlh:n:hyp}</column>
       <column name="examples">
@@ -949,6 +1047,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bodyguard</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -956,6 +1055,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -969,6 +1069,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="definition_ru">использовать или манипулировать мечом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">用劍</column>
       <column name="definition_pt">usar ou manipular uma espada</column>
+      <column name="definition_fi">käyttää/käsitellä miekkaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yan:n}, {'etlh:n}, {yanwI':n}</column>
@@ -979,6 +1080,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">De acordo com {KGT p.79:src}, {raQ:v} pode ser usado como um substituto para {yan:v:nolink} no contexto de espadas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{KGT p.79:src}: n mukaan {raQ:v}: ta voidaan käyttää korvaamaan {yan:v:nolink} miekkojen yhteydessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -988,6 +1090,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -995,6 +1098,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1008,6 +1112,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="definition_ru">мечник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">劍客</column>
       <column name="definition_pt">luta de espadas</column>
+      <column name="definition_fi">miekkataistelija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1018,6 +1123,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is defined in the body of {KGT:src} on p.61.</column>
       <column name="components">{yan:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1027,6 +1133,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1034,6 +1141,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1047,6 +1155,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="definition_ru">гнездо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">巢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ninho</column>
+      <column name="definition_fi">pesä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -1057,6 +1166,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Chinese term for bird's nest as a food item is "yànwō" (燕窝).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1066,6 +1176,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1073,6 +1184,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1086,6 +1198,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="definition_ru">изображение с (резинового) штампа [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">來自（橡膠）郵票的圖像 [AUTOTRANSLATED]</column>
       <column name="definition_pt">imagem de um carimbo (de borracha)</column>
+      <column name="definition_fi">(kumileimasimella tehty) leima</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toqwIn:n}, {vem:n}</column>
@@ -1096,6 +1209,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Chinese word for stamp (印) is "yìn". Negative images are like "yīn" and "yáng" (陰陽).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1105,6 +1219,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1112,6 +1227,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -1125,6 +1241,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="definition_ru">быть достаточным</column>
       <column name="definition_zh_HK">足夠</column>
       <column name="definition_pt">ser suficiente</column>
+      <column name="definition_fi">olla riittävä, olla tarpeeksi, riittää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vey':v}, {law':v}, {puS:v:1}, {vuS:v}, {lach:v}</column>
@@ -1135,6 +1252,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Enough "yap"ping.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1145,6 +1263,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1152,6 +1271,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1165,6 +1285,7 @@ Esta palavra também é usada como gíria para um "arco", que é usado para toca
       <column name="definition_ru">офицер</column>
       <column name="definition_zh_HK">軍官</column>
       <column name="definition_pt">oficial</column>
+      <column name="definition_fi">upseeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'utlh:n}, {negh:n}, {QaS:n:1h}</column>
@@ -1186,6 +1307,18 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Virkailijoita[2] on yhdeksän ({patlh:n}):
+▶ {'aj:n} "amiraali"
+▶ {Sa':n} "yleinen"
+▶ {totlh:n} "commodore"
+▶ {'ech:n} "prikaatinkenraali"
+▶ {HoD:n} "kapteeni"
+▶ {la':n} "komentaja"
+▶ {Sogh:n} "luutnantti"
+▶ {lagh:n} "lippu"
+▶ {ne':n} "yeoman"
+
+Korkein armeijan upseeri, {ra'ghomquv:n}: n päällikkö, on {la'quv:n}. Joku, joka on {Sogh:n} tai sitä korkeampi, voidaan kutsua myös nimellä {ra'wI':n}. Erityistunnusta {la''a':n} käytetään virkamiehille, jotka vastaavat tietyistä armeijan erikoistuneista yksiköistä heidän virallisista riveistään riippumatta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1195,6 +1328,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1202,6 +1336,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.52:src}</column>
     </table>
     <table name="mem">
@@ -1215,6 +1350,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">Второй офицер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">二偈、二副</column>
       <column name="definition_pt">Segundo Oficial</column>
+      <column name="definition_fi">aliperämies, toinen perämies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1225,6 +1361,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru">Это может быть использовано в качестве заголовка.[1, p.53] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">可以用作標題。[1, p.53] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado como um título.[1, p.53] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää otsikkona.[1, p.53] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yaS:n}, {cha'DIch:n:1,num}</column>
       <column name="examples"></column>
@@ -1234,6 +1371,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1241,6 +1379,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1254,6 +1393,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">штаб офицеров [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">軍官宿舍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aposentos dos oficiais</column>
+      <column name="definition_fi">upseerien tilat</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pa'mey:n:hyp}</column>
@@ -1264,6 +1404,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yaS:n}, {pa':n:1}, {-mey:n}</column>
       <column name="examples"></column>
@@ -1273,6 +1414,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1280,6 +1422,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1293,6 +1436,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">Первый сотрудник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大偈、大副</column>
       <column name="definition_pt">Primeiro oficial</column>
+      <column name="definition_fi">yliperämies, ensimmäinen perämies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1303,6 +1447,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru">Это может быть использовано в качестве заголовка.[1, p.53] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">可以用作標題。[1, p.53] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado como um título.[1, p.53] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää otsikkona.[1, p.53] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yaS:n}, {wa'DIch:n:num}</column>
       <column name="examples"></column>
@@ -1312,6 +1457,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1319,6 +1465,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1332,6 +1479,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">своего рода птица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um tipo de pássaro</column>
+      <column name="definition_fi">eräs lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1342,6 +1490,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru">Это серая (иногда белая) птица, которая может путешествовать особенно на большие расстояния без остановки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一隻灰色（有時是白色）的鳥，可以不停地走很長的距離。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um pássaro cinzento (às vezes branco) que pode viajar longas distâncias sem fazer uma pausa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on harmaa (joskus valkoinen) lintu, joka voi kulkea erityisen pitkiä matkoja pysähtymättä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Yacht Cup". The Swallow is a type of keelboat.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1351,6 +1500,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1358,6 +1508,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1371,6 +1522,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">быть беременной [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">懷孕</column>
       <column name="definition_pt">estar grávida</column>
+      <column name="definition_fi">olla raskaana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghu:n}, {chI'ID:n}, {pIr:v}</column>
@@ -1381,6 +1533,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1390,6 +1543,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1397,6 +1551,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {paq'batlh p.184-185:src}</column>
     </table>
     <table name="mem">
@@ -1410,6 +1565,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">земля</column>
       <column name="definition_zh_HK">地</column>
       <column name="definition_pt">terra</column>
+      <column name="definition_fi">maa, maanpinta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chal:n}, {puH:n}, {wutlh:n}, {yotlh:n}</column>
@@ -1420,6 +1576,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1429,6 +1586,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1436,6 +1594,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1449,6 +1608,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">победа, триумф</column>
       <column name="definition_zh_HK">勝利</column>
       <column name="definition_pt">vitória, triunfo</column>
+      <column name="definition_fi">voitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qap:v:1}, {chargh:v}, {jey:v}</column>
@@ -1459,6 +1619,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Yay!</column>
       <column name="components"></column>
       <column name="examples">
@@ -1471,6 +1632,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1478,6 +1640,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TKW:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1491,6 +1654,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">Победа должна быть заслужена. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勝利是必須要贏返來的。</column>
       <column name="definition_pt">A vitória deve ser conquistada.</column>
+      <column name="definition_fi">Voitto on ansaittava.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1501,6 +1665,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1510,6 +1675,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1517,6 +1683,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.125:src}</column>
     </table>
     <table name="mem">
@@ -1530,6 +1697,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">череда побед [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">連勝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">série de vitórias</column>
+      <column name="definition_fi">voittoputki</column>
       <column name="synonyms">{QapwI' mIr:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1540,6 +1708,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru">Это обычный способ сказать это. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是常見的說法。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a maneira comum de dizer isso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleinen tapa sanoa tämä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yay:n:2}, {mIr:n:2}</column>
       <column name="examples"></column>
@@ -1549,6 +1718,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1556,6 +1726,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1569,6 +1740,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">коэффициент побед, частота побед [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勝利率、勝利次數 [AUTOTRANSLATED]</column>
       <column name="definition_pt">relação de vitória, frequência das vitórias</column>
+      <column name="definition_fi">voittosuhde, voittojen tiheys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1579,6 +1751,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yay:n:2}, {SubmaH:n}</column>
       <column name="examples"></column>
@@ -1588,6 +1761,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1595,6 +1769,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1608,6 +1783,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="definition_ru">каракули, каракули [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">塗鴉、塗鴉 [AUTOTRANSLATED]</column>
       <column name="definition_pt">rabisco</column>
+      <column name="definition_fi">töherrys, (epäselvä) piirros</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wev:v}</column>
@@ -1618,6 +1794,7 @@ The highest military officer, the head of the {ra'ghomquv:n}, is the {la'quv:n}.
       <column name="notes_ru">Это относится к «картинке», которая возникает в результате рисования, если ее трудно идентифицировать или назвать. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指“圖片”，如果不容易識別或命名，則是由於塗鴉而產生的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à "imagem" resultante de rabiscos, se não for facilmente identificável ou nomeada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa "kuvaan", joka syntyy doodlingista, ellei sitä voida helposti tunnistaa tai nimetä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word wasn't given an English definition but was described, along with the example "just circles or squiggles or jagged lines or a mishmash of things".
 
 Maltz thought there must have been, historically, a connection between this word and {yay:n:2}, but wasn't sure.
@@ -1631,6 +1808,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1638,6 +1816,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.10.18:src}</column>
     </table>
     <table name="mem">
@@ -1651,6 +1830,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">быть потрясенным</column>
       <column name="definition_zh_HK">受震驚</column>
       <column name="definition_pt">ficar chocado, pasmado</column>
+      <column name="definition_fi">olla järkyttynyt, sanaton, mykistynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mer:v}, {Duq:v}</column>
@@ -1661,6 +1841,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Yikes".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1670,6 +1851,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1677,6 +1859,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1690,6 +1873,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">эхо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">迴聲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">eco</column>
+      <column name="definition_fi">kaiku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wab:n}</column>
@@ -1700,6 +1884,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru">Для глагола "повторить", см. {'et:v} "отскок". [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對於動詞“ to echo”，請參見{'et:v}“ rebound”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para o verbo "ecoar", consulte {'et:v} "rebote". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Verbi "kaikua", katso {'et:v} "rebound". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Toyota Yaris was also sold under the name Toyota Echo.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1709,6 +1894,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1716,6 +1902,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1729,6 +1916,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">запястье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">手腕（也是俚語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">punho, pulso</column>
+      <column name="definition_fi">ranne</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DeS:n:1}, {ghop:n}, {ngIb:n:1}, {wIlle':n}</column>
@@ -1739,6 +1927,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru">Это также сленговый термин обесценивания ({yeb:n:2}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也是棄用的語（{yeb:n:2}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse também é um termo de gíria de descontinuação ({yeb:n:2}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on myös slangin poistotermi ({yeb:n:2}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is listed in the {KGT:src} word lists as "wrist (also a slang term of deprecation)". The two meanings have been split into separate entries for consistency with other slang terms.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1748,6 +1937,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1755,6 +1945,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1768,6 +1959,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">сленг срок амортизации [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">de貶詞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gíria termo de depreciação</column>
+      <column name="definition_fi">puhekielinen sana paheksumiselle</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1778,6 +1970,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru">На это сленговое значение повлияло произношение Krotmag слова {yeb:n:1}, которое звучит как {yem:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">語的含義受到{yeb:n:1}的Krotmag發音的影響，聽起來像{yem:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse significado de gíria foi influenciado pela pronúncia Krotmag de {yeb:n:1}, que soa como {yem:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tähän slangin merkitykseen vaikutti Krotmag-ääntäminen {yeb:n:1}, joka kuulostaa {yem:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1787,6 +1980,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1794,6 +1988,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.166:src}</column>
     </table>
     <table name="mem">
@@ -1807,6 +2002,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">быть замеченным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被發現 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser manchado</column>
+      <column name="definition_fi">olla pilkullinen, täplikäs</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oDtu':n}, {way:v}</column>
@@ -1817,6 +2013,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1826,6 +2023,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">getüpfelt</column>
       <column name="search_tags_fa"></column>
@@ -1833,6 +2031,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1846,6 +2045,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">совет</column>
       <column name="definition_zh_HK">大會、會議</column>
       <column name="definition_pt">assembleia, conselho</column>
+      <column name="definition_fi">neuvosto, (edustajien tms.) kokous</column>
       <column name="synonyms">{rIp:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{yejquv:n}, {yejHaD:n}, {yej'an:n}</column>
@@ -1856,6 +2056,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1865,6 +2066,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1872,6 +2074,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1885,6 +2088,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">институт, институт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">學院</column>
       <column name="definition_pt">instituto, instituição</column>
+      <column name="definition_fi">(tieteellinen, tutkimus-, tms.) laitos, instituutti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DuSaQ:n}, {'ampaS:n}</column>
@@ -1895,6 +2099,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yej:n}?, {HaD:v} or {HaD:n:hyp,nolink}</column>
       <column name="examples">
@@ -1905,6 +2110,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1912,6 +2118,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 4.4, p.11:src}</column>
     </table>
     <table name="mem">
@@ -1925,6 +2132,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">высокий совет</column>
       <column name="definition_zh_HK">高級會議</column>
       <column name="definition_pt">Alto Conselho</column>
+      <column name="definition_fi">Korkein neuvosto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yo'SeH yaHnIv:n}</column>
@@ -1935,6 +2143,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yej:n}, {quv:v}</column>
       <column name="examples"></column>
@@ -1944,6 +2153,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1951,6 +2161,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1964,6 +2175,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">Лидер Высшего Совета [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">高級會議領導人</column>
       <column name="definition_pt">Líder do Alto Conselho</column>
+      <column name="definition_fi">Korkeimman neuvoston johtaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1974,6 +2186,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yejquv:n}, {DevwI':n}</column>
       <column name="examples"></column>
@@ -1983,6 +2196,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1990,6 +2204,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 25:src}</column>
     </table>
     <table name="mem">
@@ -2003,6 +2218,7 @@ Maltz thought there must have been, historically, a connection between this word
       <column name="definition_ru">society (e.g., scholarly society) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">學會</column>
       <column name="definition_pt">sociedade (por exemplo, sociedade acadêmica)</column>
+      <column name="definition_fi">(tieteellinen, akateeminen) seura, yhdistys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DuSaQ:n}, {'ampaS:n}</column>
@@ -2027,6 +2243,9 @@ Förväxla inte detta med ett samhälle i kulturell mening, som se {nugh:n}.[1] 
       <column name="notes_pt">Esta é uma organização dedicada a atividades escolares ou pesquisas. A distinção entre {yej'an:n:nolink} e {yejHaD:n} não é clara, mas {yejHaD:n:nolink} é geralmente usado para organizações maiores. Não se sabe se a primeira sílaba é a palavra {yej:n}, mas pode haver alguma conexão histórica.[1]
 
 Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh:n}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on organisaatio, joka on omistautunut skolastisiin harrastuksiin tai tutkimukseen. {yej'an:n:nolink}: n ja {yejHaD:n}: n välinen ero ei ole selvä, mutta {yejHaD:n:nolink}: ta käytetään yleensä suuremmissa organisaatioissa. Ei tiedetä, onko ensimmäinen tavu sana {yej:n}, mutta historiallinen yhteys saattaa olla olemassa.
+
+Älä sekoita tätä yhteiskuntaan kulttuurisessa mielessä, josta ks.{nugh:n}.[1][1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yej:n}?, {'an:v:0} or {'an:v:1} or {'an:n:hyp,nolink}</column>
       <column name="examples">
@@ -2037,6 +2256,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2044,6 +2264,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 4.4, p.11, Dec. 1995:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2057,6 +2278,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">грешить</column>
       <column name="definition_zh_HK">造孽</column>
       <column name="definition_pt">pecado</column>
+      <column name="definition_fi">tehdä syntiä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{mIt:v}</column>
       <column name="see_also">{HeS:v}</column>
@@ -2067,6 +2289,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2077,6 +2300,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2084,6 +2308,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2097,6 +2322,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">быть осторожным</column>
       <column name="definition_zh_HK">小心</column>
       <column name="definition_pt">ser cuidadoso</column>
+      <column name="definition_fi">olla varovainen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yepHa':v}</column>
       <column name="see_also">{Hoj:v}</column>
@@ -2107,6 +2333,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2116,6 +2343,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2123,6 +2351,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2136,6 +2365,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">быть небрежным</column>
       <column name="definition_zh_HK">粗心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser descuidado</column>
+      <column name="definition_fi">olla huolimaton, varomaton</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yep:v}</column>
       <column name="see_also"></column>
@@ -2146,6 +2376,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{ruq'e'vet:n}-murreessa {ghIH:v:2} tarkoittaa {yepHa':v:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yep:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -2155,6 +2386,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2162,6 +2394,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2175,6 +2408,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">сотрудничать</column>
       <column name="definition_zh_HK">合作 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colaborar</column>
+      <column name="definition_fi">tehdä yhteistyötä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIj:v}</column>
@@ -2185,6 +2419,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru">Предметом являются сотрудничающие стороны. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">主題是合作方。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O assunto são as partes que colaboraram. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Aihe on yhteistyössä toimineet osapuolet. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the K-E side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2212,6 +2447,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">unite, unity</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2219,6 +2455,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh:src}</column>
     </table>
     <table name="mem">
@@ -2232,6 +2469,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">владения, земля, территория</column>
       <column name="definition_zh_HK">域名、館藏、領土 [AUTOTRANSLATED]</column>
       <column name="definition_pt">domínio, explorações, território</column>
+      <column name="definition_fi">maa-alue, kiinteistö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DoQ:v}, {yer ghajwI' chaw':n}, {yergho:n}, {teblaw':n}, {Daq'a':n}</column>
@@ -2242,6 +2480,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru">Это слово используется в {Klingon Monopoly:src} для обозначения игрового квадрата, включая те, которые соответствуют четырем классам кораблей. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{Klingon Monopoly:src}中使用此詞表示遊戲廣場，包括對應於四個飛船類別的遊戲廣場。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada em {Klingon Monopoly:src} para denotar um quadrado de jogo, incluindo aqueles correspondentes às quatro classes de navios. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään kohdassa {Klingon Monopoly:src} pelin neliötä, mukaan lukien ne, jotka vastaavat neljää laivaluokkaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2252,6 +2491,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">property, game square</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2259,6 +2499,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src}), [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -2272,6 +2513,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">титул на право собственности [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地契 [AUTOTRANSLATED]</column>
       <column name="definition_pt">título de propriedade</column>
+      <column name="definition_fi">saantokirja, lainhuudatustodistus, omistusoikeustodistus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2282,6 +2524,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru">Обратите внимание, что клингоны рассматривают титулы как тип {chaw':n}, а не тип {Qoyje':n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，克林崗人將產權契據視為{chaw':n}的一種，而不是{Qoyje':n}的一種。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que os Klingons consideram os títulos de propriedade como um tipo de {chaw':n}, em vez de um tipo de {Qoyje':n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yer:n}, {ghajwI':n}, {chaw':n}</column>
       <column name="examples"></column>
@@ -2291,6 +2534,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">property, ownership</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2298,6 +2542,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}, [2] {KLI mailing list 2015.05.29:src}</column>
     </table>
     <table name="mem">
@@ -2311,6 +2556,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">многогранник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">多面體</column>
       <column name="definition_pt">poliedro</column>
+      <column name="definition_fi">monitahokas, polyedri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mey':n}, {tut:n:2}</column>
@@ -2321,6 +2567,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2330,6 +2577,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2337,6 +2585,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2350,6 +2599,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">городская стена [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一座城市的牆 [AUTOTRANSLATED]</column>
       <column name="definition_pt">muros da cidade</column>
+      <column name="definition_fi">kaupungin muuri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2360,6 +2610,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to the walls of "Jericho".</column>
       <column name="components">{yer:n}, {gho:n}</column>
       <column name="examples"></column>
@@ -2369,6 +2620,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2376,6 +2628,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1998.12.07:src} (reprinted in {HQ 8.1, p.9, Mar. 1999:src})</column>
     </table>
     <table name="mem">
@@ -2389,6 +2642,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">приостанавливаться</column>
       <column name="definition_zh_HK">暫停 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pausa</column>
+      <column name="definition_fi">pitää tauko, levätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mev:v}, {bup:v}</column>
@@ -2399,6 +2653,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2408,6 +2663,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2415,6 +2671,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2428,6 +2685,7 @@ Não confunda isso com uma sociedade no sentido cultural, para a qual veja {nugh
       <column name="definition_ru">императив: ты-ничего, ты-его/её, вы-его/её</column>
       <column name="definition_zh_HK">（命令）你：無、他、它；你們：他、它</column>
       <column name="definition_pt">imperativo: você-nenhum, você-ele/ela, vocês-ele/ela</column>
+      <column name="definition_fi">imperatiivi: sinä-ei mitään, sinä/te-häntä/sitä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bI-:v:pref}, {Da-:v:pref}, {bo-:v:pref}</column>
@@ -2444,6 +2702,13 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{SoH:n}: {pagh:n:1h} = {yI-:v:pref,nolink} (imp.)
+{SoH:n}: {ghaH:n} / {'oH:n} = {yI-:v:pref,nolink} (imp.)
+{tlhIH:n}: {ghaH:n} / {'oH:n} = {yI-:v:pref,nolink} (imp.)
+
+Jos komento on annettu useammalle henkilölle ja objektia ei ole, ole varovainen, että käytät sen sijaan {pe-:v}-komentoa.
+
+Yleensä kun olotilaa kuvaavaa verbiä käytetään välttämättömänä, sen kanssa käytetään loppuliitteitä {-'egh:v} ja {-moH:v}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2453,6 +2718,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">you-him, you-her, you-it</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2460,6 +2726,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.117:src}</column>
     </table>
     <table name="mem">
@@ -2473,6 +2740,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">отдушина</column>
       <column name="definition_zh_HK">排氣孔</column>
       <column name="definition_pt">desabafar</column>
+      <column name="definition_fi">tuuletusaukko, ilmanpoistokanava, ilmareikä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nIj:v}</column>
@@ -2483,6 +2751,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2492,6 +2761,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2499,6 +2769,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <!-- Gowron says {yIbej!}: http://youtu.be/32-QCG_al2I -->
@@ -2512,7 +2783,8 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_sv">tribbel</column>
       <column name="definition_ru">Триббл</column>
       <column name="definition_zh_HK">符段 [AUTOTRANSLATED]</column>
-      <column name="definition_pt">tribble</column>
+      <column name="definition_pt">eräs eläin, tribble</column>
+      <column name="definition_fi">trible</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIlo'meH:n:extcan}</column>
@@ -2523,6 +2795,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru">Существует идиома {'up; yIH rur@@'up:v, yIH:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{'up; yIH rur@@'up:v, yIH:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {'up; yIH rur@@'up:v, yIH:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {'up; yIH rur@@'up:v, yIH:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2532,6 +2805,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2539,6 +2813,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2552,6 +2827,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Покажи(те) его/её на эране!</column>
       <column name="definition_zh_HK">把他放在屏幕上。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Coloque-o na tela.</column>
+      <column name="definition_fi">Pane hänet ruudulle.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIHotlh!:sen:2}</column>
@@ -2562,6 +2838,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru">Это также может означать «Вывести ее на экран» или «Вывести ее на экран». Короче говоря, на английском языке это просто «На экране». Тем не менее, «положить их на экран» будет {tIHotlh.:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也可能意味著“將她放在屏幕上”或“將其放在屏幕上”。用英語寫它的一種簡短方法是“在屏幕上”。但是，“將它們放在屏幕上”將是{tIHotlh.:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode significar "Coloque-a na tela" ou "Coloque-a na tela". Uma maneira mais curta de colocá-lo em inglês é apenas "Na tela". No entanto, "Colocá-los na tela" seria {tIHotlh.:sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi tarkoittaa myös "Laita hänet näytölle" tai "Laita se näytölle". Lyhyempi tapa laittaa se englanniksi on vain "Näytöllä". "Laita ne ruudulle" olisi kuitenkin {tIHotlh.:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {Hotlh:v:1}</column>
       <column name="examples"></column>
@@ -2571,6 +2848,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">On screen.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2578,6 +2856,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}</column>
     </table>
     <table name="mem">
@@ -2591,6 +2870,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Scan it! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">掃一掃！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Escaneie-o!</column>
+      <column name="definition_fi">Skannaa se!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIHotlh!:sen:1}</column>
@@ -2601,6 +2881,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {Hotlh:v:2}</column>
       <column name="examples"></column>
@@ -2610,6 +2891,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2617,6 +2899,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.189:src}</column>
     </table>
     <table name="mem">
@@ -2630,6 +2913,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Get up! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">起身！</column>
       <column name="definition_pt">Levante-se!</column>
+      <column name="definition_fi">Nouse ylös!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2640,6 +2924,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {Hu':v}</column>
       <column name="examples"></column>
@@ -2649,6 +2934,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2656,6 +2942,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}, [2] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2669,6 +2956,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Не говори(те)!</column>
       <column name="definition_zh_HK">閉嘴！</column>
       <column name="definition_pt">Fique quieto! (ex., Não fale!)</column>
+      <column name="definition_fi">Älä puhu! (Ole hiljaa!)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -2681,6 +2969,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2690,6 +2979,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2697,6 +2987,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -2710,6 +3001,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Не скажи(те) ему/ей!</column>
       <column name="definition_zh_HK">不要告訴他/她！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Não conte a ele/ela!</column>
+      <column name="definition_fi">Älä kerro hänelle!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2720,6 +3012,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was used as the refrain of a song in {TNG - Birthright, Part I:src}. The actors mispronounced it so badly that it was retrofitted by the fan community and performed by the Indianapolis "il Troubadore" as {yIjaH Qey' 'oH:sen:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2729,6 +3022,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">yIjaH Qey' 'oH</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2736,6 +3030,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -2749,6 +3044,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Покорми(те) его/её!</column>
       <column name="definition_zh_HK">喂它！</column>
       <column name="definition_pt">Alimente-o!</column>
+      <column name="definition_fi">Ruoki hänet!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2759,6 +3055,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The English translation given on {TKD p.170:src} is "Feed him!", but this also means "Feed her!" or "Feed it!"</column>
       <column name="components">{yI-:v}, {je':v:2}</column>
       <column name="examples"></column>
@@ -2768,6 +3065,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">feed her, feed it</column>
       <column name="search_tags_de">füttere sie, füttere es</column>
       <column name="search_tags_fa"></column>
@@ -2775,6 +3073,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}, [2] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -2788,6 +3087,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Отпусти его! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">釋放他！</column>
       <column name="definition_pt">Liberte-o!</column>
+      <column name="definition_fi">Vapauta hänet!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2798,6 +3098,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {jonHa':v}</column>
       <column name="examples"></column>
@@ -2807,6 +3108,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2814,6 +3116,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -2827,6 +3130,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Уклоняйсь!</column>
       <column name="definition_zh_HK">採取規避行動！</column>
       <column name="definition_pt">Tome medidas evasivas!</column>
+      <column name="definition_fi">Tee väistöliikkeitä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2837,6 +3141,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2846,6 +3151,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2853,6 +3159,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek I:src}</column>
     </table>
     <table name="mem">
@@ -2866,6 +3173,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Празднуйте! Завтра мы можем умереть! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">慶祝！明天我們可能會死！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Celebre! Amanhã podemos morrer!</column>
+      <column name="definition_fi">Juhli! Ehkä huomenna kuolemme!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2876,6 +3184,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2885,6 +3194,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2892,6 +3202,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.153:src}</column>
     </table>
     <!-- Gowron says {yImev}: http://youtu.be/HH15mWq8J9I -->
@@ -2906,6 +3217,7 @@ Generally, when a verb describing a state of being is used as an imperative, the
       <column name="definition_ru">Обрати(те) внимание!</column>
       <column name="definition_zh_HK">注意！</column>
       <column name="definition_pt">Preste atenção!</column>
+      <column name="definition_fi">Kiinnitä huomiota!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2944,6 +3256,11 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/YogSytvb8cc} [AUTOTRAN
 Uma resposta apropriada para isso é {nuqneH:excl} "O que você quer?"
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YogSytvb8cc} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on suunnattu yhdelle henkilölle. Kun puhut useille ihmisille, sano sen sijaan {peqIm!:sen:nolink}.
+
+Sopiva vastaus tähän on {nuqneH:excl} "Mitä haluat?"
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/YogSytvb8cc} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2953,6 +3270,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YogSytvb8cc} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2960,6 +3278,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YogSytvb8cc} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -2973,6 +3292,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YogSytvb8cc} [A
       <column name="definition_ru">жизнь</column>
       <column name="definition_zh_HK">生命</column>
       <column name="definition_pt">vida</column>
+      <column name="definition_fi">elämä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hegh:n}</column>
       <column name="see_also">{yIn:v}, {'umber:n}</column>
@@ -2983,6 +3303,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YogSytvb8cc} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2993,6 +3314,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YogSytvb8cc} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3000,6 +3322,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YogSytvb8cc} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3013,6 +3336,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/YogSytvb8cc} [A
       <column name="definition_ru">жить</column>
       <column name="definition_zh_HK">生活 [AUTOTRANSLATED]</column>
       <column name="definition_pt">viver</column>
+      <column name="definition_fi">elää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Hegh:v}</column>
       <column name="see_also">{taH:v:1}, {Dab:v}, {yIn:n}</column>
@@ -3026,6 +3350,9 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä sanaa voidaan käyttää väliaikaisesti sanomaan esimerkiksi {tlhIngan yIn DayIn:sen:nolink} "Elät klingonielämää". [2]
+
+Käytä {Dab:v} -sanetta sanomaan, että joku "asuu" paikassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Klingon sentence {tlhIngan yIn DayIn:sen:nolink} was written by MO in someone's {KGT:src} when he autographed it. It does not actually appear in the {HQ 7.4:src} article, but it is alluded to there by its English translation.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3036,6 +3363,7 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3043,6 +3371,7 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, p.2, Dec. 1998:src}</column>
     </table>
     <table name="mem">
@@ -3056,6 +3385,7 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="definition_ru">Чтобы понять жизнь, терпеть боль. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要了解生活，忍受痛苦。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Para entender a vida, suporte a dor.</column>
+      <column name="definition_fi">Elämän ymmärtämiseksi on sidettävä kipua.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3066,6 +3396,7 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yIn:n}, {Da-:v}, {yaj:v}, {-meH:v}, {'oy':n}, {yI-:v}, {SIQ:v}</column>
       <column name="examples"></column>
@@ -3075,6 +3406,7 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3082,6 +3414,7 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.43:src}</column>
     </table>
     <table name="mem">
@@ -3095,6 +3428,7 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="definition_ru">Живи долго и процветай! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">健康長壽·繁榮昌盛！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Vida longa e próspera!</column>
+      <column name="definition_fi">Elä pitkään ja menesty!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIpoq:n:name}, {pIj tay'taH Doch pIm:sen}</column>
@@ -3105,6 +3439,7 @@ To say that someone "lives at" a place, use {Dab:v}.</column>
       <column name="notes_ru">Это обычная вулканская поговорка. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是瓦肯人常說的話。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um ditado vulcano comum. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleinen vulkanilainen sanonta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This translation also appeared in the Klingon subtitles for {DSC - The Vulcan Hello:src}.
 
 An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversary Special (1991), spoken by Leonard Nimoy (not in character as Spock): {yItaH 'ej yIcheptaH@@yI-:v, taH:v:1, 'ej:conj, yI-:v, chep:v, -taH:v}.</column>
@@ -3116,6 +3451,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3123,6 +3459,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Radio Times Star Trek 30th Anniversary Special Issue:src}</column>
     </table>
     <table name="mem">
@@ -3136,6 +3473,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">зомби [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">殭屍</column>
       <column name="definition_pt">zumbi</column>
+      <column name="definition_fi">zombi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iw remwI':n}, {tlhapragh:n}</column>
@@ -3146,6 +3484,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yIn:v}, {-bogh:v}, {lom:n}</column>
       <column name="examples"></column>
@@ -3155,6 +3494,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3162,6 +3502,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3175,6 +3516,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">Survival must be earned. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">必須獲得生存。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A sobrevivência deve ser conquistada.</column>
+      <column name="definition_fi">Selviytyminen on ansaittava.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3185,6 +3527,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3194,6 +3537,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3201,6 +3545,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.125:src}</column>
     </table>
     <table name="mem">
@@ -3214,6 +3559,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">признаки жизни</column>
       <column name="definition_zh_HK">生命跡象 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sinais de vida</column>
+      <column name="definition_fi">elämän merkit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3224,6 +3570,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yIn:n}, {roH:n:hyp}</column>
       <column name="examples"></column>
@@ -3233,6 +3580,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3240,6 +3588,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3253,6 +3602,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">кислород [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">氧氣</column>
       <column name="definition_pt">oxigênio</column>
+      <column name="definition_fi">happi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIp:n}, {yoq yIn yuQ:n}, {tamler:n}</column>
@@ -3263,6 +3613,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru">Это буквально означает «газ жизни». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“生命之氣”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso literalmente significa "gás natural". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "elämän kaasua". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yIn:n}, {SIp:n}</column>
       <column name="examples"></column>
@@ -3272,6 +3623,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3279,6 +3631,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3292,6 +3645,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">система жизнеобеспечения</column>
       <column name="definition_zh_HK">生命支持系統 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sistema de suporte de vida</column>
+      <column name="definition_fi">elämän ylläpitojärjestelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{muD ngeb SeHwI' pat:n}</column>
@@ -3302,6 +3656,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yIn:n}, {tagh:n}</column>
       <column name="examples"></column>
@@ -3311,6 +3666,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">life support system</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3318,6 +3674,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3331,6 +3688,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">(бранное слово)</column>
       <column name="definition_zh_HK">稱號 [AUTOTRANSLATED]</column>
       <column name="definition_pt">epíteto</column>
+      <column name="definition_fi">eräs haukkumasana</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3341,6 +3699,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/sKHEvMGdaxE} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/sKHEvMGdaxE} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/sKHEvMGdaxE} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/sKHEvMGdaxE} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Toral, son of Duras ({DuraS:n:name}), calls Gowron this in the episode {TNG - Redemption:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3350,6 +3709,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3357,6 +3717,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {TNG - Redemption:src}</column>
     </table>
     <table name="mem">
@@ -3370,6 +3731,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">Gagh is always best when served live. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Gagh在現場直播時總是最好的。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Gagh é sempre melhor quando servido ao vivo.</column>
+      <column name="definition_fi">Gagh on aina parasta tarjoiltuna elävänä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3380,6 +3742,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yIn:v}, {-taH:v}, {-bogh:v}, {qagh:n}, {jab:v}, {-lu':v}, {-DI':v}, {reH:adv}, {nIv:v}, {-qu':v}, {qagh:n}</column>
       <column name="examples"></column>
@@ -3389,6 +3752,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3396,6 +3760,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.141:src}</column>
     </table>
     <table name="mem">
@@ -3409,6 +3774,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">экологический костюм [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">環保套裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">traje espacial</column>
+      <column name="definition_fi">avaruuspuku, suojapuku</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3419,6 +3785,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yIn:n}, {'eSqa':n}</column>
       <column name="examples"></column>
@@ -3428,6 +3795,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3435,6 +3803,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3448,6 +3817,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">Быть здоровым! Поправляйся! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">健康！痊癒！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Seja saudável! Fica bem!</column>
+      <column name="definition_fi">Voi hyvin! Parane!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3458,6 +3828,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was used by MO in a "get well" letter to Glen Proechel in March of 1998. According to the rule given in {KGT:src}, this should've been {yIpIv'eghmoH!:sen@@yI-:v, pIv:v, -'egh:v, -moH:v} See under {taD:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3467,6 +3838,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3474,6 +3846,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -3487,6 +3860,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">быть влажным</column>
       <column name="definition_zh_HK">濕了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser molhado</column>
+      <column name="definition_fi">olla märkä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaH:v:1}, {QaD:v:1}, {char:v}, {bIQ:n}, {Qal:v}</column>
@@ -3497,6 +3871,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples">{puH yIQ:n}</column>
@@ -3506,6 +3881,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3513,6 +3889,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3526,6 +3903,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">Don't just aim; hit the target! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不要只是瞄準，要擊中目標！</column>
       <column name="definition_pt">Não apenas mire; atinja o alvo!</column>
+      <column name="definition_fi">Älä vain tähtää, osu kohteeseen!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3536,6 +3914,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {Qeq:v:1}, {-Qo':v}, {neH:adv}, {DoS:n}, {yI-:v}, {qIp:v}</column>
       <column name="examples"></column>
@@ -3545,6 +3924,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3552,6 +3932,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.191:src}</column>
     </table>
     <table name="mem">
@@ -3565,6 +3946,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">собирать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">收集 [AUTOTRANSLATED]</column>
       <column name="definition_pt">reunir</column>
+      <column name="definition_fi">koota, kerätä (esim. varusteet)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boS:v}, {lIq:v}</column>
@@ -3575,6 +3957,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="notes_ru">Например, используется для описания воина, собирающего свою броню и оружие перед битвой. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">例如，用來形容戰士在戰鬥前收集盔甲和武器的戰士。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Por exemplo, costumava descrever um guerreiro reunindo suas armaduras e armas antes de uma batalha. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Esimerkiksi käytetään kuvaamaan soturia, joka kerää panssarinsa ja aseensa ennen taistelua. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -3585,6 +3968,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3592,6 +3976,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'u':src}, [2] {paq'batlh p.181:src}</column>
     </table>
     <table name="mem">
@@ -3605,6 +3990,7 @@ An earlier translation of this phrase appears in UPN's Star Trek 25th Anniversar
       <column name="definition_ru">Оставаться! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">留！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Fique!</column>
+      <column name="definition_fi">Jää!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3629,6 +4015,9 @@ Se Gowron säga detta: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [AUTOTRAN
       <column name="notes_pt">Isso é usado ao se dirigir a uma única pessoa. Para se dirigir a várias pessoas, diga {peratlh!:sen@@pe-:v, ratlh:v}
 
 Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään puhuttaessa yksittäiseen henkilöön. Jos haluat puhua useille ihmisille, sano {peratlh!:sen@@pe-:v, ratlh:v}
+
+Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {ratlh:v}</column>
       <column name="examples"></column>
@@ -3638,6 +4027,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3645,6 +4035,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -3658,6 +4049,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">Иридиан (человек) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Yridian（人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Yridian (pessoa)</column>
+      <column name="definition_fi">yridialainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngan:n}</column>
@@ -3668,6 +4060,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is misspelled as "Yiridian" in both word lists in {KGT:src}, but it is consistently spelled "Yridian" elsewhere, including {TKW:src} as well as Star Trek canon.</column>
       <column name="components"></column>
       <column name="examples">
@@ -3678,6 +4071,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Yiridian</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3685,6 +4079,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -3698,6 +4093,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">Приготовьтесь к плащу. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">準備隱形。</column>
       <column name="definition_pt">Preparar para camuflagem.</column>
+      <column name="definition_fi">Valmistaudu verhoutumaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{So'wI' yIchu'!:sen}</column>
@@ -3708,6 +4104,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {So':v:1}, {-rup:v}</column>
       <column name="examples"></column>
@@ -3717,6 +4114,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3724,6 +4122,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -3737,6 +4136,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">Stand by to de-cloak for firing. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">準備解除隱形並開火。</column>
       <column name="definition_pt">Aguarde para descamuflar para atirar.</column>
+      <column name="definition_fi">Ole valmis poistamaan verhoutuminen ja ampumaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{So'wI' yIchu'Ha'!:sen}</column>
@@ -3747,6 +4147,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {So'Ha':v:1}, {-rup:v}, {yI-:v}, {ghuS:v:1}</column>
       <column name="examples"></column>
@@ -3756,6 +4157,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3763,6 +4165,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -3776,6 +4179,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">гулять, ходить</column>
       <column name="definition_zh_HK">步行</column>
       <column name="definition_pt">caminhar, andar</column>
+      <column name="definition_fi">kävellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qet:v}, {rIgh:v}, {lID:v}</column>
@@ -3786,6 +4190,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3795,6 +4200,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3802,6 +4208,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3815,6 +4222,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">Будь тихом!</column>
       <column name="definition_zh_HK">唔好嘈！</column>
       <column name="definition_pt">Fique quieto! (ou seja, fique quieto!)</column>
+      <column name="definition_fi">Hiljenny! (Ole hiljaa!)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -3827,6 +4235,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru">Посмотрите, как Говрон говорит: {YouTube video:url:http://youtu.be/PUwSJai1cps} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看Gowron這樣說：{YouTube video:url:http://youtu.be/PUwSJai1cps} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/PUwSJai1cps} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/PUwSJai1cps} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {tam:v:1}, {-choH:v}</column>
       <column name="examples"></column>
@@ -3836,6 +4245,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3843,6 +4253,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.172:src}</column>
     </table>
     <table name="mem">
@@ -3856,6 +4267,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">быть строгим, суровым, твердым, суровым, авторитарным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嚴謹、嚴厲、堅定、嚴厲、專制 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser rígido, severo, firme, austero, autoritário</column>
+      <column name="definition_fi">olla tiukka, ankara, autoritaarinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yItlhHa':v}</column>
       <column name="see_also"></column>
@@ -3866,6 +4278,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3875,6 +4288,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3882,6 +4296,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -3895,6 +4310,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">быть снисходительным, снисходительным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">寬容、放縱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser branda, indulgente</column>
+      <column name="definition_fi">olla lempeä, suopea, armollinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yItlh:v}</column>
       <column name="see_also"></column>
@@ -3905,6 +4321,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yItlh:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -3914,6 +4331,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3921,6 +4339,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <!-- Gowron says {yItlhutlhchu'!}: http://youtu.be/BClxiHuCjh4-->
@@ -3935,6 +4354,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">жевать</column>
       <column name="definition_zh_HK">嚼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mastigar</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choptaH:v}, {tlhIS:v}, {ngal:v}, {yIv:v:2}</column>
@@ -3945,6 +4365,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3954,6 +4375,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3961,6 +4383,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -3974,6 +4397,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">раздражать, беспокоить, раздражать, раздражать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">煩惱、煩、煩惱、煩惱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">irritar, incomodar</column>
+      <column name="definition_fi"></column>
       <column name="synonyms">{nuQ:v}, {berghmoH:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{yIv:v:1}</column>
@@ -3984,6 +4408,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="notes_ru">Предметом этого глагола может быть только человек или существо, а не неодушевленный предмет или ситуация. Смотрите {KGT p.167:src} для объяснения этого жаргонного слова. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞的主語只能是人或生物，不能是無生命的物體或情況。有關此s語的解釋，請參見{KGT p.167:src}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O sujeito deste verbo pode ser apenas uma pessoa ou criatura, não um objeto ou situação inanimada. Veja {KGT p.167:src} para obter uma explicação dessa gíria. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3993,6 +4418,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4000,6 +4426,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4013,6 +4440,7 @@ Veja Gowron dizer o seguinte: {YouTube video:url:http://youtu.be/HVOJkR51lBU} [A
       <column name="definition_ru">туника</column>
       <column name="definition_zh_HK">中山裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">túnica</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhay:n:2h}</column>
@@ -4037,6 +4465,7 @@ I {TNK:src} används detta ord för att översätta "skjorta", och {yIvbeH SeQHa
       <column name="notes_pt">Esta palavra originalmente se referia a uma vestimenta sem mangas (ver {yIvbeH:n:2}).
 
 Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:nolink} é usada para "T-shirt". [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4046,6 +4475,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">shirt, garment, T-shirt, t-shirt</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4053,6 +4483,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4066,6 +4497,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">Безрукавка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">無袖上衣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">camisa sem mangas</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIvbeH:n:1}, {wep:n:2}, {tlhay:n:2h}</column>
@@ -4076,6 +4508,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru">Это слово имеет это значение на диалекте {voSpegh Sep:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞在{voSpegh Sep:n}方言中具有此含義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra tem esse significado no dialeto {voSpegh Sep:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4085,6 +4518,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4092,6 +4526,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4105,6 +4540,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">Доверяй, но найди двери. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">相信，但找到門。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Confie, mas localize as portas.</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4115,6 +4551,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">There is a grammatical error with this sentence. It should be {tISam:sen@@tI-:v, Sam:v} rather than {yISam:sen:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4124,6 +4561,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4131,6 +4569,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.186:src}</column>
     </table>
     <table name="mem">
@@ -4144,6 +4583,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">Trust, but verify. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">信任但要驗證。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Confie, mas verifique.</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIlaSnoS:n}</column>
@@ -4154,6 +4594,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4163,6 +4604,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4170,6 +4612,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.186:src}</column>
     </table>
     <table name="mem">
@@ -4183,6 +4626,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">говорить честно или почтительно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">以尊重或尊重的方式說話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falar de uma maneira honrosa ou respeitosa</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms">{vaq:v}, {tIch:v}</column>
       <column name="see_also">{-neS:v:suff}</column>
@@ -4193,6 +4637,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The example sentence appears to be a lip-match for {HIja':excl}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4203,6 +4648,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">speak in an honourable or respectful fashion</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4210,6 +4656,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2013:src}, [2] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -4223,6 +4670,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">ударить ладонью [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">打巴掌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tapa, bater com a palma da mão</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toch:n}</column>
@@ -4233,6 +4681,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru">Для того, чтобы поразить ударную инструкцию ладонью, рассмотрите {weq:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">若要用手掌敲打打擊樂器，請考慮{weq:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para tocar uma instrução de percussão com a palma da mão, considere {weq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4242,6 +4691,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4249,6 +4699,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4262,6 +4713,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">собирать</column>
       <column name="definition_zh_HK">收成 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colheita</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wIj:v}, {poch:v}, {Du':n}, {Du' naH:n}, {naH tlhab:n}, {yotlh:n}, {tIr:n}, {qInut:n}</column>
@@ -4272,6 +4724,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru">Это слово используется для сбора растений или частей растений, будь то {Du' naH:n} или {naH tlhab:n}. (См. {KGT p.89:src}.) [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此詞用於收集植物或植物部位，無論是{Du' naH:n}還是{naH tlhab:n}。 （請參閱{KGT p.89:src}。） [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada para reunir plantas ou partes de plantas, seja {Du' naH:n} ou {naH tlhab:n}. (Consulte {KGT p.89:src}.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4281,6 +4734,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4288,6 +4742,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4301,6 +4756,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">TRANSLATE</column>
       <column name="definition_zh_HK">豐收節日 [AUTOTRANSLATED]</column>
       <column name="definition_pt">festival da colheita</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yob:v}, {yupma':n}</column>
@@ -4311,6 +4767,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru">Согласно {A Burning House:src}, это праздник клингонов, чтобы отпраздновать конец урожая. Его название буквально происходит от {yob:v} и {-ta':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{A Burning House:src}表示，這是一個克林崗節，以慶祝收成的結束。它的名字實際上來自{yob:v}和{-ta':v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com {A Burning House:src}, este é um festival Klingon para comemorar o fim da colheita. Seu nome literalmente vem de {yob:v} e {-ta':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yob:v}, {-ta':v}, {yupma':n}</column>
       <column name="examples"></column>
@@ -4320,6 +4777,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4327,6 +4785,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -4340,6 +4799,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">щит</column>
       <column name="definition_zh_HK">盾牌、擋箭牌</column>
       <column name="definition_pt">escudo</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yoD:v}, {SIryoD:n}</column>
@@ -4350,6 +4810,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4359,6 +4820,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4366,6 +4828,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.67:src}</column>
     </table>
     <table name="mem">
@@ -4379,6 +4842,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">защищать щитом</column>
       <column name="definition_zh_HK">屏蔽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">se proteger (com escudo)</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yoD:n}</column>
@@ -4389,6 +4853,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru">Это используется для реальных (физических) щитов. «Защищать себя» - это {yoD'egh:v@@yoD:v, -'egh:v}. Для силовых полей используйте {botjan:n} с {chu':v:2}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於真實（物理）屏蔽。 “保護自己”是{yoD'egh:v@@yoD:v, -'egh:v}。對於力場，請使用{botjan:n}和{chu':v:2}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para escudos reais (físicos). "Proteger-se" é {yoD'egh:v@@yoD:v, -'egh:v}. Para campos de força, use {botjan:n} com {chu':v:2}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4398,6 +4863,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4405,6 +4871,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.67:src}</column>
     </table>
     <table name="mem">
@@ -4418,6 +4885,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">быть храбрым</column>
       <column name="definition_zh_HK">勇敢</column>
       <column name="definition_pt">ser corajoso</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jaq:v}, {yoHwI':n}</column>
@@ -4428,6 +4896,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4438,6 +4907,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4445,6 +4915,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4458,6 +4929,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">храбрый [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勇敢人</column>
       <column name="definition_pt">um corajoso</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms">{nuch:n}</column>
       <column name="see_also"></column>
@@ -4468,6 +4940,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yoH:v}, {-wI':v}</column>
       <column name="examples">
@@ -4478,6 +4951,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4485,6 +4959,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -4498,6 +4973,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">суждение</column>
       <column name="definition_zh_HK">判斷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">julgamento</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noH:v}, {chov:v}, {nuD:v}, {meqba':n}, {ruv:n}</column>
@@ -4508,6 +4984,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4517,6 +4994,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">judgment, verdict</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4524,6 +5002,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4537,6 +5016,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">конфликт</column>
       <column name="definition_zh_HK">衝突 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conflito</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{may':n}, {noH:n}</column>
@@ -4547,6 +5027,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4556,6 +5037,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4563,6 +5045,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4576,6 +5059,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">нейтрон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">中子</column>
       <column name="definition_pt">nêutron</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeySel:n}, {valtIn:n}, {tem:n}</column>
@@ -4586,6 +5070,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Reverse of {jImoy:sen:nolink} "Jimmy", a reference to the character Jimmy Neutron.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4595,6 +5080,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4602,6 +5088,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4615,6 +5102,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">быть удовлетворенным</column>
       <column name="definition_zh_HK">滿意</column>
       <column name="definition_pt">ser satisfeito</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bel:v:is}, {yonmoH:v}</column>
@@ -4625,6 +5113,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The English translation of the sentence from {Star Trek Constellations:src} does not appear in the book, but in the author's annotations which was a separate document.</column>
       <column name="components"></column>
       <column name="examples">
@@ -4635,6 +5124,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">smug</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4642,6 +5132,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Star Trek Constellations p.259:src}</column>
     </table>
     <table name="mem">
@@ -4655,6 +5146,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">удовлетворять</column>
       <column name="definition_zh_HK">滿足</column>
       <column name="definition_pt">satisfazer</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4665,6 +5157,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yon:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -4674,6 +5167,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4681,6 +5175,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4694,6 +5189,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">попасть в</column>
       <column name="definition_zh_HK">進入</column>
       <column name="definition_pt">entrar</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms">{Haw':v}</column>
       <column name="see_also">{lel:v}, {lIt:v}, {'el:v}</column>
@@ -4704,6 +5200,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4714,6 +5211,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4721,6 +5219,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -4734,6 +5233,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">брюки</column>
       <column name="definition_zh_HK">褲</column>
       <column name="definition_pt">calça</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qogh:n:1}, {yopwaH bID:n}</column>
@@ -4744,6 +5244,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4753,6 +5254,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4760,6 +5262,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4773,6 +5276,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">шорты [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">短褲</column>
       <column name="definition_pt">calção, short</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yopwaH:n}, {bID:n}</column>
@@ -4783,6 +5287,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yopwaH:n}, {bID:n}</column>
       <column name="examples"></column>
@@ -4792,6 +5297,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4799,6 +5305,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4812,6 +5319,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">гуманоид</column>
       <column name="definition_zh_HK">人形 [AUTOTRANSLATED]</column>
       <column name="definition_pt">humanóide</column>
+      <column name="definition_fi"></column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dep:n}, {ghot:n}, {nuv:n}</column>
@@ -4823,6 +5331,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4832,6 +5341,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4839,6 +5349,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -4852,6 +5363,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">планета класса М [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Ｍ級行星</column>
       <column name="definition_pt">planeta classe M</column>
+      <column name="definition_fi">M-luokan planeetta, elinkelpoinen planeetta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yInSIp:n}</column>
@@ -4862,6 +5374,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yoq:n}, {yIn:n}, {yuQ:n}</column>
       <column name="examples">
@@ -4873,6 +5386,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4880,6 +5394,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 27:src}</column>
     </table>
     <table name="mem">
@@ -4893,6 +5408,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">верхняя часть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頂部（外部） [AUTOTRANSLATED]</column>
       <column name="definition_pt">parte superior (exterior)</column>
+      <column name="definition_fi">(ulkopuolinen) yläpinta</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pIrmuS:n}</column>
       <column name="see_also">{Dung:n}, {beb:n}, {bIS'ub:n}, {Hur:n}</column>
@@ -4903,6 +5419,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru">Это слово не используется для съемной верхней части, которая была бы «крышкой» {yuvtlhe':n}. Другая сторона объекта {yor:n:nolink} называется его {'aqroS:n:1}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta palavra não é usada para uma parte superior removível, que seria uma "tampa" de {yuvtlhe':n}. A outra face do {yor:n:nolink} de um objeto é chamada de {'aqroS:n:1}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa ei käytetä irrotettavaan yläosaan, joka olisi {yuvtlhe':n}-kansi. Objektin {yor:n:nolink} toista kasvoa kutsutaan sen {'aqroS:n:1}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"You're the Top" is a song by Cole Porter.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4912,6 +5429,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">exterior, outside top</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4919,6 +5437,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -4932,6 +5451,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">полка, книжная полка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">架子、書架</column>
       <column name="definition_pt">prateleira, estante</column>
+      <column name="definition_fi">hylly, kirjahylly</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DeSwar:n}, {'ut'at:n}, {paq:n:1h}</column>
@@ -4942,6 +5462,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="notes_ru">Это общий термин для фиксированной или нефиксированной полки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是固定或非固定架子的總稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o termo geral para uma prateleira fixa ou não fixa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleinen termi kiinteälle tai kiinteälle hyllylle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4951,6 +5472,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4958,6 +5480,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -4971,6 +5494,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">район</column>
       <column name="definition_zh_HK">區</column>
       <column name="definition_pt">distrito, área</column>
+      <column name="definition_fi">alue, seutu, piiri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sep:n}, {veng:n}</column>
@@ -4985,6 +5509,11 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa alueeseen {Sep:n}:issa, jossa on yleensä ainakin yksi tärkeä {veng:n}.
+
+{Qo'noS:n}:n tunnettuja alueita on:
+▶ {HuD beQ yoS:n}
+▶ {tlhIng yoS:n}</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4994,6 +5523,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">province, state</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5001,6 +5531,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.16:src}</column>
     </table>
     <table name="mem">
@@ -5014,6 +5545,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">захватчик</column>
       <column name="definition_zh_HK">入侵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">invadir</column>
+      <column name="definition_fi">hyökätä, tunkeutua (toiseen maahan tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{weH:v}, {HIv:v}, {yot:n}</column>
@@ -5024,6 +5556,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5033,6 +5566,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5040,6 +5574,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5053,6 +5588,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">нарушитель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">入侵者</column>
       <column name="definition_pt">intruso</column>
+      <column name="definition_fi">tunkeilija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5063,6 +5599,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru">Эта строка говорилась на клингонском языке, но не имела субтитров. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此行在克林崗語中被使用，但沒有字幕。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta linha foi falada em klingon, mas não foi legendada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä rivi puhuttiin Klingonissa, mutta sitä ei tekstitetty. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yot:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -5072,6 +5609,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5079,6 +5617,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -5092,6 +5631,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">вторжение</column>
       <column name="definition_zh_HK">侵入 [AUTOTRANSLATED]</column>
       <column name="definition_pt">invasão</column>
+      <column name="definition_fi">hyökkäys (toiseen maahan tms.), maahantunkeutuminen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yot:v}</column>
@@ -5102,6 +5642,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is listed among other militaristic terminology in the body of {KGT:src} on p.48.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5111,6 +5652,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5118,6 +5660,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5131,6 +5674,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">участок</column>
       <column name="definition_zh_HK">田地（土地）、公園（如娛樂） [AUTOTRANSLATED]</column>
       <column name="definition_pt">campo (de terra), parque (por exemplo, recreacional)</column>
+      <column name="definition_fi">kenttä, puisto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Du':n}, {yob:v}, {puH:n}, {yav:n}, {che'ron:n}, {Hatlh:n}, {tlhop:n:2}</column>
@@ -5141,6 +5685,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was defined only as "field (of land)" in {TKD:src}. The definition "park (e.g., recreational)" was added at the {Saarbrücken qepHom'a' 2016:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5150,6 +5695,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5157,6 +5703,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5170,6 +5717,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">атаковать</column>
       <column name="definition_zh_HK">收費（軍事用語） [AUTOTRANSLATED]</column>
       <column name="definition_pt">encarregar (termo militar)</column>
+      <column name="definition_fi">hyökätä, rynnätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIv:v}</column>
@@ -5180,6 +5728,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5189,6 +5738,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">storm</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5196,6 +5746,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5209,6 +5760,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">быть в обратном порядке</column>
       <column name="definition_zh_HK">顛倒了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estar de cabeça para baixo</column>
+      <column name="definition_fi">olla ylösalaisin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5219,6 +5771,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5228,6 +5781,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5235,6 +5789,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -5248,6 +5803,7 @@ Some of the known districts on {Qo'noS:n} are:
           <column name="definition_ru">перевернуть, перевернуть, перевернуть [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">翻轉、反轉</column>
           <column name="definition_pt">virar de cabeça para baixo, virar, inverter</column>
+      <column name="definition_fi">kääntää ylösalaisin, kääntää ympäri, kääntää nurin tai päinvastaiseksi</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{DopmoH:v}</column>
@@ -5258,6 +5814,7 @@ Some of the known districts on {Qo'noS:n} are:
           <column name="notes_ru">Это может использоваться для обозначения «перевернуть (полностью)» (т.е. перевернуть что-нибудь еще). Если что-то просто перевернуто, но не перевернуто, см. {qaw'moH:v}. Если что-то перевернуто само по себе или, по-видимому, само по себе, глаголом будет {tach:v}.[2] [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這可以用來表示“（完全翻轉）”（即，將其他東西翻轉過來）。如果某物只是翻倒而不是翻倒，請參閱{qaw'moH:v}。如果某事完全按照自己的意願或看似完全按照自己的意願進行了翻轉，則使用的動詞為{tach:v}.[2] [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso pode ser usado para significar "virar (até o fim)" (ou seja, virar outra coisa). Se algo for virado, mas não virado, consulte {qaw'moH:v}. Se algo mudasse completamente por conta própria ou aparentemente por conta própria, o verbo a ser usado seria {tach:v}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää tarkoittamaan "käännä (kokonaan) yli" (ts. Käännä jotain muuta). Jos jotain vain kaatetaan, mutta ei käännetä, katso {qaw'moH:v}. Jos jotain käännettäisiin kokonaan omasta tai näennäisesti itsestään, käytettävä verbi olisi {tach:v}.[2] [AUTOTRANSLATED]</column>
           <column name="hidden_notes">The verb {yoy:v} does not appear with the suffix {-moH:v} in canon. However, MO approved of {yoymoHwI'} as a bit of technobabble meaning "inverter".[1] Subsequently, MO approved of the gloss "turn upside down, flip, invert".[2]</column>
           <column name="components">{yoy:v}, {-moH:v}</column>
           <column name="examples"></column>
@@ -5267,6 +5824,7 @@ Some of the known districts on {Qo'noS:n} are:
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">inverter</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5274,6 +5832,7 @@ Some of the known districts on {Qo'noS:n} are:
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 1997.04.07:src}, [2] {KLI mailing list 2020.06.09:src}</column>
         </table>
     <table name="mem">
@@ -5287,6 +5846,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">флот</column>
       <column name="definition_zh_HK">艦隊</column>
       <column name="definition_pt">frota (de navios)</column>
+      <column name="definition_fi">laivasto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5297,6 +5857,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru">Флот состоит из более чем одного {nawlogh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一支艦隊由一個以上的{nawlogh:n}組成。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma frota consiste em mais de um {nawlogh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Laivasto koostuu useammasta kuin yhdestä {nawlogh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5307,6 +5868,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">convoy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5314,6 +5876,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5327,6 +5890,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">Черный флот [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">黑色艦隊</column>
       <column name="definition_pt">Frota negra</column>
+      <column name="definition_fi">Musta laivasto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qoy qeylIS puqloD:sen}</column>
@@ -5337,6 +5901,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru">Этот термин относится к концепции, которая появляется в верованиях клингонов о загробной жизни. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個術語是指在克林崗人關於來世的信仰中出現的一個概念。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo refere-se a um conceito que aparece nas crenças de Klingon sobre a vida após a morte. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä termi viittaa käsitteeseen, joka esiintyy Klingonin uskomuksissa tuonpuoleisesta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yo':n}, {qIj:v}</column>
       <column name="examples"></column>
@@ -5346,6 +5911,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5353,6 +5919,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -5366,6 +5933,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">Операционная команда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">操作命令 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Comando de operações</column>
+      <column name="definition_fi">laivaston johto?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yejquv:n}, {jonSeH yaH:n}, {'ejyo'SeH yaHnIv:n}</column>
@@ -5376,6 +5944,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The sentence in which this appeared was actually written with hyphens, like this: {HoD, yo'-SeH yaH-nIv-vo' potlh De' wI-Hev-taH:sen:nolink}, with a newline between {potlh:sen:nolink} and {De':sen:nolink}.[1] The correct spelling (and spacing) was later confirmed.[3]</column>
       <column name="components">{yo':n}, {SeH:v} or {SeH:n:hyp,nolink}, {yaH:n}, {nIv:v}</column>
       <column name="examples">
@@ -5386,6 +5955,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">yo' SeHyaH nIv</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5393,6 +5963,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.11, Dec. 1999:src}, [2] {Star Trek V:src}, [3] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -5406,6 +5977,7 @@ Some of the known districts on {Qo'noS:n} are:
       <column name="definition_ru">первый (и последний) тон неатонической музыкальной гаммы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">非音階音階的第一個（也是最後一個）音調 [AUTOTRANSLATED]</column>
       <column name="definition_pt">primeiro (e último) tom da escala musical não-atônica</column>
+      <column name="definition_fi">nonatoonisen musiikkiasteikon ensimmäinen (ja viimeinen) sävel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5418,6 +5990,9 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin musiikkiasteikon sävyt (katso {yutlhegh:n}) ovat: {yu:n:nolink}, {bIm:n}, {'egh:n}, {loS:n:2}, {vagh:n:2}, {jav:n:2}, {Soch:n:2}, {chorgh:n:2}, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DOT
+
+Ensimmäinen ja toinen {yu:n:nolink} eivät ole oktaavierot, vaan pikemminkin nonave-erotukset.[2] Katso {Savvanwer:n}.{yu:n:nolink}[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Instead of "doe", which is a deer, an "ewe" is a sheep.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5427,6 +6002,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5434,6 +6010,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.09.01:src}</column>
     </table>
     <table name="mem">
@@ -5447,6 +6024,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">шелуха, кожура, кожура, скорлупа (фруктов, орехов) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">稻殼、果皮、果皮、殼（水果、堅果） [AUTOTRANSLATED]</column>
       <column name="definition_pt">casca (de frutas, nozes)</column>
+      <column name="definition_fi">(hedelmän, pähkinän tms.) kuori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naH:n}</column>
@@ -5457,6 +6035,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5466,6 +6045,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5473,6 +6053,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -5486,6 +6067,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">шоколад</column>
       <column name="definition_zh_HK">巧克力</column>
       <column name="definition_pt">chocolate</column>
+      <column name="definition_fi">suklaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5496,6 +6078,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru">Люди едят {yuch ngoghmey:n:nolink}, который Мальц считает странным. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">人類吃了{yuch ngoghmey:n:nolink}，Maltz發現它很奇怪。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Os humanos comem {yuch ngoghmey:n:nolink}, o que Maltz acha estranho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ihmiset syövät {yuch ngoghmey:n:nolink}-aineistoa, jonka Maltz pitää outona. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5506,6 +6089,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5513,6 +6097,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -5526,6 +6111,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">быть нечестным</column>
       <column name="definition_zh_HK">是不誠實的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desonesto</column>
+      <column name="definition_fi">olla epärehellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yuDHa':v}</column>
       <column name="see_also">{jey'naS:n}</column>
@@ -5536,6 +6122,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru">Существует идиома {yuD; jey'naS rur@@yuD:v, jey'naS:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{yuD; jey'naS rur@@yuD:v, jey'naS:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {yuD; jey'naS rur@@yuD:v, jey'naS:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {yuD; jey'naS rur@@yuD:v, jey'naS:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5545,6 +6132,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5552,6 +6140,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5565,6 +6154,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">быть честным</column>
       <column name="definition_zh_HK">說實話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser honesto</column>
+      <column name="definition_fi">olla rehellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{yuD:v}</column>
       <column name="see_also">{ghIt:n:0}</column>
@@ -5575,6 +6165,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru">Существует идиома {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {yuDHa'; ghIt rur@@yuDHa':v, ghIt:n:0, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yuD:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -5584,6 +6175,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5591,6 +6183,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5604,6 +6197,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">включать, состоять, состоять из [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">包括、由...組成 [AUTOTRANSLATED]</column>
       <column name="definition_pt">incluir, consistir em, ser composto de</column>
+      <column name="definition_fi">sisältää, koostua jostakin</column>
       <column name="synonyms">{'uch:v:3}</column>
       <column name="antonyms"></column>
       <column name="see_also">{HeySel:n}, {tamler:n}, {'o'rIS:n}, {tamlerQeD:n}, {loch:v}</column>
@@ -5614,6 +6208,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru">Это используется для разговоров о химии. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於談論化學。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para falar sobre química. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään puhumaan kemiasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5624,6 +6219,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5631,6 +6227,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
         <table name="mem">
@@ -5644,6 +6241,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
           <column name="definition_ru">фильтр только для X, включая только X [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">僅限X過濾、僅包含X. [AUTOTRANSLATED]</column>
           <column name="definition_pt">filtro apenas para X, incluir apenas X</column>
+      <column name="definition_fi">suodata muu kuin X, sisällytä vain X</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -5654,6 +6252,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{neH:adv}, {yugh:v}, {-moH:v}</column>
           <column name="examples"></column>
@@ -5663,6 +6262,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -5670,6 +6270,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2018.02.17:src}</column>
         </table>
     <table name="mem">
@@ -5683,6 +6284,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">титан [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鈦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">titânio</column>
+      <column name="definition_fi">titaani</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baS:n}, {tamler:n}</column>
@@ -5693,6 +6295,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru">Это металлический химический элемент с символом Ti и атомным номером 22. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是金屬化學元素，符號為Ti，原子序數為22。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o elemento químico metálico com o símbolo Ti e o número atômico 22. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on metallinen kemiallinen alkuaine, jolla on symboli Ti ja atominumero 22. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5702,6 +6305,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5709,6 +6313,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5722,6 +6327,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">зудеть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">發癢 [AUTOTRANSLATED]</column>
       <column name="definition_pt">coçar</column>
+      <column name="definition_fi">olla kutiava, kutiseva</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5732,6 +6338,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5741,6 +6348,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5748,6 +6356,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -5761,6 +6370,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">Юлий Цезарь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">尤利烏斯·凱撒</column>
       <column name="definition_pt">Julius Caesar</column>
+      <column name="definition_fi">Julius Caesar</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{maS'e' So'bogh pagh:n}</column>
@@ -5771,6 +6381,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru">Это название пьесы {wIlyam SeQpIr:n:name}, а также название ее титульного персонажа. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{wIlyam SeQpIr:n:name}的戲劇的名稱，也是其名義人物的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma peça de {wIlyam SeQpIr:n:name}, e também o nome de seu personagem titular. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {wIlyam SeQpIr:n:name}: n näytelmän nimi ja myös sen nimimerkki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5780,6 +6391,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <!-- This isn't a mistake. It does appear in Hamlet. -->
       <column name="search_tags_de"></column>
@@ -5788,6 +6400,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -5801,6 +6414,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">насос [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">水泵 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bomba (hidráulica)</column>
+      <column name="definition_fi">pumpata</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5811,6 +6425,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5820,6 +6435,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5827,6 +6443,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5840,6 +6457,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">фестиваль</column>
       <column name="definition_zh_HK">節 [AUTOTRANSLATED]</column>
       <column name="definition_pt">festival</column>
+      <column name="definition_fi">festivaali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lop:v}, {lop:n}, {lopno':n}</column>
@@ -5850,6 +6468,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5859,6 +6478,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">holiday</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5866,6 +6486,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5879,6 +6500,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">перехитрить, перехитрить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">智取</column>
       <column name="definition_pt">levar a melhor em, superar (em esperteza, inteligência)</column>
+      <column name="definition_fi">olla ovelampi kuin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yut:v}</column>
@@ -5889,6 +6511,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5899,6 +6522,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5906,6 +6530,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -5919,6 +6544,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">планета</column>
       <column name="definition_zh_HK">行星</column>
       <column name="definition_pt">planeta</column>
+      <column name="definition_fi">planeetta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bav:v}, {Hov:n}, {maS:n}, {yoq yIn yuQ:n}, {mID:n}, {jul:n}, {ghaptal:n}</column>
@@ -5929,6 +6555,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5938,6 +6565,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5945,6 +6573,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5958,6 +6587,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">малая планета</column>
       <column name="definition_zh_HK">小行星、次要行星</column>
       <column name="definition_pt">planetoide</column>
+      <column name="definition_fi">pikkuplaneetta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5968,6 +6598,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yuQ:n}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -5977,6 +6608,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5984,6 +6616,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -5997,6 +6630,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">Объединённая федерация планет</column>
       <column name="definition_zh_HK">星際聯邦</column>
       <column name="definition_pt">Federação Unida de Planetas</column>
+      <column name="definition_fi">Yhdistyneiden planeettojen liitto</column>
       <column name="synonyms">{yuQjIjQa':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{DIvI':n}</column>
@@ -6007,6 +6641,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">行星聯合會通常簡稱為“聯合會”（{DIvI':n}）。另一個名稱是{yuQjIjQa':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Yhdistynyttä planeettojen federaatiota kutsutaan usein yksinkertaisesti "federaatioksi" ({DIvI':n}). Toinen sana sille on {yuQjIjQa':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the K-E side of {TKD:src}.</column>
       <column name="components">{yuQ:n}, {jIj:v}, {DIvI':n}</column>
       <column name="examples"></column>
@@ -6016,6 +6651,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6023,6 +6659,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6036,6 +6673,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">Объединённая федерация планет</column>
       <column name="definition_zh_HK">星際聯邦</column>
       <column name="definition_pt">Federação Unida de Planetas</column>
+      <column name="definition_fi">Yhdistyneiden planeettojen liitto</column>
       <column name="synonyms">{yuQjIjDIvI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{'amerI'qa' SepjIjQa':n}, {tuqjIjQa':n}</column>
@@ -6046,6 +6684,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Toinen sana yhdistyneelle planeettojen federaatiolle on {yuQjIjDIvI':n:nolink} (usein lyhennetty vain {DIvI':n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components">{yuQ:n}, {jIj:v}, {Qa':n:2,hyp}</column>
       <column name="examples"></column>
@@ -6055,6 +6694,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6062,6 +6702,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6075,6 +6716,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">география [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地理學</column>
       <column name="definition_pt">geografia</column>
+      <column name="definition_fi">maantiede</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuQ:n}, {yuQtej:n}, {QeD:n}</column>
@@ -6085,6 +6727,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yuQ:n}, {QeD:n}</column>
       <column name="examples"></column>
@@ -6094,6 +6737,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6101,6 +6745,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -6114,6 +6759,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">географ [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">地理學家</column>
       <column name="definition_pt">geógrafo</column>
+      <column name="definition_fi">maantieteilijä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuQQeD:n}, {tej:n}</column>
@@ -6124,6 +6770,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yuQ:n}, {tej:n}</column>
       <column name="examples"></column>
@@ -6133,6 +6780,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6140,6 +6788,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -6153,6 +6802,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">отвлекать, создавать диверсию [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">分散注意力、創造一種轉移 [AUTOTRANSLATED]</column>
       <column name="definition_pt">distrair, criar uma diversão</column>
+      <column name="definition_fi">häiritä, harhauttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuq:v}</column>
@@ -6163,6 +6813,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="notes_ru">Объект этого глагола (когда он есть) - это человек или группа людей (обычно) отвлекающихся. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個動詞的對象（如果有）是分散注意力的一個人或一群人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto desse verbo (quando existe um) é a pessoa ou grupo de pessoas (geralmente) que está sendo distraído. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän verbin kohde (kun sellainen on) on henkilö tai ihmisryhmä (yleensä) hämmentynyt. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6172,6 +6823,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6179,6 +6831,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -6192,6 +6845,7 @@ The first and second {yu:n:nolink} are not an octave apart, but rather a nonave 
       <column name="definition_ru">спектр, музыкальный масштаб, диапазон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頻譜、音階、範圍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espectro, escala musical, alcance</column>
+      <column name="definition_fi">spektri, musiikkiasteikko, skaala</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Har'ey:n}, {qIr'a':n}</column>
@@ -6204,6 +6858,9 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on sana musiikilliselle asteikolle, mutta sitä voidaan käyttää myös muuntyyppisille alueille.
+
+Klingonin musiikkiasteikon sävyt ovat: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}, {vagh:n:2}, {jav:n:2}, {Soch:n:2}, {chorgh:n:2}, {yu:n:nolink}.DONOTTRANSLATE9.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yu:n}, {tlhegh:n}</column>
       <column name="examples"></column>
@@ -6213,6 +6870,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6220,6 +6878,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Festival of the Spoken Nerd DVD:src}</column>
     </table>
     <table name="mem">
@@ -6233,6 +6892,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="definition_ru">дальний родственник или племянник / племянница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">遠房表親或侄子/侄女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">primo distante ou sobrinho/sobrinha</column>
+      <column name="definition_fi">kaukainen serkku tai sisaruksen lapsi (lapsenlapset jne.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tey':n:0}, {lor:n:0}, {vIn:n}</column>
@@ -6243,6 +6903,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="notes_ru">Форма единственного числа никогда не используется вместо {tey':n:nolink} или {lor:n:nolink}, но множественное число может использоваться для группы, включающей {tey':n:nolink} и / или {lor:n:nolink}, при условии, что в группе есть по крайней мере еще один дальний родственник, племянница или племянник. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Yksittäistä muotoa ei koskaan käytetä {tey':n:nolink}- tai {lor:n:nolink}-tilan sijaan, mutta monikkomuotoa voidaan käyttää ryhmälle, joka sisältää {tey':n:nolink} ja / tai {lor:n:nolink}, kunhan ryhmässä on vielä vähintään yksi etäinen serkku, veljentytär tai veljenpoika. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"You're it." Cousin Itt is a character in the Addams Family.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6252,6 +6913,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6259,6 +6921,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -6272,6 +6935,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="definition_ru">юрий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">yurium [AUTOTRANSLATED]</column>
       <column name="definition_pt">yurium</column>
+      <column name="definition_fi">eräs yhdiste, jurium</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6282,6 +6946,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="notes_ru">Это химическое соединение, которое в сочетании с {'anISyum:n} реагирует на взрыв. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種化學物質，與{'anISyum:n}結合時會發生爆炸。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um composto químico que reage para criar uma explosão quando combinado com {'anISyum:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kemiallinen yhdiste, joka reagoi muodostaen räjähdyksen yhdistettynä {'anISyum:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6291,6 +6956,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6298,6 +6964,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Magic to Make the Sanest Man Go Mad:src}</column>
     </table>
     <table name="mem">
@@ -6311,6 +6978,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="definition_ru">континент [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">大陸、大洲</column>
       <column name="definition_pt">continente</column>
+      <column name="definition_fi">manner(maa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puH:n}, {'ambay:n}</column>
@@ -6321,6 +6989,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to the merger between United Airlines (UA) and Continental Airlines.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6330,6 +6999,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6337,6 +7007,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -6350,6 +7021,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="definition_ru">толкать</column>
       <column name="definition_zh_HK">推</column>
       <column name="definition_pt">empurrar</column>
+      <column name="definition_fi">työntää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{luH:v:1}</column>
       <column name="see_also">{yuvtlhe':n}, {vo':v}, {'uy:v}, {leQ:n}</column>
@@ -6360,6 +7032,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6369,6 +7042,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6376,6 +7050,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6389,6 +7064,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="definition_ru">крышка, крышка, крышка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蓋</column>
       <column name="definition_pt">tampa, cobertura</column>
+      <column name="definition_fi">kansi, päällinen, korkki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yor:n}, {yuv:v}, {tlhe':v}, {qorghwI':n}</column>
@@ -6399,6 +7075,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Literally, "push, turn" (how you open a so-called child-proof lid).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6408,6 +7085,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6415,6 +7093,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -6428,6 +7107,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="definition_ru">допрашивать</column>
       <column name="definition_zh_HK">審問、審訊</column>
       <column name="definition_pt">questionar, interrogar</column>
+      <column name="definition_fi">kysyä, kuulustella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghel:v}, {tlhob:v}</column>
@@ -6438,6 +7118,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6447,6 +7128,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6454,6 +7136,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi">kysellä</column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6467,6 +7150,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="definition_ru">волна</column>
       <column name="definition_zh_HK">波浪</column>
       <column name="definition_pt">onda</column>
+      <column name="definition_fi">aalto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIQ'a':n}, {wal:v}, {vI'Ir:n}, {'o'nI':n}</column>
@@ -6477,6 +7161,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">可能只是巧合，但是{yu:n}和{'egh:n}是克林崗語非音階音樂聲階的第一聲和第三聲。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Se voi olla vain sattumaa, mutta {yu:n} ja {'egh:n} ovat Klingonin nonatonisen musiikkiasteikon ensimmäinen ja kolmas sävy. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the E-K side of {TKD:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6486,6 +7171,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6493,6 +7179,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -6506,6 +7193,7 @@ The tones of the Klingon musical scale are: {yu:n}, {bIm:n}, {'egh:n}, {loS:n:2}
       <column name="definition_ru">form (to be filled out) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">表格（待填寫） [AUTOTRANSLATED]</column>
       <column name="definition_pt">formulário (a ser preenchido)</column>
+      <column name="definition_fi">lomake</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wa'chaw:n}</column>
@@ -6530,6 +7218,9 @@ Verbetet {naQmoH:v@@naQ:v, -moH:v} används för att fylla i formulär. [AUTOTRA
       <column name="notes_pt">Não há diferença entre um formulário em papel ou um formulário digital na tela do computador.
 
 O verbo {naQmoH:v@@naQ:v, -moH:v} é usado para preencher formulários. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Paperilomakkeen tai digitaalisen lomakkeen välillä ei ole eroa tietokoneen näytöllä.
+
+Verbiä {naQmoH:v@@naQ:v, -moH:v} käytetään lomakkeiden täyttämiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Questionnaire" (see {yu':v}, {muD:n:1}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6539,6 +7230,7 @@ O verbo {naQmoH:v@@naQ:v, -moH:v} é usado para preencher formulários. [AUTOTRA
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">survey, questionnaire, application, formula</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6546,5 +7238,6 @@ O verbo {naQmoH:v@@naQ:v, -moH:v} é usado para preencher formulários. [AUTOTRA
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>

--- a/mem-20-y.xml
+++ b/mem-20-y.xml
@@ -804,7 +804,7 @@ Mikä tahansa paikka, joka on nimenomaisesti tarkoitettu tietyn tehtävän tai t
       <column name="notes_ru">Это в обрезанном клингоне. В стандартном клингоне "понимаешь?" (говорит с одним человеком) будет {bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是在修剪過的克林崗語中。在標準的克林貢語中，“您了解嗎？” （與一個人交談）將是{bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso está no Klingon cortado. No Klingon padrão, "você entende?" (falando com uma pessoa) seria {bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Tämä on leikattu Klingon. Tavallisessa Klingon-muodossa "ymmärrätkö?" (puhuminen yhdelle henkilölle) olisi {bIyaj'a '?: sen: nolink}{bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on leikattu Klingon. Tavallisessa Klingon-muodossa "ymmärrätkö?" (puhuminen yhdelle henkilölle) olisi {bIyaj'a'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yaj:v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -847,7 +847,7 @@ Mikä tahansa paikka, joka on nimenomaisesti tarkoitettu tietyn tehtävän tai t
       <column name="notes_ru">Это можно сказать в ответ на {yaj'a'?:sen} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能是對{yaj'a'?:sen}的回應 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser dito em resposta ao {yaj'a'?:sen} [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Tämä voidaan sanoa vastauksena {yaj'a '?: Sen}{yaj'a'?:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voidaan sanoa vastauksena {yaj'a'?:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yaj:v}, {-chu':v}</column>
       <column name="examples"></column>

--- a/mem-20-y.xml
+++ b/mem-20-y.xml
@@ -4354,7 +4354,7 @@ Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/HVOJkR51l
       <column name="definition_ru">жевать</column>
       <column name="definition_zh_HK">嚼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mastigar</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">pureskella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choptaH:v}, {tlhIS:v}, {ngal:v}, {yIv:v:2}</column>
@@ -4397,7 +4397,7 @@ Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/HVOJkR51l
       <column name="definition_ru">раздражать, беспокоить, раздражать, раздражать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">煩惱、煩、煩惱、煩惱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">irritar, incomodar</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">ärsyttää, häiritä, vaivata</column>
       <column name="synonyms">{nuQ:v}, {berghmoH:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{yIv:v:1}</column>
@@ -4440,7 +4440,7 @@ Katso, kuinka Gowron sanoo tämän: {YouTube video:url:http://youtu.be/HVOJkR51l
       <column name="definition_ru">туника</column>
       <column name="definition_zh_HK">中山裝 [AUTOTRANSLATED]</column>
       <column name="definition_pt">túnica</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">tunika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhay:n:2h}</column>
@@ -4497,7 +4497,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">Безрукавка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">無袖上衣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">camisa sem mangas</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">hihaton paita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIvbeH:n:1}, {wep:n:2}, {tlhay:n:2h}</column>
@@ -4540,7 +4540,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">Доверяй, но найди двери. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">相信，但找到門。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Confie, mas localize as portas.</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">Luota, mutta etsi ovet. ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4583,7 +4583,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">Trust, but verify. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">信任但要驗證。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Confie, mas verifique.</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">Luota, mutta varmista.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIlaSnoS:n}</column>
@@ -4626,7 +4626,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">говорить честно или почтительно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">以尊重或尊重的方式說話 [AUTOTRANSLATED]</column>
       <column name="definition_pt">falar de uma maneira honrosa ou respeitosa</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">puhua kunniallisesti tai kunnioittavasti</column>
       <column name="synonyms"></column>
       <column name="antonyms">{vaq:v}, {tIch:v}</column>
       <column name="see_also">{-neS:v:suff}</column>
@@ -4670,7 +4670,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">ударить ладонью [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">打巴掌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tapa, bater com a palma da mão</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">läimäyttää, iskeä kämmenellä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{toch:n}</column>
@@ -4713,7 +4713,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">собирать</column>
       <column name="definition_zh_HK">收成 [AUTOTRANSLATED]</column>
       <column name="definition_pt">colheita</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">korjata (satoa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wIj:v}, {poch:v}, {Du':n}, {Du' naH:n}, {naH tlhab:n}, {yotlh:n}, {tIr:n}, {qInut:n}</column>
@@ -4756,7 +4756,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">TRANSLATE</column>
       <column name="definition_zh_HK">豐收節日 [AUTOTRANSLATED]</column>
       <column name="definition_pt">festival da colheita</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">sadonkorjuujuhla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yob:v}, {yupma':n}</column>
@@ -4799,7 +4799,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">щит</column>
       <column name="definition_zh_HK">盾牌、擋箭牌</column>
       <column name="definition_pt">escudo</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">kilpi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yoD:v}, {SIryoD:n}</column>
@@ -4842,7 +4842,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">защищать щитом</column>
       <column name="definition_zh_HK">屏蔽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">se proteger (com escudo)</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">suojata (kilvellä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yoD:n}</column>
@@ -4885,7 +4885,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">быть храбрым</column>
       <column name="definition_zh_HK">勇敢</column>
       <column name="definition_pt">ser corajoso</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">olla rohkea, urhea</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jaq:v}, {yoHwI':n}</column>
@@ -4929,7 +4929,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">храбрый [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勇敢人</column>
       <column name="definition_pt">um corajoso</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">urho, urhea henkilö</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nuch:n}</column>
       <column name="see_also"></column>
@@ -4973,7 +4973,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">суждение</column>
       <column name="definition_zh_HK">判斷 [AUTOTRANSLATED]</column>
       <column name="definition_pt">julgamento</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">tuomio, arvio, lausunto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noH:v}, {chov:v}, {nuD:v}, {meqba':n}, {ruv:n}</column>
@@ -5016,7 +5016,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">конфликт</column>
       <column name="definition_zh_HK">衝突 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conflito</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">konflikti, yhteenotto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{may':n}, {noH:n}</column>
@@ -5059,7 +5059,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">нейтрон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">中子</column>
       <column name="definition_pt">nêutron</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">neutroni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeySel:n}, {valtIn:n}, {tem:n}</column>
@@ -5102,7 +5102,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">быть удовлетворенным</column>
       <column name="definition_zh_HK">滿意</column>
       <column name="definition_pt">ser satisfeito</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">olla tyytyväinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bel:v:is}, {yonmoH:v}</column>
@@ -5146,7 +5146,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">удовлетворять</column>
       <column name="definition_zh_HK">滿足</column>
       <column name="definition_pt">satisfazer</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">tyydyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5189,7 +5189,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">попасть в</column>
       <column name="definition_zh_HK">進入</column>
       <column name="definition_pt">entrar</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">käydä sisään</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Haw':v}</column>
       <column name="see_also">{lel:v}, {lIt:v}, {'el:v}</column>
@@ -5233,7 +5233,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">брюки</column>
       <column name="definition_zh_HK">褲</column>
       <column name="definition_pt">calça</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">housut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qogh:n:1}, {yopwaH bID:n}</column>
@@ -5276,7 +5276,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">шорты [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">短褲</column>
       <column name="definition_pt">calção, short</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">shortsit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yopwaH:n}, {bID:n}</column>
@@ -5319,7 +5319,7 @@ Em {TNK:src}, esta palavra é usada para traduzir "camisa" e {yIvbeH SeQHa':n:no
       <column name="definition_ru">гуманоид</column>
       <column name="definition_zh_HK">人形 [AUTOTRANSLATED]</column>
       <column name="definition_pt">humanóide</column>
-      <column name="definition_fi"></column>
+      <column name="definition_fi">humanoidi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dep:n}, {ghot:n}, {nuv:n}</column>

--- a/mem-21-a.xml
+++ b/mem-21-a.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {a:sen:nolink}</column>
       <column name="definition_zh_HK">元音{a:sen:nolink}</column>
       <column name="definition_pt">a vogal {a:sen:nolink}</column>
+      <column name="definition_fi">vokaali {a:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">{'ach:conj}</column>
       <column name="definition_zh_HK">{'ach:conj}</column>
       <column name="definition_pt">{'ach:conj}</column>
+      <column name="definition_fi">{'ach:conj}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -58,6 +63,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">иметь длину / высоту [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">長度/高度為 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter um comprimento/altura de</column>
+      <column name="definition_fi">olla pituudeltaan/korkeudeltaan jotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uj:n}, {woch:v}, {tIq:v}, {jen:v}, {run:v}, {juch:v}, {Saw':v}, {juv:v}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Tanto {'ab:v:nolink} quanto {'aD:v} significam "tamanho", mas são usados ​​em contextos diferentes. {'ab:v:nolink} é usado para itens longos e para expressar altura. O objeto de {'ab:v:nolink} é o comprimento ou a altura do assunto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sekä {'ab:v:nolink} että {'aD:v} tarkoittavat "on pituus", mutta niitä käytetään eri tilanteissa. {'ab:v:nolink}: ta käytetään pitkiä esineitä varten ja korkeuden ilmaisemiseen. {'ab:v:nolink}: n kohde on kohteen pituus tai korkeus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In anatomy, abduction refers to moving away from a midline. In particular, abduction at the shoulder means raising the arms up, an action which is often done to measure the length of something. Its counterpart, adduction, refers to movement towards a midline.</column>
       <column name="components"></column>
       <column name="examples">
@@ -114,6 +124,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">length, height, long, high, have a length of, have a height of</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -121,6 +132,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 32:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src}), [2] {msn 1997.10.22:src}, [3] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -134,6 +146,7 @@
       <column name="definition_ru">но, а</column>
       <column name="definition_zh_HK">但是、儘管如此、然而、儘管如此 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mas, no entanto, mesmo assim, enquanto</column>
+      <column name="definition_fi">mutta, silti, kuitenkin, kun taas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -145,6 +158,7 @@
       <column name="notes_ru">Это иногда сокращается до {'a:conj:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有時將其縮短為{'a:conj:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Às vezes, isso é encurtado para {'a:conj:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lyhennetään joskus {'a:conj:nolink}-muotoon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "but, nevertheless, even so, however" in {TKD:src}. The definition "whereas" for expressing contrast was added at {qep'a' 25 (2018):src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -154,6 +168,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -161,6 +176,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -174,6 +190,7 @@
       <column name="definition_ru">недействительным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">虛空 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vazio</column>
+      <column name="definition_fi">tyhjiö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh:n}, {chIm:v}, {pagh:n:1}</column>
@@ -184,6 +201,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Beatles song "Tomorrow Never Knows" contains the lyric "surrender to the void" ({jegh:v} "surrender" + {cha':n:num} "two").
 
 The example which came with the request is about outer space, so this seems to be a scientific term rather than a philosophical term.</column>
@@ -195,6 +213,7 @@ The example which came with the request is about outer space, so this seems to b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">vacuum</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -202,6 +221,7 @@ The example which came with the request is about outer space, so this seems to b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -215,6 +235,7 @@ The example which came with the request is about outer space, so this seems to b
       <column name="definition_ru">затылок, загривок, задняя часть шеи [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頸背頸背後頸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">nuca</column>
+      <column name="definition_fi">niska</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mong:n}, {mong'em:n}</column>
@@ -225,6 +246,7 @@ The example which came with the request is about outer space, so this seems to b
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -234,6 +256,7 @@ The example which came with the request is about outer space, so this seems to b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nape</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -241,6 +264,7 @@ The example which came with the request is about outer space, so this seems to b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -254,6 +278,7 @@ The example which came with the request is about outer space, so this seems to b
       <column name="definition_ru">вена, артерия, кровеносный сосуд</column>
       <column name="definition_zh_HK">靜脈、動脈、血管 [AUTOTRANSLATED]</column>
       <column name="definition_pt">veia, artéria, vaso sanguíneo</column>
+      <column name="definition_fi">verisuoni, laskimo, valtimo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mej'aD:n}, {paw'aD:n}, {'Iw:n}, {regh:v}</column>
@@ -264,6 +289,7 @@ The example which came with the request is about outer space, so this seems to b
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was originally defined as "vein" in {TKD:src}, and subsequently expanded to mean "blood vessel" in general.
 
 A German word for "vein" is "Ader".</column>
@@ -275,6 +301,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -282,6 +309,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
         <table name="mem">
@@ -295,6 +323,7 @@ A German word for "vein" is "Ader".</column>
           <column name="definition_ru">капиллярный [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">毛細血管 [AUTOTRANSLATED]</column>
           <column name="definition_pt">capilar</column>
+      <column name="definition_fi">hiussuoni, kapillaari</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -305,6 +334,7 @@ A German word for "vein" is "Ader".</column>
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'aD:n}, {-Hom:n}</column>
           <column name="examples"></column>
@@ -314,6 +344,7 @@ A German word for "vein" is "Ader".</column>
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -321,6 +352,7 @@ A German word for "vein" is "Ader".</column>
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -334,6 +366,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">иметь длину, меру [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有一個長度、衡量 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ter um comprimento de, medir</column>
+      <column name="definition_fi">olla pituudeltaan jotain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uj:n}, {juch:v}, {Saw':v}, {juv:v}, {men:v}</column>
@@ -344,6 +377,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru">Как {'aD:v:nolink}, так и {'ab:v} означают «иметь длину», но они используются немного по-разному. Для плоских объектов, таких как столешницы, {'aD:v:nolink} используется для одного измерения, а {juch:v} - для другого. Для длинных объектов и для высоты вместо этого используется {'ab:v:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{'aD:v:nolink}和{'ab:v}均表示“長度為”，但用法略有不同。對於諸如桌面之類的扁平物體，{'aD:v:nolink}用於一個尺寸，而{juch:v}用於另一尺寸。對於長物體和高度，將使用{'ab:v:nolink}代替。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ambos {'aD:v:nolink} e {'ab:v} significam "têm um comprimento de", mas são usados ​​de forma ligeiramente diferente. Para objetos planos, como tampos de mesa, {'aD:v:nolink} é usado para uma dimensão enquanto {juch:v} é usado para a outra. Para objetos longos e para altura, {'ab:v:nolink} é usado em seu lugar.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sekä {'aD:v:nolink} että {'ab:v} tarkoittavat "on pituus", mutta niitä käytetään hieman eri tavalla. Litteille esineille, kuten pöytälevyille, {'aD:v:nolink} käytetään yhdessä ulottuvuudessa ja {juch:v} toisessa. Pitkille esineille ja korkeudelle käytetään sen sijaan {'ab:v:nolink}[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In anatomy, abduction refers to moving away from a midline. In particular, abduction at the shoulder means raising the arms up, an action which is often done to measure the length of something. Its counterpart, adduction, refers to movement towards a midline.</column>
       <column name="components"></column>
       <column name="examples">
@@ -354,6 +388,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">long</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -361,6 +396,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.10.22:src}, [3] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -374,6 +410,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">показать, продемонстрировать, отобразить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">展示、表現</column>
       <column name="definition_pt">mostrar, demonstrar, apresentar</column>
+      <column name="definition_fi">osoittaa, näyttää, ilmentää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ang:v}, {chIw:v}</column>
@@ -384,6 +421,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The English translation of the sentence from {Star Trek Constellations:src} does not appear in the book, but in the author's annotations which was a separate document.</column>
       <column name="components"></column>
       <column name="examples">
@@ -406,6 +444,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -413,6 +452,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {Star Trek Constellations p.259:src}, [3] {paq'batlh p.118-121:src}</column>
     </table>
     <table name="mem">
@@ -426,6 +466,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">принадлежности</column>
       <column name="definition_zh_HK">用具 [AUTOTRANSLATED]</column>
       <column name="definition_pt">parafernália</column>
+      <column name="definition_fi">varusteet, tarvikkeet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hov leng:n}</column>
@@ -436,6 +477,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -445,6 +487,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -452,6 +495,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -465,6 +509,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">опытный образец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">原型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">protótipo</column>
+      <column name="definition_fi">prototyyppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -475,6 +520,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -484,6 +530,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -491,6 +538,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -504,6 +552,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">адмирал</column>
       <column name="definition_zh_HK">上將</column>
       <column name="definition_pt">almirante</column>
+      <column name="definition_fi">amiraali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -514,6 +563,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru">Это 1-й ранг {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{yaS:n}的第一等級。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o 1º ranking do {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {yaS:n}: n 1. sijoitus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -523,6 +573,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -530,6 +581,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -543,6 +595,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">плавать (в / в воздухе) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">漂浮（氣體中／上）</column>
       <column name="definition_pt">flutuar (no ar)</column>
+      <column name="definition_fi">leijua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'oq:v}</column>
       <column name="see_also">{puv:v}, {'ay:v}</column>
@@ -553,6 +606,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這也用於隨機數，例如擲骰子（{mI' nagh:n}）時。參見{'al:v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é usado para números aleatórios, como ao jogar dados ({mI' nagh:n}). Consulte {'al:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään myös satunnaislukuihin, kuten noppaa heitettäessä ({mI' nagh:n}). Katso {'al:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Muhammad Ali said to "float like a butterfly and sting like a bee".</column>
       <column name="components"></column>
       <column name="examples">The fact that this can be used adjectivally for numbers[2] suggests that it is a stative verb, but it is not out of the question that maybe it can be used adjectivally only for numbers but can take an object otherwise.</column>
@@ -562,6 +616,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -569,6 +624,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}, [2] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -582,6 +638,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">быть случайным (число) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">隨機（數字） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser aleatório</column>
+      <column name="definition_fi">olla satunnainen (luvusta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI':n}</column>
@@ -592,6 +649,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru">Это просто глагол {'al:v:1}, применяемый к числам. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是應用於數字的動詞{'al:v:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é apenas o verbo {'al:v:1} aplicado aos números. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain verbi {'al:v:1}, jota käytetään numeroihin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Based on the explanation and the examples, this is a stative verb. However, the definition of {'al:v:1:nolink} as "float (in/on air)" rather than "be floating" leaves open the possibility that it can take an object in other contexts.</column>
       <column name="components"></column>
       <column name="examples">
@@ -603,6 +661,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -610,6 +669,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -623,6 +683,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">пряжка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">帶釦</column>
       <column name="definition_pt">fivela (de cinto)</column>
+      <column name="definition_fi">(vyön) solki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qogh:n:1}</column>
@@ -633,6 +694,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Alnilam is the star in the middle of Orion's belt.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -642,6 +704,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">belt buckle</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -649,6 +712,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -662,6 +726,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">веснушка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雀斑 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sardas</column>
+      <column name="definition_fi">pisama</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qab:n}</column>
@@ -672,6 +737,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The request was "freckle(s)" so this is how it may appear in other word lists, but the "(s)" has been removed here for consistency with other definitions.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -681,6 +747,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -688,6 +755,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -701,6 +769,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">топор с шипом на конце [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斧頭與穗末端 [AUTOTRANSLATED]</column>
       <column name="definition_pt">machado com ponta no fim</column>
+      <column name="definition_fi">eräs ase; kirves, jonka päässä on piikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'obmaQ:n}</column>
@@ -711,6 +780,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -720,6 +790,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">axe with spike at end</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -727,6 +798,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -740,6 +812,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">стекло (материал) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">玻璃（材料） [AUTOTRANSLATED]</column>
       <column name="definition_pt">vidro (material)</column>
+      <column name="definition_fi">lasi (materiaali)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baS:n}, {Sor Hap:n}, {mep:n}</column>
@@ -750,6 +823,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The definition is given as "glass", in a list of materials.
 
 "Aluminium oxynitride" is the ceramic known as "transparent aluminum".</column>
@@ -761,6 +835,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -768,6 +843,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -781,6 +857,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">остров [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">島</column>
       <column name="definition_pt">ilha</column>
+      <column name="definition_fi">saari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{puH:n}, {yuwey:n}</column>
@@ -791,6 +868,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -800,6 +878,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -807,6 +886,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -820,6 +900,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">академия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">學堂</column>
       <column name="definition_pt">academia</column>
+      <column name="definition_fi">akatemia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yejHaD:n}, {yej'an:n}</column>
@@ -830,6 +911,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru">Это специализированная школа.[2] (наиболее общее слово для места обучения см. {DuSaQ:n}.) [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta é uma escola especializada.[2] (Para a palavra mais genérica para um local de aprendizado, consulte {DuSaQ:n}.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to the Academy of Motion Picture Arts and Sciences (AMPAS).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -839,6 +921,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -846,6 +929,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {HQ 4.4, p.11:src}</column>
     </table>
     <table name="mem">
@@ -859,6 +943,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">балкон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陽台 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sacada</column>
+      <column name="definition_fi">parveke</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -869,6 +954,7 @@ A German word for "vein" is "Ader".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Irma was the main character of the 1957 play "The Balcony".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -878,6 +964,7 @@ A German word for "vein" is "Ader".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -885,6 +972,7 @@ A German word for "vein" is "Ader".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -898,6 +986,7 @@ A German word for "vein" is "Ader".</column>
       <column name="definition_ru">быть тратой [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嘥</column>
       <column name="definition_pt">ser um desperdício</column>
+      <column name="definition_fi">olla tuhlausta, haaskausta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -916,6 +1005,9 @@ De flesta lexikografer från Klingon betraktar detta och {'an:v:2} som två homo
       <column name="notes_pt">Isso pode ser usado para quando alguém sacrifica forças por um determinado objetivo ou apenas desperdiça seus recursos.[1]
 
 A maioria dos lexicógrafos Klingon considera isso e {'an:v:2} como duas palavras homófonas, mas historicamente, o significado "ser um desperdício" desenvolvido a partir do significado "ser petrificado", talvez porque algo perde qualquer uso original que poderia ter tido se fosse transformado em pedra .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää, kun joku uhraa voimia tiettyyn tavoitteeseen tai vain tuhlaa resurssejaan.
+
+Suurin osa Klingonin leksikografeista pitää tätä ja {'an:v:2}: ta kahtena homofonisena sanana, mutta historiallisesti "olla tuhla" -merkitys syntynyt "olla kivettynyt" -merkinnästä, ehkä siksi, että jokin menettää alkuperäisen käyttötarkoituksensa, joka sillä voi olla, jos se muuttuu kiveksi .DONOTTRANSLATE 3[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was revealed to express "it's such a waste", as one might say if one sees an almost full bottle of cola in the garbage. It was defined as "waste [as someone sacrifices forces for a certain goal or just wastes one's resources]" in the KLI new words list in 2018, but as a verb.[1] Some people found this to be confusing, and Dr. Okrand was asked for clarification. At the {Saarbrücken qepHom'a':src} a few months later, Dr. Okrand recorded a {video:url:http://youtu.be/f2cgPd-TBJE&amp;start=229} explaining the usage. Some people felt that this was still unclear, so at the {Saarbrücken qepHom'a':src} after that (in 2019), the homophonous {'an:v:2} was revealed, and an explanation was given about how these verbs were historically related.[2]
 
 The German definition "Verschwendung sein" comes from the {Saarbrücken qepHom'a' 2019:src} booklet.[2]</column>
@@ -927,6 +1019,7 @@ The German definition "Verschwendung sein" comes from the {Saarbrücken qepHom'a
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">verbrauchen</column>
       <column name="search_tags_fa"></column>
@@ -934,6 +1027,7 @@ The German definition "Verschwendung sein" comes from the {Saarbrücken qepHom'a
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
         <table name="mem">
@@ -947,6 +1041,7 @@ The German definition "Verschwendung sein" comes from the {Saarbrücken qepHom'a
           <column name="definition_ru">приносить в жертву [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">犧</column>
           <column name="definition_pt">sacrifício</column>
+      <column name="definition_fi">uhrata, tuhlata, haaskata</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{weS:v}</column>
@@ -957,6 +1052,7 @@ The German definition "Verschwendung sein" comes from the {Saarbrücken qepHom'a
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'an:v:1}, {-moH:v}</column>
           <column name="examples"></column>
@@ -966,6 +1062,7 @@ The German definition "Verschwendung sein" comes from the {Saarbrücken qepHom'a
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -973,6 +1070,7 @@ The German definition "Verschwendung sein" comes from the {Saarbrücken qepHom'a
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
     <table name="mem">
@@ -986,6 +1084,7 @@ The German definition "Verschwendung sein" comes from the {Saarbrücken qepHom'a
       <column name="definition_ru">окаменеть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被嚇呆了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser petrificado</column>
+      <column name="definition_fi">olla kivettynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nagh:n}, {'an'or:n}</column>
@@ -1010,6 +1109,9 @@ När den tillämpas på människor kan det bara betyda bokstavlig vändning till
       <column name="notes_pt">Isso é usado para falar sobre fósseis. A maioria dos lexicógrafos Klingon considera isso e {'an:v:1} como duas palavras homófonas, mas historicamente, o significado "ser um desperdício" desenvolvido a partir do significado "ser petrificado", talvez porque algo perde qualquer uso original que poderia ter tido se fosse transformado em pedra .
 
 Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não significa "realmente assustado" como "petrificado" em inglês.) [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään puhumaan fossiileista. Suurin osa Klingonin leksikografeista pitää tätä ja {'an:v:1}-sanaa kahtena homofonisena sanana, mutta historiallisesti "olla tuhla" -merkitys, joka on kehittynyt "olla kivettynyt" -merkinnästä, ehkä siksi, että jokin menettää alkuperäisen käyttötarkoituksensa, joka sillä voi olla, jos se muutetaan kiveksi .
+
+Kun sitä käytetään ihmisiin, se voi tarkoittaa vain kirjaimellista kivenmuutosta. (Se ei tarkoita "todella peloissaan", kuten "kivettynyt" englanniksi.) [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The German definition comes from the {Saarbrücken qepHom'a' 2019:src} booklet.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1019,6 +1121,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1026,6 +1129,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1041,6 +1145,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">Андория [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">安多利星</column>
       <column name="definition_pt">Andoria</column>
+      <column name="definition_fi">Andoria</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'anDorya'ngan:n}</column>
@@ -1051,6 +1156,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru">Планета в Федерации. Также называется {'anDorya':n:nolink}. Не путать со страной на Земле под названием {'anDo'ra':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">聯邦中的一顆行星。也稱為{'anDorya':n:nolink}。不要與地球上叫做{'anDo'ra':n}的國家相混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Planeetta federaatiossa. Kutsutaan myös nimellä {'anDorya':n:nolink}. Ei pidä sekoittaa maanpäälliseen maahan nimeltä {'anDo'ra':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1060,6 +1166,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1067,6 +1174,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1080,6 +1188,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">{'anDor:n}</column>
       <column name="definition_zh_HK">{'anDor:n}</column>
       <column name="definition_pt">{'anDor:n}</column>
+      <column name="definition_fi">{'anDor:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1090,6 +1199,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1099,6 +1209,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1106,6 +1217,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1119,6 +1231,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">{'anDorya'ngan:n}</column>
       <column name="definition_zh_HK">{'anDorya'ngan:n}</column>
       <column name="definition_pt">{'anDorya'ngan:n}</column>
+      <column name="definition_fi">{'anDorya'ngan:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1129,6 +1242,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word has not explicitly appeared in canon, but is implied to exist by {'anDor:n} and {'anDorya'ngan:n}, and the variations in planet names described in {KGT p.141-142:src}.</column>
       <column name="components">{'anDor:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -1138,6 +1252,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1145,6 +1260,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1158,6 +1274,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">андорианский [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">安多利人</column>
       <column name="definition_pt">Andoriano</column>
+      <column name="definition_fi">andorialainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'anDor:n}</column>
@@ -1168,6 +1285,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'anDorya':n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -1177,6 +1295,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1184,6 +1303,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1197,6 +1317,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">аниций [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">anicium [AUTOTRANSLATED]</column>
       <column name="definition_pt">anicium</column>
+      <column name="definition_fi">eräs yhdiste, anicium</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1207,6 +1328,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru">Это химическое соединение, которое в сочетании с {yuryum:n} реагирует на взрыв. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種化學物質，與{yuryum:n}結合時會發生爆炸。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um composto químico que reage para criar uma explosão quando combinado com {yuryum:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kemiallinen yhdiste, joka reagoi muodostaen räjähdyksen yhdistettynä {yuryum:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1216,6 +1338,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1223,6 +1346,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Magic to Make the Sanest Man Go Mad:src}</column>
     </table>
     <table name="mem">
@@ -1236,6 +1360,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">Антоний</column>
       <column name="definition_zh_HK">安東尼</column>
       <column name="definition_pt">Antony</column>
+      <column name="definition_fi">Antonius</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhI'yopatra':n:name}</column>
@@ -1246,6 +1371,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是{wIlyam SeQpIr:n:name}的戲劇{'antonI' tlhI'yopatra' je:sen:nolink}的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um nome da peça de {wIlyam SeQpIr:n:name} de {'antonI' tlhI'yopatra' je:sen:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on nimi {wIlyam SeQpIr:n:name}: n näytelmästä {'antonI' tlhI'yopatra' je:sen:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1255,6 +1381,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1262,6 +1389,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.110:src}</column>
     </table>
     <table name="mem">
@@ -1275,6 +1403,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">лук [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">洋蔥</column>
       <column name="definition_pt">cebola</column>
+      <column name="definition_fi">sipuli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oQqar:n}, {gharlIq 'oQqar:n}</column>
@@ -1285,6 +1414,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru">Это то, что клингоны назвали бы терранским овощем. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族蔬菜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que os klingons chamariam de vegetal terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-vihannekseksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1294,6 +1424,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1301,6 +1432,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -1314,6 +1446,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">ископаемое [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">化石 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fóssil</column>
+      <column name="definition_fi">fossiili</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'an'orQeD:n}, {'an'ortej:n}, {'an:v:2}, {molHa':v}, {Hom:n:1}</column>
@@ -1324,6 +1457,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru">Это же слово используется для окаменелостей растений, костей и т. Д. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">同一詞用於植物，骨骼等的化石。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A mesma palavra é usada para fósseis de plantas, ossos, etc. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Rhona Fenwick is a Klingon speaker who is an archeologist.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1333,6 +1467,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1340,6 +1475,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1353,6 +1489,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">палеонтология [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">古生物學 [AUTOTRANSLATED]</column>
       <column name="definition_pt">paleontologia</column>
+      <column name="definition_fi">paleontologia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'an'or:n}, {QeD:n}, {'an'ortej:n}</column>
@@ -1363,6 +1500,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'an'or:n}, {QeD:n}</column>
       <column name="examples"></column>
@@ -1372,6 +1510,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">palaeontology</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1379,6 +1518,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1392,6 +1532,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">палеонтолог [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">古生物學家 [AUTOTRANSLATED]</column>
       <column name="definition_pt">paleontólogo</column>
+      <column name="definition_fi">paleontologi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'an'or:n}, {tej:n}, {'an'orQeD:n}</column>
@@ -1402,6 +1543,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'an'or:n}, {tej:n}</column>
       <column name="examples"></column>
@@ -1411,6 +1553,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">palaeontologist</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1418,6 +1561,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1431,6 +1575,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">показать</column>
       <column name="definition_zh_HK">顯示、揭示 [AUTOTRANSLATED]</column>
       <column name="definition_pt">apresentar, revelar</column>
+      <column name="definition_fi">näyttää, paljastaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'agh:v}, {cha':v}</column>
@@ -1441,6 +1586,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1452,6 +1598,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1459,6 +1606,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1472,6 +1620,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">Только враг без чести отказывается показывать себя в бою. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">只有沒有榮譽的敵人才會拒絕在戰鬥中展示自己。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Apenas um inimigo sem honra recusa se mostrar em batalha.</column>
+      <column name="definition_fi">Vain vihollinen, jolla ei ole kunniaa, kieltäytyy paljastamasta itseään taistelussa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1482,6 +1631,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'ang:v}, {-'egh:v}, {-Qo':v}, {quv:n}, {Hutlh:v}, {-bogh:v}, {jagh:n}, {neH:adv}, {ghob:v}, {-taH:v}, {-vIS:v}, {ghaH:n}</column>
       <column name="examples"></column>
@@ -1491,6 +1641,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Only an enemy without honour refuses to show himself in battle.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1498,6 +1649,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.61:src}</column>
     </table>
     <table name="mem">
@@ -1511,6 +1663,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">музей [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">博物馆</column>
       <column name="definition_pt">museu</column>
+      <column name="definition_fi">museo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1521,6 +1674,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Welsh word for "museum" is "amgueddfa".</column>
       <column name="components"></column>
       <column name="examples">
@@ -1531,6 +1685,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1538,6 +1693,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1551,6 +1707,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">Кос'Карий (одиночка) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">科斯卡里（單一） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Kos'Karii (singular)</column>
+      <column name="definition_fi">eräs eläin, kos'karii</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1561,6 +1718,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Latin word for eel is "anguilla".</column>
       <column name="components">{qoSqa'rIy:n:inhpl}</column>
       <column name="examples"></column>
@@ -1570,6 +1728,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1577,6 +1736,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1590,6 +1750,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">быть помятым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被打敗了 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser amolgado, amassado</column>
+      <column name="definition_fi">olla hammastettu, lovettu, kuhmuinen, kolhittu ?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{taw':v}</column>
       <column name="see_also">{retlaw:n}</column>
@@ -1600,6 +1761,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Arthur Philip Dent is the protagonist of {The Hitchhiker's Guide to the Galaxy:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1609,6 +1771,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">concave</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1616,6 +1779,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
         <table name="mem">
@@ -1629,6 +1793,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
           <column name="definition_ru">вмятина [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">凹痕 [AUTOTRANSLATED]</column>
           <column name="definition_pt">dente</column>
+      <column name="definition_fi">loveta, hammastaa, kolhia, lommottaa ?</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{retlaw:n}</column>
@@ -1639,6 +1804,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'ap:v}, {-moH:v}</column>
           <column name="examples"></column>
@@ -1648,6 +1814,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1655,6 +1822,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 24 (2017):src}</column>
         </table>
     <table name="mem">
@@ -1668,6 +1836,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">гранула [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">丸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Pellet, grão, grânulos</column>
+      <column name="definition_fi">pelletti, pieni pallo, kuula</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1678,6 +1847,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{chuch 'aplom:n}</column>
@@ -1687,6 +1857,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1694,6 +1865,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
         <table name="mem">
@@ -1707,6 +1879,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
           <column name="definition_ru">{chuch 'aplom:n}</column>
           <column name="definition_zh_HK">{chuch 'aplom:n}</column>
           <column name="definition_pt">{chuch 'aplom:n}</column>
+      <column name="definition_fi">{chuch 'aplom:n}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1717,6 +1890,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -1726,6 +1900,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1733,6 +1908,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 24 (2017):src}</column>
         </table>
     <table name="mem">
@@ -1747,6 +1923,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">кейс, контейнер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">案例、容器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">caso, recipiente</column>
+      <column name="definition_fi">kotelo, rasia, lipas, säiliö, laatikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngaSwI':n}, {vey:n}</column>
@@ -1757,6 +1934,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru">Это общий термин для небольшого контейнера.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個小容器的總稱。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o termo geral para um pequeno recipiente.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleinen termi pienelle kontille.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word was originally used to translated "Limited Edition" for {Klingon Monopoly:src}, as {'aplo'mey puS neH chenmoHlu'pu':sen:nolink}, before {'aplo':n:nolink} was changed to {vey:n}. The Klingon version of the list of the game box's "contents" also has the heading {ngaS 'aplo':sen:nolink}. (There is a typo in {ngaS 'aplo':sen:nolink}: it actually reads {naS 'aplo':sen:nolink} on the box, but it's clear what was meant.)</column>
       <column name="components"></column>
       <column name="examples">{'ul 'aplo':n}, {wab qoSta' 'aplo':n}</column>
@@ -1766,6 +1944,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1773,6 +1952,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}, [2] {TNK:src}, [3] {Facebook "Learn Klingon" group 2013.08.10:src}</column>
     </table>
     <table name="mem">
@@ -1786,6 +1966,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">кальций [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鈣 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cálcio</column>
+      <column name="definition_fi">kalsium</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'evtlhev:n}, {baS:n}, {tamler:n}</column>
@@ -1796,6 +1977,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru">Это металлический химический элемент с символом Ca и атомным номером 20. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是金屬化學元素，符號為Ca，原子序數為20。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o elemento químico metálico com o símbolo Ca e o número atômico 20. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on metallinen kemiallinen alkuaine, jolla on symboli Ca ja atominumero 20. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1805,6 +1987,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Kalzium</column>
       <column name="search_tags_fa"></column>
@@ -1812,6 +1995,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1825,6 +2009,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">ястребиная птица [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一隻鷹般的鳥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um pássaro parecido com um falcão</column>
+      <column name="definition_fi">eräs haukan kaltainen lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}</column>
@@ -1835,6 +2020,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="notes_ru">Это особый вид {toQ:n}, который летит особенно быстро. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種特別飛行的{toQ:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo particular de {toQ:n} que voa particularmente rápido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on erityinen {toQ:n}, joka lentää erityisen nopeasti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Apus" is the Latin name for the birds commonly known as swifts.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1844,6 +2030,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1851,6 +2038,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.10:src}</column>
     </table>
     <table name="mem">
@@ -1864,6 +2052,7 @@ Quando aplicado a pessoas, só pode significar literalmente virar pedra. (Não s
       <column name="definition_ru">предсказывать, прогнозировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">預測、預計</column>
       <column name="definition_pt">prever, prognóstico</column>
+      <column name="definition_fi">ennustaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghut:v}, {qut:v}, {meq:v}</column>
@@ -1878,6 +2067,9 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä viittaa ennustamiseen, joka perustuu deduktiiviseen päättelyyn, tutkimukseen tai tieteeseen.
+
+Huomaa, että sääennusteissa (katso {muD Dotlh:n}) käytetään yleensä {'e' -lu:sen@@'e':n, -lu':v}: ta {net:n}: n sijaan, mutta {net:n:nolink}: n käyttö ei olisi väärin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The word for "reason" or "intellect" in Arabic is "'aql".</column>
       <column name="components"></column>
       <column name="examples">
@@ -1894,6 +2086,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">forecast</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1901,6 +2094,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1914,6 +2108,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="definition_ru">type of weapon (half ax, half bat'leth) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">武器類型（半斧、半蝙蝠） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de arma (meio machado, meio bat'leth)</column>
+      <column name="definition_fi">eräs ase (puoliksi kirves, puoliksi bat'leth)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qach:v}</column>
@@ -1924,6 +2119,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1933,6 +2129,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1940,6 +2137,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1953,6 +2151,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="definition_ru">type of knife (general purpose) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刀型（通用型） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de faca (uso geral)</column>
+      <column name="definition_fi">eräs yleiskäyttöinen veitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1963,6 +2162,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="notes_ru">Это нож общего назначения, который, кажется, способен прорезать что угодно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一把通用刀具，似乎可以切穿任何東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma faca de uso geral que parece capaz de cortar qualquer coisa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleiskäyttöinen veitsi, joka näyttää pystyvän leikkaamaan kaiken. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The phrase "Act now!" is used repeatedly in TV informercials for Ginsu knives.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1972,6 +2172,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1979,6 +2180,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1993,6 +2195,7 @@ Man beachte dass es bei der Wettervorhersage (siehe {muD Dotlh:n}) üblich ist {
       <column name="definition_ru">нижняя поверхность стола, потолок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">桌子的底面、天花板 [AUTOTRANSLATED]</column>
       <column name="definition_pt">superfície inferior de uma mesa, teto</column>
+      <column name="definition_fi">yläosan alaosa, pöydän alapinta, katon alapinta</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bIS'ub:n}, {rav:n:1}</column>
       <column name="see_also">{Dung:n}, {rav'eq:n}, {pa' beb:n}, {raS:n}</column>
@@ -2017,6 +2220,9 @@ Detta ord kan användas för att hänvisa till ett tak, men termerna {pa' beb:n}
       <column name="notes_pt">A outra face do {'aqroS:n:1,nolink} de um objeto é seu {yor:n}.[1]
 
 Esta palavra pode ser usada para se referir a um teto, embora os termos {pa' beb:n} e {rav'eq:n} (que dependem da existência de andares acima) sejam mais comuns.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Objektin {'aqroS:n:1,nolink} toinen puoli on sen {yor:n}.[1]
+
+Tätä sanaa voidaan käyttää viittaamaan kattoon, vaikka termit {pa' beb:n} ja {rav'eq:n} (jotka riippuvat siitä, onko sen yläpuolella kerroksia) ovat yleisempiä.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Across".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2026,6 +2232,7 @@ Esta palavra pode ser usada para se referir a um teto, embora os termos {pa' beb
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">interior, inside top</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2033,6 +2240,7 @@ Esta palavra pode ser usada para se referir a um teto, embora os termos {pa' beb
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -2047,6 +2255,7 @@ Esta palavra pode ser usada para se referir a um teto, embora os termos {pa' beb
       <column name="definition_ru">максимальная [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">最大 [AUTOTRANSLATED]</column>
       <column name="definition_pt">máximo, valor mais alto</column>
+      <column name="definition_fi">enintään, enimmäismäärä, maksimi</column>
       <column name="synonyms"></column>
       <column name="antonyms">{rav:n:2}</column>
       <column name="see_also">{vuS:v}, {rav ... 'aqroS ...:sen}</column>
@@ -2071,6 +2280,9 @@ In anderen Kontexten sollten Sie das Verbsuffix {-qu':v} verwenden. Zum Beispiel
       <column name="notes_pt">Esta palavra é usada para especificar um limite ou restrição.
 
 Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom yIghoSqu'!:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään määrittämään raja tai rajoitus.
+
+Harkitse muissa yhteyksissä verbiliitteen {-qu':v} käyttöä. Esimerkiksi: {nom yIghoSqu'!:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Across".</column>
       <column name="components"></column>
       <column name="examples">
@@ -2082,6 +2294,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">most, utmost, extreme, below</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2089,6 +2302,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}, [2] {HQ 8.3, p.2, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -2102,6 +2316,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="definition_ru">максимальная крейсерская скорость [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">最大巡航速度 [AUTOTRANSLATED]</column>
       <column name="definition_pt">velocidade máxima de cruzeiro</column>
+      <column name="definition_fi">suurin matkanopeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2112,6 +2327,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'aqroS:n:2}, {qughDo:n}</column>
       <column name="examples"></column>
@@ -2121,6 +2337,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2128,6 +2345,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2141,6 +2359,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="definition_ru">{rav ... 'aqroS ...:sen}</column>
       <column name="definition_zh_HK">{rav ... 'aqroS ...:sen}</column>
       <column name="definition_pt">{rav ... 'aqroS ...:sen}</column>
+      <column name="definition_fi">{rav ... 'aqroS ...:sen}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2151,6 +2370,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2160,6 +2380,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2167,6 +2388,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2180,6 +2402,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="definition_ru">Актух [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Aktuh [AUTOTRANSLATED]</column>
       <column name="definition_pt">Aktuh</column>
+      <column name="definition_fi">Aktuh</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mellota':n:name}, {ghe'naQ:n}</column>
@@ -2190,6 +2413,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="notes_ru">Персонаж в известной клингонской опере. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">著名的克林崗歌劇中的角色。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um personagem de uma famosa ópera Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2199,6 +2423,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2206,6 +2431,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW:src}</column>
     </table>
     <table name="mem">
@@ -2219,6 +2445,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="definition_ru">тыква, тыква, тыква [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">葫蘆南瓜西葫蘆 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cabaça, abóbora</column>
+      <column name="definition_fi">kurpitsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naH:n}</column>
@@ -2229,6 +2456,7 @@ Em outros contextos, considere usar o sufixo verbal {-qu':v}. Por exemplo: {nom 
       <column name="notes_ru">Это относится к самому висячему или вьющемуся растению. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指拖尾植物或攀援植物本身。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à planta de reboque ou trepadeira em si. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Luffa acutangula" is a type of gourd known as vegetable gourd or Chinese okra. In the episode {TOS - The Apple:src}, a character named Akuta smashes a Persian melon.
 
 The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':n, naH:n}.</column>
@@ -2240,6 +2468,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2247,6 +2476,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2260,6 +2490,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="definition_ru">лоб [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">額頭</column>
       <column name="definition_pt">testa</column>
+      <column name="definition_fi">otsa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quch:n}</column>
@@ -2270,6 +2501,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2279,6 +2511,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2286,6 +2519,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2299,6 +2533,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="definition_ru">акт наблюдения за телом павшего воина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">看著墮落的戰士身體的行為 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ato de vigiar o corpo de um guerreiro caído</column>
+      <column name="definition_fi">kaatuneen soturin ruumiin vartiointi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nol:n}, {Heghtay:n}, {SonchIy:n}</column>
@@ -2309,6 +2544,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="notes_ru">Это древняя традиция, когда товарищи воина, погибшего в бою, оставались с телом, чтобы удерживать хищников, что позволило духу ({qa':n}) покинуть тело, когда оно было готово к путешествию в Сто-Во-Кор ( {Suto'vo'qor:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種古老的傳統，在戰鬥中喪生的戰士的同志們與屍體呆在一起，以遠離掠食者，這使得靈魂（{qa':n}）在準備前往Sto-Vo-Kor的旅程中離開了屍體（ {Suto'vo'qor:n}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on ikivanha perinne, jossa taistelussa kuolleiden sotureiden toverit pysyivät ruumiin kanssa pitääkseen saalistajat, mikä antoi henkelle ({qa':n}) mahdollisuuden lähteä ruumiista, kun se oli valmis matkalle Sto-Vo-Koriin ( {Suto'vo'qor:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2318,6 +2554,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">ak'voh</column>
       <column name="search_tags_de">ak'voh</column>
       <column name="search_tags_fa"></column>
@@ -2325,6 +2562,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -2338,6 +2576,7 @@ The request was for the plant. Presumably, the fruit be {'aquta' naH:n@@'aquta':
       <column name="definition_ru">сколько?</column>
       <column name="definition_zh_HK">多少？多少？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">quantos?</column>
+      <column name="definition_fi">kuinka monta? kuinka paljon?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'arlogh:ques}</column>
@@ -2358,6 +2597,9 @@ Grammatiskt används ett flertalsprefix om det ifrågasatta substantivet kan var
       <column name="notes_pt">Esta palavra interrogativa segue o substantivo ao qual se refere, que nunca tem um sufixo de plural.[1]
 
 Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder ser singular ou plural e a tradução for "quantos?" Um prefixo singular é usado se o substantivo questionado for algo que não pode ser contado e a tradução for "quanto?" [2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kysymyssana seuraa substantiivia, johon se viittaa, ja jolla ei koskaan ole monikon loppuliitettä.
+
+Kieliopillisesti monikon etuliitettä käytetään, jos kyseenalaistettu substantiivi voi olla yksikkö tai monikko ja käännös on "kuinka monta?" Yksittäistä etuliitettä käytetään, jos kyseenalaistettua substantiivia ei voida laskea ja käännös on "kuinka paljon?" [2][1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2372,6 +2614,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2379,6 +2622,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.4:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2392,6 +2636,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="definition_ru">плющоподобное растение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">常春藤般的植物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">planta parecida com a ivy</column>
+      <column name="definition_fi">eräs muratin kaltainen kasvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2402,6 +2647,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The ivy belongs to the genus "Hedera".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2411,6 +2657,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2418,6 +2665,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2431,6 +2679,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="definition_ru">ухудшаться</column>
       <column name="definition_zh_HK">惡化 [AUTOTRANSLATED]</column>
       <column name="definition_pt">piorar</column>
+      <column name="definition_fi">pahentua, huonontua</column>
       <column name="synonyms">{Sab:v}</column>
       <column name="antonyms">{Dub:v}, {rach:v}</column>
       <column name="see_also">{qab:v}</column>
@@ -2441,6 +2690,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Argh!" One might say this when one's writer's cramp worsens.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2450,6 +2700,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2457,6 +2708,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2470,6 +2722,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="definition_ru">сколько раз? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">多少次？</column>
       <column name="definition_pt">Quantas vezes?</column>
+      <column name="definition_fi">kuinka monta kertaa?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2480,6 +2733,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'ar:ques}, {-logh:n:num,suff}</column>
       <column name="examples"></column>
@@ -2489,6 +2743,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2496,6 +2751,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.02.02:src}</column>
     </table>
     <table name="mem">
@@ -2509,6 +2765,7 @@ Gramaticamente, um prefixo de plural é usado se o substantivo questionado puder
       <column name="definition_ru">Который сейчас час? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">幾點了？</column>
       <column name="definition_pt">Que horas são?</column>
+      <column name="definition_fi">Paljonko kello on?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghorgh:ques}</column>
@@ -2521,6 +2778,9 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on yleisin monista tapoista kysyä aikaa Klingonissa. Voidaan myös kysyä, {'arlogh wab Qoylu'pu'?: Sen: nolink} tai {qen 'arlogh Qoylu'pu'?: Sen: nolink} Vastaus tähän kysymykseen on esimerkiksi {cha'logh Qoylu'pu':sen:nolink} "Se on kuultu kahdesti ", mikä tarkoittaa" kaksi ".
+
+Liiton 24 tunnin järjestelmää ({tera' poH:n}) käytetään joskus planeettojen välisessä viestinnässä. Kun työskentelet tässä järjestelmässä, aika kysyä on antaa komento, {rep yIper!:sen:nolink} Vastaamalla tähän komentoon tunteja ei lasketa, vaan numeroidaan 1: stä 24. Esimerkiksi {tera' rep cha':sen:nolink} tai {rep cha':sen:nolink} on "kaksi o 'kello". Kun asiayhteys on selvä, {tera':n} voidaan jättää pois.{'arlogh wab Qoylu'pu'?:sen:nolink}{qen 'arlogh Qoylu'pu'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2531,6 +2791,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2538,6 +2799,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.02.02:src}</column>
     </table>
     <table name="mem">
@@ -2551,6 +2813,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">унаследуют [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">繼承 [AUTOTRANSLATED]</column>
       <column name="definition_pt">herdar</column>
+      <column name="definition_fi">periä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2561,6 +2824,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru">Это относится к наследованию в том смысле, что, если отец умирает, его сын наследует его имущество. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指繼承，即父親去世，兒子繼承其財產。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à herança no sentido de que, se um pai morre, seu filho herda seus bens. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa perintöön siinä mielessä, että jos isä kuolee, hänen poikansa perii omaisuutensa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2570,6 +2834,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2577,6 +2842,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -2590,6 +2856,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">A'trom [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">A'trom [AUTOTRANSLATED]</column>
       <column name="definition_pt">A'trom</column>
+      <column name="definition_fi">A'trom</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HuS:n:name}</column>
@@ -2600,6 +2867,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2609,6 +2877,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2616,6 +2885,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2629,6 +2899,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">тип гриба [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">真菌的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de fungo</column>
+      <column name="definition_fi">eräs sieni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wech:v}, {tera' yav 'atlhqam:n}</column>
@@ -2639,6 +2910,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru">Обычно это встречается на ногах какого-то клингонского животного или на клингонских деревьях. В ненаучной повседневной речи это, по-видимому, служит общим термином «гриб».[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常在某種克林崗動物的腳上或克林貢樹上發現。在非科學的日常用語中，這似乎是“真菌”的總稱。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso geralmente é encontrado nos pés de algum tipo de animal Klingon ou em árvores Klingon. No discurso cotidiano não científico, isso parece funcionar como um termo geral para "fungo".[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä löytyy tyypillisesti jonkinlaisen klingonilaisen eläimen jaloista tai klingonipuista. Ei-tieteellisessä, jokapäiväisessä puheessa tämä näyttää toimivan yleisenä terminä "sieni".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Athlete's foot". Also "huitlacoche".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2648,6 +2920,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2655,6 +2928,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.92:src}, [2] {KLI mailing list 2017.11.20:src}</column>
     </table>
     <table name="mem">
@@ -2668,6 +2942,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">тип формы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種模具 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de fungo</column>
+      <column name="definition_fi">eräs homesieni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2678,6 +2953,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru">Это буквально означает «мягкий грибок». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“軟木耳”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "fungo mole". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "pehmeää sientä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'atlhqam:n}, {tun:v}</column>
       <column name="examples"></column>
@@ -2687,6 +2963,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2694,6 +2971,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2707,6 +2985,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">охранять</column>
       <column name="definition_zh_HK">守衛</column>
       <column name="definition_pt">guardar</column>
+      <column name="definition_fi">vartioida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'avwI':n}</column>
@@ -2717,6 +2996,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2726,6 +3006,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2733,6 +3014,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2746,6 +3028,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">стража</column>
       <column name="definition_zh_HK">警衛</column>
       <column name="definition_pt">guarda</column>
+      <column name="definition_fi">vartija</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIghHa':n}, {qama':n}</column>
@@ -2756,6 +3039,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'av:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2765,6 +3049,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2772,6 +3057,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2785,6 +3071,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">Когда сбежавший заключенный ищет охранника, он всегда находит его. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">當逃脫的囚犯尋找警衛時，他總能找到一個。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quando um prisioneiro escapado procura um guarda, ele sempre encontra um.</column>
+      <column name="definition_fi">Kun paennut vanki etsii vartijaa, hän aina löytää sellaisen.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2795,6 +3082,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'avwI':n}, {nej:v}, {-DI':v}, {nargh:v:2}, {-ta':v}, {-bogh:v}, {qama':n}, {reH:adv}, {'avwI':n}, {Sam:v}, {-bej:v}</column>
       <column name="examples"></column>
@@ -2804,6 +3092,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2811,6 +3100,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.200:src}</column>
     </table>
     <table name="mem">
@@ -2824,6 +3114,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">пройти, пройти (материя) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通過，通過 [AUTOTRANSLATED]</column>
       <column name="definition_pt">atravessar, passar (matéria)</column>
+      <column name="definition_fi">käydä läpi (aineen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vegh:v}, {tol:v}</column>
@@ -2834,6 +3125,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru">Это относится к прохождению через материю, как это могут делать призраки, фазированные формы жизни или частицы. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指穿過物質，就像鬼影，分階段的生命形式或粒子可能發生的那樣。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à passagem pela matéria, como fantasmas, formas de vida em fases ou partículas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa aineen kulkemiseen, kuten aaveet, vaiheittaiset elämänmuodot tai hiukkaset voivat tehdä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2843,6 +3135,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2850,6 +3143,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2863,6 +3157,7 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="definition_ru">type of beverage (root beer) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">飲料類型（根汁汽水）</column>
       <column name="definition_pt">tipo de bebida (cerveja de raiz)</column>
+      <column name="definition_fi">eräs juurioluen kaltainen juoma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qo'la' 'awje':n}</column>
@@ -2883,6 +3178,9 @@ Detta ord hänvisar inte till en specifik drink, utan till en smal klass relater
       <column name="notes_pt">Este é um tipo de bebida feita a partir (entre outras coisas) da {melchoQ:n} de uma {teghbat:n}. Tem uma semelhança superficial com a cerveja de raiz terráquea.[1, p.95]
 
 Esta palavra não se refere a uma bebida específica, mas a uma classe restrita de bebidas relacionadas.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen juoma, joka on valmistettu (muun muassa) {teghbat:n}: n {melchoQ:n}: stä. Sillä on pinnallinen samankaltaisuus Terran-juuren oluen kanssa.[1, p.95]
+
+Tämä sana ei tarkoita tiettyä juomaa, vaan suppeaa sukulaisjuomaryhmää[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"A&amp;W" is a brand of root beer.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2892,6 +3190,7 @@ Esta palavra não se refere a uma bebida específica, mas a uma classe restrita 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">root beer</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2899,6 +3198,7 @@ Esta palavra não se refere a uma bebida específica, mas a uma classe restrita 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src} [2] {HQ 6.2, p.20, Jun. 1997:src}</column>
     </table>
     <table name="mem">
@@ -2912,6 +3212,7 @@ Esta palavra não se refere a uma bebida específica, mas a uma classe restrita 
       <column name="definition_ru">жалить</column>
       <column name="definition_zh_HK">刺 [AUTOTRANSLATED]</column>
       <column name="definition_pt">picar</column>
+      <column name="definition_fi">pistää, kirvellä, kirpaista, polttaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oy':v}, {tlhar:v}</column>
@@ -2922,6 +3223,7 @@ Esta palavra não se refere a uma bebida específica, mas a uma classe restrita 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Ow".
 
 The example literally means "My eyes sting me", which shows that {'aw':v:nolink} can take an object.</column>
@@ -2934,6 +3236,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2941,6 +3244,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {CK:src}</column>
     </table>
     <table name="mem">
@@ -2954,6 +3258,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="definition_ru">плавать (в / на жидкость) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">漂浮（液體中或上）</column>
       <column name="definition_pt">flutuador (em / no líquido)</column>
+      <column name="definition_fi">kellua, keijua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'oq:v}</column>
       <column name="see_also">{'al:v:1}</column>
@@ -2964,6 +3269,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="notes_ru">Это означает плавать в / на воде или других жидкостях. Что-то свободно плавающее в космосе, смотрите {rIjHa':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這意味著要漂浮在水或其他液體中/上面。有關可在太空中自由漂浮的東西，請參閱{rIjHa':v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa flutuar na água ou em outros líquidos. Para algo flutuando livremente no espaço, consulte {rIjHa':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kellumista vedessä tai muissa nesteissä. Jos haluat jotain, joka kelluu vapaasti avaruudessa, katso {rIjHa':v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Floaters are found in the vitreous of the eye.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2973,6 +3279,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2980,6 +3287,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2993,6 +3301,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="definition_ru">часть</column>
       <column name="definition_zh_HK">部分</column>
       <column name="definition_pt">seção, parte, componente, peça</column>
+      <column name="definition_fi">osa, pala, komponentti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mutlh:v}, {baylaD:n}</column>
@@ -3003,6 +3312,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="notes_ru">Это может быть использовано для любого вида строительных элементов, строительных деталей или даже деталей Lego.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它可以用於任何類型的建築元素，建築零件，甚至是樂高積木。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para qualquer tipo de elemento de construção, peça de construção ou mesmo peças de Lego.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää mihin tahansa rakennusosaan, rakennusosaan tai jopa Lego-kappaleisiin[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3012,6 +3322,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3019,6 +3330,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -3032,6 +3344,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="definition_ru">магистр, профессор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">老師、教授 [AUTOTRANSLATED]</column>
       <column name="definition_pt">professor mestre, professor</column>
+      <column name="definition_fi">mestari, professori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghojmoHwI':n}</column>
@@ -3042,6 +3355,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3051,6 +3365,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3058,6 +3373,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3071,6 +3387,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="definition_ru">Ацетбур</column>
       <column name="definition_zh_HK">「阿澤特巴爾」</column>
       <column name="definition_pt">Azetbur</column>
+      <column name="definition_fi">Azetbur</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3081,6 +3398,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3090,6 +3408,7 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3097,5 +3416,6 @@ The example literally means "My eyes sting me", which shows that {'aw':v:nolink}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}, [2] {Star Trek VI:src}</column>
     </table>

--- a/mem-21-a.xml
+++ b/mem-21-a.xml
@@ -2778,9 +2778,9 @@ The Federation's 24-hour system ({tera' poH:n}) is sometimes used in interplanet
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
-      <column name="notes_fi">Tämä on yleisin monista tapoista kysyä aikaa Klingonissa. Voidaan myös kysyä, {'arlogh wab Qoylu'pu'?: Sen: nolink} tai {qen 'arlogh Qoylu'pu'?: Sen: nolink} Vastaus tähän kysymykseen on esimerkiksi {cha'logh Qoylu'pu':sen:nolink} "Se on kuultu kahdesti ", mikä tarkoittaa" kaksi ".
+      <column name="notes_fi">Tämä on yleisin monista tapoista kysyä aikaa Klingonissa. Voidaan myös kysyä, {'arlogh wab Qoylu'pu'?:sen:nolink} tai {qen 'arlogh Qoylu'pu'?:sen:nolink} Vastaus tähän kysymykseen on esimerkiksi {cha'logh Qoylu'pu':sen:nolink} "Se on kuultu kahdesti ", mikä tarkoittaa" kaksi ".
 
-Liiton 24 tunnin järjestelmää ({tera' poH:n}) käytetään joskus planeettojen välisessä viestinnässä. Kun työskentelet tässä järjestelmässä, aika kysyä on antaa komento, {rep yIper!:sen:nolink} Vastaamalla tähän komentoon tunteja ei lasketa, vaan numeroidaan 1: stä 24. Esimerkiksi {tera' rep cha':sen:nolink} tai {rep cha':sen:nolink} on "kaksi o 'kello". Kun asiayhteys on selvä, {tera':n} voidaan jättää pois.{'arlogh wab Qoylu'pu'?:sen:nolink}{qen 'arlogh Qoylu'pu'?:sen:nolink} [AUTOTRANSLATED]</column>
+Liiton 24 tunnin järjestelmää ({tera' poH:n}) käytetään joskus planeettojen välisessä viestinnässä. Kun työskentelet tässä järjestelmässä, aika kysyä on antaa komento, {rep yIper!:sen:nolink} Vastaamalla tähän komentoon tunteja ei lasketa, vaan numeroidaan 1: stä 24. Esimerkiksi {tera' rep cha':sen:nolink} tai {rep cha':sen:nolink} on "kaksi o 'kello". Kun asiayhteys on selvä, {tera':n} voidaan jättää pois. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">

--- a/mem-22-e.xml
+++ b/mem-22-e.xml
@@ -1115,7 +1115,7 @@ Kun yhdistetään useita lauseita, tarvitaan vain viimeinen yhdistelmä. Katso e
       <column name="notes_ru">Объект - это то, что вводится. {-Daq:n:suff} не требуется.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對像是輸入的東西。 {-Daq:n:suff}是不必要的。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é a coisa que está sendo inserida. {-Daq:n:suff} é desnecessário.[2] [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Kohde on syötettävä asia. {-Daq:n:suff} on tarpeeton.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on asia, jonka sisään mennään. {-Daq:n:suff} on tarpeeton.[2]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">

--- a/mem-22-e.xml
+++ b/mem-22-e.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {e:sen:nolink}</column>
       <column name="definition_zh_HK">元音{e:sen:nolink}</column>
       <column name="definition_pt">a vogal {e:sen:nolink}</column>
+      <column name="definition_fi">vokaali {e:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">возможность, шанс, открытие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">機會、機會、開放 [AUTOTRANSLATED]</column>
       <column name="definition_pt">oportunidade, chance, abertura</column>
+      <column name="definition_fi">mahdollisuus, tilaisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jon:v}, {nargh:v:2}, {pel'aQDaj ghorpa':sen:idiom}, {'eq:v}, {paS:v}</column>
@@ -72,6 +77,9 @@ I en Klingon-bar ropar bartendern ({chom:n}) {'eb Qav:n} för "senaste samtal" .
       <column name="notes_pt">Diz-se que uma oportunidade foi capturada ({jon:v}), e se alguém perder uma oportunidade, diz-se que escapou ({nargh:v:2}) .[3] "matar o tempo" é {'ebmey jonHa':sen}.[5]
 
 Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" .[4] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Mahdollisuuden sanotaan olevan kiinni ({jon:v}), ja jos joku menettää mahdollisuuden, sen sanotaan paenneen ({nargh:v:2}) .[3] "Aikaa tappaa" tarkoittaa {'ebmey jonHa':sen}.[5]
+
+Baarimikko ({chom:n}) huutaa Klingon-baarissa {'eb Qav:n} "viimeisestä puhelusta".[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -84,6 +92,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -91,6 +100,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}, [3] {s.e 1998.01.18:src}, [4] {CK:src}, [5] {KLI mailing list 2020.03.30:src}</column>
     </table>
         <table name="mem">
@@ -104,6 +114,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="definition_ru">последний звонок [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">最後機會</column>
           <column name="definition_pt">última chamada</column>
+      <column name="definition_fi">viimeinen kuulutus, viimeiset hetket (tilata)</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -114,6 +125,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="notes_ru">Это выкрикивается барменом ({chom:n}) в баре Klingon ({tach:n}) до того, как алкогольные напитки перестают подавать. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">在停止提供酒精飲料之前，調酒師（{chom:n}）在克林崗酒吧（{tach:n}）大喊。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso é gritado pelo barman ({chom:n}) em um bar Klingon ({tach:n}) antes que as bebidas alcoólicas deixem de ser servidas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Baarimikko ({chom:n}) huusi tämän Klingon-baarissa ({tach:n}) ennen alkoholijuomien tarjoamisen lopettamista. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{'eb:n}, {Qav:v}</column>
           <column name="examples"></column>
@@ -123,6 +135,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -130,6 +143,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {CK:src}</column>
         </table>
         <table name="mem">
@@ -143,6 +157,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="definition_ru">убивать время [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">消磨時間 [AUTOTRANSLATED]</column>
           <column name="definition_pt">matar o tempo</column>
+      <column name="definition_fi">tappaa aikaa</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">
@@ -154,6 +169,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="notes_ru">Это буквально означает «освободить (или отменить) возможности». [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">從字面上看，這意味著“釋放（或捕獲）機會”。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Isso significa literalmente "liberar (ou capturar) oportunidades". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "vapauttamaan (tai poistamaan sieppauksen) mahdollisuuksia". [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{'eb:n}, {-mey:n}, {jonHa':v}</column>
           <column name="examples"></column>
@@ -163,6 +179,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -170,6 +187,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
         </table>
     <table name="mem">
@@ -183,6 +201,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="definition_ru">бригадир</column>
       <column name="definition_zh_HK">準將 [AUTOTRANSLATED]</column>
       <column name="definition_pt">brigadeiro</column>
+      <column name="definition_fi">prikaatinkenraali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -193,6 +212,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="notes_ru">Это 4-й ранг {yaS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{yaS:n}的第四等級。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o 4º ranking do {yaS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {yaS:n}: n 4. sijoitus. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -202,6 +222,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -209,6 +230,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -222,6 +244,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="definition_ru">доска [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">板</column>
       <column name="definition_pt">tabuleiro</column>
+      <column name="definition_fi">lauta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'echletHom:n}</column>
@@ -232,6 +255,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{Quj 'echlet:n}, {'echlet Hab:n}</column>
@@ -241,6 +265,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -248,6 +273,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
         <table name="mem">
@@ -261,6 +287,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="definition_ru">тачпад [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">觸摸板 [AUTOTRANSLATED]</column>
           <column name="definition_pt">touchpad</column>
+      <column name="definition_fi">kosketuslevy</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nItlh 'echlet:n}, {'eQway':n}</column>
@@ -271,6 +298,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="notes_ru">Это относится к устройству ввода компьютера. [AUTOTRANSLATED]</column>
           <column name="notes_zh_HK">這是指計算機輸入設備。 [AUTOTRANSLATED]</column>
           <column name="notes_pt">Refere-se a um dispositivo de entrada do computador. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tietokoneen syöttölaitteeseen. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{'echlet:n}, {Hab:v}</column>
           <column name="examples"></column>
@@ -280,6 +308,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -287,6 +316,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
         </table>
         <table name="mem">
@@ -300,6 +330,7 @@ Em um bar Klingon, o barman ({chom:n}) grita {'eb Qav:n} para "última chamada" 
           <column name="definition_ru">открытка [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">卡片、紙牌</column>
           <column name="definition_pt">cartão</column>
+      <column name="definition_fi">kortti</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{nav:n}, {qoS:n}, {rIb:v}</column>
@@ -324,6 +355,9 @@ Kostymerna i ett kortlek med kort kallas {Degh:n:1}. [AUTOTRANSLATED]</column>
           <column name="notes_pt">Em {Klingon Monopoly:src}, {'echletHom:n:nolink} é usado para os vários tipos de cartas de jogo. Em {TNK:src}, {QIn 'echletHom:n} é usado para significar "cartão postal".
 
 Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Klingon Monopoly:src}: ssä {'echletHom:n:nolink}: ta käytetään erilaisiin pelikortteihin. Kohdassa {TNK:src} {QIn 'echletHom:n} tarkoittaa "postikortti".
+
+Pelikorttipakan pukuja kutsutaan nimellä {Degh:n:1}. [AUTOTRANSLATED]</column>
           <column name="hidden_notes"></column>
           <column name="components">{'echlet:n}, {-Hom:n}</column>
           <column name="examples">
@@ -335,6 +369,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -342,6 +377,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {Klingon Monopoly:src}, [2] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -355,6 +391,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
           <column name="definition_ru">колода карт [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">一副牌</column>
           <column name="definition_pt">deck de cartas</column>
+      <column name="definition_fi">korttipakka</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -365,6 +402,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'echletHom:n}, {vey:n}</column>
           <column name="examples"></column>
@@ -374,6 +412,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -381,6 +420,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
     <table name="mem">
@@ -394,6 +434,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="definition_ru">ползать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">爬行</column>
       <column name="definition_pt">rastejar</column>
+      <column name="definition_fi">ryömiä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qIv:n}, {tor:v:1}</column>
@@ -404,6 +445,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -413,6 +455,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -420,6 +463,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -433,6 +477,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="definition_ru">высокомерный или высокомерный человек [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">傲慢或傲慢的人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma pessoa arrogante ou altiva</column>
+      <column name="definition_fi">ylimielinen tai kopea henkilö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIy:v}</column>
@@ -443,6 +488,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="notes_ru">Это относится к человеку, который {nguq:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是{nguq:v}的人。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa que é {nguq:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, joka on {nguq:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Mister Ed is a famous horse from television, and {jen:v} means "high". An arrogant person is said to be sitting on a "high horse".</column>
       <column name="components">{'eD:n:hyp,nolink} or {'eD:v:1}, {jen:v:is}</column>
       <column name="examples"></column>
@@ -452,6 +498,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -459,6 +506,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.3, Sept. 2003:src}</column>
     </table>
     <table name="mem">
@@ -472,6 +520,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="definition_ru">Взлетно-посадочные двигатели [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">起飛/降落推進器 [AUTOTRANSLATED]</column>
       <column name="definition_pt">propulsores de decolagem/pouso</column>
+      <column name="definition_fi">lentoonlähtö- ja laskeutumismoottorit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chuyDaH:n}, {lolSeHcha:n}, {muDDaq 'eDSeHcha lulaQlu'bogh:n}</column>
@@ -482,6 +531,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="notes_ru">Это слово во множественном числе. Его единственная форма неизвестна. По-видимому, он состоит из элементов {SeH:n:archaic,hyp} и {cha:n} (или их гомофона) и элемента, который является либо {'eD:v:1}, либо гомофоном, значение которого неизвестно. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞是複數的。其單數形式未知。它似乎由元素{SeH:n:archaic,hyp}和{cha:n}（或其同音詞）以及一個元素{'eD:v:1}或含義不明的同音詞組成。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é plural. Sua forma singular é desconhecida. Parece consistir nos elementos {SeH:n:archaic,hyp} e {cha:n} (ou um seu homofone) e um elemento que é {'eD:v:1} ou um homófono cujo significado é desconhecido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana on monikko. Sen yksikkömuotoa ei tunneta. Se näyttää koostuvan elementeistä {SeH:n:archaic,hyp} ja {cha:n} (tai niiden homofonista) ja elementistä, joka on joko {'eD:v:1} tai homofonista, jonka merkitystä ei tunneta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Some information was revealed about {SeH:n:archaic,hyp,nolink} at {qep'a' 27 (2020):src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -491,6 +541,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -498,6 +549,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -511,6 +563,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="definition_ru">третий тон неатонической музыкальной гаммы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">非音階音階的第三音 [AUTOTRANSLATED]</column>
       <column name="definition_pt">terceiro tom da escala musical não-atônica</column>
+      <column name="definition_fi">nonatoonisen musiikkiasteikon kolmas sävel</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -521,6 +574,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonin musiikkiasteikon sävyt (katso {yutlhegh:n}) ovat: {yu:n}, {bIm:n}, {'egh:n:nolink}, {loS:n:2}, {vagh:n:2}, {jav:n:2}, {Soch:n:2}, {chorgh:n:2}, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DONOTTRANSLATE9, DOT{yu:n:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The third tone of the musical scale is "me", and {-'egh:v:suff} is the "self" suffix.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -530,6 +584,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -537,6 +592,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -550,6 +606,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="definition_ru">приготовься!</column>
       <column name="definition_zh_HK">準備！</column>
       <column name="definition_pt">Atenção! Pronto!</column>
+      <column name="definition_fi">Valmiina!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuH:excl}</column>
@@ -560,6 +617,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="notes_ru">Это выражение указывает на то, что говорящий собирается дать команду. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該表達表示說話者將要發出命令。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta expressão indica que o falante está prestes a dar um comando. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä lauseke osoittaa, että puhuja on antamassa komentoa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -569,6 +627,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -576,6 +635,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -589,6 +649,7 @@ Os naipes em um baralho de cartas são chamados de {Degh:n:1}. [AUTOTRANSLATED]<
       <column name="definition_ru">и, а (для присоединения предложений)</column>
       <column name="definition_zh_HK">和（加入句子） [AUTOTRANSLATED]</column>
       <column name="definition_pt">e (juntando sentenças)</column>
+      <column name="definition_fi">ja (yhdistää lauseita, verbejä)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qoj:conj}, {je:conj}</column>
@@ -613,6 +674,9 @@ Vid anslutning av flera meningar behövs endast den slutliga konjunktionen. Se e
       <column name="notes_pt">A conjunção {'ej:conj} não tem quaisquer implicações temporais ou sequenciais.[2] Para expressar esses significados, use {ghIq:adv} ou {ngugh:adv}.
 
 Ao conectar várias frases, apenas a conjunção final é necessária. Veja o exemplo em {qoj:conj}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yhdistelmällä {'ej:conj} ei ole ajallisia tai peräkkäisiä vaikutuksia.
+
+Kun yhdistetään useita lauseita, tarvitaan vain viimeinen yhdistelmä. Katso esimerkki kohdasta {qoj:conj}.[2]{ghIq:adv}{ngugh:adv} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -622,6 +686,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -629,6 +694,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1998.03.20:src}</column>
     </table>
     <table name="mem">
@@ -642,6 +708,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">кстати, в скобках [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">順便說一句 [AUTOTRANSLATED]</column>
       <column name="definition_pt">a propósito, entre parênteses</column>
+      <column name="definition_fi">muuten</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -652,6 +719,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru">Это приходит в начале предложения. Это полная форма. В повседневной беседе {'ej:conj} и / или {De':n} (и даже {vI-:v:pref}) часто опускаются. Клингонские грамматики спорят о том, следует ли считать получившийся в результате {De'chel:adv} наречным по своей сути. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是在句子的開頭。這是完整表格。在日常對話中，通常會忽略{'ej:conj}和/或{De':n}（甚至{vI-:v:pref}）。克林崗語語法學家爭論是否應將產生的{De'chel:adv}本身視為副詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso vem no início de uma frase. Este é o formulário completo. Na conversa cotidiana, {'ej:conj} e / ou {De':n} (e até {vI-:v:pref}) são frequentemente omitidos. Os gramáticos de Klingon discutem se o {De'chel:adv} resultante deve ser considerado um adverbial por si só. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tulee lauseen alkuun. Tämä on koko lomake. Jokapäiväisessä keskustelussa {'ej:conj} ja / tai {De':n} (ja jopa {vI-:v:pref}) jätetään usein pois. Klingonin kielioppilaiset kiistävät, pitäisikö tuloksena olevaa {De'chel:adv}: tä pitää pitää itsenäisenä adverbiaalina. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -661,6 +729,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -668,6 +737,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -681,6 +751,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">звездолет</column>
       <column name="definition_zh_HK">星艦、星艦級</column>
       <column name="definition_pt">nave estelar</column>
+      <column name="definition_fi">tähtilaiva, tähtilaivaluokka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -691,6 +762,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru">Скорее всего, {Do':n:archaic,hyp} - устаревшее слово для современного {Duj:n:1}.[1, p.20] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{Do':n:archaic,hyp}可能是現代{Duj:n:1}的古老單詞。[1, p.20] [AUTOTRANSLATED]</column>
       <column name="notes_pt">É provável que {Do':n:archaic,hyp} seja uma palavra arcaica para o moderno {Duj:n:1}.[1, p.20] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On todennäköistä, että {Do':n:archaic,hyp} on arkaainen sana nykyajan {Duj:n:1}: lle.[1, p.20] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'ej:n:hyp}, {Do':n:hyp}</column>
       <column name="examples"></column>
@@ -700,6 +772,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">spaceship</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -707,6 +780,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -720,6 +794,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">полоса [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">條紋 [AUTOTRANSLATED]</column>
       <column name="definition_pt">listra, faixa</column>
+      <column name="definition_fi">raita</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DujtlhuQ:n}, {way:v}</column>
@@ -730,6 +805,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Stars ({Hov:n}) and ({je:conj}) Stripes".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -739,6 +815,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -746,6 +823,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -759,6 +837,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">опухоль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">瘤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tumor</column>
+      <column name="definition_fi">kasvain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -769,6 +848,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The request which resulted in this word was categorised as a body part question by the requester, but it seems the word isn't a body part.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -778,6 +858,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tumour</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -785,6 +866,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -798,6 +880,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">звездный флот</column>
       <column name="definition_zh_HK">星際艦隊</column>
       <column name="definition_pt">Frota Estelar</column>
+      <column name="definition_fi">Tähtilaivasto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -808,6 +891,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'ej:n:hyp}, {yo':n}</column>
       <column name="examples"></column>
@@ -817,6 +901,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -824,6 +909,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -837,6 +923,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">Командование Звездного Флота [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星際艦隊司令部</column>
       <column name="definition_pt">Comando da Frota Estelar</column>
+      <column name="definition_fi">Tähtilaivaston johto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ejyo'SeH yaHnIv:n}</column>
@@ -847,6 +934,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'ejyo':n}, {ra'ghomquv:n}</column>
       <column name="examples"></column>
@@ -856,6 +944,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -863,6 +952,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -876,6 +966,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">Командование операций Звездного Флота [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星際艦隊作戰司令部 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Comando de Operações da Frota Estelar</column>
+      <column name="definition_fi">Tähtilaivaston operaatioiden johto?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ejyo' ra'ghomquv:n}</column>
@@ -886,6 +977,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru">Это то, что теоретически будет называться эквивалентом {yo'SeH yaHnIv:n} Звездного Флота. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從理論上講，這就是STAROTTLESLATE相當於{yo'SeH yaHnIv:n}的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é o que o equivalente da Starfleet ao {yo'SeH yaHnIv:n} seria chamado teoricamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä {yo'SeH yaHnIv:n}: n Tähtilaivasto-ekvivalenttia kutsutaan teoreettisesti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'ejyo':n}, {SeH:v} or {SeH:n:hyp,nolink}, {yaH:n}, {nIv:v}</column>
       <column name="examples"></column>
@@ -895,6 +987,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -902,6 +995,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -915,6 +1009,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">звездная база</column>
       <column name="definition_zh_HK">星空基地</column>
       <column name="definition_pt">Base estelar</column>
+      <column name="definition_fi">tähtiasema, Tähtilaivaston avaruusasema</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tengchaH:n}</column>
@@ -925,6 +1020,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'ejyo':n}, {waw':n}</column>
       <column name="examples"></column>
@@ -934,6 +1030,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">starbase</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -941,6 +1038,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -955,6 +1053,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">И кровь была по колено (застольная песня)</column>
       <column name="definition_zh_HK">踝深的血（飲酒歌）</column>
       <column name="definition_pt">E o sangue estava no tornozelo (canção para beber)</column>
+      <column name="definition_fi">eräs juomalaulu, Ja veri ulottui nilkkoihin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIqral bIQtIq:n}</column>
@@ -973,6 +1072,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -982,6 +1082,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">drinking song</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -989,6 +1090,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DS9 - The Way of the Warrior:src}</column>
     </table>
     <table name="mem">
@@ -1002,6 +1104,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">войти</column>
       <column name="definition_zh_HK">進入、進去</column>
       <column name="definition_pt">entrar</column>
+      <column name="definition_fi">mennä tai tulla sisään johonkin, astua sisään</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lIt:v}, {yong:v}</column>
@@ -1012,6 +1115,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru">Объект - это то, что вводится. {-Daq:n:suff} не требуется.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">對像是輸入的東西。 {-Daq:n:suff}是不必要的。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">O objeto é a coisa que está sendo inserida. {-Daq:n:suff} é desnecessário.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kohde on syötettävä asia. {-Daq:n:suff} on tarpeeton.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1023,6 +1127,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1030,6 +1135,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {HQ 7.4, Dec. 1998:src}, [3] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1043,6 +1149,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">Элас (планета)</column>
       <column name="definition_zh_HK">ELAS [AUTOTRANSLATED]</column>
       <column name="definition_pt">Elas</column>
+      <column name="definition_fi">Elas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Doy'yuS:n}, {telun Hovtay':n}</column>
@@ -1053,6 +1160,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1062,6 +1170,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1069,6 +1178,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1082,6 +1192,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">билет, входной билет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">門票、入場飛</column>
       <column name="definition_pt">bilhete, passe de entrada</column>
+      <column name="definition_fi">pääsylippu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1092,6 +1203,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru">Обратите внимание, что это именно билет для входа. Для других типов билетов рассмотрите другой глагол вместо {'el:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，這特別是門票。對於其他類型的票證，請考慮使用其他動詞代替{'el:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Observe que este é especificamente um ingresso para entrada. Para outros tipos de tickets, considere outro verbo no lugar de {'el:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä on nimenomaan pääsylippu. Muun tyyppisten lippujen osalta harkitse toista verbiä {'el:v}: n sijasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">At "By Any Other Name: An Evening of Shakespeare in Klingon", put on by the Washington Shakespeare company, the sign on the will-call tickets window said {'elmeH chaw'mey je'lu'ta'bogh:n:nolink}. This translation was supplied by MO.</column>
       <column name="components">{'el:v}, {-meH:v}, {chaw':n}</column>
       <column name="examples"></column>
@@ -1101,6 +1213,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1108,6 +1221,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2011.09.30:src}</column>
     </table>
     <table name="mem">
@@ -1121,6 +1235,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="definition_ru">неожиданный посетитель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">意外的訪客 [AUTOTRANSLATED]</column>
       <column name="definition_pt">visitante inesperado</column>
+      <column name="definition_fi">yllätysvieras</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{meb:n}</column>
@@ -1131,6 +1246,7 @@ Ao conectar várias frases, apenas a conjunção final é necessária. Veja o ex
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to a Passover custom in which an empty seat is reserved for the prophet Elijah.
 
 This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted to the mailing list in 2007. It was written by Okrand in {'ISqu':n:name}'s notebook, and under it Lawrence Schoen had copied down the definition as "unexpected visitor". The notebook was shown to {Qov:n:name} at {qep'a' 14:src}, after which she posted it to the mailing list misspelled as {'el'I'jaH:n:nolink} with the misremembered definition "uninvited guest". The glosses "uninvited guest" and "unexpected guest" which appear in some word lists seem to be based on word-of-mouth transmission, and the written definition in {'ISqu':n:name,nolink}'s notebook has been taken as authoritative here.</column>
@@ -1142,6 +1258,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">unexpected guest, uninvited guest</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1149,6 +1266,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 13 (2006):src}</column>
     </table>
     <table name="mem">
@@ -1162,6 +1280,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="definition_ru">блюдо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">服務拼盤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">servir bandeja</column>
+      <column name="definition_fi">tarjoiluvati tai -lautanen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1172,6 +1291,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="notes_ru">Обычно это сделано из металла. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這通常是金屬製成的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso geralmente é feito de metal. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yleensä metallia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The platter is the spinning surface of a turntable on which an "LP" (long-playing music record) is placed.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1181,6 +1301,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1188,6 +1309,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1201,6 +1323,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="definition_ru">позади, область позади [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">後面、後方</column>
       <column name="definition_pt">atrás, área atrás</column>
+      <column name="definition_fi">takana, alue takana</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhop:n:1}</column>
       <column name="see_also">{bIng:n}, {Dung:n}, {joj:n}, {retlh:n}, {poS:n}, {nIH:n}, {'o':n}</column>
@@ -1211,6 +1334,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="notes_ru">Для задней части объекта, см. {'o':n}. Смотрите также {lurgh:n} для других слов, связанных с пространственными направлениями. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Katso kohteen takaosa kohdasta {'o':n}. Katso myös {lurgh:n} muista paikkatietoihin liittyvistä sanoista. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The explanation for {tlhop:n:2} seems to imply that {'em:n:nolink} could be used to mean "private area" (of a property), but this isn't explicitly stated.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1220,6 +1344,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">back</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1227,6 +1352,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1240,6 +1366,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="definition_ru">рвотное [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">嘔吐 [AUTOTRANSLATED]</column>
       <column name="definition_pt">vomitar</column>
+      <column name="definition_fi">oksentaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quy'Ip:n}</column>
@@ -1250,6 +1377,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Emesis".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1259,6 +1387,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1266,6 +1395,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1279,6 +1409,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="definition_ru">предок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">祖先 [AUTOTRANSLATED]</column>
       <column name="definition_pt">antepassado</column>
+      <column name="definition_fi">esivanhempi, esi-isä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{nortlham:n}</column>
       <column name="see_also">{SoS:n}, {vav:n}, {SoSnI':n}, {vavnI':n}, {'ISyar:n}</column>
@@ -1289,6 +1420,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="notes_ru">Это относится к прямому предку, от которого происходит потомок по родословной, тогда как {qempa':n} ({no':n}) не обязательно связан с кровью и относится больше к культурным или социальным предкам, таким как предки или предки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso se refere a um ancestral direto do qual descende por linhagem, enquanto o {qempa':n} ({no':n}) não é necessariamente relacionado ao sangue e se refere mais a ancestrais culturais ou sociais, como antepassados ​​ou antepassados. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa suoraan esi-isään, josta verilinja polveutuu, kun taas {qempa':n} ({no':n}) ei välttämättä liity veriin ja viittaa enemmän kulttuurisiin tai yhteiskunnallisiin esi-isiin, kuten esi-isiin tai esi-isiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1298,6 +1430,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1305,6 +1438,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1318,6 +1452,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="definition_ru">pin (straight) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">針（直的）</column>
       <column name="definition_pt">pino (reto)</column>
+      <column name="definition_fi">nuppineula</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vev:v}</column>
@@ -1328,6 +1463,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1337,6 +1473,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1344,6 +1481,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1357,6 +1495,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="definition_ru">не быть чем-то, не [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不是什麼，非 [AUTOTRANSLATED]</column>
       <column name="definition_pt">não ser algo, não-</column>
+      <column name="definition_fi">ei olla (jotain), ei-</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Deq:v}</column>
@@ -1367,6 +1506,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1376,6 +1516,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1383,6 +1524,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1397,6 +1539,7 @@ This was revealed to a small group in 2006 at {qep'a' 13:src}, but only posted t
       <column name="definition_ru">мочевой пузырь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">膀胱 [AUTOTRANSLATED]</column>
       <column name="definition_pt">bexiga</column>
+      <column name="definition_fi">virtsarakko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HuH:n}</column>
@@ -1417,6 +1560,9 @@ Det tar suffixet {-Du':n} även om det används metaforiskt. [2] [AUTOTRANSLATED
       <column name="notes_pt">Isso se refere à anatomia, mas pode ser usado metaforicamente em outros contextos.
 
 Leva o sufixo {-Du':n} mesmo quando usado metaforicamente.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa anatomiaan, mutta sitä voidaan käyttää metaforisesti muissa yhteyksissä.
+
+Se vaatii loppuliitteen {-Du':n}, vaikka sitä käytettäisiin metaforisesti.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1427,6 +1573,7 @@ Leva o sufixo {-Du':n} mesmo quando usado metaforicamente.[2] [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1434,6 +1581,7 @@ Leva o sufixo {-Du':n} mesmo quando usado metaforicamente.[2] [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}, [2] {KLI mailing list 2018.11.22:src}</column>
     </table>
     <table name="mem">
@@ -1447,6 +1595,7 @@ Leva o sufixo {-Du':n} mesmo quando usado metaforicamente.[2] [AUTOTRANSLATED]</
       <column name="definition_ru">препарат, средство, медикамент [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">藥品 [AUTOTRANSLATED]</column>
       <column name="definition_pt">medicamento</column>
+      <column name="definition_fi">huume</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIq:n}</column>
@@ -1457,6 +1606,7 @@ Leva o sufixo {-Du':n} mesmo quando usado metaforicamente.[2] [AUTOTRANSLATED]</
       <column name="notes_ru">Большинство {'enteDmey:n@@'enteD:n, -mey:n} используются ритуально, но для рекреационных целей не является неслыханным (как с алкоголем). Это слово не распространяется на лекарственные препараты, которые {Hergh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">多數{'enteDmey:n@@'enteD:n, -mey:n}都在儀式上使用，但娛樂用途並不是聞所未聞的（與酒精一樣）。這個詞不包括藥用藥物，即{Hergh:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A maioria do {'enteDmey:n@@'enteD:n, -mey:n} é usada ritualisticamente, mas o uso recreativo não é inédito (como no álcool). Esta palavra não abrange medicamentos, que são {Hergh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Suurinta osaa {'enteDmey:n@@'enteD:n, -mey:n}: tä käytetään rituaalisesti, mutta virkistyskäyttö ei ole ennenkuulumatonta (kuten alkoholin kohdalla). Tämä sana ei kata lääkkeitä, jotka ovat {Hergh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Bill &amp; Ted".
 
 It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink} do not overlap.</column>
@@ -1468,6 +1618,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1475,6 +1626,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1488,6 +1640,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="definition_ru">предприятие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">企業號（星艦）</column>
       <column name="definition_pt">Empreendimento</column>
+      <column name="definition_fi">Enterprise</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hov leng:n}</column>
@@ -1498,6 +1651,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="notes_ru">Это название серии космических кораблей Федерации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一系列聯邦飛船的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma série de naves estelares da Federação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sarjan federaation tähtialusten nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1508,6 +1662,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1515,6 +1670,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {SkyBox 15:src} (reprinted in {HQ 3.4, p.10-11, Dec. 1994:src}), [2] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1528,6 +1684,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="definition_ru">облако</column>
       <column name="definition_zh_HK">雲</column>
       <column name="definition_pt">nuvem</column>
+      <column name="definition_fi">pilvi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chal:n}, {tlhoD:v}, {vI'laS:n}, {SIS:v}, {muD Dotlh:n}</column>
@@ -1538,6 +1695,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1549,6 +1707,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1556,6 +1715,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -1569,6 +1729,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="definition_ru">употреблять суп [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">喝湯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">consumir sopa</column>
+      <column name="definition_fi">syödä keittoa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{je':v:2}</column>
@@ -1579,6 +1740,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä verbi viittaa toimintaan, joka on {Sop:v}: n ja {tlhutlh:v}: n välillä. Se viittaa erityisesti {chatlh:n:1}: n kulutukseen, joka sisältää vähemmän nestettä kuin mitä Terran voisi tunnistaa keittona.[1, p.206] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1588,6 +1750,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">slurp</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1595,6 +1758,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1608,6 +1772,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="definition_ru">поцелуй в человеческом стиле [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">人性之吻 [AUTOTRANSLATED]</column>
       <column name="definition_pt">beijo em estilo humano</column>
+      <column name="definition_fi">suudella (kuten ihmiset suutelevat)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chop:v}</column>
@@ -1618,6 +1783,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="notes_ru">Это нестандартное, лживое выражение для поцелуев в человеческом стиле. Поцеловать в стиле клингон было бы {chop:v}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是人式接吻的不規範，語表達。親吻Klingon風格將是{chop:v}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma expressão gíria não padrão para beijos no estilo humano. Beijar ao estilo Klingon seria {chop:v}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on epätyypillinen, slanginen ilmaus ihmistyyliselle suudelulle. Klingon-tyylisen suudella olisi {chop:v}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The expression {qab rem:sen@@qab:n, rem:v} would not be considered good Klingon, not even good slang.[1]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1627,6 +1793,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1634,6 +1801,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -1647,6 +1815,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="definition_ru">персик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">桃子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pêssego</column>
+      <column name="definition_fi">eräs persikkaa muistuttava hedelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1657,6 +1826,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="notes_ru">Плод клингона, похожий на персик, сливу или абрикос. Когда требуется разъяснение, для плода Земли предшествует {tera':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">克林崗水果，類似於桃子，李子或杏子。當需要澄清時，對於大地水果，請先添加{tera':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma fruta klingon semelhante a um pêssego, ameixa ou damasco. Quando for necessário esclarecimento, para os frutos da Terra, anteceda o {tera':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonin hedelmä, joka on samanlainen kuin persikka, luumu tai aprikoosi. Kun tarvitaan selvennystä, maan hedelmää edeltää {tera':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1666,6 +1836,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">plum, apricot</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1673,6 +1844,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1686,6 +1858,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="definition_ru">только сейчас, всего несколько секунд или минут назад, мгновение назад [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">就在幾秒鐘或幾分鐘前 [AUTOTRANSLATED]</column>
       <column name="definition_pt">agora mesmo, apenas alguns segundos ou minutos atrás, um momento atrás</column>
+      <column name="definition_fi">juuri nyt, aivan äsken, hetki sitten</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1696,6 +1869,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1707,6 +1881,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1714,6 +1889,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1727,6 +1903,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="definition_ru">пупок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肚臍窿</column>
       <column name="definition_pt">umbigo</column>
+      <column name="definition_fi">napa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chor:n:1}</column>
@@ -1737,6 +1914,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="notes_ru">Это слово не следует путать с {'eQway':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此詞不應與{'eQway':n}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra não deve ser confundida com {'eQway':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa ei pidä sekoittaa {'eQway':n}-sanaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Kyle XY" was an American TV show the title character of which lacks this body part.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1746,6 +1924,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1753,6 +1932,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, via {'ISqu':n:name}</column>
     </table>
     <table name="mem">
@@ -1766,6 +1946,7 @@ It was clarified during the Q &amp; A session that this word and {Hergh:n:nolink
       <column name="definition_ru">мышь (компьютерное устройство) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滑鼠</column>
       <column name="definition_pt">mouse (dispositivo de computador)</column>
+      <column name="definition_fi">hiiri (tietokonelaite)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlh 'echlet:n}, {'echlet Hab:n}</column>
@@ -1790,6 +1971,9 @@ Detta ord bör inte förväxlas med {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um dispositivo de entrada do computador. Normalmente tem dois botões (chamados {leQ:n}): um {poS leQ:n@@poS:n, leQ:n} e um {nIH leQ:n@@nIH:n, leQ:n}.
 
 Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tietokoneen syöttölaitteeseen. Siinä on tyypillisesti kaksi painiketta (kutsutaan {leQ:n}): {poS leQ:n@@poS:n, leQ:n} ja {nIH leQ:n@@nIH:n, leQ:n}.
+
+Tätä sanaa ei pidä sekoittaa {'eQway:n}-sanaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A computer mouse is used to choose the (X,Y) coordinate on a computer screen.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1799,6 +1983,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1806,6 +1991,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1819,6 +2005,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">коврик для мыши [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鼠標墊 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tapete de mouse</column>
+      <column name="definition_fi">hiirimatto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1829,6 +2016,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'eQway':n}, {'echlet:n}</column>
       <column name="examples"></column>
@@ -1838,6 +2026,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1845,6 +2034,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -1858,6 +2048,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">будь пораньше [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要早點 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser cedo</column>
+      <column name="definition_fi">olla aikainen, varhainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paS:v}, {vem'eq:n}</column>
@@ -1868,6 +2059,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1877,6 +2069,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1884,6 +2077,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1897,6 +2091,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">тип животного</column>
       <column name="definition_zh_HK">動物的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal</column>
+      <column name="definition_fi">eräs eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naQ 'er:n}, {Saj:n}</column>
@@ -1907,6 +2102,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это животное хранится как домашнее животное. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種動物被當作寵物飼養。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este animal é mantido como animal de estimação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä eläintä pidetään lemmikkinä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1916,6 +2112,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1923,6 +2120,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1936,6 +2134,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">галлюцинировать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">幻覺的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alucinar</column>
+      <column name="definition_fi">hallusinoida, nähdä harhanäkyjä jostain</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Suchtuv:n}, {jal:v}, {naj:v}</column>
@@ -1946,6 +2145,7 @@ Esta palavra não deve ser confundida com {'eQway:n}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">LSD is short for Lys"erg"ic Acid Diethylamide.
 
 This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was officially revealed at {qep'a' 27 (2020):src}. The transitivity was confirmed during the Q &amp; A session.</column>
@@ -1957,6 +2157,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1964,6 +2165,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1977,6 +2179,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">телепатия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">心靈感應 [AUTOTRANSLATED]</column>
       <column name="definition_pt">telepatia</column>
+      <column name="definition_fi">telepatia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tova'Daq:n}, {relleghDaq:n}</column>
@@ -1987,6 +2190,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1996,6 +2200,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2003,6 +2208,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2016,6 +2222,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">end (of stick, rope, etc.), other end from {megh'an:n} [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結束（棍棒、繩索等）、另一端來自{megh'an:n} [AUTOTRANSLATED]</column>
       <column name="definition_pt">fim (de vara, corda, etc.), outro fim de {megh'an:n}</column>
+      <column name="definition_fi">(kepin, köyden tms.) pää (vastakkainen pää on {megh'an:n})</column>
       <column name="synonyms">{megh'an:n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{DIn:n}, {qa'rI':n}</column>
@@ -2026,6 +2233,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Это может относиться к любому концу веревки, клюшке или какому-либо другому, но как только вы произвольно выбираете конец для вызова {'er'In:n:nolink}, другой конец называется {megh'an:n:nolink}. Прежде чем сделать эту начальную ссылку, любой конец может быть назван либо {'er'In:n:nolink}, либо {megh'an:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可以指的是繩子，木棒或其他任何一端，但是一旦您任意選擇一個叫{'er'In:n:nolink}的一端，另一端稱為{megh'an:n:nolink}。在進行此初始參考之前，可以將任一端稱為{'er'In:n:nolink}或{megh'an:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode se referir a qualquer extremidade da corda, stick ou qualquer outra coisa, mas uma vez que você escolhe arbitrariamente um final para chamar {'er'In:n:nolink}, o outro lado é chamado {megh'an:n:nolink}. Antes de fazer essa referência inicial, qualquer extremidade pode ser chamada {'er'In:n:nolink} ou {megh'an:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata köyden, kepin tai mihin tahansa päähän, mutta kun olet mielivaltaisesti päättänyt kutsumaan {'er'In:n:nolink}, toisen pään nimi on {megh'an:n:nolink}. Ennen kuin teet tämän alkuperäisen viitteen, kumpaakin päätä voidaan kutsua joko {'er'In:n:nolink} tai {megh'an:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a private joke referring to a specific person.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2035,6 +2243,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2042,6 +2251,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -2056,6 +2266,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">быть низким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要低 [AUTOTRANSLATED]</column>
       <column name="definition_pt">abaixo</column>
+      <column name="definition_fi">olla matala</column>
       <column name="synonyms"></column>
       <column name="antonyms">{jen:v}</column>
       <column name="see_also">{run:v}, {'ab:v}, {joD:v}</column>
@@ -2066,6 +2277,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2075,6 +2287,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2082,6 +2295,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2095,6 +2309,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">религиозная одежда, халат, который носит судья [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">宗教服裝，法官穿的長袍 [AUTOTRANSLATED]</column>
       <column name="definition_pt">roupa religiosa, o roupão usado por um juiz</column>
+      <column name="definition_fi">uskonnollinen tai muulla tavoin rituaalinen vaate</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIn 'eSqa':n}, {mop:n}</column>
@@ -2105,6 +2320,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Это старое слово, относящееся к специализированной или ритуальной одежде (хотя и не униформе). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個古老的詞，指的是專門的或儀式的服裝（儘管不是製服）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra antiga que se refere a roupas especializadas ou rituais (embora não seja uniforme). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vanha sana, joka viittaa erikoistuneisiin tai rituaalisiin vaatteisiin (vaikkakaan ei yhtenäiseen). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2114,6 +2330,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2121,6 +2338,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2134,6 +2352,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">роса [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">露 [AUTOTRANSLATED]</column>
       <column name="definition_pt">orvalho</column>
+      <column name="definition_fi">kaste</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{po:n}, {magh:n}</column>
@@ -2144,6 +2363,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In Ancient Greek, "ἕρση" (hérsē) means "dew".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2153,6 +2373,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Tauwasser</column>
       <column name="search_tags_fa"></column>
@@ -2160,6 +2381,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2173,6 +2395,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">отскок, отскок, рикошет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">彈跳、反彈</column>
       <column name="definition_pt">salto, rebote, ricochete</column>
+      <column name="definition_fi">kimmota</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ya'rIS:n}, {nar:v}</column>
@@ -2183,6 +2406,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">То, от чего отскакивает субъект, отмечено {-vo':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">被攝對象彈起的東西用{-vo':n}標記。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A coisa da qual o assunto ricocheteia é marcada com {-vo':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Aihe, josta kohde palautuu, on merkitty {-vo':n}-merkinnällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{'et:n:1} is the letter "e", which corresponds to "echo" in Greek.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2192,6 +2416,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">echo, reflect</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2199,6 +2424,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2212,6 +2438,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">носовая часть</column>
       <column name="definition_zh_HK">前面 [AUTOTRANSLATED]</column>
       <column name="definition_pt">à frente, à proa</column>
+      <column name="definition_fi">etu- ?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'o':n}</column>
       <column name="see_also">{poS:n}, {nIH:n}, {tlhop:n:1}</column>
@@ -2222,6 +2449,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Для области перед объектом, см. {tlhop:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關對象前面的區域，請參見{tlhop:n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para a área na frente de um objeto, consulte {tlhop:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso kohteen edessä oleva alue kohdasta {tlhop:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2231,6 +2459,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bow, forward</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2238,6 +2467,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2251,6 +2481,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">меч</column>
       <column name="definition_zh_HK">劍、刃</column>
       <column name="definition_pt">espada, lâmina</column>
+      <column name="definition_fi">miekka, terä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yan:n}, {tIqleH:n}</column>
@@ -2261,6 +2492,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Это может относиться к лезвию ножа или копья. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這可能是指刀或矛的刀片。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode se referir à lâmina de uma faca ou lança. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata veitsen tai keihään terään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2270,6 +2502,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2277,6 +2510,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2290,6 +2524,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">Даже самый лучший клинок будет ржаветь и тускнеть, если о нем не позаботятся. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">即使是最好的刀片也會生鏽，並且除非得到照顧，否則會變鈍。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Até a melhor lâmina enferruja e fica sem brilho, a menos que seja cuidada.</column>
+      <column name="definition_fi">Paraskin terä ruostuu ja tylsyy, ellei sitä hoideta.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2300,6 +2535,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'etlh:n}, {Qorgh:v}, {-Ha':v}, {-lu':v}, {-chugh:v}, {ragh:v}, {'etlh:n}, {nIv:v}, {'ej:conj}, {jejHa':v}, {-choH:v}</column>
       <column name="examples"></column>
@@ -2309,6 +2545,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2316,6 +2553,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.101:src}</column>
     </table>
     <table name="mem">
@@ -2329,6 +2567,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">область к северо-западу, область к северо-западу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">西北面、西北方</column>
       <column name="definition_pt">área para noroeste, área em direção ao noroeste</column>
+      <column name="definition_fi">alue luoteessa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lurgh:n}, {chan:n}, {tIng:n}, {SInan:n}</column>
@@ -2339,6 +2578,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Это примерно 320 градусов на терранском компасе, если север равен 0, а градусы отсчитываются по часовой стрелке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果north為0，並且順時針計數角度，則在Terran羅盤上大約為320度。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é aproximadamente 320 graus em uma bússola terráquea, se o norte for 0 e os graus forem contados no sentido horário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on noin 320 astetta Terran-kompassilla, jos pohjoinen on 0 ja astetta lasketaan myötäpäivään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Eva Saint Marie starred in Alfred Hitchcock's "North-by-Northwest".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2348,6 +2588,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2355,6 +2596,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.11.21:src} (reprinted in {HQ 8.4, p.6, Dec. 1999:src})</column>
     </table>
         <table name="mem">
@@ -2368,6 +2610,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
           <column name="definition_ru">{tIng 'ev:n}</column>
           <column name="definition_zh_HK">{tIng 'ev:n}</column>
           <column name="definition_pt">{tIng 'ev:n}</column>
+      <column name="definition_fi">{tIng 'ev:n}</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -2378,6 +2621,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components"></column>
           <column name="examples"></column>
@@ -2387,6 +2631,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -2394,6 +2639,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {s.k 1999.11.21:src} (reprinted in {HQ 8.4, p.6, Dec. 1999:src})</column>
         </table>
     <table name="mem">
@@ -2407,6 +2653,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">аплодируют [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鼓掌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aplaudir</column>
+      <column name="definition_fi">taputtaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hoy':v}</column>
@@ -2417,6 +2664,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Это относится ко всему, что делают клингоны, чтобы аплодировать или демонстрировать одобрение / благодарность. Наиболее распространенный способ обозначить аплодисменты, которые совершают люди, - это фраза {toch yo:sen@@toch:n, yo:v} «пощечина ладони». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這適用於克林崗人鼓掌或表示認可/讚賞的方式。提到人類拍手的最常見方法是用短語{toch yo:sen@@toch:n, yo:v}“拍手掌”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se aplica a tudo o que os klingons fazem para aplaudir ou mostrar aprovação / apreciação. A maneira mais comum de se referir às palmas que os humanos fazem é pela frase {toch yo:sen@@toch:n, yo:v} "palma (s) de tapa". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä pätee mihin tahansa, mitä Klingonit tekevät taputtamaan tai osoittamaan hyväksyntää / arvostusta. Yleisin tapa viitata ihmisten tekemään taputukseen on lause {toch yo:sen@@toch:n, yo:v} "löysä kämmen (t)". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2426,6 +2674,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">clap</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2433,6 +2682,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2446,6 +2696,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">подпространство</column>
       <column name="definition_zh_HK">子空間</column>
       <column name="definition_pt">subespaço</column>
+      <column name="definition_fi">aliavaruus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{logh:n}, {tlhey'at:n}</column>
@@ -2456,6 +2707,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2467,6 +2719,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2474,6 +2727,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {SkyBox 19:src}</column>
     </table>
     <table name="mem">
@@ -2487,6 +2741,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">подпространственное радио [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">子空通訊</column>
       <column name="definition_pt">rádio subespacial</column>
+      <column name="definition_fi">aliavaruusradio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2497,6 +2752,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'evnagh:n}, {Se' HablI':n}</column>
       <column name="examples"></column>
@@ -2506,6 +2762,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2513,6 +2770,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2526,6 +2784,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">животное, похожее на тритона или саламандру [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">類似於蠑螈或蠑螈的動物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">animal semelhante a um tritão ou salamandra</column>
+      <column name="definition_fi">eräs vesiliskon tai salamanterin kaltainen eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lung:n}</column>
@@ -2536,6 +2795,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A newt is called an "eft" in its terrestrial juvenile phase.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2545,6 +2805,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2552,6 +2813,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -2565,6 +2827,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">база (химия) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">基礎（化學） [AUTOTRANSLATED]</column>
       <column name="definition_pt">base (química)</column>
+      <column name="definition_fi">emäs</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pey:n}</column>
       <column name="see_also"></column>
@@ -2575,6 +2838,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Это относится к классификации веществ в химии. Это не то же самое, что «щелочь», но включает щелочи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指化學中的物質分類。它與“鹼”不同，但包括鹼。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a uma classificação de substâncias em química. Não é o mesmo que "álcali", mas inclui álcalis. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa aineiden luokitusta kemiassa. Se ei ole sama kuin "alkali", mutta sisältää alkalit. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was defined as "base" with an explanation. The word "chemistry" was added for clarification.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2584,6 +2848,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">alkali</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2591,6 +2856,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2604,6 +2870,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">будь хорошим, будь вкусным, будь вкусным, будь гармоничным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">好吃、好聽</column>
       <column name="definition_pt">ser bom, ser delicioso, ser gostoso, ser harmonioso</column>
+      <column name="definition_fi">olla hyvän makuinen, herkullinen, maukas; olla hyvältä kuulostava, sopusointuinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'eyHa':v}</column>
       <column name="see_also">{jej:v}, {wejwa':n}, {DuQ:v:2}, {tlhorgh:v}, {mum:v}, {tIv:v}</column>
@@ -2614,6 +2881,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Это слово применяется к еде и музыке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞適用於食物和音樂。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é aplicada à comida e música. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään ruokaan ja musiikkiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In English slang, "ey!" is an expression of satisfaction.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2623,6 +2891,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2630,6 +2899,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2643,6 +2913,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">быть непривлекательным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不好吃</column>
       <column name="definition_pt">ser indesejável, ser não delicioso</column>
+      <column name="definition_fi">olla pahan makuinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'ey:v}</column>
       <column name="see_also">{jejHa':v}, {'up:v}, {ngIm:v}, {ragh:v}, {natlh:v:2}, {Qop:v:2}</column>
@@ -2653,6 +2924,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="notes_ru">Это используется для пищи, которая была приготовлена ​​плохо. [1, p.84] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於準備不好的食物。[1, p.84] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para alimentos que foram mal preparados.[1, p.84] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään elintarvikkeisiin, jotka on valmistettu huonosti[1, p.84] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'ey:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -2662,6 +2934,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">gross, disgusting</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2669,6 +2942,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2682,6 +2956,7 @@ This was rumoured to have been revealed at {qep'a' 26 (2019):src}, and was offic
       <column name="definition_ru">что (предыдущая тема)</column>
       <column name="definition_zh_HK">（上一個主題） [AUTOTRANSLATED]</column>
       <column name="definition_pt">aquele, que (tópico anterior)</column>
+      <column name="definition_fi">se, että (edelliseen lauseeseen tai aiheeseen viittaava pronomini)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2720,6 +2995,11 @@ Förväxla inte detta pronomen med suffixet {-'e':n:suff}. [AUTOTRANSLATED]</col
 Normalmente, {net:n:pro} é usado quando o sujeito do verbo é indefinido (ou seja, {X net Y:sen:nolink} é usado em vez de {X 'e' Y-lu':sen:nolink}). No entanto, nem sempre é esse o caso. Veja {net:n:pro} para exemplos.
 
 Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä pronominia käytetään toisen lauseen objektina lause-esine-rakenteessa. Se viittaa edelliseen lauseeseen kokonaisuutena. Tällaisessa konstruktiossa toiseen lauseeseen ei koskaan sisälly aspektiin.
+
+Normaalisti {net:n:pro}: tä käytetään, kun verbin aihe on määrittelemätön (toisin sanoen {X net Y:sen:nolink}: ta käytetään {X 'e' Y-lu':sen:nolink}: n sijasta). Näin ei kuitenkaan aina ole. Katso esimerkkejä kohdasta {net:n:pro}.
+
+Älä sekoita tätä pronominia päätteeseen {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The rule that the second sentence never takes an aspect suffix was due to the backfitting of {qama'pu' jonta' neH.:sen} This rule is violated by the text on {SkyBox 25:src} and {SkyBox 26:src}.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2731,6 +3011,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">dass</column>
       <column name="search_tags_fa"></column>
@@ -2738,6 +3019,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.2.5:src}</column>
     </table>
     <table name="mem">
@@ -2751,6 +3033,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">вместо того [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">代替</column>
       <column name="definition_pt">ao invés de</column>
+      <column name="definition_fi">(jonkin) sijasta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2761,6 +3044,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_ru">При использовании в словосочетаниях с существительными {'e':n:pro} не требуется грамматически, но из-за общего использования конструкции {'e' qa':sen:nolink} он все равно иногда слышен. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">當在名詞短語上使用時，{'e':n:pro}在語法上是不需要的，但是由於{'e' qa':sen:nolink}構造的常用用法，無論如何有時都會聽到它。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando usado em sintagmas nominais, o {'e':n:pro} não é necessário gramaticalmente, mas devido ao uso comum da construção {'e' qa':sen:nolink}, às vezes é ouvido de qualquer maneira. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun käytetään substantiivilausekkeita, {'e':n:pro}: tä ei tarvita kieliopillisesti, mutta {'e' qa':sen:nolink}-rakenteen yleisen käytön vuoksi se kuuluu joskus joka tapauksessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'e':n:pro, qa':v}</column>
       <column name="examples">
@@ -2774,6 +3058,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2781,6 +3066,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -2794,6 +3080,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">тетя (сестра отца) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">阿姨（父親的妹妹） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tia (irmã do pai)</column>
+      <column name="definition_fi">täti (isän sisar)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vav:n}, {tennuS:n}</column>
@@ -2804,6 +3091,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">{'e'mam:n:nolink}的孩子是{lor:n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{'e'mam:n:nolink}: n lapsi on {lor:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to "Auntie Mame", a broadway play.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2813,6 +3101,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">father's sister</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2820,6 +3109,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -2833,6 +3123,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">aunt (father's brother's wife) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">阿姨（父親的兄弟的妻子） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tia (esposa do irmão do pai)</column>
+      <column name="definition_fi">isän veljen vaimo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vav:n}, {tennuS:n}</column>
@@ -2843,6 +3134,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'e'mam:n}, {'e'nal:n}</column>
       <column name="examples"></column>
@@ -2852,6 +3144,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">father's brother's wife</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2859,6 +3152,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -2872,6 +3166,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="definition_ru">кто-то, кто женился на семье [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">與家人結婚的人 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alguém que se casou com a família</column>
+      <column name="definition_fi">sukulainen avioliiton kautta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loDnal:n}, {be'nal:n}, {'e'mamnal:n}, {tennuSnal:n}, {me'nal:n}, {'IrneHnal:n}</column>
@@ -2882,6 +3177,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nal:n:hyp}</column>
       <column name="examples"></column>
@@ -2891,6 +3187,7 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">inlaw, in-law</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2898,5 +3195,6 @@ Não confunda este pronome com o sufixo {-'e':n:suff}. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>

--- a/mem-23-I.xml
+++ b/mem-23-I.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {I:sen:nolink}</column>
       <column name="definition_zh_HK">元音{I:sen:nolink}</column>
       <column name="definition_pt">a vogal {I:sen:nolink}</column>
+      <column name="definition_fi">vokaali {I:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">ванна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">盆、桶</column>
       <column name="definition_pt">banheira</column>
+      <column name="definition_fi">vuoka (ruoan marinoimiseen)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bargh:n}, {HaySIn:n}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Это квадратная или прямоугольная ванна, используемая для хранения пищи во время брожения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個方形或矩形的桶，用於在發酵時盛裝食物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma banheira quadrada ou retangular usada para armazenar alimentos durante a fermentação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on neliö tai suorakaiteen muotoinen amme, jota käytetään ruoan pitämiseen käymisen aikana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">быть скользким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">滑溜</column>
       <column name="definition_pt">ser escorregadio</column>
+      <column name="definition_fi">olla liukas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hab:v}</column>
@@ -97,6 +106,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -106,6 +116,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -113,6 +124,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -126,6 +138,7 @@
       <column name="definition_ru">магия, волшебство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">魔術、巫術</column>
       <column name="definition_pt">magia, bruxaria</column>
+      <column name="definition_fi">taikuus, noituus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IDnar lIl:sen}, {reS:v}, {'IDnar pIn'a':n}, {boqHar:n}</column>
@@ -136,6 +149,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">James Randi is a famous magician.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -145,6 +159,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -152,6 +167,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -165,6 +181,7 @@
       <column name="definition_ru">выполнять магию [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">表演魔術</column>
       <column name="definition_pt">realizar mágica</column>
+      <column name="definition_fi">taikoa</column>
       <column name="synonyms">{mIn yuq:sen}</column>
       <column name="antonyms"></column>
       <column name="see_also">{'IDnar lIlwI':n}, {gho''ong:n}</column>
@@ -175,6 +192,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'IDnar:n}, {lIl:v}</column>
       <column name="examples"></column>
@@ -184,6 +202,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -191,6 +210,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -204,6 +224,7 @@
       <column name="definition_ru">волшебник [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">魔術師</column>
       <column name="definition_pt">mágico</column>
+      <column name="definition_fi">taikuri</column>
       <column name="synonyms">{mIn yuqwI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also">{'IDnar lIl:sen}</column>
@@ -214,6 +235,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'IDnar:n}, {lIlwI':n}</column>
       <column name="examples"></column>
@@ -223,6 +245,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -230,6 +253,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -243,6 +267,7 @@
       <column name="definition_ru">волшебник, колдун [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">巫師、妖人</column>
       <column name="definition_pt">mago, feiticeiro</column>
+      <column name="definition_fi">velho, maagi, noita</column>
       <column name="synonyms">{reSwI':n@@reS:v, -wI':v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{reS:v}</column>
@@ -253,6 +278,7 @@
       <column name="notes_ru">Это относится к настоящему волшебнику или колдуну. Для мага, см. {mIn yuqwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指真正的巫師或巫師。對於魔術師，請參閱{mIn yuqwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um verdadeiro mago ou feiticeiro. Para um mágico, consulte {mIn yuqwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa oikeaan velhoon tai velhoon. Taikuri, katso {mIn yuqwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'IDnar:n}, {pIn'a':n}</column>
       <column name="examples"></column>
@@ -262,6 +288,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -269,6 +296,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2016.11.25:src}</column>
     </table>
     <table name="mem">
@@ -282,6 +310,7 @@
       <column name="definition_ru">будь проклят [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">被詛咒</column>
       <column name="definition_pt">ser amaldiçoado, ser jinxed</column>
+      <column name="definition_fi">olla kirottu, noiduttu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -292,6 +321,7 @@
       <column name="notes_ru">Это слово имеет негативную коннотацию и считается довольно оскорбительным применительно к человеку. [1, p.167] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tällä sanalla on kielteisiä merkityksiä, ja sitä pidetään melko loukkaavana, kun sitä käytetään henkilöön.[1, p.167] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -301,6 +331,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -308,6 +339,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -321,6 +353,7 @@
       <column name="definition_ru">вид животного, игва [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《igvah》（動物的類型）</column>
       <column name="definition_pt">tipo de animal, igvah</column>
+      <column name="definition_fi">eräs eläin, igvah</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghaw':n:1}</column>
@@ -331,6 +364,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -340,6 +374,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -347,6 +382,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -360,6 +396,7 @@
       <column name="definition_ru">суп из печени игвы [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">《igvah》肝湯</column>
       <column name="definition_pt">sopa de figado de igvah</column>
+      <column name="definition_fi">eräs ruokalaji, igvah-maksakeitto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -370,6 +407,7 @@
       <column name="notes_ru">В {voSpegh Sep:n} это используется вместо {ghaw':n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{voSpegh Sep:n}中，使用它代替{ghaw':n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em {voSpegh Sep:n}, isso é usado em vez de {ghaw':n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{voSpegh Sep:n}: ssä tätä käytetään {ghaw':n:1}: n sijaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'IghvaH:n}, {chej:n}, {chatlh:n:1}</column>
       <column name="examples"></column>
@@ -379,6 +417,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -386,6 +425,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -399,6 +439,7 @@
       <column name="definition_ru">быть красивой</column>
       <column name="definition_zh_HK">美麗、英俊</column>
       <column name="definition_pt">ser bonito</column>
+      <column name="definition_fi">olla kaunis, olla komea</column>
       <column name="synonyms"></column>
       <column name="antonyms">{moH:v:1}</column>
       <column name="see_also"></column>
@@ -409,6 +450,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -419,6 +461,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -426,6 +469,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -439,6 +483,7 @@
       <column name="definition_ru">слушать</column>
       <column name="definition_zh_HK">聽</column>
       <column name="definition_pt">ouvir, escutar</column>
+      <column name="definition_fi">kuunnella</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qoy:v}</column>
@@ -449,6 +494,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -459,6 +505,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -466,6 +513,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -479,6 +527,7 @@
       <column name="definition_ru">быть искренним</column>
       <column name="definition_zh_HK">真誠</column>
       <column name="definition_pt">ser sincero</column>
+      <column name="definition_fi">olla vilpitön, rehellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'IlHa':v}</column>
       <column name="see_also"></column>
@@ -489,6 +538,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Bearing no "ill"-will.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -498,6 +548,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -505,6 +556,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -518,6 +570,7 @@
           <column name="definition_ru">быть неискренним [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">不真誠 [AUTOTRANSLATED]</column>
           <column name="definition_pt">ser insincero</column>
+      <column name="definition_fi">olla vilpillinen, epärehellinen</column>
           <column name="synonyms"></column>
           <column name="antonyms">{'Il:v}</column>
           <column name="see_also"></column>
@@ -528,6 +581,7 @@
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">The request was for a word for "be a hypocrite". The response was to use the existing word {'Il:v:nolink} (which is in {TKD:src}) with the {-Ha':v} suffix.</column>
           <column name="components">{'Il:v}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -537,6 +591,7 @@
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">hypocrite, hypocritical</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -544,6 +599,7 @@
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
     <table name="mem">
@@ -557,6 +613,7 @@
       <column name="definition_ru">сделать, варить (жир) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">渲染、煮（脂肪） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cozimento (com gordura)</column>
+      <column name="definition_fi">sulattaa, keittää (rasvaa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pub:v}, {tlhagh:n}, {mIQ:v}</column>
@@ -567,6 +624,7 @@
       <column name="notes_ru">В то время как общее слово для «кипения» - {pub:v}, глагол, используемый специально для обозначения кипения жира - {'Im:v:nolink}.[1, p.94] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">雖然“煮沸”的通用詞是{pub:v}，但是專門用來指代脂肪沸騰的動詞是{'Im:v:nolink}.[1, p.94] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Enquanto a palavra geral para "ferver" é {pub:v}, o verbo usado especificamente para se referir à ebulição da gordura é {'Im:v:nolink}.[1, p.94] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -577,6 +635,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -584,6 +643,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -597,6 +657,7 @@
       <column name="definition_ru">пирамида (геометрия) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">錐體</column>
       <column name="definition_pt">pirâmide (geometria)</column>
+      <column name="definition_fi">särmäkartio, pyramidi (geometria)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mey':n}, {jItuj'ep:n}, {nev'aQ:n}, {nebeylI':n}</column>
@@ -607,6 +668,7 @@
       <column name="notes_ru">Пирамида с трехсторонним основанием называется {qu'vu':n}. Пирамида с n-сторонним основанием является {n reD 'Impey':n:nolink} для n> 3. Например: {loS reD 'Impey':n@@loS:n:1,num, reD:n:2, 'Impey':n}, {vagh reD 'Impey':n@@vagh:n:1,num, reD:n:2, 'Impey':n}. Конус {gho 'Impey':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">具有三邊底的金字塔稱為{qu'vu':n}。具有n邊基數的金字塔是n> 3的{n reD 'Impey':n:nolink}。例如：{loS reD 'Impey':n@@loS:n:1,num, reD:n:2, 'Impey':n}、{vagh reD 'Impey':n@@vagh:n:1,num, reD:n:2, 'Impey':n}。圓錐體是{gho 'Impey':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Uma pirâmide com uma base de três lados é chamada {qu'vu':n}. Uma pirâmide com uma base de n lados é um {n reD 'Impey':n:nolink} para n> 3. Por exemplo: {loS reD 'Impey':n@@loS:n:1,num, reD:n:2, 'Impey':n}, {vagh reD 'Impey':n@@vagh:n:1,num, reD:n:2, 'Impey':n}. Um cone é um {gho 'Impey':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kolmiulotteisella pohjalla olevaa pyramidia kutsutaan {qu'vu':n}. Pyramidi, jonka pohja on n-puolinen, on {n reD 'Impey':n:nolink} n: lle 3. Esimerkiksi: {loS reD 'Impey':n@@loS:n:1,num, reD:n:2, 'Impey':n}, {vagh reD 'Impey':n@@vagh:n:1,num, reD:n:2, 'Impey':n}. Kartio on {gho 'Impey':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"I. M. Pei" is the architect who designed the pyramid at the Louvre.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -616,6 +678,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -623,6 +686,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.01.27:src}</column>
     </table>
     <table name="mem">
@@ -636,6 +700,7 @@
       <column name="definition_ru">сточная труба [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">下水道 [AUTOTRANSLATED]</column>
       <column name="definition_pt">esgoto</column>
+      <column name="definition_fi">viemäri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wutlh:n}, {DIn:n}, {qa'rI':n}, {puch:n}</column>
@@ -646,6 +711,7 @@
       <column name="notes_ru">Это относится ко всей канализационной системе: туннели, трубопроводы, клапаны и т. Д. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是整個下水道系統：隧道，管道，閥門等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a todo o sistema de esgoto: túneis, conduítes, válvulas etc. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa koko viemärijärjestelmään: tunnelit, putket, venttiilit jne. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -655,6 +721,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -662,6 +729,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -675,6 +743,7 @@
       <column name="definition_ru">звук, издаваемый {vIghro':n} или {ghISnar:n} [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">{vIghro':n}或{ghISnar:n}發出的聲音</column>
       <column name="definition_pt">som produzido por um {vIghro':n} ou um {ghISnar:n}</column>
+      <column name="definition_fi">eräs {vIghro':n}:n tai {ghISnar:n}:in tekemä ääni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghugh:v}</column>
@@ -685,6 +754,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -694,6 +764,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">meow</column>
       <column name="search_tags_de">miau</column>
       <column name="search_tags_fa"></column>
@@ -701,6 +772,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -714,6 +786,7 @@
       <column name="definition_ru">ударный инструмент (барабан, звонок) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">打擊樂器（鼓、鈴）</column>
       <column name="definition_pt">instrumento de percussão (tambor, sino)</column>
+      <column name="definition_fi">lyömäsoitin (rumpu, kello tms.)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{baS 'In:n}, {Sor Hap 'In:n}, {DIr 'In:n}</column>
@@ -724,6 +797,7 @@
       <column name="notes_ru">Определенный ударный инструмент можно ударить ладонью ({toch:n}; глагол - {weq:v}), кулаком ({ro':n}; глагол - {tlhaw':v}) или палкой ({mupwI'Hom:n}, если он напоминает маленький молоток, {naQHom:n}, если он напоминает палку; такое {moq:v}) .[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tietyn lyömäsoittimen voi lyödä kämmenellä ({toch:n}; verbi on {weq:v}), nyrkillä ({ro':n}; verbi on {tlhaw':v}) tai kepillä ({mupwI'Hom:n}, jos se muistuttaa pientä vasaraa, {naQHom:n}, jos tavallinen; on {moq:v}) .[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -733,6 +807,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -740,6 +815,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.74-75:src}</column>
     </table>
     <table name="mem">
@@ -753,6 +829,7 @@
       <column name="definition_ru">слог [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">音節 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sílaba</column>
+      <column name="definition_fi">tavu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghuQ:n}</column>
@@ -763,6 +840,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Silly ({Dogh:v}) + bell ({'In:n}).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -772,6 +850,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -779,6 +858,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -792,6 +872,7 @@
       <column name="definition_ru">пенис [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陰莖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pênis</column>
+      <column name="definition_fi">penis</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaynguH:n}, {qey'Hav:n}, {ngagh:v}, {nga'chuq:v}, {loDmach:n}</column>
@@ -802,6 +883,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This anagram alludes to a line from a Christopher Nolan movie.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -812,6 +894,7 @@
       <column name="examples_zh_HK"></column>
       <!-- Note: Vulgar search terms have been deliberately left out. -->
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -819,6 +902,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -832,6 +916,7 @@
       <column name="definition_ru">цветок [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">花</column>
       <column name="definition_pt">flor</column>
+      <column name="definition_fi">kukka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'uma':n}, {Qechjem:n}, {ghub:n}, {tI:n}</column>
@@ -842,6 +927,7 @@
       <column name="notes_ru">Это относится к яркой части растения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指植物的明亮部分。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à parte brilhante de uma planta. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa kasvin kirkkaaseen osaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">A reference to the novel "Flower Drum Song" by C. Y. Lee (see {'In:n}), or the Rodgers and Hammerstein musical of the same name.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -851,6 +937,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -858,6 +945,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -871,6 +959,7 @@
       <column name="definition_ru">интернет [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">互聯網</column>
       <column name="definition_pt">a Internet</column>
+      <column name="definition_fi">Internet</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{weQmoQnaQ:n}</column>
@@ -881,6 +970,7 @@
       <column name="notes_ru">Мальц настаивал на том, что это правильное клингонское слово.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">馬爾茨堅持認為這是一個恰當的克林崗語。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Maltz insistiu que essa era uma palavra klingon adequada.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Maltz vaati, että tämä oli oikea klingonilainen sana.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -890,6 +980,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -897,6 +988,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -910,6 +1002,7 @@
       <column name="definition_ru">мелодия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">旋律 [AUTOTRANSLATED]</column>
       <column name="definition_pt">melodia</column>
+      <column name="definition_fi">melodia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ISQIm:n}, {jaghIv:n}, {QoQ:n}, {bom:n}</column>
@@ -920,6 +1013,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -929,6 +1023,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -936,6 +1031,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -949,6 +1045,7 @@
       <column name="definition_ru">обет, клятва</column>
       <column name="definition_zh_HK">誓言、承諾</column>
       <column name="definition_pt">juramento, promessa</column>
+      <column name="definition_fi">vala, lupaus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Ip:v}</column>
@@ -959,6 +1056,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{'Ip:n}: n tekeminen on {'Ip:v} tai {lay':v}; sen pitäminen on {pab:v} the {'Ip:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -969,6 +1067,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -976,6 +1075,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {paq'batlh p.60-61:src}</column>
     </table>
     <table name="mem">
@@ -989,6 +1089,7 @@
       <column name="definition_ru">давать обет, клясться</column>
       <column name="definition_zh_HK">發誓</column>
       <column name="definition_pt">jurar</column>
+      <column name="definition_fi">vannoa</column>
       <column name="synonyms">{lay':v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{'Ip:n}, {vIt:v}, {Hovmey Davan.:sen}</column>
@@ -999,6 +1100,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1008,6 +1110,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1015,6 +1118,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1028,6 +1132,7 @@
       <column name="definition_ru">супруга (гендерно-нейтральный термин) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">配偶（不分性別） [AUTOTRANSLATED]</column>
       <column name="definition_pt">cônjuge (termo neutro em termos de gênero)</column>
+      <column name="definition_fi">puoliso</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{be'nal:n}, {loDnal:n}</column>
@@ -1038,6 +1143,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'Ip:n}, {nal:n:hyp}</column>
       <column name="examples"></column>
@@ -1047,6 +1153,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1054,6 +1161,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1067,6 +1175,7 @@
       <column name="definition_ru">эпетаи (ранг) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">epetai（排名） [AUTOTRANSLATED]</column>
       <column name="definition_pt">epetai (classificação)</column>
+      <column name="definition_fi">epetai (arvo)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1077,6 +1186,7 @@
       <column name="notes_ru">От низшего к высшему эти ранги: {tay:n:3}, {Sutay:n}, {veStay:n}, {Santay:n}, {'Iptay:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">從最低到最高，這些排名是：{tay:n:3}、{Sutay:n}、{veStay:n}、{Santay:n}、{'Iptay:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Alimmasta korkeimpaan nämä rivit ovat: {tay:n:3}, {Sutay:n}, {veStay:n}, {Santay:n}, {'Iptay:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a rank from John M. Ford's 1984 novel "The Final Reflection". These ranks are used by many Klingon fan clubs, despite not appearing in canon (i.e., in any TV episode or movie).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1086,6 +1196,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1093,6 +1204,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1106,6 +1218,7 @@
       <column name="definition_ru">быть слишком много, быть слишком много [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">太多</column>
       <column name="definition_pt">ser demais, ser muitos</column>
+      <column name="definition_fi">olla liikaa, liian paljon, liian monta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhoy:adv}, {law':v}, {vItlh:v}, {vey':v}, {Hutvagh:n}, {wogh:v}</column>
@@ -1116,6 +1229,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1125,6 +1239,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1132,6 +1247,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.3, p.3, Sept. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1145,6 +1261,7 @@
       <column name="definition_ru">слизь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">粘液</column>
       <column name="definition_pt">muco</column>
+      <column name="definition_fi">lima</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qo'qaD:n}, {'IqnaH QaD:n}, {chuy:v}</column>
@@ -1155,6 +1272,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is "hanky" (hankerchief) backwards.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1164,6 +1282,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1171,6 +1290,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1184,6 +1304,7 @@
       <column name="definition_ru">сухая слизь, бугер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">幹粘液、鼻屎</column>
       <column name="definition_pt">muco seco, meleca</column>
+      <column name="definition_fi">kuiva lima ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1194,6 +1315,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'IqnaH:n}, {QaD:v:1}</column>
       <column name="examples"></column>
@@ -1203,6 +1325,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1210,6 +1333,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.4, Dec. 2003:src}</column>
     </table>
     <table name="mem">
@@ -1223,6 +1347,7 @@
       <column name="definition_ru">спираль, пружина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">彈簧</column>
       <column name="definition_pt">bobina, mola</column>
+      <column name="definition_fi">käämi, (kierre)jousi, vieteri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vatlh:v}</column>
@@ -1233,6 +1358,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Slinky".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1242,6 +1368,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1249,6 +1376,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1262,6 +1390,7 @@
       <column name="definition_ru">быть грустным</column>
       <column name="definition_zh_HK">不高興 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser triste</column>
+      <column name="definition_fi">olla surullinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{Quch:v}</column>
       <column name="see_also">{vup:v}, {'It:v}, {'ub:v}</column>
@@ -1282,6 +1411,9 @@ Se {rav:n:1} för ett formspråk relaterat till sorg. [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso não é exatamente o mesmo que {QuchHa':v}, pois o último implica uma mudança de ser feliz para não ser feliz.[2]
 
 Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä ei ole täsmälleen sama kuin {QuchHa':v}, koska jälkimmäinen tarkoittaa muutosta onnellisuudesta ei-onnelliseksi.
+
+Katso {rav:n:1} surullisuuteen liittyvästä idiomasta.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1292,6 +1424,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1299,6 +1432,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {s.k 1998.03.02:src}</column>
     </table>
     <table name="mem">
@@ -1312,6 +1446,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">угадай, предположим, представь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">猜，想像，想像 [AUTOTRANSLATED]</column>
       <column name="definition_pt">supor, imaginar</column>
+      <column name="definition_fi">kuvitella, olettaa, arvioida</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{loy:v}, {jal:v}</column>
@@ -1322,6 +1457,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1332,6 +1468,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1339,6 +1476,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1352,6 +1490,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть сливочным, пастообразным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">奶油，糊狀 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser cremoso, pastoso</column>
+      <column name="definition_fi">olla kermainen, tahnamainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qulcher:n}</column>
@@ -1362,6 +1501,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это означает «сливочный» в смысле зубной пасты. Это описывает гладкие, густые жидкости или подобные жидкости вещи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在牙膏的意義上，這意味著“乳脂狀”。它描述了光滑，濃稠的液體或類似液體的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "cremoso" no sentido de creme dental. Descreve líquidos suaves e espessos ou coisas do tipo líquido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa hammastahnassa "kermaista". Se kuvaa sileitä, paksuja nesteitä tai nestemäisiä asioita. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It was clarified during the Q &amp; A session that this could be used for both non-food and food.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1371,6 +1511,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1378,6 +1519,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1391,6 +1533,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">задирать, запугивать, придираться, беспокоить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">欺負、恐嚇、挑選、騷擾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">intimidar, perseguir, assediar</column>
+      <column name="definition_fi">kiusata, pelotella, ärsyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1401,6 +1544,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это слово используется не только для детей, но и для взрослых.[3] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞不僅用於兒童，而且用於成人。[3] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra é usada não apenas para crianças, mas também para adultos.[3] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa ei käytetä vain lapsille, vaan myös aikuisille.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Irk".</column>
       <column name="components"></column>
       <column name="examples">
@@ -1411,6 +1555,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1418,6 +1563,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Pop Culture Hero Coalition announcement:src} ({KLI mailing list 2016.11.30:src}), [2] {qep'a' 24 (2017):src}, [3] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1431,6 +1577,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">eddy (air) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">渦流（空氣） [AUTOTRANSLATED]</column>
       <column name="definition_pt">redemoinho (ar)</column>
+      <column name="definition_fi">pyörre (ilmassa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{marQen:n}, {pep'en:n}</column>
@@ -1441,6 +1588,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это относится к движению воздуха. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指空氣的運動。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um movimento do ar. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa ilman liikkumiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1450,6 +1598,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1457,6 +1606,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1470,6 +1620,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">дядя (брат матери) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">叔叔（母親的兄弟） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tio (irmão da mãe)</column>
+      <column name="definition_fi">eno (äidin veli)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoS:n}, {me':n}</column>
@@ -1480,6 +1631,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Дитя {'IrneH:n:nolink} является {lor:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{'IrneH:n:nolink}的孩子是{lor:n:1}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O filho de um {'IrneH:n:nolink} é um {lor:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{'IrneH:n:nolink}: n lapsi on {lor:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a reference to Uncle "Henry" from The Wizard of Oz.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1489,6 +1641,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mother's brother</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1496,6 +1649,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -1509,6 +1663,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">дядя (муж сестры мамы) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">叔叔（母親的妹妹的丈夫） [AUTOTRANSLATED]</column>
       <column name="definition_pt">tio (marido da irmã da mãe)</column>
+      <column name="definition_fi">äidin sisaren aviomies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SoS:n}, {me':n}</column>
@@ -1519,6 +1674,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'IrneH:n}, {'e'nal:n}</column>
       <column name="examples"></column>
@@ -1528,6 +1684,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mother's sister's husband</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1535,6 +1692,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 9.3, Sept. 2000:src}</column>
     </table>
     <table name="mem">
@@ -1548,6 +1706,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">календарь</column>
       <column name="definition_zh_HK">日曆</column>
       <column name="definition_pt">calendário</column>
+      <column name="definition_fi">kalenteri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIS:n:2}, {jar:n}, {Hogh:n}, {jaj:n}</column>
@@ -1558,6 +1717,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is {DIS:n:2} plus {jar:n} with the first and last letters replaced.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1567,6 +1727,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1574,6 +1735,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1587,6 +1749,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">гармония [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">和諧 [AUTOTRANSLATED]</column>
       <column name="definition_pt">harmonia</column>
+      <column name="definition_fi">sointu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IngSav:n}, {jaghIv:n}, {QoQ:n}, {bom:n}</column>
@@ -1597,6 +1760,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это касается только музыки, а не людей, живущих вместе. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這僅指音樂，而不指相處的人們。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere apenas à música, e não às pessoas que se dão bem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa vain musiikkiin, eikä ihmisiin, jotka tulevat toimeen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In the musical "The Music Man", Prof. Harold Hill turns four members of the River City school board into an impromptu barbershop quartet by getting each of them in turn to sing the word "ice-cream".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1606,6 +1770,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1613,6 +1778,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1626,6 +1792,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">наследие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">遺產 [AUTOTRANSLATED]</column>
       <column name="definition_pt">legado</column>
+      <column name="definition_fi">perintö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qempa':n}, {no':n}, {nortlham:n}, {'emrIgh:n}, {nubwI':n}, {cho':n}, {quH:n}</column>
@@ -1636,6 +1803,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это что-то унаследованное от предшественника, или то, что осталось от исторической фигуры. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是從前輩繼承的東西，或者是歷史人物留下的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é algo herdado de um predecessor, ou o que é deixado por uma figura histórica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on jotain, joka on peritty edeltäjältä, tai mitä historiallinen hahmo on jättänyt. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Tasha Yar's sister, Ishara Yar, was the central character in {TNG - Legacy:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1645,6 +1813,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1652,6 +1821,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1665,6 +1835,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть подавленным</column>
       <column name="definition_zh_HK">鬱悶、抑鬱</column>
       <column name="definition_pt">ser deprimido</column>
+      <column name="definition_fi">olla masentunut</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Quch:v}, {'IQ:v}, {vup:v}, {'ub:v}</column>
@@ -1675,6 +1846,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1684,6 +1856,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1691,6 +1864,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1704,6 +1878,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">быть передовым</column>
       <column name="definition_zh_HK">先進、高度發達</column>
       <column name="definition_pt">ser avançado, altamente desenvolvido</column>
+      <column name="definition_fi">olla edistynyt, erittäin kehittynyt</column>
       <column name="synonyms"></column>
       <column name="antonyms">{lutlh:v}</column>
       <column name="see_also">{Hach:v}</column>
@@ -1714,6 +1889,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1723,6 +1899,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1730,6 +1907,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1743,6 +1921,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">кто?</column>
       <column name="definition_zh_HK">誰？</column>
       <column name="definition_pt">quem?</column>
+      <column name="definition_fi">kuka?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1753,6 +1932,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Это слово вписывается в предложение в том месте, которое будет занято ответом.[1] Он работает как местоимение в вопросах с «быть» в английских переводах.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞適合答案所在的句子。[1]在英語翻譯中，它像代詞“ to be”的問題時的代名詞。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra se encaixa em uma frase no lugar que seria ocupado pela resposta.[1] Funciona como um pronome em perguntas com "to be" nas traduções para o inglês.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1763,6 +1943,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1770,6 +1951,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 6.4:src}, [2] {msn 1996.12.12:src}, [3] {CK:src}</column>
     </table>
     <table name="mem">
@@ -1783,6 +1965,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">высота</column>
       <column name="definition_zh_HK">高度</column>
       <column name="definition_pt">altitude</column>
+      <column name="definition_fi">korkeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jen:v}</column>
@@ -1793,6 +1976,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1802,6 +1986,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1809,6 +1994,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1822,6 +2008,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">ананасоподобный фрукт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">菠蘿狀水果 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fruta semelhante ao abacaxi</column>
+      <column name="definition_fi">eräs ananaksen kaltainen hedelmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pItSa' chab:n}</column>
@@ -1832,6 +2019,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是一種稍帶果的果實，在堅硬的外殼或皮膚上有刺突。內部比甜的更苦（與地球菠蘿不同，它可能被稱為{tera' 'IventoH:n@@tera':n, 'IventoH:n}）。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on suuri hedelmä, jossa on piikkisiä ulkonemia kohtuullisen kovassa kuoressa tai kuoressa. Sisäpuoli on enemmän katkera kuin makea (toisin kuin maan ananas, jota voidaan kutsua nimellä {tera' 'IventoH:n@@tera':n, 'IventoH:n}).[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Lake Ivanhoe in Orlando was once the centre of the US pineapple industry.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1841,6 +2029,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1848,6 +2037,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1861,6 +2051,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">тазобедренный [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">胯、髖關節</column>
       <column name="definition_pt">anca</column>
+      <column name="definition_fi">lanne, lonkka, lantio</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1871,6 +2062,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">{'Iv:ques:1h} "who" + {tIH:n:1} "ray" = "hooray", as in "hip hip hooray".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1880,6 +2072,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1887,6 +2080,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}, via {'ISqu':n:name}</column>
     </table>
     <table name="mem">
@@ -1900,6 +2094,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">{SoH 'Iv?:sen}</column>
       <column name="definition_zh_HK">{SoH 'Iv?:sen}</column>
       <column name="definition_pt">{SoH 'Iv?:sen}</column>
+      <column name="definition_fi">{SoH 'Iv?:sen}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1910,6 +2105,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'Iv:ques:1h}, {SoH:n}</column>
       <column name="examples"></column>
@@ -1919,6 +2115,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1926,6 +2123,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1939,6 +2137,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="definition_ru">кровь</column>
       <column name="definition_zh_HK">血</column>
       <column name="definition_pt">sangue</column>
+      <column name="definition_fi">veri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{regh:v}, {'aD:n}</column>
@@ -1949,6 +2148,7 @@ Veja {rav:n:1} para um idioma relacionado à tristeza. [AUTOTRANSLATED]</column>
       <column name="notes_ru">Существует идиома {HoS; 'Iw rur:sen@@HoS:v, 'Iw:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{HoS; 'Iw rur:sen@@HoS:v, 'Iw:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {HoS; 'Iw rur:sen@@HoS:v, 'Iw:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {HoS; 'Iw rur:sen@@HoS:v, 'Iw:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This sounds like what a human would say upon seeing blood.
 
 It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that this is not grammatically considered a body part. Rather, it is a substance and does not take a plural suffix..</column>
@@ -1961,6 +2161,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1968,6 +2169,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1981,6 +2183,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Путушествую по реке крови.</column>
       <column name="definition_zh_HK">我在血河裡旅行。</column>
       <column name="definition_pt">Eu viajo pelo rio de sangue.</column>
+      <column name="definition_fi">Matkustan verijokea pitkin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iw bIQtIqDaq bIlengjaj.:sen}</column>
@@ -1991,6 +2194,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2000,6 +2204,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2007,6 +2212,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.203:src}</column>
     </table>
     <table name="mem">
@@ -2020,6 +2226,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Пусть ты путешествуешь по реке крови.</column>
       <column name="definition_zh_HK">願你在血河裡旅行。</column>
       <column name="definition_pt">Que você viaje pelo rio de sangue.</column>
+      <column name="definition_fi">Toivon, että matkustat verijoessa.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iw bIQtIqDaq jIjaH.:sen}</column>
@@ -2030,6 +2237,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2039,6 +2247,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2046,6 +2255,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2059,6 +2269,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">кровавое вино [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">血酒</column>
       <column name="definition_pt">vinho de sangue</column>
+      <column name="definition_fi">veriviini</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2069,6 +2280,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">最好在{porgh Hat:n}.[1, p.94]上享用 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä tarjoillaan parhaiten osoitteessa {porgh Hat:n}.[1, p.94] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'Iw:n}, {HIq:n}</column>
       <column name="examples"></column>
@@ -2078,6 +2290,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">bloodwine</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2085,6 +2298,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2098,6 +2312,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Достаточного кровяного вина не существует. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沒有足夠的血酒。</column>
       <column name="definition_pt">Não existe vinho de sangue em quantidade suficiente.</column>
+      <column name="definition_fi">Veriviiniä ei voi olla riittävästi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2108,6 +2323,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was the winning secrecy proverb entry, submitted by Lawrence Schoen ({'angghal:n:name,nolink}), in the proverbs competition at {qep'a' 21 (2014):src}.</column>
       <column name="components">{'Iw HIq:n}, {yap:v}, {tu'lu':v}, {-be':v}</column>
       <column name="examples"></column>
@@ -2117,6 +2333,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">secrecy proverb</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2124,6 +2341,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 21 (2014):src}</column>
     </table>
     <table name="mem">
@@ -2137,6 +2355,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">разбавленная кровь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">稀釋的血液</column>
       <column name="definition_pt">sangue diluído</column>
+      <column name="definition_fi">laimennettu veri ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2147,6 +2366,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru">Это используется в подготовке {qagh:n}. [1, p.87] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於{qagh:n}.[1, p.87]的準備中 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä käytetään valmistettaessa {qagh:n}.[1, p.87] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'Iw:n}, {puj:v}</column>
       <column name="examples"></column>
@@ -2156,6 +2376,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2163,6 +2384,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2176,6 +2398,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">вампир [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吸血殭屍、吸血鬼</column>
       <column name="definition_pt">vampiro</column>
+      <column name="definition_fi">vampyyri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yInbogh lom:n}, {tlhapragh:n}</column>
@@ -2186,6 +2409,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'Iw:n}, {rem:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -2195,6 +2419,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2202,6 +2427,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2215,6 +2441,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Круги клятвы крови [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">血誓圈</column>
       <column name="definition_pt">Círculos de Juramento de Sangue</column>
+      <column name="definition_fi">Verivalapiirit ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hew:n}</column>
@@ -2225,6 +2452,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru">Это название статуи скульптора {mIStaq:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是雕刻家{mIStaq:n:name}的雕像名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma estátua do escultor {mIStaq:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kuvanveistäjän {mIStaq:n:name} patsas. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'Iw:n}, {'Ip:n}, {gho:n}, {-mey:n}</column>
       <column name="examples"></column>
@@ -2234,6 +2462,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2241,6 +2470,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -2254,6 +2484,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">мотыль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">血蟲</column>
       <column name="definition_pt">verme de sangue</column>
+      <column name="definition_fi">eräs eläin, verimato</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2264,6 +2495,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'Iw:n}, {ghargh:n}</column>
       <column name="examples"></column>
@@ -2273,6 +2505,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2280,6 +2513,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2293,6 +2527,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Listen to the voice of your blood. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聽聽你的血液的聲音。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Escute a voz do seu sangue.</column>
+      <column name="definition_fi">Kuuntele veresi ääntä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2303,6 +2538,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2312,6 +2548,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2319,6 +2556,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.31:src}</column>
     </table>
     <table name="mem">
@@ -2332,6 +2570,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Пусть твоя кровь кричит! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">願你的血液尖叫！</column>
       <column name="definition_pt">Que seu sangue grite!</column>
+      <column name="definition_fi">Huutakoon veresi!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2342,6 +2581,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru">Посмотрите урок на этом тосте: {YouTube video:url:http://youtu.be/_mHUA5QKSG0} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">觀看有關此吐司的課程：{YouTube video:url:http://youtu.be/_mHUA5QKSG0} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Assista a uma lição sobre este brinde: {YouTube video:url:http://youtu.be/_mHUA5QKSG0} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso oppitunti tästä paahtoleivästä: {YouTube video:url:http://youtu.be/_mHUA5QKSG0} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">When this toast first appeared in {CK:src}, it was thought that its grammar was incorrect. However, this toast was repeated in {PK:src}, where it was noted that toasts follow special grammar. This grammar was finally explained in {KGT:src} (see under {-jaj:v}).[3]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2351,6 +2591,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2358,6 +2599,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}, [2] {PK:src}, [3] {KGT p.25:src}</column>
     </table>
     <table name="mem">
@@ -2371,6 +2613,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">Моя кровь гуще твоей. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我的血比你的血濃。</column>
       <column name="definition_pt">Meu sangue é mais espesso que o seu.</column>
+      <column name="definition_fi">Minun vereni on sakeampaa kuin sinun veresi.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2381,6 +2624,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru">Эта идиоматическая фраза несет в себе значение: «Я намного сильнее тебя». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個慣用語帶有“我比你強得多”的意思。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta frase idiomática carrega o significado: "Eu sou muito mais forte que você". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tällä idiomaattisella lauseella on merkitys: "Olen paljon vahvempi kuin sinä." [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'Iw:n}, {-wIj:n}, {jeD:v}, {... law':sen}, {'Iw:n}, {-lIj:n}, {jeD:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -2390,6 +2634,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">stronger</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2397,6 +2642,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2410,6 +2656,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">подмышка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">胳肋底</column>
       <column name="definition_pt">sovaco</column>
+      <column name="definition_fi">kainalo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noSvagh:n}</column>
@@ -2420,6 +2667,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word was originally made up by Mark Shoulson to illustrate why people shouldn't make up words, since no one else would understand them. When MO heard about it, he turned it into a real word as a joke.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2429,6 +2677,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2436,6 +2685,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KLI mailing list 1996.08.21:src} (reprinted in {HQ 5.3, p.14, Sept. 1996:src})</column>
     </table>
     <table name="mem">
@@ -2449,6 +2699,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">ошибка, которая напоминает жука [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一种甲虫般的昆虫</column>
       <column name="definition_pt">um inseto que se parece com um besouro</column>
+      <column name="definition_fi">eräs kovakuoriaista muistuttava hyönteinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vetlh:n}</column>
@@ -2459,6 +2710,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The name of the star Betelgeuse (popularly pronounced "beetle juice") was incorrectly thought to mean "the armpit of Orion".</column>
       <column name="components">{'I':n}, {ghew:n}</column>
       <column name="examples"></column>
@@ -2468,6 +2720,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2475,6 +2728,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -2488,6 +2742,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="definition_ru">скряга [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">守財奴 [AUTOTRANSLATED]</column>
       <column name="definition_pt">malandro</column>
+      <column name="definition_fi">äkämys</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qej:v}</column>
@@ -2498,6 +2753,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="notes_ru">Это не точный перевод, но {'I'SeghIm:n:nolink} является ближайшим клингонским эквивалентом английского слова "curmudgeon" .[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta não é uma tradução exata, mas {'I'SeghIm:n:nolink} é o equivalente mais próximo do Klingon da palavra "mesquinho" .[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to "Isegrim" (or "Ysengrimus"), a wolf who is the chief character in a series of fables.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2507,6 +2763,7 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">grumpy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2514,5 +2771,6 @@ It was confirmed during the Q &amp; A session at {qep'a'2 27 (2020):src} that th
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.04.01:src}</column>
     </table>

--- a/mem-24-o.xml
+++ b/mem-24-o.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {o:sen:nolink}</column>
       <column name="definition_zh_HK">元音{o:sen:nolink}</column>
       <column name="definition_pt">a vogal {o:sen:nolink}</column>
+      <column name="definition_fi">vokaali {o:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">O [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">啊</column>
       <column name="definition_pt">Oh</column>
+      <column name="definition_fi">oi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Это появляется перед именем, используемым в качестве прямого адреса, почти как приативный префикс. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它出現在用作直接地址的名稱之前，幾乎像呼聲前綴一樣。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso aparece antes de um nome usado como endereço direto, quase como um prefixo vocativo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä näkyy ennen nimeä, jota käytetään suorana osoitteena, melkein kuin vokatiivista etuliitettä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -68,6 +74,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -75,6 +82,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 18 (2011):src}</column>
     </table>
     <table name="mem">
@@ -88,6 +96,7 @@
       <column name="definition_ru">О для муза огня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">O為火繆斯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Oh! para uma musa de fogo</column>
+      <column name="definition_fi">Oi Tuulen muusa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -98,6 +107,7 @@
       <column name="notes_ru">Это первая линия {HenrI' vagh:n:name} от {wIlyam SeQpIr:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta é a linha de abertura de {HenrI' vagh:n:name} por {wIlyam SeQpIr:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {HenrI' vagh:n:name} by {wIlyam SeQpIr:n:name}: n alkulinja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -107,6 +117,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -114,6 +125,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -127,6 +139,7 @@
       <column name="definition_ru">быть изогнутым, изогнутым [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">彎曲，弧形 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser curvado, arqueado</column>
+      <column name="definition_fi">olla käyrä, kaareva, kaartuva</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wan:v}</column>
       <column name="see_also">{SIH:v}, {rutlh:v}</column>
@@ -137,6 +150,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -146,6 +160,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -153,6 +168,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -166,6 +182,7 @@
       <column name="definition_ru">заказ, группа официально признана правительством [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">勳章（政府正式承認的嘉獎）</column>
       <column name="definition_pt">ordem, grupo oficialmente reconhecido pelo governo</column>
+      <column name="definition_fi">ritarikunta?, hallituksen virallisesti tunnustama ryhmä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -176,6 +193,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Order of the British Empire".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -185,6 +203,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -192,6 +211,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -205,6 +225,7 @@
       <column name="definition_ru">топор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斧頭</column>
       <column name="definition_pt">machado</column>
+      <column name="definition_fi">kirves</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jey'naS:n}, {'alngegh:n}, {Qach:v}</column>
@@ -215,6 +236,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">斧頭的一部分包括其手柄{DeS:n:2}和其刀片{ghIt:n:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Partes de um machado incluem sua alça, {DeS:n:2}, e sua lâmina, {ghIt:n:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -224,6 +246,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">axe</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -231,6 +254,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -244,6 +268,7 @@
       <column name="definition_ru">скорпионоподобное существо [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蝎子般的生物</column>
       <column name="definition_pt">criatura parecida com um escorpião</column>
+      <column name="definition_fi">eräs skorpionin kaltainen eläin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -254,6 +279,7 @@
       <column name="notes_ru">Это существо, которое очень быстро бегает, казалось бы, бессистемно и имеет опасный (острый и ядовитый) хвост. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種生物，它以看似隨意的方式運行得非常快，並且尾巴很危險（鋒利而有毒）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma criatura que corre muito rápido de uma maneira aparentemente casual e tem uma cauda perigosa (afiada e venenosa). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on olento, joka juoksee todella nopeasti näennäisesti sattumanvaraisella tavalla ja jolla on vaarallinen (terävä ja myrkyllinen) häntä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Walter O'Brien is the main character of the TV series Scorpion.
 
 The original description said "sharp and poisonous", but it was clarified that Maltz meant venomous.</column>
@@ -265,6 +291,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">arachnid</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -272,6 +299,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -285,6 +313,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="definition_ru">тоннель, трубопровод</column>
       <column name="definition_zh_HK">隧道、管路</column>
       <column name="definition_pt">túnel, conduto</column>
+      <column name="definition_fi">tunneli, putki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chob:n}, {vegh:v}, {DIn:n}, {qa'rI':n}, {qatlhDa':n}, {qung:n}, {ghImwI':n}</column>
@@ -295,6 +324,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -304,6 +334,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">pipe</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -311,6 +342,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -324,6 +356,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="definition_ru">сантехник, трубоукладчик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">水管工、管道工</column>
       <column name="definition_pt">canalizador, camada de tubo</column>
+      <column name="definition_fi">putkimies, putkiasentaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qatlhDa':n}</column>
@@ -334,6 +367,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是指將管道（無論是用於水還是用於其他任何東西）放入管道中的人。輸送水的管道有一個特殊的詞，{qatlhDa':n}，但將其放入水的人仍稱為{'och mutlhwI':n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma pessoa que coloca tubos (seja por água ou por qualquer outra coisa). Existe uma palavra especial para um cano que transporta água, {qatlhDa':n}, mas a pessoa que coloca isso ainda é chamada de {'och mutlhwI':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa henkilöön, joka laittaa putkia (joko vettä tai muuta varten). Vettä kuljettavalle putkelle on erityinen sana {qatlhDa':n}, mutta tämän asettanutta kutsutaan silti {'och mutlhwI':n:nolink}: ksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'och:n}, {mutlh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -343,6 +377,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -350,6 +385,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.10:src}</column>
     </table>
     <table name="mem">
@@ -363,6 +399,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="definition_ru">посредничать</column>
       <column name="definition_zh_HK">仲裁、調解、公斷</column>
       <column name="definition_pt">arbitrar, mediar</column>
+      <column name="definition_fi">sovitella, välittää, toimia välimiehenä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{noH:v}, {'oDwI':n}</column>
@@ -373,6 +410,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -382,6 +420,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -389,6 +428,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -402,6 +442,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="definition_ru">арбитр [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">仲裁人、公斷人</column>
       <column name="definition_pt">árbitro</column>
+      <column name="definition_fi">sovittelija, välittäjä, välimies</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -412,6 +453,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'oD:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -421,6 +463,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -428,6 +471,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -441,6 +485,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="definition_ru">пятна, пятна, пятна, пятна [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斑點、污點</column>
       <column name="definition_pt">ponto, mancha</column>
+      <column name="definition_fi">täplä, läikkä, läiskä, laikku, tahra</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yegh:v}</column>
@@ -451,6 +496,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Ode to Spot" is the name of a poem Data wrote to his cat, Spot.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -460,6 +506,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -467,6 +514,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -480,6 +528,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="definition_ru">изобретать</column>
       <column name="definition_zh_HK">發明、設計</column>
       <column name="definition_pt">inventar, conceber</column>
+      <column name="definition_fi">keksiä, laatia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rIq:v}</column>
@@ -490,6 +539,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="notes_ru">Это слово подразумевает создание чего-то, что не было создано ранее. В этом он отличается от {ren:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞意味著創造了以前沒有創造過的東西。在這方面，它與{ren:v}不同。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra implica a criação de algo que não foi criado antes. Neste, difere de {ren:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana merkitsee sellaisen luomista, jota ei ole aiemmin luotu. Tässä se eroaa {ren:v}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -499,6 +549,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -506,6 +557,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -519,6 +571,7 @@ The original description said "sharp and poisonous", but it was clarified that M
       <column name="definition_ru">он, она, оно, его, её (для вещей, не способных использовать речь)</column>
       <column name="definition_zh_HK">它、牠</column>
       <column name="definition_pt">ele/ela (objetos, seres não capazes de linguagem)</column>
+      <column name="definition_fi">se</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghaH:n:pro}, {-Daj:n}</column>
@@ -547,6 +600,25 @@ The imperative verb prefix when {'oH:n:nolink} is the object is {yI-:v:pref}.</c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän pronominin monikko on {bIH:n:pro}.
+
+Verbien etuliitteet, kun aihe {'oH:n:nolink} on:
+▶ {'oH:n:nolink}: {pagh:n:1h} = {0:v:pref}
+▶ {'oH:n:nolink}: {jIH:n:1h} = {mu-:v:pref}
+▶ {'oH:n:nolink}: {maH:n:1h} = {nu-:v:pref}
+▶ {'oH:n:nolink}: {SoH:n} = {Du-:v:pref}
+▶ {'oH:n:nolink}: {tlhIH:n} = {lI-:v:pref}
+▶ {'oH:n:nolink}: {ghaH:n} / {'oH:n:nolink} / {chaH:n} / {bIH:n} = {0:v:pref}
+
+Verbien etuliitteet, kun {'oH:n:nolink} on objekti:
+▶ {jIH:n:1h}: {'oH:n:nolink} = {vI-:v:pref}
+▶ {maH:n:1h}: {'oH:n:nolink} = {wI-:v:pref}
+▶ {SoH:n}: {'oH:n:nolink} = {Da-:v:pref}
+▶ {tlhIH:n}: {'oH:n:nolink} = {bo-:v:pref}
+▶ {ghaH:n} / {'oH:n:nolink}: {'oH:n:nolink} = {0:v:pref}
+▶ {chaH:n} / {bIH:n}: {'oH:n:nolink} = {lu-:v:pref}
+
+Pakollinen verbin etuliite, kun kohde on {'oH:n:nolink}, on {yI-:v:pref}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -556,6 +628,7 @@ The imperative verb prefix when {'oH:n:nolink} is the object is {yI-:v:pref}.</c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -563,6 +636,7 @@ The imperative verb prefix when {'oH:n:nolink} is the object is {yI-:v:pref}.</c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -576,6 +650,7 @@ The imperative verb prefix when {'oH:n:nolink} is the object is {yI-:v:pref}.</c
       <column name="definition_ru">испытывать жажду</column>
       <column name="definition_zh_HK">口渴</column>
       <column name="definition_pt">ter sede</column>
+      <column name="definition_fi">olla janoinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghung:v}, {tlhutlh:v}, {bomwI':n}</column>
@@ -586,6 +661,7 @@ The imperative verb prefix when {'oH:n:nolink} is the object is {yI-:v:pref}.</c
       <column name="notes_ru">{'ojHa':v@@ghung:v, -Ha':v} будет что-то вроде "не пить больше" .[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{'ojHa':v@@ghung:v, -Ha':v}類似於“不再口渴”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">{'ojHa':v@@ghung:v, -Ha':v} seria algo como "não está mais com sede" .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{'ojHa':v@@ghung:v, -Ha':v} olisi jotain "ei jano enää".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Orange juice".
 
 The sentence {wI'oj:sen@@wI-:v, 'oj:v} appears on {KGT p.101:src}, but this is believed to be a mistake, as the translation is "We're thirsty" and not, for example, "We're thirsty (for) it". The correct sentence should be {ma'oj:sen@@ma-:v, 'oj:v}.</column>
@@ -597,6 +673,7 @@ The sentence {wI'oj:sen@@wI-:v, 'oj:v} appears on {KGT p.101:src}, but this is b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -604,6 +681,7 @@ The sentence {wI'oj:sen@@wI-:v, 'oj:v} appears on {KGT p.101:src}, but this is b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KLI mailing list 2011.11.15:src}</column>
     </table>
     <table name="mem">
@@ -617,6 +695,7 @@ The sentence {wI'oj:sen@@wI-:v, 'oj:v} appears on {KGT p.101:src}, but this is b
       <column name="definition_ru">проверить</column>
       <column name="definition_zh_HK">驗證、檢查（某事）是否為真、確保（某事）是真的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">verificar, checar se (algo) é verdadeiro, verifique se (algo) é verdadeiro</column>
+      <column name="definition_fi">tarkistaa, varmistaa, todentaa (jonkin totuudenmukaisuus)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{teH:v}, {ngeb:v}, {tob:v}, {Daj:v:2}, {waH:v:1}, {nuD:v}, {poj:v}</column>
@@ -627,6 +706,7 @@ The sentence {wI'oj:sen@@wI-:v, 'oj:v} appears on {KGT p.101:src}, but this is b
       <column name="notes_ru">Обратите внимание, что {'ol:v:nolink} используется для проверки факта, в то время как {woq:v} используется для его подтверждения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">請注意，{'ol:v:nolink}用於檢查事實，而{woq:v}用於確認事實。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Huomaa, että {'ol:v:nolink} käytetään tosiasian tarkistamiseen, kun taas {woq:v} käytetään sen vahvistamiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The {TKD:src} definition says only "verify". This was expanded upon at {Saarbrücken qepHom'a' 2017:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -636,6 +716,7 @@ The sentence {wI'oj:sen@@wI-:v, 'oj:v} appears on {KGT p.101:src}, but this is b
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -643,6 +724,7 @@ The sentence {wI'oj:sen@@wI-:v, 'oj:v} appears on {KGT p.101:src}, but this is b
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -656,6 +738,7 @@ The sentence {wI'oj:sen@@wI-:v, 'oj:v} appears on {KGT p.101:src}, but this is b
       <column name="definition_ru">разрыв [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">間隙</column>
       <column name="definition_pt">lacuna</column>
+      <column name="definition_fi">rako, väli, tila</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qoch:v}</column>
@@ -680,6 +763,9 @@ Ett verb som vanligen används med {'olQan:n:nolink} är {'uch:v:1}. [AUTOTRANSL
       <column name="notes_pt">Isso pode se referir ao espaço entre os dentes ou a área entre as fileiras de assentos em um teatro, mas (e {'olQanmey:n@@'olQan:n, -mey:n}) pode ser usado para o espaço em uma sala, em uma mesa, etc.
 
 Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata hampaiden väliseen tilaan tai teatterin istuinrivien väliseen alueeseen, mutta sitä (ja {'olQanmey:n@@'olQan:n, -mey:n}) voidaan käyttää huoneen, pöydän jne. Tilaan.
+
+{'olQan:n:nolink}: n kanssa yleisesti käytetty verbi on {'uch:v:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -689,6 +775,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">space, room</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -696,6 +783,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -709,6 +797,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">сопротивляться, отбиваться [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">抵抗、抵擋</column>
       <column name="definition_pt">resistir, afastar</column>
+      <column name="definition_fi">vastustaa, torjua</column>
       <column name="synonyms"></column>
       <column name="antonyms">{HeQ:v}</column>
       <column name="see_also">{Hub:v}</column>
@@ -719,6 +808,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Ohm" is the unit of electrical resistance.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -728,6 +818,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -735,6 +826,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -748,6 +840,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">капля (жидкости) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">掉落（液體） [AUTOTRANSLATED]</column>
       <column name="definition_pt">gota (de líquido)</column>
+      <column name="definition_fi">pisara</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SIS:v}, {De'lor:n}</column>
@@ -758,6 +851,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru">Это может относиться к капле дождя или любой жидкости.[1] В частности, его можно использовать для капли {watrIn:n}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso pode se referir a uma gota de chuva ou uma gota de qualquer líquido.[1] Em particular, pode ser usado para uma gota de {watrIn:n}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi viitata sadepisaraan tai pisaraan mitä tahansa nestettä.[1]{watrIn:n}[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">{mIn 'onroS:n}</column>
@@ -767,6 +861,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -774,6 +869,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}, [2] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -787,6 +883,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">быть хитрым</column>
       <column name="definition_zh_HK">狡猾</column>
       <column name="definition_pt">ser astuto, manhoso</column>
+      <column name="definition_fi">olla ovela, viekas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIQHa':v}</column>
@@ -797,6 +894,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -806,6 +904,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -813,6 +912,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -826,6 +926,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">некоторое, неизвестное или неуказанное количество [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一些（未知或未指定的數量）</column>
       <column name="definition_pt">alguma quantidade desconhecida ou não especificada</column>
+      <column name="definition_fi">(laskettaville sanoille:) jotkut; (ainesanoille:) vähän, jonkin verran</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hoch:n}, {HochHom:n}, {ngIq:n}</column>
@@ -836,6 +937,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -849,6 +951,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">indeterminate</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -856,6 +959,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {SkyBox 7:src}</column>
     </table>
     <table name="mem">
@@ -869,6 +973,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">однажды, однажды [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">有一日、有一天</column>
       <column name="definition_pt">um dia, algum dia</column>
+      <column name="definition_fi">jonain päivänä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -879,6 +984,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'op:n}, {leS:n}</column>
       <column name="examples">
@@ -894,6 +1000,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -901,6 +1008,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.58-59:src}</column>
     </table>
     <table name="mem">
@@ -914,6 +1022,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">девушка легкого поведения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">妓女 [AUTOTRANSLATED]</column>
       <column name="definition_pt">prostituta</column>
+      <column name="definition_fi">prostituoitu</column>
       <column name="synonyms">{qItoy:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -924,6 +1033,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'opuH:v:hyp,nolink}, {-wI':v}</column>
       <column name="examples"></column>
@@ -933,6 +1043,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -940,6 +1051,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -953,6 +1065,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">раковина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">沉沒、下沉</column>
       <column name="definition_pt">pia</column>
+      <column name="definition_fi">upota, vajota</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'al:v:1}, {'ay:v}</column>
       <column name="see_also">{luS:v}, {Qal:v}</column>
@@ -963,6 +1076,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru">Это можно использовать для погружения в воду и так далее. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">可用於沉入水中等。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso pode ser usado para afundar na água e assim por diante. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä voidaan käyttää uppoamiseen veteen ja niin edelleen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -972,6 +1086,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">dive</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -979,6 +1094,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -992,6 +1108,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">Погрузитесь [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">淹沒</column>
       <column name="definition_pt">submergir</column>
+      <column name="definition_fi">upottaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1002,6 +1119,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'oq:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -1011,6 +1129,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1018,6 +1137,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1031,6 +1151,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">коралловый [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">珊瑚 [AUTOTRANSLATED]</column>
       <column name="definition_pt">coral</column>
+      <column name="definition_fi">koralli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlher'aq:n}</column>
@@ -1041,6 +1162,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru">Это относится к колонии морских полипов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指海洋息肉的殖民地。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma colônia de pólipos marinhos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa meripolyyppien siirtokuntaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The O.K. Corral was a building which is associated with a famous gunfight.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1050,6 +1172,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">reef</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1057,6 +1180,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1070,6 +1194,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">корень, клубень [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">根、塊莖</column>
       <column name="definition_pt">raiz, tubérculo</column>
+      <column name="definition_fi">juuri, mukula</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naH:n}, {qurgh:n}</column>
@@ -1080,6 +1205,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Ocar"ina.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1093,6 +1219,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1100,6 +1227,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1113,6 +1241,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">пилот, управляй (самолет) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">駕駛（飛機、船）</column>
       <column name="definition_pt">pilotar, operar (uma aeronave)</column>
+      <column name="definition_fi">lentää, ohjata (lentokonetta)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SeD:v}, {puv:v}, {muD Duj:n}, {'orwI':n}, {chIj:v}, {raQ:v}</column>
@@ -1123,6 +1252,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Os verbos relacionados ao movimento de aeronaves (ou naves espaciais) incluem: {Dav:v:2}, {Der:v:2}, {jer:v}, {jIm:v:2}, {lol:v:2}, {ron:v:2}, {tor:v:2}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Ilma-alusten (tai avaruusalusten) liikkeeseen liittyviä verbejä ovat: {Dav:v:2}, {Der:v:2}, {jer:v}, {jIm:v:2}, {lol:v:2}, {ron:v:2}, {tor:v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">See under {'orwI':n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1132,6 +1262,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1139,6 +1270,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -1152,6 +1284,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">Orion (planet) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">獵戶座（行星） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Órion (planeta)</column>
+      <column name="definition_fi">Orion</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'orayngan:n}</column>
@@ -1162,6 +1295,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1171,6 +1305,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1178,6 +1313,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.12.09:src}</column>
     </table>
     <table name="mem">
@@ -1191,6 +1327,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">{'oray:n}</column>
       <column name="definition_zh_HK">{'oray:n}</column>
       <column name="definition_pt">{'oray:n}</column>
+      <column name="definition_fi">{'oray:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1201,6 +1338,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1210,6 +1348,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1217,6 +1356,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.12.09:src}</column>
     </table>
     <table name="mem">
@@ -1230,6 +1370,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">Орион (человек) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">獵戶座（人） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Orion (pessoa)</column>
+      <column name="definition_fi">orionlainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oray:n}</column>
@@ -1240,6 +1381,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'oray:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -1249,6 +1391,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1256,6 +1399,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.12.09:src}</column>
     </table>
     <table name="mem">
@@ -1269,6 +1413,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">{'orayngan:n}</column>
       <column name="definition_zh_HK">{'orayngan:n}</column>
       <column name="definition_pt">{'orayngan:n}</column>
+      <column name="definition_fi">{'orayngan:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1279,6 +1424,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'orayya':n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -1288,6 +1434,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1295,6 +1442,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.12.09:src}</column>
     </table>
     <table name="mem">
@@ -1308,6 +1456,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">Оргения</column>
       <column name="definition_zh_HK">「歐加尼安」星</column>
       <column name="definition_pt">Organia</column>
+      <column name="definition_fi">Organia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'orghengan:n}</column>
@@ -1318,6 +1467,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru">Это также называется {'orghenya':n:nolink}, как правило, старшими ораторами.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso também é chamado {'orghenya':n:nolink}, geralmente por falantes mais antigos.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä kutsutaan tyypillisesti vanhemmiksi puhujiksi {'orghenya':n:nolink}[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1327,6 +1477,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1334,6 +1485,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT p.141-142:src}</column>
     </table>
     <table name="mem">
@@ -1347,6 +1499,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">{'orghen:n}</column>
       <column name="definition_zh_HK">{'orghen:n}</column>
       <column name="definition_pt">{'orghen:n}</column>
+      <column name="definition_fi">{'orghen:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1357,6 +1510,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1366,6 +1520,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1373,6 +1528,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1386,6 +1542,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">Оргенский мирный догоров</column>
       <column name="definition_zh_HK">「歐加尼安」和平協議</column>
       <column name="definition_pt">Tratado de Paz Organiano</column>
+      <column name="definition_fi">Organian rauhansopimus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1396,6 +1553,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru">Это также называется {'orghenya' rojmab:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也稱為{'orghenya' rojmab:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também é chamado de {'orghenya' rojmab:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'orghen:n}, {rojmab:n}</column>
       <column name="examples"></column>
@@ -1405,6 +1563,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1412,6 +1571,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1425,6 +1585,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">{'orghen rojmab:n}</column>
       <column name="definition_zh_HK">{'orghen rojmab:n}</column>
       <column name="definition_pt">{'orghen rojmab:n}</column>
+      <column name="definition_fi">{'orghen rojmab:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1435,6 +1596,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1444,6 +1606,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1451,6 +1614,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1464,6 +1628,7 @@ Um verbo comumente usado com {'olQan:n:nolink} é {'uch:v:1}. [AUTOTRANSLATED]</
       <column name="definition_ru">Оргенский (человек из Органии)</column>
       <column name="definition_zh_HK">歐加尼安人</column>
       <column name="definition_pt">Organiano</column>
+      <column name="definition_fi">organialainen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'orghen:n}</column>
@@ -1488,6 +1653,9 @@ Detta ord är också skrivet {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</column
       <column name="notes_pt">Observe que este é {'orghengan:n:nolink} e não {'orghenngan:n:nolink} (o {n:sen:nolink} no final de {'orghen:n:nolink} é descartado).
 
 Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Huomaa, että tämä on {'orghengan:n:nolink} eikä {'orghenngan:n:nolink} ({n:sen:nolink} {'orghen:n:nolink}: n lopussa hylätään).
+
+Tämä sana on myös kirjoitettu {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'orghen:n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -1497,6 +1665,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">'orghenngan</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1504,6 +1673,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1517,6 +1687,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">{'orghengan:n}</column>
       <column name="definition_zh_HK">{'orghengan:n}</column>
       <column name="definition_pt">{'orghengan:n}</column>
+      <column name="definition_fi">{'orghengan:n}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1527,6 +1698,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'orghenya':n}, {ngan:n}</column>
       <column name="examples"></column>
@@ -1536,6 +1708,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1543,6 +1716,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1556,6 +1730,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">pilot, one who operates (an aircraft) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">飛機師</column>
       <column name="definition_pt">piloto, aquele que opera (uma aeronave)</column>
+      <column name="definition_fi">pilotti, (lentokoneen) ohjaaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Degh:n:2}, {'or:v}, {raQpo':n}</column>
@@ -1566,6 +1741,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word consists of the first two letters of "Or"ville and "Wi"lbur Wright's names.</column>
       <column name="components">{'or:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1575,6 +1751,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1582,6 +1759,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 11.2, Jun. 2002:src}</column>
     </table>
     <table name="mem">
@@ -1595,6 +1773,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Or'Eq</column>
       <column name="definition_zh_HK">Or'Eq</column>
       <column name="definition_pt">Or'Eq</column>
+      <column name="definition_fi">Or'Eq</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1605,6 +1784,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Он был последователем {tIquvma:n:name} и братом {rej'aq:n:name}. После того, как {rej'aq:n:name} был убит, позиция {Sech qengwI':n} перешла бы к {'or'eq:n:name}, но его перевели на {voq:n:name}, когда он выразил сомнения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Hän oli {tIquvma:n:name}: n seuraaja ja {rej'aq:n:name}: n veli. Kun {rej'aq:n:name} oli tapettu, {Sech qengwI':n}: n asema olisi siirtynyt {'or'eq:n:name}: lle, mutta hänet siirrettiin {voq:n:name}: lle, kun hän ilmaisi epäilynsä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1614,6 +1794,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1621,6 +1802,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - The Vulcan Hello:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -1634,6 +1816,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">представлять</column>
       <column name="definition_zh_HK">代表</column>
       <column name="definition_pt">representar</column>
+      <column name="definition_fi">edustaa jotakuta; merkitä, symboloida; (sanasta) tarkoittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oSwI':n}, {Degh:n:1}</column>
@@ -1644,6 +1827,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1656,6 +1840,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1663,6 +1848,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {SkyBox 20:src} (reprinted in {HQ 5.2, p.14, Jun. 1996:src}), [3] {SkyBox 31:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
         <table name="mem">
@@ -1676,6 +1862,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
           <column name="definition_ru">эмиссар</column>
           <column name="definition_zh_HK">使者</column>
           <column name="definition_pt">emissário</column>
+      <column name="definition_fi">lähettiläs</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{Duy'a':n}, {Duy:n}</column>
@@ -1686,6 +1873,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'oS:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -1695,6 +1883,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">representative</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1702,6 +1891,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKD:src}</column>
         </table>
     <table name="mem">
@@ -1715,6 +1905,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">селезенка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">脾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">baço</column>
+      <column name="definition_fi">perna</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1725,6 +1916,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The spleen represents anger ({'oS:v} + {QeH:n}), as in the idiom "to vent one's spleen".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1734,6 +1926,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Spleen</column>
       <column name="search_tags_fa"></column>
@@ -1741,6 +1934,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -1754,6 +1948,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Осрик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">空間Osric [AUTOTRANSLATED]</column>
       <column name="definition_pt">Osric</column>
+      <column name="definition_fi">Osric</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -1764,6 +1959,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1773,6 +1969,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1780,6 +1977,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -1793,6 +1991,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">удерживать (информация) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">扣留（資料） [AUTOTRANSLATED]</column>
       <column name="definition_pt">reter (informação)</column>
+      <column name="definition_fi">salata, kieltäytyä antamasta tietoja</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'otHa':v}</column>
       <column name="see_also">{pegh:v:1}</column>
@@ -1803,6 +2002,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1812,6 +2012,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1819,6 +2020,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2017.09.27:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -1832,6 +2034,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">раскрывать, разглашать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">披露、洩露 [AUTOTRANSLATED]</column>
       <column name="definition_pt">divulgar, revelar</column>
+      <column name="definition_fi">paljastaa, tuoda julki (tietoja)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'ot:v}</column>
       <column name="see_also">{ja':v}</column>
@@ -1842,6 +2045,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'ot:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -1851,6 +2055,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1858,6 +2063,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2017.09.27:src}, [2] {Saarbrücken qepHom'a' 2017:src}</column>
     </table>
     <table name="mem">
@@ -1871,6 +2077,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">док [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">碼頭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">doca</column>
+      <column name="definition_fi">telakka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vergh:n}, {rIj:v}</column>
@@ -1881,6 +2088,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Это относится к любому месту стоянки судна, даже если оно отсутствует. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這指的是船隻停泊的任何地方，即使沒有結構。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a qualquer local em que um navio esteja atracado, mesmo que não haja estrutura. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa mihin tahansa paikkaan, johon alus on kiinnitetty, vaikka rakennetta ei olisikaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"The Tragedy of Othello, the Moor of Venice" is a play by William Shakespeare.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1890,6 +2098,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">jetty, pier</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1897,6 +2106,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1910,6 +2120,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">фотон</column>
       <column name="definition_zh_HK">光子</column>
       <column name="definition_pt">fóton</column>
+      <column name="definition_fi">fotoni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wov:v}, {'uD:n}, {tamghay:n}, {rob'agh:n}, {namchIl:n}</column>
@@ -1920,6 +2131,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1929,6 +2141,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1936,6 +2149,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1949,6 +2163,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">фотонная торпеда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">光子魚雷</column>
       <column name="definition_pt">torpedo de fóton</column>
+      <column name="definition_fi">fotonitorpedo</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1959,6 +2174,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'otlh:n}, {peng:n}</column>
       <column name="examples"></column>
@@ -1968,6 +2184,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1975,6 +2192,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1988,6 +2206,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">фотон торпедоносец [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">光子魚雷發射器</column>
       <column name="definition_pt">lançador de torpedo de fóton</column>
+      <column name="definition_fi">fotonitorpedonheitin</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1998,6 +2217,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'otlh peng:n}, {baHjan:n}</column>
       <column name="examples"></column>
@@ -2007,6 +2227,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2014,6 +2235,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2027,6 +2249,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Планковское время [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">普朗克時間</column>
       <column name="definition_pt">Tempo de Planck</column>
+      <column name="definition_fi">Planckin aika</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2037,6 +2260,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'otlh:n}, {poH:n}</column>
       <column name="examples"></column>
@@ -2046,6 +2270,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2053,6 +2278,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2066,6 +2292,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">квантовая теория, квантовая механика, квантовая физика [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">量子理論、量子力學、量子物理</column>
       <column name="definition_pt">teoria quântica, mecânica quântica, física quântica</column>
+      <column name="definition_fi">kvanttiteoria, kvanttimekaniikka, kvanttifysiikka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'otlh:n}, {HapQeD:n}, {'otlhtej:n}, {QeD:n}, {SuyDar:n}</column>
@@ -2076,6 +2303,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was first defined as "quantum theory, quantum mechanics" in 2014, and subsequently as "quantum physics" in 2015.</column>
       <column name="components">{'otlh:n}, {QeD:n}</column>
       <column name="examples"></column>
@@ -2085,6 +2313,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2092,6 +2321,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2105,6 +2335,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">квантовый физик [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">量子物理學家</column>
       <column name="definition_pt">físico quântico</column>
+      <column name="definition_fi">kvanttifyysikko</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'otlh:n}, {'otlhQeD:n}, {tej:n}, {Haptej:n}</column>
@@ -2115,6 +2346,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In 2014, following the definition of {'otlhQeD:n}, this was glossed as "the corresponding scientist, someone who studies quantum mechanics". It was subsequently given the stand-alone definition of "quantum physicist" in 2015.</column>
       <column name="components">{'otlh:n}, {tej:n}</column>
       <column name="examples"></column>
@@ -2124,6 +2356,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2131,6 +2364,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}, [2] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -2144,6 +2378,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">конкурировать</column>
       <column name="definition_zh_HK">競爭</column>
       <column name="definition_pt">competir</column>
+      <column name="definition_fi">kilpailla</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Qap:v:1}, {luj:v}, {qaD:n}, {Do qaD:n}</column>
@@ -2154,6 +2389,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2163,6 +2399,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2170,6 +2407,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
       <table name="mem">
@@ -2183,6 +2421,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
         <column name="definition_ru">конкурент, игрок [AUTOTRANSLATED]</column>
         <column name="definition_zh_HK">選手，選手 [AUTOTRANSLATED]</column>
         <column name="definition_pt">concorrente, jogador</column>
+      <column name="definition_fi">kilpailija, pelaaja</column>
         <column name="synonyms"></column>
         <column name="antonyms"></column>
         <column name="see_also"></column>
@@ -2193,6 +2432,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
         <column name="notes_ru">Это используется для «игрока» в смысле соревновательной игры, такой как некоторые карточные игры. [AUTOTRANSLATED]</column>
         <column name="notes_zh_HK">在競爭性遊戲（例如某些紙牌遊戲）的意義上，它用於“玩家”。 [AUTOTRANSLATED]</column>
         <column name="notes_pt">Isso é usado para "jogador" no sentido de um jogo competitivo, como alguns jogos de cartas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään "pelaajaan" kilpailupelissä, kuten joissakin korttipeleissä. [AUTOTRANSLATED]</column>
         <column name="hidden_notes">This was not explicitly defined. The definition comes from the components and example.</column>
         <column name="components">{'ov:v}, {-wI':v}</column>
         <column name="examples">
@@ -2203,6 +2443,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
         <column name="examples_ru"></column>
         <column name="examples_zh_HK"></column>
         <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
         <column name="search_tags"></column>
         <column name="search_tags_de"></column>
         <column name="search_tags_fa"></column>
@@ -2210,6 +2451,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
         <column name="search_tags_ru"></column>
         <column name="search_tags_zh_HK"></column>
         <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
         <column name="source">[1] {qep'a' 27 (2020):src}</column>
       </table>
     <table name="mem">
@@ -2223,6 +2465,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Офелия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">「歐菲」</column>
       <column name="definition_pt">Ophelia</column>
+      <column name="definition_fi">Ofelia</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hamlet:n:name}</column>
@@ -2233,6 +2476,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2242,6 +2486,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2249,6 +2494,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Hamlet:src}</column>
     </table>
     <table name="mem">
@@ -2262,6 +2508,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">прямой объект [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">直接賓語 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Objeto direto</column>
+      <column name="definition_fi">suora objekti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vI'Hop:n}, {SeSor:n}</column>
@@ -2272,6 +2519,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Это грамматический термин. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個語法術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um termo gramatical. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kieliopin termi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"The Object Of My ({'ovmay:sen:nolink}) Affection" was a 1998 film.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2281,6 +2529,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2288,6 +2537,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2301,6 +2551,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">неуточненная плоть (животного) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">肉（動物）</column>
       <column name="definition_pt">carne não especificada (de um animal)</column>
+      <column name="definition_fi">(eläimen) liha</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'DIbaH:n:1}, {Qenno':n}</column>
@@ -2311,6 +2562,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A reference to Antonio ({tonyo':sen:nolink}) from The Merchant of Venice.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2320,6 +2572,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2327,6 +2580,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -2340,6 +2594,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">болеть</column>
       <column name="definition_zh_HK">疼痛</column>
       <column name="definition_pt">ter dor, machucar, estar dolorido</column>
+      <column name="definition_fi">särkeä, sattua, olla kipeä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'aw':v}, {'oy':n}</column>
@@ -2350,6 +2605,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2359,6 +2615,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2366,6 +2623,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2379,6 +2637,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">боль</column>
       <column name="definition_zh_HK">痛</column>
       <column name="definition_pt">dor</column>
+      <column name="definition_fi">särky, kipu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bep:n}, {'oy':v}</column>
@@ -2389,6 +2648,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2398,6 +2658,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2405,6 +2666,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2418,6 +2680,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Под лежачий камень вода на течет. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一分耕耘一分收穫。</column>
       <column name="definition_pt">Sem dor sem ganho.</column>
+      <column name="definition_fi">Ei kipua ei hyötyä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2428,6 +2691,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'oy':v}, {-be':v}, {-lu':v}, {-chugh:v}, {Qap:v:1}, {-be':v}, {-lu':v}</column>
       <column name="examples"></column>
@@ -2437,6 +2701,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2444,6 +2709,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.175:src}</column>
     </table>
     <table name="mem">
@@ -2457,6 +2723,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">палка причиняющая боль</column>
       <column name="definition_zh_HK">痛苦棒</column>
       <column name="definition_pt">palito</column>
+      <column name="definition_fi">kipukeppi ?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SonchIy:n}</column>
@@ -2467,6 +2734,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is spelled "painstik" (without the "c") throughout Star Trek canon, except in {TKDA:src} where it is spelled "painstick".</column>
       <column name="components">{'oy':n}, {naQ:n:1}</column>
       <column name="examples">
@@ -2481,6 +2749,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">painstik, pain stick</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2488,6 +2757,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}, [2] {SkyBox 32:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src})</column>
     </table>
     <table name="mem">
@@ -2501,6 +2771,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Если вы не используете болеутоляющее средство, ребенок никогда не будет отмечать свою эпоху вознесения. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">如果你不使用painstik，孩子將永遠不會慶祝他的提升時代。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Se você não usar o bastão agonizador, a criança nunca celebrará sua Era de Ascensão.</column>
+      <column name="definition_fi">Jos ei käytä kipukeppiä (?), lapsi ei koskaan pääse juhlimaan aikuistumistaan (?).</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2511,6 +2782,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'oy'naQ:n}, {Da-:v}, {lo':v}, {-be':v}, {-chugh:v}, {not:adv}, {nenghep:n}, {lop:v}, {puq:n}</column>
       <column name="examples"></column>
@@ -2520,6 +2792,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2527,6 +2800,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.205:src}</column>
     </table>
     <table name="mem">
@@ -2540,6 +2814,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Я очень зол. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我非常生氣。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Estou extremamente zangado.</column>
+      <column name="definition_fi">Olen hyvin vihainen.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2550,6 +2825,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Это идиоматическое выражение буквально означает «у меня болит маленький палец». Смотрите {Qay':v:2} для объяснения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種慣用語的字面意思是“我的小腳趾很疼”。有關說明，請參見{Qay':v:2}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta expressão idiomática literalmente significa "Meu dedinho do pé muito". Consulte {Qay':v:2} para obter uma explicação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä idiomaattinen ilmaisu tarkoittaa kirjaimellisesti "pieni varpaani särkee paljon". Katso selitys kohdasta {Qay':v:2}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2559,6 +2835,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2566,6 +2843,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -2579,6 +2857,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Будет ли это больно? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">它會引起疼痛嗎？</column>
       <column name="definition_pt">Vai doer?</column>
+      <column name="definition_fi">Sattuuko se?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2589,6 +2868,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2598,6 +2878,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2605,6 +2886,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.170:src}</column>
     </table>
     <table name="mem">
@@ -2618,6 +2900,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">Можешь терпеть боль! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">願你忍受痛苦！</column>
       <column name="definition_pt">Que você possa suportar a dor!</column>
+      <column name="definition_fi">Toivon, että kestät kipua!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2628,6 +2911,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'oy':n}, {Da-:v}, {SIQ:v}, {-jaj:v}</column>
       <column name="examples"></column>
@@ -2637,6 +2921,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2644,6 +2929,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -2658,6 +2944,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">корма</column>
       <column name="definition_zh_HK">船尾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">à popa</column>
+      <column name="definition_fi">perä, takaosa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'et:n:2h}</column>
       <column name="see_also">{poS:n}, {nIH:n}, {'em:n}, {Sa'Hut:n}</column>
@@ -2668,6 +2955,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Для области позади объекта, см. {'em:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關對像後面的區域，請參見{'em:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para a área atrás de um objeto, consulte {'em:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso kohteen takana oleva alue kohdasta {'em:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2677,6 +2965,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">stern, quarter</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2684,6 +2973,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2697,6 +2987,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">кормовые подруливающие устройства [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">船尾火箭推進器（眾數）</column>
       <column name="definition_pt">propulsores à popa</column>
+      <column name="definition_fi">perämoottorit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2707,6 +2998,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru">{'o' chuyDaH:n:nolink} находится рядом с {Hongghor:n}. Они перечислены вместе как {'o' chuyDaH Hongghor je:n:nolink} на плакате {BoP:src}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">O {'o' chuyDaH:n:nolink} está localizado próximo ao {Hongghor:n}. Eles são listados juntos como {'o' chuyDaH Hongghor je:n:nolink} no pôster {BoP:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{'o' chuyDaH:n:nolink} sijaitsee lähellä {Hongghor:n}. Ne on lueteltu yhdessä {'o' chuyDaH Hongghor je:n:nolink}-julisteella {BoP:src}-julisteessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'o':n}, {chuyDaH:n}</column>
       <column name="examples"></column>
@@ -2716,6 +3008,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2723,6 +3016,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -2737,6 +3031,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">тип барабана [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鼓類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de tambor</column>
+      <column name="definition_fi">eräs rumputyyppi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIr 'In:n}</column>
@@ -2747,6 +3042,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on rumpu, jonka iho on venytetty molempien päiden yli[1, p.75] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2756,6 +3052,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2763,6 +3060,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2776,6 +3074,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">O'mat Gri T'M pffiots [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">奧馬特·格里（O'mat Gri） [AUTOTRANSLATED]</column>
       <column name="definition_pt">O'mat Gri T'M pffiots</column>
+      <column name="definition_fi">eräs ateria, O'mat Gri T'M pffiots</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2786,6 +3085,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Это сочетание клингонской еды и напитков. Первая часть - {'o'mat ghIrI':n}, разновидность мясной и пастообразной смеси. Вторая часть - это команда {tI'Im:sen@@tI-:v, 'Im:v}. Один из необязательных способов приготовления этого блюда - это варить жир, и команда указывает, что делать это нужно каждому блюду. Последняя часть - напиток {pIvyoch:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esta é uma combinação de comida e bebida Klingon. A primeira parte é {'o'mat ghIrI':n}, que é algum tipo de mistura de carne e macarrão. A segunda parte é o comando {tI'Im:sen@@tI-:v, 'Im:v}. Uma das maneiras opcionais de preparar este prato é ferver a gordura, e o comando especifica fazer isso para cada entrada. A última parte é a bebida {pIvyoch:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yhdistelmä Klingonin ruokaa ja juomaa. Ensimmäinen osa on {'o'mat ghIrI':n}, joka on jonkinlainen liha- ja pastamainen keitos. Toinen osa on komento {tI'Im:sen@@tI-:v, 'Im:v}. Yksi valinnaisista tavoista valmistaa tämä ruokalaji on rasvojen keittäminen, ja komento määrittää tekemään sen jokaiselle annokselle. Viimeinen osa on juoma {pIvyoch:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2795,6 +3095,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2802,6 +3103,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {TNG - Heart of Glory:src}</column>
     </table>
     <table name="mem">
@@ -2815,6 +3117,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">О'Мат Гри [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">奧馬特·格里 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O'mat Gri</column>
+      <column name="definition_fi">eräs ruokalaji, O'mat Gri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'o'mat ghIrI', tI'Im, pIvyoch:n}</column>
@@ -2825,6 +3128,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="notes_ru">Это какая-то мясная и пастообразная смесь. Один из необязательных способов приготовления этого блюда - варить жир (см. {'Im:v}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種類似肉類和麵食的調料。準備這道菜的一種可選方法是將脂肪煮沸（請參閱{'Im:v}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é algum tipo de mistura de carne e macarrão. Uma das maneiras opcionais de preparar este prato é ferver a gordura (consulte {'Im:v}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on jonkinlainen liha- ja pastamainen keitos. Yksi valinnaisista tavoista valmistaa tämä ruokalaji on rasvojen keittäminen (katso {'Im:v}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2834,6 +3138,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2841,6 +3146,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}, [2] {TNG - Heart of Glory:src}</column>
     </table>
     <table name="mem">
@@ -2854,6 +3160,7 @@ Esta palavra também é escrita {'orghenya'ngan:n:nolink}. [AUTOTRANSLATED]</col
       <column name="definition_ru">end (of a song) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">結尾（一首歌） [AUTOTRANSLATED]</column>
       <column name="definition_pt">fim (de uma canção)</column>
+      <column name="definition_fi">(laulun, kappaleen) loppu</column>
       <column name="synonyms"></column>
       <column name="antonyms">{namtun:n}</column>
       <column name="see_also">{bertlham:n}, {Dor:v:2}, {ghang:v}, {rIn:v}, {van:v:2}</column>
@@ -2878,6 +3185,9 @@ Alla Klingon-låtar har {'o'meghmey:n:nolink}. Om en låt bleknar i stället fö
       <column name="notes_pt">Esta palavra é usada apenas para canções. A frase ou porção final em outros tipos de apresentações é referida usando {bertlham:n}.
 
 Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparecer ao invés de terminar apropriadamente, como algumas músicas da Federação fazem, o final de tal música pode ser chamado de {'o'meghqoq:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa käytetään vain kappaleisiin. Viimeiseen lauseeseen tai osaan muun tyyppisissä esityksissä viitataan käyttämällä {bertlham:n}.
+
+Kaikilla Klingonin kappaleilla on {'o'meghmey:n:nolink}. Jos kappale haihtuu kunnollisen päättymisen sijasta, kuten jotkut federaation kappaleet tekevät, tällaisen kappaleen loppua voidaan kutsua nimellä {'o'meghqoq:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Omega, obviously.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2887,6 +3197,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2894,6 +3205,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
     </table>
     <table name="mem">
@@ -2907,6 +3219,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="definition_ru">пена, пена [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">泡沫，泡沫 [AUTOTRANSLATED]</column>
       <column name="definition_pt">espuma</column>
+      <column name="definition_fi">vaahto, kuohu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ba'Suq:n}, {yu'egh:n}</column>
@@ -2917,6 +3230,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A cappuc"ino" is a drink with foamy or frothy milk.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2926,6 +3240,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2933,6 +3248,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -2946,6 +3262,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="definition_ru">мелки [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">堊粉</column>
       <column name="definition_pt">giz</column>
+      <column name="definition_fi">liitu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2956,6 +3273,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to O. Roy Chalk.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2965,6 +3283,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2972,6 +3291,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -2985,6 +3305,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="definition_ru">молекула [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">分子</column>
       <column name="definition_pt">molécula</column>
+      <column name="definition_fi">molekyyli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HeySel:n}, {tamler:n}, {yugh:v}, {pay'an:n}</column>
@@ -2995,6 +3316,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3004,6 +3326,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3011,6 +3334,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -3024,6 +3348,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="definition_ru">кто-то (или что-то) с неоднозначным статусом [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">某人（或某事）具有模棱兩可的地位 [AUTOTRANSLATED]</column>
       <column name="definition_pt">alguém (ou algo) de status ambíguo</column>
+      <column name="definition_fi">joku tai jokin, jonka asema on epäselvä; kaksoisagentti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jey'naS ghoqwI':n}</column>
@@ -3034,6 +3359,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="notes_ru">Этот термин может использоваться для «двойного агента» (для сленга это {jey'naS ghoqwI':n}), но его значение немного шире. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該術語可用於“雙重代理”（其agent語是{jey'naS ghoqwI':n}），但其含義要寬一些。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo pode ser usado para "agente duplo" (para o qual um termo de gíria é {jey'naS ghoqwI':n}), mas seu significado é um pouco mais amplo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä termiä voidaan käyttää "kaksoisagenttiin" (jolle slangitermi on {jey'naS ghoqwI':n}), mutta sen merkitys on hieman laajempi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Possibly a reference to Owen Lattimore, who was accused under McCarthyism of being a spy.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3043,6 +3369,7 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3050,5 +3377,6 @@ Todas as canções Klingon têm {'o'meghmey:n:nolink}. Se uma música desaparece
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.01.26:src}</column>
     </table>

--- a/mem-25-u.xml
+++ b/mem-25-u.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">буква {u:sen:nolink}</column>
       <column name="definition_zh_HK">元音{u:sen:nolink}</column>
       <column name="definition_pt">a vogal {u:sen:nolink}</column>
+      <column name="definition_fi">vokaali {u:sen:nolink}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -19,6 +20,7 @@
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -28,6 +30,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -35,6 +38,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2009.07.27:src}</column>
     </table>
     <table name="mem">
@@ -48,6 +52,7 @@
       <column name="definition_ru">быть одиноким [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">孤獨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser sozinho</column>
+      <column name="definition_fi">olla yksinäinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'IQ:v}, {'It:v}, {mob:v:1}</column>
@@ -58,6 +63,7 @@
       <column name="notes_ru">Это относится к эмоциям, а не к фактическому состоянию одиночества. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指情感，而不是孤獨的實際狀態。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere à emoção, não ao estado real de estar sozinho. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa tunteeseen, ei todelliseen yksinolon tilaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -67,6 +73,7 @@
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -74,6 +81,7 @@
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -87,6 +95,7 @@
       <column name="definition_ru">держать, хватать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">抓</column>
       <column name="definition_pt">segurar, agarrar</column>
+      <column name="definition_fi">pitää kiinni, pidellä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'uchHa':v}</column>
       <column name="see_also"></column>
@@ -109,6 +118,9 @@ När objektet för detta verb är {'olQan:n} kan det ofta översättas "ockupera
       <column name="notes_pt">Quando aplicado a sistemas de armas, é usado para travar em um alvo. Consulte {'uch:v:2}.
 
 Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como "ocupar" ou "pegar" .[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun sitä käytetään asejärjestelmiin, sitä käytetään kohteen lukitsemiseen. Katso {'uch:v:2}.
+
+Kun tämän verbin kohde on {'olQan:n}, se voidaan usein kääntää "miehittää" tai "ottaa käyttöön".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -118,6 +130,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">occupy, take up</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -125,6 +138,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -138,6 +152,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="definition_ru">заблокировать (цель) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鎖定（目標） [AUTOTRANSLATED]</column>
       <column name="definition_pt">bloquear (um alvo)</column>
+      <column name="definition_fi">lukittua kohteeseen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DoS:n}, {buS:v}</column>
@@ -148,6 +163,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="notes_ru">Это приложение {'uch:v:1} к контексту систем вооружений. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{'uch:v:1}在武器系統環境中的應用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma aplicação do {'uch:v:1} para um contexto de sistemas de armas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {'uch:v:1} -sovelluksen käyttö asejärjestelmien yhteydessä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -158,6 +174,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -165,6 +182,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -178,6 +196,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="definition_ru">включать, состоять из, состоять из [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">包括、由...組成 [AUTOTRANSLATED]</column>
       <column name="definition_pt">incluir, consistir em, ser composto de</column>
+      <column name="definition_fi">sisältää, koostua jostakin</column>
       <column name="synonyms">{yugh:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{tamlerQeD:n}</column>
@@ -188,6 +207,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="notes_ru">Это используется для разговоров о химии. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這用於談論化學。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado para falar sobre química. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään puhumaan kemiasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -197,6 +217,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -204,6 +225,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
         <table name="mem">
@@ -217,6 +239,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
           <column name="definition_ru">отпустить [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">放手</column>
           <column name="definition_pt">soltar de</column>
+      <column name="definition_fi">päästää irti, hellittää ote jostain</column>
           <column name="synonyms"></column>
           <column name="antonyms">{'uch:v:1}</column>
           <column name="see_also"></column>
@@ -227,6 +250,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'uch:v:1}, {-Ha':v}</column>
           <column name="examples"></column>
@@ -236,6 +260,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -243,6 +268,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {HQ 12.2, Jun. 2003:src}</column>
         </table>
     <table name="mem">
@@ -256,6 +282,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="definition_ru">РНК [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">核糖核酸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">RNA</column>
+      <column name="definition_fi">RNA</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{roSghaH:n}</column>
@@ -266,6 +293,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It was confirmed during the Q &amp; A session that this is not grammatically considered a body part.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -275,6 +303,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -282,6 +311,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -295,6 +325,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="definition_ru">лазер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">激光</column>
       <column name="definition_pt">laser</column>
+      <column name="definition_fi">laser</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'otlh:n}</column>
@@ -305,6 +336,7 @@ Quando o objeto deste verbo é {'olQan:n}, muitas vezes pode ser traduzido como 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The word {'uD'a':n:nolink} appears in {HQ 1.3, Sept. 1992:src}, where it is also defined as just "laser".
 
 Shintaro Uda was a co-inventor of the beam antenna.</column>
@@ -316,6 +348,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -323,6 +356,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -336,6 +370,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="definition_ru">лазерный скальпель [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">激光手術刀</column>
       <column name="definition_pt">bisturi a laser</column>
+      <column name="definition_fi">laserveitsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HaqwI':n}</column>
@@ -346,6 +381,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'uD:n}, {Haqtaj:n}</column>
       <column name="examples"></column>
@@ -355,6 +391,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -362,6 +399,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 1.3, Sept. 1992:src}</column>
     </table>
     <table name="mem">
@@ -375,6 +413,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="definition_ru">быть тяжелым</column>
       <column name="definition_zh_HK">重</column>
       <column name="definition_pt">ser pesado</column>
+      <column name="definition_fi">olla raskas, painava</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tIS:v}</column>
       <column name="see_also">{cheb:n}, {ngI':v}</column>
@@ -385,6 +424,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -395,6 +435,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">burden</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -402,6 +443,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -415,6 +457,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="definition_ru">гусеница [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">毛蟲</column>
       <column name="definition_pt">lagarta</column>
+      <column name="definition_fi">toukka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghargh:n}</column>
@@ -425,6 +468,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="notes_ru">Это немного извилистая вещь, которая почему-то превращается в {Su'wan ghew:n}. Не используется, чтобы сделать {qagh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on pieni mutkikas juttu, josta joku muuttuu {Su'wan ghew:n}: ksi. Sitä ei käytetä {qagh:n}: n valmistamiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The {'ugh:sen:nolink}ly {Duq:sen:nolink}ling becomes a {Su'wan:sen:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -434,6 +478,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -441,6 +486,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -454,6 +500,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="definition_ru">иметь похмелье</column>
       <column name="definition_zh_HK">宿醉、宿酒</column>
       <column name="definition_pt">ter uma ressaca, estar de ressaca</column>
+      <column name="definition_fi">olla krapulassa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chech:v}, {HIq:n}, {wuQ:v}, {nuch Hergh:n}</column>
@@ -464,6 +511,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -473,6 +521,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -480,6 +529,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -493,6 +543,7 @@ Shintaro Uda was a co-inventor of the beam antenna.</column>
       <column name="definition_ru">uj (единица измерения линейной длины, 34,83 ​​см) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">uj（線性測量單位、34.83 cm） [AUTOTRANSLATED]</column>
       <column name="definition_pt">uj (unidade de medida linear, 34,83 ​​cm)</column>
+      <column name="definition_fi">eräs pituuden yksikkö, uj (n. 34,83 cm)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ab:v}, {'aD:v}, {juch:v}, {Saw':v}, {woch:v}, {juv:v}, {'uj'a':n}, {morgh:n}, {lID:v}</column>
@@ -507,6 +558,9 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{BoP:src}-julisteen mittausten perusteella yksi {'uj:n:nolink} on hyvin lähellä 34,83 ​​cm.
+
+Kolme {'uj:n:nolink} on noin 3'5 ", viisi {'uj:n:nolink} on noin 5'8" ja kuusi {'uj:n:nolink} on noin 6'10 ".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {KGT:src}, this unit is described as "about 35 cm". Also, Okrand has not been consistent in writing the plural of this in English, using "ujs" in earlier work but switching to "ujes" later.</column>
       <column name="components"></column>
       <column name="examples">
@@ -527,6 +581,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">unit, meter, metre, centimeter, centimetre</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -534,6 +589,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {msn 1997.10.22:src}, [3] {SkyBox 32:src} (reprinted in {HQ 6.2, p.9, Jun. 1997:src}), [4] {BoP:src}, [5] {Saarbrücken qepHom'a' 2015:src}, [6] {KLI mailing list 2019.03.01:src}, [7] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -547,6 +603,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">единица длины (313,47 см) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">長度單位（313.47厘米） [AUTOTRANSLATED]</column>
       <column name="definition_pt">unidade de comprimento (313.47 cm)</column>
+      <column name="definition_fi">eräs pituuden yksikkö, iso uj (n. 313,47 cm)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -557,6 +614,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Um {'uj'a':n:nolink} é igual a nove {'uj:n:nolink}. No entanto, não existe uma unidade {'ujHom:n:nolink} que denote um nono de um {'uj:n:nolink}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksi {'uj'a':n:nolink} on yhtä suuri kuin yhdeksän {'uj:n:nolink}. Ei kuitenkaan ole yksikköä {'ujHom:n:nolink}, joka merkitsisi {'uj:n:nolink}: n yhdeksäsosaa.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'uj:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -566,6 +624,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -573,6 +632,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {s.k 1999.02.03:src} (also forwarded to {KLI mailing list 1999.02.03:src})</column>
     </table>
     <table name="mem">
@@ -586,6 +646,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">Уджилли [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Ujilli [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ujilli</column>
+      <column name="definition_fi">Ujilli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -596,6 +657,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Он является членом Дома Мо'Кай ({mo'qay tuq:n:name}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">他是莫凱家族（{mo'qay tuq:n:name}）的成員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ele é um membro da Casa de Mo'Kai ({mo'qay tuq:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on Mo'Kain talon ({mo'qay tuq:n:name}) jäsen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -605,6 +667,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -612,6 +675,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Battle at the Binary Stars:src}, [2] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -625,6 +689,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">электричество [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">電、電力</column>
       <column name="definition_pt">eletricidade</column>
+      <column name="definition_fi">sähkö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peQ:n}</column>
@@ -635,6 +700,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a reference to the "Underwriter's Laboratories". A label with the acronym "UL" is found on all electrical appliances in the US.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -644,6 +710,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -651,6 +718,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
         <table name="mem">
@@ -664,6 +732,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="definition_ru">схема [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">電路 [AUTOTRANSLATED]</column>
           <column name="definition_pt">circuito</column>
+      <column name="definition_fi">virtapiiri</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -674,6 +743,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">There is a note that {'ul ghomey:n:nolink} means "circuits", though it's not clear why this note is necessary.</column>
           <column name="components">{'ul:n}, {gho:n}</column>
           <column name="examples"></column>
@@ -683,6 +753,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -690,6 +761,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 27 (2020):src}</column>
         </table>
         <table name="mem">
@@ -703,6 +775,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="definition_ru">электрик [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">電工</column>
           <column name="definition_pt">eletricista</column>
+      <column name="definition_fi">sähköasentaja</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{'ul:n}</column>
@@ -713,6 +786,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'ul:n}, {pat:n}, {mutlh:v}, {-wI':v}</column>
           <column name="examples"></column>
@@ -722,6 +796,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -729,6 +804,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {KLI mailing list 2012.01.10:src}</column>
         </table>
         <table name="mem">
@@ -742,6 +818,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="definition_ru">электрическая вилка [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">電源插頭</column>
           <column name="definition_pt">Tomada</column>
+      <column name="definition_fi">pistoke</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -752,6 +829,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'ul:n}, {rarwI':n}</column>
           <column name="examples"></column>
@@ -761,6 +839,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -768,6 +847,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {qep'a' 25 (2018):src}</column>
         </table>
         <table name="mem">
@@ -781,6 +861,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="definition_ru">фонарик [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">電筒</column>
           <column name="definition_pt">lanterna</column>
+      <column name="definition_fi">taskulamppu</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -791,6 +872,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'ul:n}, {Sech:n}</column>
           <column name="examples"></column>
@@ -800,6 +882,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags">torch, electric torch</column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -807,6 +890,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
         <table name="mem">
@@ -821,6 +905,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="definition_ru">батарея, электрохимическая ячейка [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">電心、電池</column>
           <column name="definition_pt">bateria, célula eletroquímica</column>
+      <column name="definition_fi">akku, paristo, sähkökemiallinen kenno</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{HoSHal:n}, {Huj:v:2}</column>
@@ -831,6 +916,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word appears in {TNK:src} only in the plural as {'ul 'aplo'mey:n:nolink} "batteries". Technically, what is commonly called a "battery" is a single cell, and a "battery" is an array ({DaH:n}) of such cells.</column>
           <column name="components">{'ul:n}, {'aplo':n}</column>
           <column name="examples"></column>
@@ -840,6 +926,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -847,6 +934,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TNK:src}</column>
         </table>
     <table name="mem">
@@ -860,6 +948,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">быть компетентным</column>
       <column name="definition_zh_HK">有資格</column>
       <column name="definition_pt">ser qualificado</column>
+      <column name="definition_fi">olla pätevä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'umHa':v}</column>
       <column name="see_also">{po':v}, {Han:v}, {Hen:v}</column>
@@ -870,6 +959,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -879,6 +969,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">fit, worthy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -886,6 +977,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -899,6 +991,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">быть неквалифицированным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">冇資格、不合格</column>
       <column name="definition_pt">ser desqualificado</column>
+      <column name="definition_fi">olla epäpätevä</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'um:v}</column>
       <column name="see_also"></column>
@@ -909,6 +1002,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word is not actually defined in the {paq'batlh:src}, but its derivation and meaning are clear.</column>
       <column name="components">{'um:v}, {-Ha':v}</column>
       <column name="examples">
@@ -924,6 +1018,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">unfit, unworthy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -931,6 +1026,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.96-97:src}</column>
     </table>
     <table name="mem">
@@ -944,6 +1040,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">лепесток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">花瓣</column>
       <column name="definition_pt">pétala</column>
+      <column name="definition_fi">terälehti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'InSong:n}</column>
@@ -954,6 +1051,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Petaluma" is a town in California.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -963,6 +1061,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -970,6 +1069,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -983,6 +1083,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">экосистема, окружающая среда [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">生態系統，環境 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ecossistema, meio ambiente</column>
+      <column name="definition_fi">ekosysteemi, ympäristö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{but:v}, {qo':n}, {yIn:n}</column>
@@ -993,6 +1094,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Umberto Eco.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1002,6 +1104,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1009,6 +1112,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -1022,6 +1126,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">pot (for food preparation) (general term) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鍋（用於食物準備）（總稱） [AUTOTRANSLATED]</column>
       <column name="definition_pt">panela (para preparação de alimentos) (termo geral)</column>
+      <column name="definition_fi">pata, kattila (ruoanvalmistusta varten)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DuDwI':n}, {'un naQ:n}, {bo'Dagh:n}</column>
@@ -1032,6 +1137,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1041,6 +1147,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1048,6 +1155,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1061,6 +1169,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">палочка для перемешивания, палочка для перемешивания [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">攪拌棒</column>
       <column name="definition_pt">bastão de agitação, bastão misturador</column>
+      <column name="definition_fi">sekoituspuikko (käytetään ruoanvalmistuksessa)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DuDwI':n}, {ngawDeq:n}</column>
@@ -1071,6 +1180,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'un:n}, {naQ:n:1}</column>
       <column name="examples"></column>
@@ -1080,6 +1190,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1087,6 +1198,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1100,6 +1212,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">artificially produced [qud] [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">人工製作的《qud》</column>
       <column name="definition_pt">produzido artificialmente [qud]</column>
+      <column name="definition_fi">eräs elintarvike, keinotekoisesti tuotettu [qud]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quD:n}, {burgh quD:n}</column>
@@ -1110,6 +1223,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Это {quD:n} производится с использованием химических веществ. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是使用化學品生產的{quD:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o {quD:n} produzido com produtos químicos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {quD:n}, joka on valmistettu kemikaaleilla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'un:n}, {quD:n}</column>
       <column name="examples"></column>
@@ -1119,6 +1233,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1126,6 +1241,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1139,6 +1255,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">корзина [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">籃</column>
       <column name="definition_pt">cesta</column>
+      <column name="definition_fi">kori</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1149,6 +1266,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Это сотканный контейнер для переноски вещей. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是用於搬運物品的編織容器。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um recipiente trançado para transportar coisas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kudottu astia tavaroiden kuljettamiseen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is a pot ({'un:n}) made of what looks like "wattle" fencing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1158,6 +1276,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1165,6 +1284,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1178,6 +1298,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">squat (down) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">跁低、蹲下</column>
       <column name="definition_pt">agachamento (para baixo)</column>
+      <column name="definition_fi">kyykistyä, istua kyykyssä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ba':v}, {joD:v}, {tor:v:1}</column>
@@ -1188,6 +1309,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1197,6 +1319,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1204,6 +1327,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1217,6 +1341,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">быть неприятным, отвратительным, отвратительным, отвратительным, непристойным [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">是令人討厭的、令人作嘔的、令人厭惡的、令人厭惡的、icky的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser repugnante, nojento, revoltante</column>
+      <column name="definition_fi">olla epämiellyttävä, inhottava, vastenmielinen, ällö</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'eyHa':v}, {yIH:n}, {ngIm:v}, {natlh:v:2}</column>
@@ -1227,6 +1352,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Существует идиома {'up; yIH rur@@'up:v, yIH:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個成語，{'up; yIH rur@@'up:v, yIH:n, rur:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um idioma, {'up; yIH rur@@'up:v, yIH:n, rur:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On idioomi {'up; yIH rur@@'up:v, yIH:n, rur:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Throw "up".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1236,6 +1362,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1243,6 +1370,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1256,6 +1384,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">свисток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">吹哨</column>
       <column name="definition_pt">apitar, assobiar</column>
+      <column name="definition_fi">viheltää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bom:v}, {bo'Degh:n}, {Huy:v:1}</column>
@@ -1266,6 +1395,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Если есть объект, это вещь, которую насвистывают. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">如果有物體，那就是被吹口哨的東西。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Se existe um objeto, é a coisa que está sendo assobiada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos siellä on esine, se vihelletään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1275,6 +1405,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1282,6 +1413,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -1295,6 +1427,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">ужин</column>
       <column name="definition_zh_HK">晚餐</column>
       <column name="definition_pt">jantar</column>
+      <column name="definition_fi">illallinen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ram:n}, {nay':n}, {ghem:n}, {megh:n}, {nIQ:n}</column>
@@ -1305,6 +1438,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1315,6 +1449,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1322,6 +1457,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1335,6 +1471,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">банкет, пир</column>
       <column name="definition_zh_HK">宴會、饗宴</column>
       <column name="definition_pt">banquete, festa</column>
+      <column name="definition_fi">juhla-ateria, pidot, kestit</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1345,6 +1482,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'uQ:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -1354,6 +1492,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1361,6 +1500,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1374,6 +1514,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">столовая, столовая [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">飯廳</column>
       <column name="definition_pt">sala de jantar</column>
+      <column name="definition_fi">ruokasali</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SopmeH pa':n}</column>
@@ -1384,6 +1525,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is just a regular noun-noun construction. It was used as an example in a message on the {msn:src} newsgroup to show that the known vocabulary and existing grammar can be used to say a lot of things which aren't explicitly spelled out.</column>
       <column name="components">{'uQ:n}, {pa':n:1}</column>
       <column name="examples"></column>
@@ -1393,6 +1535,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1400,6 +1543,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {msn 1997.06.18:src}</column>
     </table>
     <table name="mem">
@@ -1413,6 +1557,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">совершать измену</column>
       <column name="definition_zh_HK">賣國</column>
       <column name="definition_pt">trair, cometer traição</column>
+      <column name="definition_fi">tehdä maanpetos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{magh:v}, {bolwI':n}, {'urmang:n}</column>
@@ -1423,6 +1568,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is missing from the K-E side of {TKDA:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1432,6 +1578,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1439,6 +1586,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1452,6 +1600,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">изменник</column>
       <column name="definition_zh_HK">賣國賊</column>
       <column name="definition_pt">traidor</column>
+      <column name="definition_fi">maanpetturi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bolwI':n}, {maghwI':n}</column>
@@ -1462,6 +1611,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Это человек, который совершает государственную измену. Для человека, который предает кого-то, см. {maghwI':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是犯叛國罪的人。對於背叛某人的人，請參閱{maghwI':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma pessoa que comete traição. Para uma pessoa que trai alguém, consulte {maghwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on henkilö, joka tekee maanpetoksen. Jos joku pettää jonkun, katso {maghwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This is missing from the K-E side of {TKDA:src}.</column>
       <column name="components">{'ur:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1471,6 +1621,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1478,6 +1629,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA:src}</column>
     </table>
     <table name="mem">
@@ -1491,6 +1643,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">тыкать [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">篤、戳</column>
       <column name="definition_pt">espetar</column>
+      <column name="definition_fi">pistää, tökätä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DuQ:v:1}, {'urghwI':n}</column>
@@ -1501,6 +1654,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1510,6 +1664,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1517,6 +1672,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1530,6 +1686,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">Покер (карточная игра) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">撲克（紙牌遊戲）</column>
       <column name="definition_pt">Poker (jogo de cartas)</column>
+      <column name="definition_fi">pokeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Degh:n:1}, {'echletHom:n}, {SuD:v:2}</column>
@@ -1540,6 +1697,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Maltz viittasi federaation korttipeliin "Poker" nimellä {'urghwI':n:nolink}, vaikka muut klingonit eivät todennäköisesti ymmärtäisikään tätä.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'urgh:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1549,6 +1707,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1556,6 +1715,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -1569,6 +1729,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">измена</column>
       <column name="definition_zh_HK">叛國罪</column>
       <column name="definition_pt">traição</column>
+      <column name="definition_fi">maanpetos</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ur:v}, {Daw':n}, {QuS:n}</column>
@@ -1579,6 +1740,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1588,6 +1750,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1595,6 +1758,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1608,6 +1772,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">нога</column>
       <column name="definition_zh_HK">腿</column>
       <column name="definition_pt">perna</column>
+      <column name="definition_fi">jalka</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qam:n}, {ghIv:n}, {qIv:n}, {to'waQ:n}, {ngIb:n:1}</column>
@@ -1618,6 +1783,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1627,6 +1793,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1634,6 +1801,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -1647,6 +1815,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">своего рода птица, петух [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">公雞</column>
       <column name="definition_pt">uma espécie de pássaro, galo</column>
+      <column name="definition_fi">eräs kukon kaltainen lintu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'Degh:n}, {jajlo' Qa':n}</column>
@@ -1657,6 +1826,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Это шумная птица, которая, как известно, совершает шум на рассвете, которую сравнивают с петухом (но гораздо жестче, чем петух). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種吵鬧的鳥，已知會在黎明時引起騷動，已被比喻為公雞（但比公雞兇猛得多）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um pássaro barulhento, conhecido por fazer um tumulto ao amanhecer, que foi comparado a um galo (mas é muito mais feroz do que um galo). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on meluisa lintu, jonka tiedetään tekevän kynnyksen aamunkoitteessa, jota on verrattu kukkoon (mutta se on paljon kovempaa kuin kukko). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The "leghorn" is a type of chicken, and Foghorn Leghorn is a cartoon leghorn rooster.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1666,6 +1836,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1673,6 +1844,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.4, Dec. 2001:src}</column>
     </table>
     <table name="mem">
@@ -1686,6 +1858,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">железо (элемент) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鐵（元素）</column>
       <column name="definition_pt">ferro (elemento)</column>
+      <column name="definition_fi">rauta</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tamler:n}, {baS:n}</column>
@@ -1696,6 +1869,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The USS Constitution had the nickname "Old Ironsides".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1705,6 +1879,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1712,6 +1887,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -1725,6 +1901,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">соус для удовольствия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">薄醬</column>
       <column name="definition_pt">molho de gladst</column>
+      <column name="definition_fi">eräs kasti gladstille</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhatlh:n}, {tlhatlh vIychorgh:n}, {Se'tu':n}</column>
@@ -1735,6 +1912,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">{'uSu':n:nolink} является родным для коренных жителей планеты Танганика.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">{'uSu':n:nolink} é nativo dos habitantes originais do planeta Tanganika.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{'uSu':n:nolink} on kotoisin Tanganika-planeetan alkuperäisiltä asukkailta.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">One type of lighter soy sauce is called "usukuchi shoyu" (薄口醤油) in Japanese. Also, the "yuzu" plant is used in the creation of some sauces in Asian cuisine. However, if this word is a pun, it wasn't due to Okrand, but the writers of {DS9 - Melora:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1744,6 +1922,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1751,6 +1930,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT:src}, [2] {KCD:src}</column>
     </table>
     <table name="mem">
@@ -1764,6 +1944,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">быть необходимым</column>
       <column name="definition_zh_HK">必要、需要</column>
       <column name="definition_pt">ser essencial, ser necessário</column>
+      <column name="definition_fi">olla välttämätön, tarpeellinen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{'utbe':v}</column>
       <column name="see_also"></column>
@@ -1774,6 +1955,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Of the "ut"most importance.</column>
       <column name="components"></column>
       <column name="examples">
@@ -1784,6 +1966,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1791,6 +1974,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
         <table name="mem">
@@ -1804,6 +1988,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="definition_ru">быть необязательным, ненужным [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">不必要、不需要</column>
           <column name="definition_pt">ser desnecessário, não-essencial</column>
+      <column name="definition_fi">olla tarpeeton</column>
           <column name="synonyms"></column>
           <column name="antonyms">{'ut:v}</column>
           <column name="see_also"></column>
@@ -1814,6 +1999,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes">This word is not defined as such in canon, but appears in a sentence in {TKW:src}[1]. This entry is here for ease of reference only.</column>
           <column name="components"></column>
           <column name="examples">
@@ -1824,6 +2010,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1831,6 +2018,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.45:src}</column>
         </table>
         <table name="mem">
@@ -1844,6 +2032,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="definition_ru">Удовольствие необязательно. [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">樂趣是不重要的。</column>
           <column name="definition_pt">Prazer não é essencial.</column>
+      <column name="definition_fi">Nautinto on tarpeetonta.</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also"></column>
@@ -1854,6 +2043,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
           <column name="hidden_notes"></column>
           <column name="components">{'utbe':v}, {bel:n}</column>
           <column name="examples"></column>
@@ -1863,6 +2053,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -1870,6 +2061,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
           <column name="source">[1] {TKW p.45:src}</column>
         </table>
     <table name="mem">
@@ -1883,6 +2075,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">комод [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">抽屜櫃 [AUTOTRANSLATED]</column>
       <column name="definition_pt">cômoda</column>
+      <column name="definition_fi">lipasto</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'voD:n}, {DeSwar:n}, {yorgh:n}</column>
@@ -1893,6 +2086,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Это относится к комоду, независимо от того, есть ли на самом деле в нем ящики в данный момент. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指一個抽屜櫃，而不管當前是否有抽屜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se a uma cômoda, independentemente de haver ou não gavetas no momento. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa lipastoon riippumatta siitä, onko siinä todella laatikoita tällä hetkellä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Drawer" is slang for "underwear", and Under Armour (UA) is a brand of casual and sports clothing.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1902,6 +2096,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1909,6 +2104,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 23 (2016):src}</column>
     </table>
     <table name="mem">
@@ -1922,6 +2118,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">офицер, бывший офицер</column>
       <column name="definition_zh_HK">軍官、退休人員 [AUTOTRANSLATED]</column>
       <column name="definition_pt">oficial, oficial emérito</column>
+      <column name="definition_fi">upseeri, eläköitynyt upseeri</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yaS:n}, {paj:v}, {Deq:v}</column>
@@ -1932,6 +2129,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Офицер, который закончил службу в отставке. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">退休後退休的軍官 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um oficial que terminou o serviço na aposentadoria. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Virkamies, joka lopetti palveluksensa eläkkeellä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1941,6 +2139,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1948,6 +2147,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1961,6 +2161,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">нажимать</column>
       <column name="definition_zh_HK">撳低</column>
       <column name="definition_pt">pressionar para baixo</column>
+      <column name="definition_fi">painaa alas</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yuv:v}, {leQ:n}</column>
@@ -1971,6 +2172,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="notes_ru">Этот глагол используется для нажатия на кнопку компьютерной мыши (хотя на самом деле нужно нажать и отпустить). Для перехода по гиперссылке используется глагол {wIv:v}, а не {'uy:v:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該動詞用於單擊計算機鼠標按鈕（即使該操作實際上是按下然後釋放）。單擊超鏈接時，使用動詞{wIv:v}而不是{'uy:v:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse verbo é usado para clicar no botão do mouse do computador (mesmo que a ação seja realmente pressionar e soltar). Para clicar em um hiperlink, o verbo {wIv:v} é usado em vez de {'uy:v:nolink}.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä verbiä käytetään napsauttamaan tietokoneen hiiren painiketta (vaikka toiminnon tarkoituksena on todella painaa alas ja sitten vapauttaa). Hyperlinkkiä napsautettaessa käytetään verbiä {wIv:v} eikä {'uy:v:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1980,6 +2182,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">click</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1987,6 +2190,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -2000,6 +2204,7 @@ Drei {'uj:n:nolink} sind etwa 3 Fuß 5 Zoll, fünf {'uj:n:nolink} sind etwa 5 Fu
       <column name="definition_ru">миллион</column>
       <column name="definition_zh_HK">百萬</column>
       <column name="definition_pt">milhão</column>
+      <column name="definition_fi">miljoonaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mI':n}, {bIp:n:num}, {Saghan:n:num}</column>
@@ -2018,6 +2223,9 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kymmenien miljoonien verran {maH:n:2,num} voidaan yhdistää {'uy':n:num,nolink}: een tai {vatlh:n:num} {bIp:n:num}: n kanssa.
+
+Satoja miljoonia lukuja muodostavat elementit {vatlh'uy':n:num@@vatlh:n, 'uy':n}, {SaDbIp:n:num@@SaD:n, bIp:n} tai {SanIDbIp:n:num@@SanID:n, bIp:n} ovat mahdollisia.[2][3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2027,6 +2235,7 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2034,6 +2243,7 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}, [2] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src}), [3] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -2047,6 +2257,7 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="definition_ru">вселенная</column>
       <column name="definition_zh_HK">宇宙</column>
       <column name="definition_pt">universo</column>
+      <column name="definition_fi">maailmankaikkeus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ngeHbej:n}, {'u' Dop:n}, {'u' quq:n}</column>
@@ -2057,6 +2268,7 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="notes_ru">Это также название оперы, которая повествует о многих из тех же событий, что и в {paq'batlh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也是歌劇的名字，它講述了許多與《 {paq'batlh:n}》中的事件相同的事件。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este também é o nome de uma ópera, que narra muitos dos mesmos eventos encontrados no {paq'batlh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on myös oopperan nimi, joka kertoo monia samoja tapahtumia kuin {paq'batlh:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2066,6 +2278,7 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2073,6 +2286,7 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -2086,6 +2300,7 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="definition_ru">зеркальная вселенная [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">相反時空</column>
       <column name="definition_pt">universo espelho</column>
+      <column name="definition_fi">peilimaailma</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'u' quq:n}</column>
@@ -2096,6 +2311,7 @@ För hundratals miljoner är de nummerbildande elementen {vatlh'uy':n:num@@vatlh
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">A "Doppelgänger" is the double of a person from the mirror universe.
 
 At {qep'a' 26 (2019):src}, the note expanding {Dop:v:1} to {Dop:v:2} alludes to {'u' Dop:n:nolink} being based on the "opposite" meaning.</column>
@@ -2107,6 +2323,7 @@ At {qep'a' 26 (2019):src}, the note expanding {Dop:v:1} to {Dop:v:2} alludes to 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2114,6 +2331,7 @@ At {qep'a' 26 (2019):src}, the note expanding {Dop:v:1} to {Dop:v:2} alludes to 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.08:src}, [2] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -2127,6 +2345,7 @@ At {qep'a' 26 (2019):src}, the note expanding {Dop:v:1} to {Dop:v:2} alludes to 
       <column name="definition_ru">параллельная вселенная [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">平行時空</column>
       <column name="definition_pt">universo paralelo</column>
+      <column name="definition_fi">rinnakkaistodellisuus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'u' Dop:n}</column>
@@ -2137,6 +2356,7 @@ At {qep'a' 26 (2019):src}, the note expanding {Dop:v:1} to {Dop:v:2} alludes to 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'u':n}, {quq:v}</column>
       <column name="examples"></column>
@@ -2146,6 +2366,7 @@ At {qep'a' 26 (2019):src}, the note expanding {Dop:v:1} to {Dop:v:2} alludes to 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2153,5 +2374,6 @@ At {qep'a' 26 (2019):src}, the note expanding {Dop:v:1} to {Dop:v:2} alludes to 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.01.08:src}</column>
     </table>

--- a/mem-26-suffixes.xml
+++ b/mem-26-suffixes.xml
@@ -9,6 +9,7 @@
       <column name="definition_ru">он/она/оно-нет, он/она/оно-он/она/оно, он/она/оно-они, они-нет, они-они</column>
       <column name="definition_zh_HK">他、它：無、他、它、他們、它們；他們、它們：無、他們、它們</column>
       <column name="definition_pt">ele/ela-nenhum, ele/ela-ele/ela, ele/ela-eles, eles-nenhum, eles-eles</column>
+      <column name="definition_fi">hän/se-ei mitään, hän/se-häntä/sitä/heitä/niitä, he/ne-ei mitään, he/ne-heitä/niitä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lu-:v:pref}</column>
@@ -27,6 +28,7 @@ Note that the prefix for "they-him/her/it" is {lu-:v:pref}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -36,6 +38,7 @@ Note that the prefix for "they-him/her/it" is {lu-:v:pref}.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">he-none, she-none, it-none, he-him, he-her, he-it, she-him, she-her, she-it, he-them, she-them, it-them</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -43,6 +46,7 @@ Note that the prefix for "they-him/her/it" is {lu-:v:pref}.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -56,6 +60,7 @@ Note that the prefix for "they-him/her/it" is {lu-:v:pref}.</column>
       <column name="definition_ru">увеличение (сущ. тип 1)</column>
       <column name="definition_zh_HK">增補（第一類名詞後綴）</column>
       <column name="definition_pt">aumentativo (substantivo tipo 1)</column>
+      <column name="definition_fi">augmentatiivi (substantiiviliite 1)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{-Hom:n}</column>
       <column name="see_also"></column>
@@ -68,6 +73,9 @@ Note that the noun with {-'a':n:suff,nolink} need not be better than the bare no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{-'a':n:suff,nolink}: llä muodostettu substantiivi viittaa johonkin, joka on isompi, tärkeämpi tai voimakkaampi kuin substantiivi ilman loppuliitettä.
+
+Huomaa, että {-'a':n:suff,nolink}-substantiivin ei tarvitse olla kaikin tavoin parempi kuin paljas substantiivi, vain yhdellä tavalla, joka on merkittävä tälle substantiiville. Esimerkiksi {mIv'a':n} ei ole välttämättä kooltaan suurempi kuin {mIv:n:1}, ja {toy'wI''a':n} on todennäköisesti huonommassa asemassa monin tavoin verrattuna {toy'wI':n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -97,6 +105,7 @@ Note that the noun with {-'a':n:suff,nolink} need not be better than the bare no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 1</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -104,6 +113,7 @@ Note that the noun with {-'a':n:suff,nolink} need not be better than the bare no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.1:src}</column>
     </table>
     <table name="mem">
@@ -117,6 +127,7 @@ Note that the noun with {-'a':n:suff,nolink} need not be better than the bare no
       <column name="definition_ru">уменьшение (сущ. тип 1)</column>
       <column name="definition_zh_HK">減小（第一類名詞後綴）</column>
       <column name="definition_pt">diminutivo (substantivo tipo 1)</column>
+      <column name="definition_fi">vähättelevä diminutiivi (substantiiviliite 1)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{-'a':n}</column>
       <column name="see_also"></column>
@@ -127,6 +138,7 @@ Note that the noun with {-'a':n:suff,nolink} need not be better than the bare no
       <column name="notes_ru">Существительное, образованное с помощью {-Hom:n:suff,nolink}, относится к чему-то, что меньше, менее важно или менее сильно, чем существительное без суффикса. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">由{-Hom:n:suff,nolink}構成的名詞是指比沒有後綴的名詞更小，更重要或更不強大的事物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O substantivo formado com {-Hom:n:suff,nolink} refere-se a algo menor, menos importante ou menos poderoso que o substantivo sem o sufixo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{-Hom:n:suff,nolink}: llä muodostettu substantiivi viittaa johonkin, joka on pienempi, vähemmän tärkeä tai vähemmän voimakas kuin substantiivi ilman loppuliitettä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -151,6 +163,7 @@ Note that the noun with {-'a':n:suff,nolink} need not be better than the bare no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 1</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -158,6 +171,7 @@ Note that the noun with {-'a':n:suff,nolink} need not be better than the bare no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.1:src}</column>
     </table>
     <table name="mem">
@@ -171,6 +185,7 @@ Note that the noun with {-'a':n:suff,nolink} need not be better than the bare no
       <column name="definition_ru">привязанность (сущ. тип 1)</column>
       <column name="definition_zh_HK">愛稱（第一類名詞後綴）</column>
       <column name="definition_pt">carinho (substantivo tipo 1)</column>
+      <column name="definition_fi">hellittelevä diminutiivi (substantiiviliite 1)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -183,6 +198,9 @@ It is suspected that a {qaghwI':n} is inserted before this suffix if the noun en
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on harvoin käytetty loppuliite, jota käytetään osoittamaan mielihyvää. Se liitetään yleensä sukulaisen tai joskus eläimen, kuten lemmikin, sanaan.
+
+Epäillään, että {qaghwI':n} lisätään ennen tätä loppuliitettä, jos substantiivi päättyy vokaaliin, mutta esimerkkejä ei tunneta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This sounds like the Cantonese word for "love" (愛).</column>
       <column name="components"></column>
       <column name="examples">
@@ -194,6 +212,7 @@ It is suspected that a {qaghwI':n} is inserted before this suffix if the noun en
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 1, -'oy</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -201,6 +220,7 @@ It is suspected that a {qaghwI':n} is inserted before this suffix if the noun en
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA 3.3.1:src}, [2] {KGT p.198:src}</column>
     </table>
     <table name="mem">
@@ -214,6 +234,7 @@ It is suspected that a {qaghwI':n} is inserted before this suffix if the noun en
       <column name="definition_ru">множественное число (для существ, способных использовать речь) (сущ. тип 2)</column>
       <column name="definition_zh_HK">複數、們（能用語言）（第二類名詞後綴）</column>
       <column name="definition_pt">plural (seres capazes de usar a linguagem) (substantivo tipo 2)</column>
+      <column name="definition_fi">monikko (henkilöt, kielenkäyttäjät) (substantiiviliite 2)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-mey:n}</column>
@@ -226,6 +247,9 @@ Note that whether {-pu':n:suff,nolink} is used is a property of the noun, and no
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä pääte on liitetty substantiiviin, joka viittaa olentoja, jotka pystyvät puhumaan kieliä, kun tällaisia ​​olentoja on enemmän kuin yksi.
+
+Huomaa, että {-pu':n:suff,nolink}: n käyttö on substantiivi, eikä välttämättä niiden asioiden ominaisuus, joihin se viittaa. Esimerkiksi ryhmään klingoneita, jotka eivät pysty puhumaan, tai ryhmään klingonilaisia, jotka ovat liian nuoria ymmärtämään kieltä, kutsutaan edelleen nimellä {tlhInganpu':n:nolink}.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -236,6 +260,7 @@ Note that whether {-pu':n:suff,nolink} is used is a property of the noun, and no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 2</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -243,6 +268,7 @@ Note that whether {-pu':n:suff,nolink} is used is a property of the noun, and no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.2:src}, [2] {KLI mailing list 1998.05.28:src}</column>
     </table>
     <table name="mem">
@@ -256,6 +282,7 @@ Note that whether {-pu':n:suff,nolink} is used is a property of the noun, and no
       <column name="definition_ru">множественное число (для частей тела) (сущ. тип 2)</column>
       <column name="definition_zh_HK">複數（身體部分）（第二類名詞後綴）</column>
       <column name="definition_pt">plural (parte do corpo) (substantivo tipo 2)</column>
+      <column name="definition_fi">monikko (ruumiinosat) (substantiiviliite 2)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-mey:n}</column>
@@ -266,6 +293,7 @@ Note that whether {-pu':n:suff,nolink} is used is a property of the noun, and no
       <column name="notes_ru">Этот суффикс используется для формирования множественного числа частей тела, независимо от того, принадлежат ли они существам, способным говорить, или любому другому животному. Однако, если часть тела становится отделенной от существа и превращается во что-то, что больше не является частью тела, вместо этого используется {-mey:n:suff,nolink}. Например, множественное число «pelt» {veDDIr:n} является {veDDIrmey:n:nolink}, а не {veDDIrDu':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Esse sufixo é usado para formar o plural de partes do corpo, sejam elas de seres capazes de linguagem ou de qualquer outro animal. No entanto, se uma parte do corpo se separa de um ser e é transformada em algo que não é mais principalmente uma parte do corpo, então {-mey:n:suff,nolink} é usado. Por exemplo, o plural de {veDDIr:n} "pelt" é {veDDIrmey:n:nolink} em vez de {veDDIrDu':n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä loppuliitettä käytetään muodostamaan useita kehon osia riippumatta siitä, kuuluvatko ne kielitaitoisiin olentoihin tai mihin tahansa muuhun eläimeen. Kuitenkin, jos ruumiinosa erottuu olennosta ja muuttuu sellaiseksi, joka ei enää ole ensisijaisesti ruumiinosa, käytetään sen sijaan {-mey:n:suff,nolink}. Esimerkiksi monikko {veDDIr:n} "pelt" on {veDDIrmey:n:nolink} eikä {veDDIrDu':n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -276,6 +304,7 @@ Note that whether {-pu':n:suff,nolink} is used is a property of the noun, and no
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 2</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -283,6 +312,7 @@ Note that whether {-pu':n:suff,nolink} is used is a property of the noun, and no
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.2:src}</column>
     </table>
     <table name="mem">
@@ -296,6 +326,7 @@ Note that whether {-pu':n:suff,nolink} is used is a property of the noun, and no
       <column name="definition_ru">множественное число (в общем) (сущ. тип 2)</column>
       <column name="definition_zh_HK">複數（一般）（第二類名詞後綴）</column>
       <column name="definition_pt">plural (geral) (substantivo tipo 2)</column>
+      <column name="definition_fi">monikko (yleinen) (substantiiviliite 2)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-pu':n}, {-Du':n}</column>
@@ -308,6 +339,9 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kun tätä päätettä käytetään olentoja varten, jotka pystyvät käyttämään kieltä (katso {-pu':n}), se lisää merkitykseen käsitteen "hajallaan kaikesta". Tätä loppuliitettä ei voida käyttää ruumiinosiin (katso {-Du':n}), mutta runoilijat rikkovat joskus tätä sääntöä.
+
+Jotkut substantiivit ovat luonnostaan ​​monikkomerkityksisiä, ja yksikkömuodot ovat täysin erillisiä. Näitä luontaisesti monikkomuotoja käsitellään kieliopillisesti yksikköinä, koska niissä käytetään yksikköpronomineja ja verbi-etuliitteitä. Kun liitettä {-mey:n:nolink} käytetään näiden substantiivien yksikkömuodoihin, tuloksena oleva monikkosana sisältää merkityksen "hajallaan kaikesta". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -321,6 +355,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 2</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -328,6 +363,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.2:src}</column>
     </table>
     <table name="mem">
@@ -341,6 +377,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">так называемый (сущ. тип 3)</column>
       <column name="definition_zh_HK">所謂（第三類名詞後綴）</column>
       <column name="definition_pt">assim chamado (substantivo tipo 3)</column>
+      <column name="definition_fi">niin sanottu (substantiiviliite 3)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -351,6 +388,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Этот суффикс указывает, что существительное используется в ложной или иронической манере. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表示該名詞是以虛假或諷刺的方式使用的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que o substantivo está sendo usado de maneira falsa ou irônica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että substantiivia käytetään väärällä tai ironisella tavalla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -361,6 +399,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 3</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -368,6 +407,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.3:src}</column>
     </table>
     <table name="mem">
@@ -381,6 +421,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">по-видимому (сущ. тип 3)</column>
       <column name="definition_zh_HK">似乎（第三類名詞後綴）</column>
       <column name="definition_pt">aparente (substantivo tipo 3)</column>
+      <column name="definition_fi">ilmeisesti (substantiiviliite 3)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -391,6 +432,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Этот суффикс указывает, что говорящий думает, что объект, на который ссылается существительное, точно описан им, но имеет некоторые сомнения. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該後綴表明說話者認為名詞所指的對像已被其準確地描述了，但存在一些疑問。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que o falante acha que o objeto referido pelo substantivo é descrito com precisão por ele, mas tem algumas dúvidas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että puhuja ajattelee, että substantiivin viittaama kohde on kuvattu tarkasti, mutta hänellä on epäilyksiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -401,6 +443,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 3</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -408,6 +451,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.3:src}</column>
     </table>
     <table name="mem">
@@ -421,6 +465,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">определенно (сущ. тип 3)</column>
       <column name="definition_zh_HK">確定（第三類名詞後綴）</column>
       <column name="definition_pt">definitivo (substantivo tipo 3)</column>
+      <column name="definition_fi">selvästi (substantiiviliite 3)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -431,6 +476,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Этот суффикс указывает, что говорящий не сомневается в том, что объект, на который ссылается существительное, точно описан им. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表明，說話者毫無疑問會正確地描述名詞所指的對象。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que o falante não tem dúvida de que o objeto referido pelo substantivo é descrito com precisão por ele. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että puhujalla ei ole epäilystäkään siitä, että substantiivilla tarkoitettu objekti on kuvattu tarkasti. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -441,6 +487,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 3</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -448,6 +495,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.3:src}</column>
     </table>
     <table name="mem">
@@ -461,6 +509,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">мой, мои (сущ. тип 4)</column>
       <column name="definition_zh_HK">我的（第四類名詞後綴）</column>
       <column name="definition_pt">meu (substantivo tipo 4)</column>
+      <column name="definition_fi">minun, -ni (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-wI':n}, {jIH:n:1,pro}</column>
@@ -471,6 +520,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Считается унизительным использование этого суффикса в существительном, означающем существо, способное к языку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在帶有語言能力的名詞上使用此後綴是貶義的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É considerado depreciativo usar esse sufixo em um substantivo referente a um ser capaz de linguagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän jälkiliitteen käyttämistä pidetään halveksivana substantiivissa, joka viittaa kielitaitoon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -480,6 +530,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -487,6 +538,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -500,6 +552,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">мой, мои (для существ, способных использовать речь) (сущ. тип 4)</column>
       <column name="definition_zh_HK">我的（能用語言）（第四類名詞後綴）</column>
       <column name="definition_pt">meu (substantivo capaz de usar a linguagem) (substantivo tipo 4)</column>
+      <column name="definition_fi">minun, -ni (henkilöstä, kielenkäyttäjästä) (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-wIj:n}, {jIH:n:1,pro}</column>
@@ -510,6 +563,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Смотрите в {-pu':n:suff} объяснение, когда существительное квалифицируется как существо, способное к языку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關名詞何時具有語言能力的說明，請參見{-pu':n:suff}下的說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {-pu':n:suff} para obter uma explicação de quando um substantivo se qualifica como um ser capaz de linguagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {-pu':n:suff}-osiosta selitys siitä, milloin substantiivi luokitellaan kielikykyksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -519,6 +573,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -526,6 +581,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -539,6 +595,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">наш, наши (сущ. тип 4)</column>
       <column name="definition_zh_HK">我們（第四類名詞後綴）</column>
       <column name="definition_pt">nosso (substantivo type 4)</column>
+      <column name="definition_fi">meidän, -mme (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-ma':n}, {maH:n:1h,pro}</column>
@@ -549,6 +606,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Считается унизительным использование этого суффикса в существительном, означающем существо, способное к языку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在帶有語言能力的名詞上使用此後綴是貶義的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É considerado depreciativo usar esse sufixo em um substantivo referente a um ser capaz de linguagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän päätteen käyttämistä pidetään halveksivana substantiivissa, joka viittaa kykyyn puhua. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -558,6 +616,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -565,6 +624,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -578,6 +638,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">наш, наши (для существ, способных использовать речь) (сущ. тип 4)</column>
       <column name="definition_zh_HK">我們（能用語言）（第四類名詞後綴）</column>
       <column name="definition_pt">nosso (substantivo capaz de usar a linguagem) (substantivo tipo 4)</column>
+      <column name="definition_fi">meidän, -mme (henkilöstä, kielenkäyttäjästä) (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-maj:n}, {maH:n:1h,pro}</column>
@@ -588,6 +649,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Смотрите в {-pu':n:suff} объяснение, когда существительное квалифицируется как существо, способное к языку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關名詞何時具有語言能力的說明，請參見{-pu':n:suff}下的說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {-pu':n:suff} para obter uma explicação de quando um substantivo se qualifica como um ser capaz de linguagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {-pu':n:suff}-osiosta selitys siitä, milloin substantiivi luokitellaan kielikykyksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -597,6 +659,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -604,6 +667,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -617,6 +681,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">твой, твои (сущ. тип 4)</column>
       <column name="definition_zh_HK">你的（第四類名詞後綴）</column>
       <column name="definition_pt">seu/teu (substantivo tipo 4)</column>
+      <column name="definition_fi">sinun, -si (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-lI':n}, {SoH:n}</column>
@@ -627,6 +692,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Считается унизительным использование этого суффикса в существительном, означающем существо, способное к языку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在帶有語言能力的名詞上使用此後綴是貶義的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É considerado depreciativo usar esse sufixo em um substantivo referente a um ser capaz de linguagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän päätteen käyttämistä pidetään halveksivana substantiivissa, joka viittaa kykyyn puhua. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -636,6 +702,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -643,6 +710,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -656,6 +724,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">твой, твои (для существ, способных использовать речь) (сущ. тип 4)</column>
       <column name="definition_zh_HK">你的（能用語言）（第四類名詞後綴）</column>
       <column name="definition_pt">seu/teu (substantivo capaz de usar a linguagem) (substantivo tipo 4)</column>
+      <column name="definition_fi">sinun, -si (henkilöstä, kielenkäyttäjästä) (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-lIj:n}, {SoH:n}</column>
@@ -666,6 +735,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Смотрите в {-pu':n:suff} объяснение, когда существительное квалифицируется как существо, способное к языку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關名詞何時具有語言能力的說明，請參見{-pu':n:suff}下的說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {-pu':n:suff} para obter uma explicação de quando um substantivo se qualifica como um ser capaz de linguagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {-pu':n:suff}-osiosta selitys siitä, milloin substantiivi luokitellaan kielikykyksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -675,6 +745,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -682,6 +753,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -695,6 +767,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">ваш, ваши (сущ. тип 4)</column>
       <column name="definition_zh_HK">你們的（第四類名詞後綴）</column>
       <column name="definition_pt">seus/vosso (plural) (substantivo tipo 4)</column>
+      <column name="definition_fi">teidän, -nne (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-ra':n}, {tlhIH:n}</column>
@@ -705,6 +778,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Считается унизительным использование этого суффикса в существительном, означающем существо, способное к языку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在帶有語言能力的名詞上使用此後綴是貶義的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É considerado depreciativo usar esse sufixo em um substantivo referente a um ser capaz de linguagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -714,6 +788,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -721,6 +796,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -734,6 +810,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">ваш, ваши (для существ, способных использовать речь) (сущ. тип 4)</column>
       <column name="definition_zh_HK">你們的（能用語言）（第四類名詞後綴）</column>
       <column name="definition_pt">seus/vosso (plural) (substantivo capaz de usar o idioma) (substantivo tipo 4)</column>
+      <column name="definition_fi">teidän, -nne (henkilöstä, kielenkäyttäjästä) (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-raj:n}, {tlhIH:n}</column>
@@ -744,6 +821,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru">Смотрите в {-pu':n:suff} объяснение, когда существительное квалифицируется как существо, способное к языку. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關名詞何時具有語言能力的說明，請參見{-pu':n:suff}下的說明。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja em {-pu':n:suff} para obter uma explicação de quando um substantivo se qualifica como um ser capaz de linguagem. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -753,6 +831,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -760,6 +839,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -773,6 +853,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">его, ее (сущ. тип 4)</column>
       <column name="definition_zh_HK">他的、她的、它的（第四類名詞後綴）</column>
       <column name="definition_pt">dele, dela (substantivo tipo 4)</column>
+      <column name="definition_fi">hänen, sen, -nsa/-nsä (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'oH:n}, {ghaH:n}</column>
@@ -783,6 +864,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -792,6 +874,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -799,6 +882,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -812,6 +896,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">их (сущ. тип 4)</column>
       <column name="definition_zh_HK">他們的、她們的、它們的（第四類名詞後綴）</column>
       <column name="definition_pt">deles / delas (substantivo tipo 4)</column>
+      <column name="definition_fi">heidän, -nsa/-nsä (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIH:n}, {chaH:n}</column>
@@ -822,6 +907,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -831,6 +917,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -838,6 +925,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -851,6 +939,7 @@ Some nouns are inherently plural in meaning, with singular forms which are utter
       <column name="definition_ru">этот (сущ. тип 4)</column>
       <column name="definition_zh_HK">這（第四類名詞後綴）</column>
       <column name="definition_pt">esse (substantivo tipo 4)</column>
+      <column name="definition_fi">tämä, nämä (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-vetlh:n}</column>
@@ -863,6 +952,9 @@ For most words designating a fixed period of time, this suffix indicates the cur
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä tarkoittaa, että substantiivi viittaa esineeseen, joka on lähellä tai joka on keskustelun aihe.
+
+Suurimmalle osalle kiinteää ajanjaksoa osoittavista sanoista tämä pääte osoittaa nykyisen ajanjakson: {DISvam:n:nolink} "kuluva vuosi", {jarvam:n:nolink} "kuluva kuukausi", {Hoghvam:n:nolink} "kuluva kuukausi" jne. {jajvam:n} "nykyinen päivä" on kuitenkin ei ole täysin vaihdettavissa {DaHjaj:n}: n kanssa "tänään" .[2][1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -872,6 +964,7 @@ For most words designating a fixed period of time, this suffix indicates the cur
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -879,6 +972,7 @@ For most words designating a fixed period of time, this suffix indicates the cur
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}, [2] {msn 1997.06.29:src}</column>
     </table>
     <table name="mem">
@@ -892,6 +986,7 @@ For most words designating a fixed period of time, this suffix indicates the cur
       <column name="definition_ru">тот (сущ. тип 4)</column>
       <column name="definition_zh_HK">那（第四類名詞後綴）</column>
       <column name="definition_pt">aquele (substantivo tipo 4)</column>
+      <column name="definition_fi">tuo, nuo (substantiiviliite 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-vam:n}</column>
@@ -902,6 +997,7 @@ For most words designating a fixed period of time, this suffix indicates the cur
       <column name="notes_ru">Это указывает на то, что существительное относится к объекту, которого нет рядом или который снова упоминается как тема разговора. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這表明該名詞指的是不在附近的物體，或者該物體再次被帶出作為對話的主題。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso indica que o substantivo se refere a um objeto que não está próximo ou que é trazido novamente como o tópico da conversa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä osoittaa, että substantiivi viittaa esineeseen, joka ei ole lähellä tai joka otetaan uudelleen esiin keskustelun aiheena. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -911,6 +1007,7 @@ For most words designating a fixed period of time, this suffix indicates the cur
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -918,6 +1015,7 @@ For most words designating a fixed period of time, this suffix indicates the cur
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.4:src}</column>
     </table>
     <table name="mem">
@@ -931,6 +1029,7 @@ For most words designating a fixed period of time, this suffix indicates the cur
       <column name="definition_ru">местоположение (сущ. тип 5)</column>
       <column name="definition_zh_HK">在地方（第五類名詞後綴）</column>
       <column name="definition_pt">locativo (substantivo tipo 5)</column>
+      <column name="definition_fi">lokatiivi, -ssa/-ssä, -:n (substantiiviliite 5)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{-vo':n:suff}</column>
       <column name="see_also">{Daq:n}, {naDev:n}, {pa':n:2}, {Dat:n}, {chegh:v}</column>
@@ -946,6 +1045,11 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="notes_zh_HK"></column>
       <!-- http://www.santacruzsentinel.com/article/zz/20131109/NEWS/131107424 -->
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä pääte ilmaisee, että toiminto tapahtuu (tai on tapahtunut tai tulee tapahtumaan) sen substantiivin läheisyydessä, johon se on liitetty.[1] Sitä voidaan tyypillisesti käyttää vain fyysisiin sijainteihin.
+
+Joidenkin verbien merkitykset ovat paikannuskäsitteitä, ja {-Daq:n:suff,nolink}: n käyttämisessä tällaisten verbien kanssa on oltava varovainen. Katso lisätietoja kohdista {ghoS:v:1} ja {jaH:v}. Ammunta-verbeillä, kuten {baH:v} ja {bach:v}, {-Daq:n:suff,nolink} merkitsee kohteen.
+
+Kun verbiä käytetään adjektiivisesti, tämä pääte ja muut tyypin 5 substantiiviliitteet liitetään verbiin substantiivin sijaan.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was influenced by the locative "-tak" in the Mutsun language, which Marc Okrand wrote his Ph.D. dissertation on.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -955,6 +1059,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 5</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -962,6 +1067,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.5, 3.4, 4.4:src}, [2] {s.k 1998.03.23:src}</column>
     </table>
     <table name="mem">
@@ -975,6 +1081,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="definition_ru">из (сущ. тип 5)</column>
       <column name="definition_zh_HK">從、來自（第五類名詞後綴）</column>
       <column name="definition_pt">de (substantivo tipo 5)</column>
+      <column name="definition_fi">elatiivi, -sta/-stä (substantiiviliite 5)</column>
       <column name="synonyms"></column>
       <column name="antonyms">{-Daq:n:suff}</column>
       <column name="see_also">{chegh:v}</column>
@@ -985,6 +1092,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="notes_ru">Этот суффикс используется, когда действие идет в направлении от существительного, к которому оно прикреплено.[1] Обычно его можно использовать только для физических мест.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">當動作的方向遠離它所附加的名詞時，將使用此後綴。[1]它通常只能用於物理位置。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo é usado quando a ação está em uma direção distante do substantivo ao qual está anexada.[1] Geralmente, pode ser usado apenas para locais físicos.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä loppuliitettä käytetään, kun toiminto on suunnassa, joka on poispäin substantiivista, johon se on liitetty.[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -994,6 +1102,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 5</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1001,6 +1110,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.5:src}, [2] {s.k 1998.03.23:src}</column>
     </table>
     <table name="mem">
@@ -1014,6 +1124,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="definition_ru">из-за, потому что, благодаря (сущ. тип 5)</column>
       <column name="definition_zh_HK">因為（第五類名詞後綴）</column>
       <column name="definition_pt">porque, devido a (substantivo tipo 5)</column>
+      <column name="definition_fi">kausatiivi, koska, vuoksi (substantiiviliite 5)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1024,6 +1135,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="notes_ru">Существует суффикс глагола {-mo':v} с тем же значением. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">動詞後綴{-mo':v}具有相同的含義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um sufixo verbal {-mo':v} com o mesmo significado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On verbiliite {-mo':v}, jolla on sama merkitys. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1033,6 +1145,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 5</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1040,6 +1153,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.5:src}</column>
     </table>
     <table name="mem">
@@ -1053,6 +1167,7 @@ When a verb is used adjectivally, this suffix and the other type 5 noun suffixes
       <column name="definition_ru">для (сущ. тип 5)</column>
       <column name="definition_zh_HK">為、對（第五類名詞後綴）</column>
       <column name="definition_pt">para (substantivo tipo 5)</column>
+      <column name="definition_fi">datiivi, -lle (substantiiviliite 5)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vI'Hop:n}</column>
@@ -1067,6 +1182,11 @@ See {qawmoH:v} for an explanation of how this suffix is used with the verb suffi
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että substantiivi, johon se on liitetty, on toiminnan edunsaaja.
+
+Sitä käytetään osoittamaan epäsuora esine, kun kohde on toiminnan vastaanottaja. ({TKDA 6.8:src})
+
+Kohdasta {qawmoH:v} on selitys siitä, miten tätä päätettä käytetään verbiliitteellä {-moH:v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1076,6 +1196,7 @@ See {qawmoH:v} for an explanation of how this suffix is used with the verb suffi
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 5</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1083,6 +1204,7 @@ See {qawmoH:v} for an explanation of how this suffix is used with the verb suffi
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.5:src}</column>
     </table>
     <table name="mem">
@@ -1096,6 +1218,7 @@ See {qawmoH:v} for an explanation of how this suffix is used with the verb suffi
       <column name="definition_ru">тема (сущ. тип 5)</column>
       <column name="definition_zh_HK">主題（第五類名詞後綴）</column>
       <column name="definition_pt">tópico (substantivo tipo 5)</column>
+      <column name="definition_fi">aiheellistin (substantiiviliite 5)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1114,6 +1237,15 @@ Do not confuse this suffix with the pronoun {'e':n:pro}.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä loppuliite korostaa, että substantiivi, johon se on liitetty lauseen aiheena. katso {-bogh:v}).
+
+Jos objektin substantiivi on merkitty {-'e':n:suff,nolink}: llä, se voi tulla ennen verbiä edeltäviä adverbeja.
+
+Jos haluat käyttää {-'e':n:suff,nolink}-nimisarjaa (eli substantiiveja, jotka on liitetty {je:conj}-, {joq:conj}- tai {ghap:conj}-sarjoihin), se on liitettävä kuhunkin substantiiviin erikseen. "olemaan" -rakenteen aihe koostuu useista asioista.
+
+Morskanin murteessa (katso [1]1) tätä päätettä ei käytetä merkitsemään kohdetta "olla" -rakenteissa. Jos loppuliitettä käytetään tällaisessa lauseessa, se palvelee tavanomaista korostustoimintoa.[5]
+
+Älä sekoita tätä pääteosaa pronominiin {'e':n:pro}.[2][3][4]{mo'rISqa':n} [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The example from {TKD:src} contains an error: the {jI-:sen:nolink} prefix was omitted by mistake.[1]
 
 In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
@@ -1130,6 +1262,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">noun type 5</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1137,6 +1270,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.3.5:src}, [2] {TKD 6.3:src}, [3] {TKDA 6.7:src}, [4] {HQ 4.2, p.5-6, Jun. 1995:src}, [5] {KGT p.23:src}, [6] {SkyBox cards:src}, [7] {paq'batlh p.102-103:src}</column>
     </table>
     <table name="mem">
@@ -1150,6 +1284,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">сам себя (глагол тип 1)</column>
       <column name="definition_zh_HK">自己（第一類動詞後綴）</column>
       <column name="definition_pt">si mesmo (verbal tipo 1)</column>
+      <column name="definition_fi">itseään (verbipääte 1)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1160,6 +1295,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Когда этот суффикс используется, префикс глагола должен указывать «нет объекта». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">使用此後綴時，動詞前綴必須指示“無對象”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Quando esse sufixo é usado, o prefixo do verbo deve indicar "nenhum objeto". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kun tätä pääteosaa käytetään, verbin etuliitteen on ilmoitettava "ei objektia". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">"Ego".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1169,6 +1305,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 1, I-me, you-you, he-him, she-her, it-it, we-us, they-them</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1176,6 +1313,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.1:src}</column>
     </table>
     <table name="mem">
@@ -1189,6 +1327,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">один другого, друг друга (глагол тип 1)</column>
       <column name="definition_zh_HK">彼此（第一類動詞後綴）</column>
       <column name="definition_pt">um ao outro (verbal tipo 1)</column>
+      <column name="definition_fi">toisiaan (verbipääte 1)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1199,6 +1338,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Этот суффикс используется только во множественном числе. Когда этот суффикс используется, префикс глагола должен указывать «нет объекта». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴僅適用於多個主題。使用此後綴時，動詞前綴必須指示“無對象”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo é usado apenas com assuntos do plural. Quando esse sufixo é usado, o prefixo do verbo deve indicar "nenhum objeto". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä päätettä käytetään vain monikkomuotojen kanssa. Kun tätä pääteosaa käytetään, verbin etuliitteen on ilmoitettava "ei objektia". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1208,6 +1348,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 1, we-us, you-you, they-them</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1215,6 +1356,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.1:src}</column>
     </table>
     <table name="mem">
@@ -1228,6 +1370,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">нужно (глагол тип 2)</column>
       <column name="definition_zh_HK">需要（第二類動詞後綴）</column>
       <column name="definition_pt">necessidade (verbal tipo 2)</column>
+      <column name="definition_fi">tarve (verbipääte 2)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1238,6 +1381,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Этот суффикс указывает, что субъект должен выполнить действие. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴指示對象需要執行操作。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que o sujeito precisa executar a ação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että kohteen on tehtävä toimenpide. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1247,6 +1391,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 2</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1254,6 +1399,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.2:src}</column>
     </table>
     <table name="mem">
@@ -1267,6 +1413,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">добровольно готов (глагол тип 2)</column>
       <column name="definition_zh_HK">願意（第二類動詞後綴）</column>
       <column name="definition_pt">querendo (verbal tipo 2)</column>
+      <column name="definition_fi">halukas (verbipääte 2)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1277,6 +1424,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Этот суффикс указывает, что субъект готов выполнить действие. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表示對象願意執行該操作。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que o sujeito está disposto a executar a ação. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että kohde on halukas suorittamaan toiminnon. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1286,6 +1434,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 2</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1293,6 +1442,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.2:src}</column>
     </table>
     <table name="mem">
@@ -1306,6 +1456,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">готов (для существ) (глагол тип 2)</column>
       <column name="definition_zh_HK">準備好（生物）（第二類動詞後綴）</column>
       <column name="definition_pt">pronto, preparado (referente aos seres) (verbal tipo 2)</column>
+      <column name="definition_fi">valmis (henkilöstä) (verbipääte 2)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1316,6 +1467,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">動詞{ghuS:v:0}絕不帶有後綴{-rup:v:suff,nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Verbi {ghuS:v:0} ei koskaan ota loppuliitettä {-rup:v:suff,nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1325,6 +1477,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 2</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1332,6 +1485,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.2:src}</column>
     </table>
     <table name="mem">
@@ -1345,6 +1499,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">готов (для устройств) (глагол тип 2)</column>
       <column name="definition_zh_HK">準備好、設置好（設備）（第二類動詞後綴）</column>
       <column name="definition_pt">pronto, preparado (referindo a dispositivos) (verbal tipo 2)</column>
+      <column name="definition_fi">valmis (asiasta) (verbipääte 2)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1355,6 +1510,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1365,6 +1521,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 2</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1372,6 +1529,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.2:src}</column>
     </table>
     <table name="mem">
@@ -1385,6 +1543,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">бояться (глагол тип 2)</column>
       <column name="definition_zh_HK">害怕（第二類動詞後綴）</column>
       <column name="definition_pt">com medo (verbal tipo 2)</column>
+      <column name="definition_fi">pelokas (verbipääte 2)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1395,6 +1554,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Культурно запрещено использовать этот суффикс с темой от первого лица. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在文化上忌諱將後綴用於第一人稱主題。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">É culturalmente tabu usar esse sufixo com um assunto em primeira pessoa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On kulttuurisesti tabu käyttää tätä päätettä ensimmäisen persoonan kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The unstated exception to the rule is that it is not taboo if {-vIp:v:suff,nolink} is negated with {-be':v:suff}, as illustrated by the sentences on {TKD:src} p.49.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1404,6 +1564,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 2</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1411,6 +1572,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.2:src}</column>
     </table>
     <table name="mem">
@@ -1424,6 +1586,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">изменение в состоянии, изменение в направлении (глагол тип 3)</column>
       <column name="definition_zh_HK">改變狀態、改變方向（第三類動詞後綴）</column>
       <column name="definition_pt">mudança de estado, mudança de direção (verbal tipo 3)</column>
+      <column name="definition_fi">alkaa tehdä, muuttua (tilassa, suunnassa) (verbipääte 3)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{choH:v}</column>
@@ -1434,6 +1597,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Этот суффикс указывает, что действие, описываемое глаголом, включает в себя изменение положения дел, которое существовало до того, как действие имело место. Английский перевод этого суффикса может быть "стать" или "начать". [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該後綴表明，動詞描述的動作涉及到事態發生變化，而事態發生在動作發生之前。此後綴的英文翻譯可能是“ become”或“ begin to”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que a ação descrita pelo verbo envolve uma mudança do estado de coisas como existia antes da ação ocorrer. A tradução para o inglês deste sufixo pode ser "tornar-se" ou "começar a". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä jälkiliite osoittaa, että verbin kuvaamaan toimintaan liittyy muutos tilanteesta, joka oli olemassa ennen toiminnan tapahtumista. Tämän jälkiliitteen englanninkielinen käännös voi olla "tullut" tai "alkanut". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1443,6 +1607,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 3, become, begin to</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1450,6 +1615,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.3:src}</column>
     </table>
     <table name="mem">
@@ -1463,6 +1629,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">продолжать, возобновлять (глагол тип 3)</column>
       <column name="definition_zh_HK">恢復、重複、再做（第三類動詞後綴）</column>
       <column name="definition_pt">resumir, fazer novamente (verbal tipo 3)</column>
+      <column name="definition_fi">jatkaa, tehdä uudestaan (verrbipääte 3)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1473,6 +1640,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Этот суффикс означает, что действие имело место, затем прекратилось, а затем началось снова. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表示該操作已發生，然後停止，然後再次開始。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo implica que a ação estava ocorrendo, depois parou e começou novamente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä pääte tarkoittaa, että toiminta oli ollut käynnissä, sitten pysähtynyt ja sitten aloitettu uudelleen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1482,6 +1650,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 3</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1489,6 +1658,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.3:src}</column>
     </table>
     <table name="mem">
@@ -1502,6 +1672,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">причинять, быть причиной (глагол тип 4)</column>
       <column name="definition_zh_HK">引起、導致（第四類動詞後綴）</column>
       <column name="definition_pt">causa (verbal tipo 4)</column>
+      <column name="definition_fi">aiheuttaa, -taa (verbipääte 4)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1512,6 +1683,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Посмотрите {qawmoH:v} для примера того, как использовать это с глаголом, который берет объект. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關如何將其與帶有對象的動詞一起使用的示例，請參見{qawmoH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Consulte {qawmoH:v} para obter um exemplo de como usar isso com um verbo que aceita um objeto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {qawmoH:v}-esimerkki siitä, miten tätä käytetään objektin ottavan verbin kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1528,6 +1700,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 4</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1535,6 +1708,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.4:src}, [2] {SkyBox 20:src} (reprinted in {HQ 5.2, p.14, Jun. 1996:src}), [3] {paq'batlh p.179:src}</column>
     </table>
     <table name="mem">
@@ -1548,6 +1722,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">неопределенное дополнение (глагол тип 5)</column>
       <column name="definition_zh_HK">不定主語（第五類動詞後綴）</column>
       <column name="definition_pt">sujeito indefinido (verbal tipo 5)</column>
+      <column name="definition_fi">määrittelemätön tekijä (verbipääte 5)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tu'lu':v}, {vay':n}</column>
@@ -1558,6 +1733,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Этот суффикс указывает, что предмет неизвестен, неопределен или является общим. Он используется только с префиксами, которые обычно обозначают единичный объект от третьего лица ({vI-:v}, {Da-:v}, {wI-:v}, {bo-:v} и {lu-:v}; а также {0:v:pref}). При использовании с этим суффиксом эти префиксы меняются по значению, поэтому вместо указания лица и номера субъекта вместо них указываются лицо и номер объекта. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表示主題未知，不確定或一般。它僅與通常指示第三人稱單數對象的前綴一起使用（{vI-:v}，{Da-:v}，{wI-:v}，{bo-:v}和{lu-:v}；以及{0:v:pref}）。與該後綴一起使用時，這些前綴的含義發生了變化，因此，它們代替指示對象的人和編號，而不指示對象的人和編號。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que o assunto é desconhecido, indefinido ou geral. É usado apenas com prefixos que normalmente indicam um objeto singular na terceira pessoa ({vI-:v}, {Da-:v}, {wI-:v}, {bo-:v} e {lu-:v}; e também {0:v:pref}). Quando usados ​​com esse sufixo, esses prefixos mudam de significado para que, em vez de indicar a pessoa e o número do sujeito, indiquem a pessoa e o número do objeto. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että kohde on tuntematon, määrittelemätön tai yleinen. Sitä käytetään vain etuliitteiden kanssa, jotka normaalisti ilmaisevat kolmannen persoonan yksikön ({vI-:v}, {Da-:v}, {wI-:v}, {bo-:v} ja {lu-:v}; ja myös {0:v:pref}). Kun käytetään tämän jälkiliitteen kanssa, näiden etuliitteiden merkitys muuttuu siten, että sen sijaan, että ilmoitettaisiin kohteen henkilö ja numero, ne ilmoittavat sen sijaan kohteen henkilön ja numeron. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1568,6 +1744,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 5</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1575,6 +1752,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.5:src}</column>
     </table>
     <table name="mem">
@@ -1588,6 +1766,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">мочь, быть способным (глагол тип 5)</column>
       <column name="definition_zh_HK">可以、有能力、有本事（第五類動詞後綴）</column>
       <column name="definition_pt">capaz, poder (verbal tipo 5)</column>
+      <column name="definition_fi">voida, osata (verbipääte 5)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{laH:n}</column>
@@ -1598,6 +1777,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1607,6 +1787,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 5</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1614,6 +1795,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.5:src}</column>
     </table>
     <table name="mem">
@@ -1627,6 +1809,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">можно (глагол типа 5 - неграмотно) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一罐（動詞類型5-不合語法） [AUTOTRANSLATED]</column>
       <column name="definition_pt">pode-se (verbal tipo 5 - não gramatical)</column>
+      <column name="definition_fi">osataan, voidaan (verbipääte 5, kieliopin vastainen)</column>
       <column name="synonyms">{-la':v}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1637,6 +1820,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">一些發言者使用此功能將{-lu':v}和{-laH:v}合併為一個後綴，以同時表達不確定的主題和能力。沒有人接受這種語法上的解釋，但它的不恰當之處在於它具有雄辯的影響力。除非人們對克林崗風格的細微差別感到非常滿意，否則應避免這樣做。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Jotkut puhujat käyttävät tätä yhdistämään {-lu':v} ja {-laH:v} yhdeksi loppuliitteeksi ilmaisemaan sekä määrittelemätön aihe että kyky samanaikaisesti. Kukaan ei hyväksy tätä rakennetta kieliopiksi, mutta sen epäasianmukaisuus antaa sille äänestysmahdollisuuden. Sitä tulisi välttää, ellei joku ole kovin tyytyväinen Klingon-tyylin vivahteisiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1646,6 +1830,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1653,6 +1838,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.181:src}</column>
     </table>
     <table name="mem">
@@ -1666,6 +1852,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">можно (глагол типа 5 - неграмотно) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一罐（動詞類型5-不合語法） [AUTOTRANSLATED]</column>
       <column name="definition_pt">pode-se (verbal tipo 5 - não gramatical)</column>
+      <column name="definition_fi">osataan, voidaan (verbipääte 5, kieliopin vastainen)</column>
       <column name="synonyms">{-luH:v}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1676,6 +1863,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="notes_ru">Некоторые ораторы используют это для объединения {-lu':v} и {-laH:v} в один суффикс, чтобы выразить одновременно неопределенный субъект и способность. Никто не принимает эту конструкцию как грамматическую, но ее неуместность - вот что дает ей красноречивое влияние. Этого следует избегать, если только вы не очень довольны нюансами стиля клингон. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">一些發言者使用此功能將{-lu':v}和{-laH:v}合併為一個後綴，以同時表達不確定的主題和能力。沒有人接受這種語法上的解釋，但它的不恰當之處在於它具有雄辯的影響力。除非人們對克林崗風格的細微差別感到非常滿意，否則應避免這樣做。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Alguns alto-falantes usam isso para combinar {-lu':v} e {-laH:v} em um sufixo, para expressar assunto e capacidade indefinidos simultaneamente. Ninguém aceita essa construção como gramatical, mas sua inadequação é o que lhe confere influência elocucionária. Deve ser evitado a menos que se sinta muito confortável com as nuances do estilo klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jotkut puhujat käyttävät tätä yhdistämään {-lu':v} ja {-laH:v} yhdeksi loppuliitteeksi ilmaisemaan sekä määrittelemätön aihe että kyky samanaikaisesti. Kukaan ei hyväksy tätä rakennetta kieliopiksi, mutta sen epäasianmukaisuus antaa sille äänestysmahdollisuuden. Sitä tulisi välttää, ellei joku ole kovin tyytyväinen Klingon-tyylin vivahteisiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1685,6 +1873,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1692,6 +1881,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.181:src}</column>
     </table>
     <table name="mem">
@@ -1705,6 +1895,7 @@ In {HQ 4.2:src}, this suffix is also described as a focus marker.[4]</column>
       <column name="definition_ru">идеально, совершенно (глагол тип 6)</column>
       <column name="definition_zh_HK">完美、無瑕（第六類動詞後綴）</column>
       <column name="definition_pt">claramente, perfeitamente (verbal tipo 6)</column>
+      <column name="definition_fi">täydellisesti (verbipääte 6)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1717,6 +1908,9 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Kun sitä käytetään joidenkin taisteluverbien kanssa, tämä pääte tarkoittaa, että taistelut johtavat kuolemaan (katso {Suvchu':v}, {Hay'chu':v}).
+
+Kun sitä käytetään {chuH:v:1}: n kanssa, se tarkoittaa, että heitetty keihäs osuu kohteeseen.[2, p.49][2, p.64] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1728,6 +1922,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 6, completely, fully</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1735,6 +1930,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.6:src}, [2] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -1748,6 +1944,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="definition_ru">определенно, без сомнений (глагол тип 6)</column>
       <column name="definition_zh_HK">當然、一定（第六類動詞後綴）</column>
       <column name="definition_pt">certamente, sem dúvida (verbal tipo 6)</column>
+      <column name="definition_fi">varmasti, kiistatta (verbipääte 6)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1758,6 +1955,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1767,6 +1965,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 6</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1774,6 +1973,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.6:src}</column>
     </table>
     <table name="mem">
@@ -1787,6 +1987,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="definition_ru">очевидно (глагол тип 6)</column>
       <column name="definition_zh_HK">顯然（第六類動詞後綴）</column>
       <column name="definition_pt">obviamente (verbal tipo 6)</column>
+      <column name="definition_fi">selvästi (verbipääte 6)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1797,6 +1998,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="notes_ru">Этот суффикс указывает, что говорящий считает, что утверждение очевидно для слушателя. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表示講話者認為斷言對於聽眾是顯而易見的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que o falante acha que a afirmação é óbvia para o ouvinte. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite kertoo puhujan mielestä väitteen olevan ilmeinen kuuntelijalle. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1806,6 +2008,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 6</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1813,6 +2016,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA 4.2.6:src}</column>
     </table>
     <table name="mem">
@@ -1826,6 +2030,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="definition_ru">по-видимому (глагол тип 6)</column>
       <column name="definition_zh_HK">似乎、貌似（第六類動詞後綴）</column>
       <column name="definition_pt">aparentemente (verbal tipo 6)</column>
+      <column name="definition_fi">ilmeisesti (verbipääte 6)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1836,6 +2041,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="notes_ru">Этот суффикс выражает неопределенность со стороны говорящего. Это может быть переведено как «я думаю» или «я подозреваю». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表示發言人的不確定性。它可能被翻譯為“我認為”或“我懷疑”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo expressa incerteza por parte do falante. Pode ser traduzido como "eu acho" ou "eu suspeito". [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1845,6 +2051,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 6, suspect, think</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1852,6 +2059,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.6:src}</column>
     </table>
     <table name="mem">
@@ -1865,6 +2073,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="definition_ru">законченность действия (глагол тип 7)</column>
       <column name="definition_zh_HK">完成（第七類動詞後綴）</column>
       <column name="definition_pt">perfeito (verbal tipo 7)</column>
+      <column name="definition_fi">perfektiivi (verbipääte 7)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1875,6 +2084,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="notes_ru">Этот суффикс указывает, что действие завершено. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表示操作已完成。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que uma ação foi concluída. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että toiminto on valmis. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1884,6 +2094,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 7</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1891,6 +2102,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.7:src}</column>
     </table>
     <table name="mem">
@@ -1904,6 +2116,7 @@ When used with {chuH:v:1}, it means the target is actually hit by the thrown spe
       <column name="definition_ru">выполнено, готово (глагол тип 7)</column>
       <column name="definition_zh_HK">故意完成（第7類動詞後綴）</column>
       <column name="definition_pt">concluído, feito (verbal tipo 7)</column>
+      <column name="definition_fi">suoritettu, tehty (teelinen perfektiivi) (verbipääte 7)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1916,6 +2129,9 @@ There is a special verbal construction, {rIntaH:v}, which denotes a similar mean
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että toiminto on saatu päätökseen ja että toiminta on tarkoituksella suoritettu.
+
+On olemassa erityinen sanallinen rakenne, {rIntaH:v}, joka merkitsee samanlaista merkitystä, mutta jolla on vielä lopullisen merkitys. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1925,6 +2141,7 @@ There is a special verbal construction, {rIntaH:v}, which denotes a similar mean
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 7</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1932,6 +2149,7 @@ There is a special verbal construction, {rIntaH:v}, which denotes a similar mean
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.7:src}</column>
     </table>
     <table name="mem">
@@ -1945,6 +2163,7 @@ There is a special verbal construction, {rIntaH:v}, which denotes a similar mean
       <column name="definition_ru">длительность действия (глагол тип 7)</column>
       <column name="definition_zh_HK">連續（第七類動詞後綴）</column>
       <column name="definition_pt">contínuo (verbal tipo 7)</column>
+      <column name="definition_fi">imperfektiivi, jatkuva tekeminen (verbipääte 7)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-vIS:v:suff}</column>
@@ -1957,6 +2176,9 @@ When using a pronoun as a "to be" construction to identify the location of somet
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä pääte osoittaa, että toiminto on käynnissä.
+
+Kun pronominia käytetään olemaan "olemaan" -rakenne jonkin sijainnin tunnistamiseksi, on yleisempää käyttää {-taH:v:nolink} puhuttaessa asioista, jotka ovat melko liikkuvia ja jättävät sen pois puhuessaan asioista, jotka ovat yleensä liikkumattomia tai harvoin liikkuvia, mutta tämä on vain taipumus eikä sääntö.[3] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -1968,6 +2190,7 @@ When using a pronoun as a "to be" construction to identify the location of somet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 7, always</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1975,6 +2198,7 @@ When using a pronoun as a "to be" construction to identify the location of somet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.7:src}, [2] {KGT p.25:src}, [3] {KLI mailing list 2020.02.11:src}</column>
     </table>
     <table name="mem">
@@ -1988,6 +2212,7 @@ When using a pronoun as a "to be" construction to identify the location of somet
       <column name="definition_ru">прогресс (глагол тип 7)</column>
       <column name="definition_zh_HK">進行（第七類動詞後綴）</column>
       <column name="definition_pt">progresso (verbal tipo 7)</column>
+      <column name="definition_fi">teelinen imperfektiivi, edistyminen (verbipääte 7)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1998,6 +2223,7 @@ When using a pronoun as a "to be" construction to identify the location of somet
       <column name="notes_ru">Этот суффикс указывает, что действие продолжается и идет к известной цели или точке остановки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴表示該操作正在進行中，並且正在朝著已知目標或停止點前進。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo indica que a ação está em andamento e está avançando em direção a um objetivo ou ponto de parada conhecido. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että toiminta on käynnissä ja etenee kohti tunnettua tavoitetta tai pysähdyskohtaa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2007,6 +2233,7 @@ When using a pronoun as a "to be" construction to identify the location of somet
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 7</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2014,6 +2241,7 @@ When using a pronoun as a "to be" construction to identify the location of somet
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.7:src}</column>
     </table>
     <table name="mem">
@@ -2027,6 +2255,7 @@ When using a pronoun as a "to be" construction to identify the location of somet
       <column name="definition_ru">выражение почтения (глагол тип 8)</column>
       <column name="definition_zh_HK">敬意（第八類動詞後綴）</column>
       <column name="definition_pt">honorífico (verbal tipo 8)</column>
+      <column name="definition_fi">kunnioitus (verbipääte 8)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yI':v}</column>
@@ -2039,6 +2268,9 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Klingonit käyttävät tätä päätettä harvoin. Se ilmaisee yleensä äärimmäistä kohteliaisuutta tai kunnioitusta, ja sitä käytetään vain ylivoimaisen puheenvuoroon.
+
+Tätä loppuliitettä käytetään myös joidenkin taisteluverbien kanssa osoittaakseen, että verbi viittaa itsemurhayritykseen. Esimerkiksi {HIvneS:v} tarkoittaa, että itsemurha on osa hyökkäyssuunnitelmaa, ja vastaavasti {HubneS:v} tarkoittaa, että itsemurha on osa puolustussuunnitelmaa.[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2049,6 +2281,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">honourific, verb type 8</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2056,6 +2289,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.8:src}, [2] {KGT p.49:src}</column>
     </table>
     <table name="mem">
@@ -2069,6 +2303,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="definition_ru">когда, как только (глагол тип 9)</column>
       <column name="definition_zh_HK">一經、就（第九類動詞後綴）</column>
       <column name="definition_pt">quando, assim que (verbal tipo 9)</column>
+      <column name="definition_fi">heti kun (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2079,6 +2314,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2088,6 +2324,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2095,6 +2332,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.9, 6.2.2:src}</column>
     </table>
     <table name="mem">
@@ -2108,6 +2346,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="definition_ru">если (глагол тип 9)</column>
       <column name="definition_zh_HK">如果（第九類動詞後綴）</column>
       <column name="definition_pt">se (verbal tipo 9)</column>
+      <column name="definition_fi">jos (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2118,6 +2357,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2127,6 +2367,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2134,6 +2375,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.9, 6.2.2:src}</column>
     </table>
     <table name="mem">
@@ -2147,6 +2389,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="definition_ru">до, прежде (глагол тип 9)</column>
       <column name="definition_zh_HK">之前（第九類動詞後綴）</column>
       <column name="definition_pt">antes de (verbal tipo 9)</column>
+      <column name="definition_fi">ennen kun (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2157,6 +2400,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2167,6 +2411,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2174,6 +2419,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.9, 6.2.2:src}</column>
     </table>
     <table name="mem">
@@ -2187,6 +2433,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="definition_ru">пока, в то время как (глагол тип 9)</column>
       <column name="definition_zh_HK">當中（第九類動詞後綴）</column>
       <column name="definition_pt">enquanto (verbal tipo 9)</column>
+      <column name="definition_fi">kun, -en, -essa (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2197,6 +2444,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="notes_ru">Это всегда используется с суффиксом типа 7 {-taH:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">始終與類型7後綴{-taH:v}一起使用。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é sempre usado com o sufixo tipo 7 {-taH:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään aina tyypin 7 loppuliitteen {-taH:v} kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2206,6 +2454,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2213,6 +2462,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.9, 6.2.2:src}</column>
     </table>
     <table name="mem">
@@ -2226,6 +2476,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="definition_ru">из-за, потому что, благодаря (глагол тип 9)</column>
       <column name="definition_zh_HK">因為（第九類動詞後綴）</column>
       <column name="definition_pt">devido a, por causa de (verbal tipo 9)</column>
+      <column name="definition_fi">koska (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2236,6 +2487,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="notes_ru">Существует суффикс существительного {-mo':n} с тем же значением. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有一個名詞後綴{-mo':n}含義相同。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Existe um sufixo substantivo {-mo':n} com o mesmo significado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">On substantiiviliite {-mo':n}, jolla on sama merkitys. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2245,6 +2497,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2252,6 +2505,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA 4.2.9:src}</column>
     </table>
     <table name="mem">
@@ -2265,6 +2519,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="definition_ru">который (глагол тип 9)</column>
       <column name="definition_zh_HK">嘅（第九類動詞後綴）</column>
       <column name="definition_pt">o qual (verbal tipo 9)</column>
+      <column name="definition_fi">joka (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2275,6 +2530,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2284,6 +2540,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2291,6 +2548,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.9, 6.2.3:src}</column>
     </table>
     <table name="mem">
@@ -2304,6 +2562,7 @@ This suffix is also used with some verbs of fighting to indicate that the verb r
       <column name="definition_ru">для (глагол тип 9)</column>
       <column name="definition_zh_HK">為了（第九類動詞後綴）</column>
       <column name="definition_pt">para, com a finalidade de, a fim de (verbal tipo 9)</column>
+      <column name="definition_fi">jotta, -ksi (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2316,6 +2575,9 @@ There is an article in {HQ 7.3:src} which examines {-meH:v:suff,nolink} clauses 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tarkoituslauseke edeltää aina substantiivia tai verbiä, jonka tarkoitusta se kuvaa.[1]
+
+{HQ 7.3:src}-artikkelissa on artikkeli, jossa tarkastellaan {-meH:v:suff,nolink}-lauseita, jotka muuttavat substantiiveja.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2325,6 +2587,7 @@ There is an article in {HQ 7.3:src} which examines {-meH:v:suff,nolink} clauses 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2332,6 +2595,7 @@ There is an article in {HQ 7.3:src} which examines {-meH:v:suff,nolink} clauses 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.9, 6.2.4:src}, [2] {HQ 7.3, p.6, Sept. 1998:src}</column>
     </table>
     <table name="mem">
@@ -2345,6 +2609,7 @@ There is an article in {HQ 7.3:src} which examines {-meH:v:suff,nolink} clauses 
       <column name="definition_ru">вопрос (глагол тип 9)</column>
       <column name="definition_zh_HK">疑問句（第九類動詞後綴）</column>
       <column name="definition_pt">interrogativo (verbal tipo 9)</column>
+      <column name="definition_fi">interrogatiivi (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{HIja':excl}, {HISlaH:excl}, {ghobe':excl}</column>
@@ -2355,6 +2620,7 @@ There is an article in {HQ 7.3:src} which examines {-meH:v:suff,nolink} clauses 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2364,6 +2630,7 @@ There is an article in {HQ 7.3:src} which examines {-meH:v:suff,nolink} clauses 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2371,6 +2638,7 @@ There is an article in {HQ 7.3:src} which examines {-meH:v:suff,nolink} clauses 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.2.9:src}</column>
     </table>
     <table name="mem">
@@ -2384,6 +2652,7 @@ There is an article in {HQ 7.3:src} which examines {-meH:v:suff,nolink} clauses 
       <column name="definition_ru">да будет (глагол тип 9)</column>
       <column name="definition_zh_HK">願、祝（第九類動詞後綴）</column>
       <column name="definition_pt">que (desejo) (verbal tipo 9)</column>
+      <column name="definition_fi">jussiivi, -koon/-koot (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIn:v}</column>
@@ -2396,6 +2665,9 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä pääte ilmaisee puhujan toiveen tai toiveen siitä, että jotain tapahtuu tulevaisuudessa.
+
+Tämä pääte on liitetty paahtoleivän verbiin, joka tulee aina viimeiseksi paitsi {Sa'Qej Sep:n}- ja {noHva'Dut Sep:n}-murteissa.[1][2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">When this suffix is used, there is allegedly never a Type 7 aspect suffix.[1] However, this "rule" is contradicted by canon, as can be seen from the examples.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2407,6 +2679,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2414,6 +2687,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA 4.2.9:src}, [2] {KGT p.25-26:src}</column>
     </table>
     <table name="mem">
@@ -2427,6 +2701,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="definition_ru">тот, кто делает /то, которое делает (глагол тип 9)</column>
       <column name="definition_zh_HK">者、器；做或是的人或事物（第九類動詞後綴）</column>
       <column name="definition_pt">quem faz, coisa que faz (verbal tipo 9)</column>
+      <column name="definition_fi">joka tekee, -ja/-jä (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2437,6 +2712,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2446,6 +2722,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2453,6 +2730,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 3.2.2, 4.2.9:src}</column>
     </table>
     <table name="mem">
@@ -2466,6 +2744,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="definition_ru">существительное (глагол тип 9)</column>
       <column name="definition_zh_HK">名詞化器（第九類動詞後綴）</column>
       <column name="definition_pt">nominalizador (verbal tipo 9)</column>
+      <column name="definition_fi">substantivisoija, -uus/-yys (verbipääte 9)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2476,6 +2755,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="notes_ru">Этот суффикс обычно не используется для глагола без другого суффикса или для глагола с префиксом. Когда он прикреплен к глаголу состояния, он дает значение, подобное «-ness», а на активном глаголе - что-то вроде «-tion».[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該後綴通常不用於沒有另一個後綴的動詞或帶前綴的動詞。當它附加到一個謂詞動詞上時，其含義為“ -ness”，而在一個主動動詞上則表示“ -tion”。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo geralmente não é usado em um verbo sem outro sufixo ou em um com prefixo. Quando é anexado a um verbo estático, dá um significado como "-ness", enquanto em um verbo ativo significa algo como "-tion".[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä loppuliitettä ei yleensä käytetä verbissä, jossa ei ole toista loppuliitettä, tai yhdessä, jossa on etuliite. Kun se on liitetty staattiseen verbiin, se antaa merkityksen, kuten "-ness", kun taas aktiivisella verbillä se tarkoittaa jotain "-tion".[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2490,6 +2770,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nominaliser, verb type 9</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2497,6 +2778,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKDA 4.2.9:src}, [2] {HQ 3.3, p.10-13, Sept. 1994:src}</column>
     </table>
     <table name="mem">
@@ -2510,6 +2792,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="definition_ru">не (глагол тип R)</column>
       <column name="definition_zh_HK">不、沒（動詞流浪後綴）</column>
       <column name="definition_pt">não (verbal tipo R)</column>
+      <column name="definition_fi">ei (seikkailija)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-Qo':v:suff}</column>
@@ -2520,6 +2803,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="notes_ru">Это следует концепции, которая отрицает. Его нельзя использовать для формирования отрицательных императивов, то есть его нельзя использовать для обозначения «не» (для которого вместо этого используется {-Qo':v}) [1; 3]. Однако такая команда, как {HIleghbe'moH:sen:nolink}, возможна.[3] Этот суффикс можно применять к глаголам, используемым в качестве прилагательных.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這遵循其否定的概念。它不能用於形成否定命令，即不能用於表示“不要”（為此使用{-Qo':v}代替）[1; 3]。但是，可以使用諸如{HIleghbe'moH:sen:nolink}之類的命令。[3]該後綴可以應用於用作形容詞的動詞。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso segue o conceito que nega. Ele não pode ser usado para formar imperativos negativos, ou seja, não pode ser usado para significar "não" (para o qual, em vez disso, use {-Qo':v}) [1; 3]. No entanto, um comando como {HIleghbe'moH:sen:nolink} é possível.[3] Esse sufixo pode ser aplicado aos verbos usados ​​como adjetivos.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä seuraa käsitystä, jonka se hylkää. Sitä ei voida käyttää muodostamaan negatiivisia vaatimuksia, toisin sanoen sitä ei voida käyttää merkitsemään "älä" (johon käytetään {-Qo':v} sen sijaan) [1; 3]. Komento, kuten {HIleghbe'moH:sen:nolink}, on kuitenkin mahdollista.[3] Tätä jälkiliitettä voidaan soveltaa verbeihin, joita käytetään adjektiivina.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -2530,6 +2814,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rover, verb type R</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2537,6 +2822,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.3:src}, [2] {PK:src}, [3] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -2550,6 +2836,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="definition_ru">не буду! (глагол тип R)</column>
       <column name="definition_zh_HK">不要！、不會！（動詞流浪後綴）</column>
       <column name="definition_pt">não !, não vou! (verbal tipo R)</column>
+      <column name="definition_fi">kieltäytyminen (seikkailija)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{-be':v:suff}, {Qo':excl}</column>
@@ -2560,6 +2847,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="notes_ru">Этот суффикс используется для обозначения отказа. Это также используется в императивах. Это всегда происходит последним, если за ним не следует суффикс типа 9. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此後綴用於表示拒絕。它也用於命令中。它總是最後發生，除非後面跟著9型後綴。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse sufixo é usado para denotar recusa. Também é usado em imperativos. Sempre ocorre por último, a menos que seja seguido por um sufixo do tipo 9. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2569,6 +2857,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rover, verb type R</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2576,6 +2865,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.3:src}</column>
     </table>
     <table name="mem">
@@ -2589,6 +2879,7 @@ This suffix is attached to the verb in toasts, which always comes last except in
       <column name="definition_ru">отменить, сделать неправильно (глагол тип R)</column>
       <column name="definition_zh_HK">撤消、做錯（動詞流浪後綴）</column>
       <column name="definition_pt">desfazer, fazer de forma incorreta (verbal type R)</column>
+      <column name="definition_fi">vastakohta, tehdä väärin (seikkailija)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2601,6 +2892,9 @@ This suffix can be applied to some adverbials, but not to all of them.[2; 3] The
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä loppuliite osoittaa, että jokin aiemmin tehdyistä on nyt kumottu tai että jotain on tehty väärin. Huolimatta siitä, että se luokitellaan kuljettajaksi, tämä pääte esiintyy välittömästi verbin jälkeen, ennen muita päätteitä.[1]
+
+Tätä loppuliitettä voidaan käyttää joihinkin adverbeihin, mutta ei kaikkiin.[2; 3]{Duj ngaDHa':n}[4] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">While {-Ha':v:suff,nolink} can mean different things on different verbs, it appears to favour a fixed meaning for any particular verb, depending on whether the quality or action described by the verb has an opposite or a reversal. That meaning is determined by a greater degree of negativity than {-be':v:suff}. While this suffix is defined as "undo, do wrongly", most instances of this suffix actually denote an opposite rather than an undoing or an erroneous action. See {KLI mailing list 2019.03.22:src} for an analysis.</column>
       <column name="components"></column>
       <column name="examples">
@@ -2611,6 +2905,7 @@ This suffix can be applied to some adverbials, but not to all of them.[2; 3] The
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rover, verb type R</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2618,6 +2913,7 @@ This suffix can be applied to some adverbials, but not to all of them.[2; 3] The
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.3:src}, [2] {HQ 4.4, p.11:src}, [3] {qep'a' 19 (2012):src} ({KLI mailing list 2012.08.30:src}), [4] {KGT:src}</column>
     </table>
     <table name="mem">
@@ -2631,6 +2927,7 @@ This suffix can be applied to some adverbials, but not to all of them.[2; 3] The
       <column name="definition_ru">очень (глагол тип R)</column>
       <column name="definition_zh_HK">強調（動詞流浪後綴）</column>
       <column name="definition_pt">enfático (verbal tipo R)</column>
+      <column name="definition_fi">erittäin, hyvin, korostaja (seikkailija)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2643,6 +2940,9 @@ It can follow verbs used adjectivally, in which case it means "very".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä pääte korostaa mitä tahansa välittömästi sitä edeltävää.
+
+Se voi seurata adjektiivisesti käytettyjä verbejä, jolloin se tarkoittaa "hyvin". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">According to {TKD 4.4:src}, when a verb is used adjectivally, it can have no suffix other than noun type 5 except for {-qu':v:suff}. However, this has been contradicted by subsequent canon, e.g., {SuvwI' quvHa':n:nolink} from {HQ 12.3:src}, {Duj ngaDHa':n} from {KGT:src}, and {wa'maH yIHmey lI'be':n:nolink} from {PK:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2652,6 +2952,7 @@ It can follow verbs used adjectivally, in which case it means "very".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">rover, verb type R</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2659,5 +2960,6 @@ It can follow verbs used adjectivally, in which case it means "very".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD 4.3, 4.4:src}</column>
     </table>

--- a/mem-27-extra.xml
+++ b/mem-27-extra.xml
@@ -28,6 +28,7 @@
       <column name="definition_ru">Красные воины? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰士是紅色的嗎？</column>
       <column name="definition_pt">Os guerreiros são vermelhos?</column>
+      <column name="definition_fi">Ovatko soturit punaisia? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuD:v:0}</column>
@@ -46,6 +47,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The verb {SuD:v:0} means both "be green" and "take a risk". Also, Starfleet "redshirts" are infamous for dying.</column>
       <column name="components">{Doq:v}, {-'a':v}, {SuvwI':n}, {-pu':n}</column>
       <column name="examples"></column>
@@ -55,6 +57,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -62,6 +65,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -75,6 +79,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Клингоны никогда не уничтожат хорошую еду.</column>
       <column name="definition_zh_HK">克林崗人從不破壞美食。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Klingons nunca destroem boa comida. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Klingonit eivät koskaan tuhoa hyvää ruokaa. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -85,6 +90,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{not:adv}, {Soj:n:1}, {QaQ:v}, {Qaw':v}, {tlhIngan:n}, {-pu':n}</column>
       <column name="examples"></column>
@@ -94,6 +100,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -101,6 +108,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -114,6 +122,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Клингонские воины бодаются головами. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗族的勇士正在對頭。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Os guerreiros Klingon estão batendo cabeça. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Klingonin soturit tukevat päitä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{paw':v:2}</column>
@@ -124,6 +133,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence literally means "their heads are hitting themselves, Klingon warriors". Because of the strange grammar, many people consider this sentence to be in error.</column>
       <column name="components">{qIp:v}, {-'egh:v}, {nach:n}, {-Du':n}, {-chaj:n}, {tlhIngan:n}, {SuvwI':n}, {-pu':n}</column>
       <column name="examples"></column>
@@ -133,6 +143,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">headbutting</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -140,6 +151,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {CK:src}</column>
     </table>
     <table name="mem">
@@ -153,6 +165,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Два члена Федерации прибыли на Кронос. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">兩名聯邦船員抵達克羅諾斯。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Dois tripulantes da Federação chegam a Cronos.</column>
+      <column name="definition_fi">Kaksi federaation miehistöä saapuu Kronosille. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -177,6 +190,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qo'noS:n}, {-Daq:n}, {paw:v}, {cha':n}, {DIvI':n}, {beq:n}</column>
       <column name="examples"></column>
@@ -186,6 +200,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -193,6 +208,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
     <table name="mem">
@@ -206,6 +222,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Заключенный говорит охраннику ... [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一名囚犯對警衛說……</column>
       <column name="definition_pt">Um prisioneiro diz ao guarda ...</column>
+      <column name="definition_fi">Vanki sanoo vartijalle ... [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -234,6 +251,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'avwI':n}, {-vaD:n}, {jatlh:v}, {qama':n}</column>
       <column name="examples"></column>
@@ -243,6 +261,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -250,6 +269,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {PK:src}</column>
     </table>
 
@@ -266,6 +286,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Убери отсюда этот хлам!</column>
       <column name="definition_zh_HK">從這裡拿走那垃圾！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Tire esse pedaço de lixo daqui! [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Ota tuo roskapala pois täältä! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -276,6 +297,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -285,6 +307,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -292,6 +315,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KCD:src}</column>
     </table>
 
@@ -308,6 +332,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Удачный выстрел, сэр!</column>
       <column name="definition_zh_HK">射得太準確了，長官！</column>
       <column name="definition_pt">Um tiro de sorte, senhor!</column>
+      <column name="definition_fi">Onnekas laukaus, sir! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -318,6 +343,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{bach:n}, {Do':v}, {qaH:n}</column>
       <column name="examples"></column>
@@ -327,6 +353,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -334,6 +361,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -347,6 +375,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Стрелок, целиться только в двигатели.</column>
       <column name="definition_zh_HK">炮手……瞄準他們的引擎。</column>
       <column name="definition_pt">Artilheiro, mirar apenas no motor.</column>
+      <column name="definition_fi">Ampuja, vain kohdekone. [AUTOTRANSLATED]</column>
       <column name="synonyms">{matHa', DoS jonta' neH.:sen}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -357,6 +386,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{baHwI':n}, {DoS:n}, {yI-:v}, {buS:v}, {QuQ:n}, {neH:adv}</column>
       <column name="examples"></column>
@@ -366,6 +396,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -373,6 +404,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -386,6 +418,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Передавай данные... Немедленно!</column>
       <column name="definition_zh_HK">傳送資料，開始！</column>
       <column name="definition_pt">Transmitir dados ... Agora!</column>
+      <column name="definition_fi">Lähetä tietoja ... nyt! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -396,6 +429,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{De':n}, {yI-:v}, {lI':v:2}, {DaH:adv}</column>
       <column name="examples"></column>
@@ -405,6 +439,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -412,6 +447,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -425,6 +461,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Приготовьтесь к передаче</column>
       <column name="definition_zh_HK">準備傳遞。</column>
       <column name="definition_pt">Preparar para transmitir.</column>
+      <column name="definition_fi">Valmistaudu lähettämään. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -435,6 +472,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru">Команда отдается устройству для передачи данных ({HablI':n}).</column>
       <column name="notes_zh_HK">這是給數據收發設備（{HablI':n}）的命令。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um comando dado a um dispositivo de transmissão de dados ({HablI':n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on komento, joka on annettu tiedonsiirtolaitteelle ({HablI':n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The subtitle says "Ready to transmit", which was the original English line spoken by the actress playing Valkris. However, the Klingon is phrased as a command, so "Prepare to transmit" is a better translation.</column>
       <column name="components">{HablI':n}, {Su':excl}, {lab:v}, {-beH:v}</column>
       <column name="examples"></column>
@@ -444,6 +482,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -451,6 +490,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -464,6 +504,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Новый курс, нейтральная зона с Федерацией</column>
       <column name="definition_zh_HK">新方向：聯邦中立地帶。</column>
       <column name="definition_pt">Novo curso, Zona Neutra da Federação.</column>
+      <column name="definition_fi">Uusi kurssi, federaation neutraali alue. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -474,6 +515,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{He:n}, {chu':v:1}, {ghoS:v:1}, {DIvI':n}, {neHmaH:n}</column>
       <column name="examples"></column>
@@ -483,6 +525,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -490,6 +533,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -503,6 +547,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Стрелок, целиться только в двигатели</column>
       <column name="definition_zh_HK">炮手……瞄準他們的引擎。</column>
       <column name="definition_pt">Artilheiro, mirar apenas no motor.</column>
+      <column name="definition_fi">Ampuja, vain kohdekone. [AUTOTRANSLATED]</column>
       <column name="synonyms">{baHwI', DoS yIbuS. QuQ neH.:sen}</column>
       <column name="antonyms"></column>
       <column name="see_also">{qama'pu' jonta' neH.:sen}</column>
@@ -513,6 +558,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{matHa':n}, {DoS:n}, {jonta':n}, {neH:adv}</column>
       <column name="examples"></column>
@@ -522,6 +568,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -529,6 +576,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -543,6 +591,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Здесь ничего не происходит</column>
       <column name="definition_zh_HK">這裡什麼都沒發生。</column>
       <column name="definition_pt">Não há nada acontecendo aqui.</column>
+      <column name="definition_fi">Täällä ei tapahdu mitään. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -553,6 +602,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -562,6 +612,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -569,6 +620,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.171:src}, [2] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -582,6 +634,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Я хотел захватить заключённых</column>
       <column name="definition_zh_HK">我要俘虜他們的。（我想捕捉戰俘。）</column>
       <column name="definition_pt">Eu queria capturar prisioneiros.</column>
+      <column name="definition_fi">Halusin vangita vankeja. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{matHa', DoS jonta' neH.:sen}</column>
@@ -592,6 +645,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence was one of the most significant in the development of the Klingon language. It was originally supposed to mean "I told you, engines only." It was changed in the subtitles to say "I wanted prisoners." This led to the invention of the plural suffix for beings {-pu':n}, the accomplishment suffix {-ta':v}, the verb {neH:v} and the idea of clipped Klingon which was needed to explain its lack of any prefix, the rule that the second verb in a sentence-as-object construction never takes an aspect suffix, as well as a change in the meaning of the verb {ma':v} to mean "accommodate" (its original meaning being assigned to the new verb {ja':v}).</column>
       <column name="components">{qama':n}, {-pu':n}, {jon:v}, {-ta':v}, {neH:v}</column>
       <column name="examples"></column>
@@ -601,6 +655,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -608,6 +663,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -621,6 +677,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Я купил данные о Генезисе</column>
       <column name="definition_zh_HK">我已經獲得創世計劃的資料。</column>
       <column name="definition_pt">Eu adquiri os dados de Gênesis.</column>
+      <column name="definition_fi">Olen ostanut Genesis-tiedot. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -631,6 +688,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was dubbed over the already-filmed line spoken in English, which was "I have obtained the Genesis data." The English subtitle was changed to say "I have purchased the Genesis data."</column>
       <column name="components">{qa'vam:n}, {De':n}, {vI-:v}, {je':v:1}, {rIntaH:v}</column>
       <column name="examples"></column>
@@ -640,6 +698,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -647,6 +706,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -660,6 +720,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Кто-то определенно найдет это полезным для миссии</column>
       <column name="definition_zh_HK">你會發現它很有用處。</column>
       <column name="definition_pt">Certamente se achar útil para a missão.</column>
+      <column name="definition_fi">Yksi varmasti pitää sitä hyödyllisenä lähetystyössä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -670,6 +731,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru">Субтитры говорят "Вы найдете это полезным", которые были в оригинальном фильме на английском.</column>
       <column name="notes_zh_HK">副標題為“您會發現它有用”，這是原始的英語台詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A legenda diz "Você achará útil", que foi a linha original em inglês filmada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Alaotsikossa lukee "Löydät sen hyödylliseksi", joka oli alkuperäinen englanninkielinen rivi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Qu':n}, {-vaD:n}, {lI':v:2}, {net:n}, {tu':v}, {-bej:v}</column>
       <column name="examples"></column>
@@ -679,6 +741,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -686,6 +749,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.66:src}, [2] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -699,6 +763,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">потому ты его/её увидел(а).</column>
       <column name="definition_zh_HK">意思是你已經看過了。</column>
       <column name="definition_pt">Então você já o viu.</column>
+      <column name="definition_fi">Sitten olet nähnyt sen. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -709,6 +774,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vaj:adv}, {Da-:v}, {legh:v}, {-pu':v}</column>
       <column name="examples"></column>
@@ -718,6 +784,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -725,6 +792,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.56:src}, [2] {Star Trek III:src}</column>
     </table>
     <table name="mem">
@@ -738,6 +806,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Убей одного из них. Мне все равно, какие. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">隨便殺一個人質。</column>
       <column name="definition_pt">Mate um deles. Eu não ligo para qual.</column>
+      <column name="definition_fi">Tapa yksi heistä. En välitä mikä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -748,6 +817,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wa':n}, {yI-:v}, {HoH:v}, {jISaHbe':sen}</column>
       <column name="examples"></column>
@@ -757,6 +827,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -764,6 +835,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III:src}</column>
     </table>
 
@@ -780,6 +852,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Замедлиться до четверти импульса.</column>
       <column name="definition_zh_HK">四分之一脈衝推進。</column>
       <column name="definition_pt">Reduzir para um quarto de impulso.</column>
+      <column name="definition_fi">Hitaasti neljännesimpulssi. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nom yIghoSqu'!:sen}</column>
@@ -790,6 +863,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{cha'maH:n:num}, {vagh:n:1}, {vatlhvI':n}, {Hong:n}, {QIt:adv}, {yI-:v}, {ghoS:v:2}</column>
       <column name="examples"></column>
@@ -799,6 +873,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -806,6 +881,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -819,6 +895,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Оценка дальности атаки в 8000 келликам. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">距離射程還有約八千太空公里。</column>
       <column name="definition_pt">Estimando o alcance do ataque em 8.000 kellicams.</column>
+      <column name="definition_fi">Arvioidaan hyökkäysalue 8000 kellamassa. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -829,6 +906,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -838,6 +916,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -845,6 +924,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.12, Dec. 1999:src}, [2] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -858,6 +938,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Мы только что получили закодированное сообщение на частоте Федерации</column>
       <column name="definition_zh_HK">我們剛收到聯邦頻率的編碼信息。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Acabamos de receber uma mensagem codificada na frequência da Federação.</column>
+      <column name="definition_fi">Olemme juuri saaneet koodatun viestin federaation taajuudesta. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -868,6 +949,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru">Эта строка была вырезана из {Star Trek V:src}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這條線是從{Star Trek V:src}切割而來的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa linha foi cortada de {Star Trek V:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viiva leikattiin {Star Trek V:src}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DIvI':n}, {Se':n}, {wI-:v}, {'Ij:v}, {-taH:v}, {-vIS:v}, {DaH:adv}, {ngoqDe':n}, {wI-:v}, {Hev:v}, {-ta':v}</column>
       <column name="examples"></column>
@@ -877,6 +959,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -884,6 +967,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -897,6 +981,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">У нас есть цель на пути.</column>
       <column name="definition_zh_HK">我們發現一個目標。</column>
       <column name="definition_pt">Temos um alvo à vista.</column>
+      <column name="definition_fi">Meillä on kohde näkyvissä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -907,6 +992,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DoS:n}, {wI-:v}, {puS:v:2}, {-taH:v}</column>
       <column name="examples"></column>
@@ -916,6 +1002,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -923,6 +1010,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -936,6 +1024,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Он на шаттле.</column>
       <column name="definition_zh_HK">他在穿梭機上。</column>
       <column name="definition_pt">Ele está na nave espacial.</column>
+      <column name="definition_fi">Hän on sukkulaliikenteessä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lupDujHom:n}</column>
@@ -946,6 +1035,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Duj:n:1}, {-Hom:n}, {-Daq:n}, {ghaH:n}, {-taH:v}</column>
       <column name="examples"></column>
@@ -955,6 +1045,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -962,6 +1053,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -975,6 +1067,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Скрытное приближение</column>
       <column name="definition_zh_HK">秘密行動。</column>
       <column name="definition_pt">Abordagem furtiva</column>
+      <column name="definition_fi">Varkain lähestymistapa. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -985,6 +1078,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghoS:v:1}, {-meH:v}, {yI-:v}, {pegh:v:1}</column>
       <column name="examples"></column>
@@ -994,6 +1088,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1001,6 +1096,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1014,6 +1110,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Отследить её курс</column>
       <column name="definition_zh_HK">追蹤他們的航線。</column>
       <column name="definition_pt">Acompanhe o curso dela.</column>
+      <column name="definition_fi">Seuraa hänen kurssiaan. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1024,6 +1121,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru">Здесь «она» относится к Предприятию ({'entepray':n:name}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在此，“她”是指企業（{'entepray':n:name}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Aqui, "ela" refere-se à empresa ({'entepray':n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tässä "her" viittaa yritystoimintaan ({'entepray':n:name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1033,6 +1131,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1040,6 +1139,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1053,6 +1153,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Этот курс приведет нас и к Барьеру. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">但這樣的話我們也會駛向大屏障。</column>
       <column name="definition_pt">Esse curso também nos levará à Barreira.</column>
+      <column name="definition_fi">Se kurssi vie meidät myös esteeseen. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1063,6 +1164,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{He:n}, {-vetlh:n}, {wI-:v}, {ghoS:v:1}, {-chugh:v}, {veH tIn:n}, {wI-:v}, {'el:v}, {maH:n:1h}, {-'e':n}</column>
       <column name="examples"></column>
@@ -1072,6 +1174,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1079,6 +1182,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1092,6 +1196,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Проложить курс 0-0-0, отметка 2</column>
       <column name="definition_zh_HK">設定航線零零零點二。</column>
       <column name="definition_pt">Traçar o curso zero-zero-zero, marca dois.</column>
+      <column name="definition_fi">Piirrä kurssi nolla-nolla-nolla, merkitse kaksi. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1102,6 +1207,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{He:n}, {pagh:n:2}, {pagh:n:2}, {pagh:n:2}, {DoD:n}, {cha':n}, {yI-:v}, {nab:v}</column>
       <column name="examples"></column>
@@ -1111,6 +1217,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1118,6 +1225,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1131,6 +1239,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Наша высшая имперская награда была помещена в его голову</column>
       <column name="definition_zh_HK">我們帝國最高的恩惠已經擺在他的頭上。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A maior recompensa de nosso império foi colocada sobre sua cabeça.</column>
+      <column name="definition_fi">Imperiumimme korkein palkkio on asetettu hänen päähänsä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1141,6 +1250,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jon:v}, {-lu':v}, {-meH:v}, {wo':n}, {-maj:n}, {pop:n}, {tIn:v}, {... law':sen}, {Hoch:n}, {tIn:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -1150,6 +1260,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1157,6 +1268,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V deleted scene:src}, [2] {HQ 8.4, p.12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1170,6 +1282,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Я следил за его историей с самого детства. Мужчину восхищать ... и ненавидеть. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我從小就跟隨他的歷史。一個男人要佩服......而且討厭。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu acompanho a história dele desde criança. Um homem para admirar ... e odiar.</column>
+      <column name="definition_fi">Olen seurannut hänen historiaansa pojasta asti. Mies ihailemaan ... ja vihaa. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1180,6 +1293,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru">Эта строка была вырезана из {Star Trek V:src}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這條線是從{Star Trek V:src}切割而來的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa linha foi cortada de {Star Trek V:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viiva leikattiin {Star Trek V:src}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1189,6 +1303,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1196,6 +1311,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1209,6 +1325,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Не задерживай. Измените свой курс сейчас. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不要拖延。立即改變你的課程。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Não atrase. Altere seu curso agora.</column>
+      <column name="definition_fi">Älä viivyttele. Muuta kurssiasi nyt. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1219,6 +1336,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru">Эта строка была вырезана из {Star Trek V:src}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這條線是從{Star Trek V:src}切割而來的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Essa linha foi cortada de {Star Trek V:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viiva leikattiin {Star Trek V:src}: stä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{mIm:v}, {-Qo':v}, {DaH:adv}, {He:n}, {-raj:n}, {yI-:v}, {choH:v}</column>
       <column name="examples"></column>
@@ -1228,6 +1346,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1235,6 +1354,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.11, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1248,6 +1368,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Мне нужна цель, которая сопротивляется</column>
       <column name="definition_zh_HK">我需要一個反擊的目標。</column>
       <column name="definition_pt">Eu preciso de um alvo que revide.</column>
+      <column name="definition_fi">Tarvitsen tavoitteen, joka taistelee takaisin. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1258,6 +1379,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{mu-:v}, {Suv:v}, {-bogh:v}, {DoS:n}, {vI-:v}, {poQ:v}</column>
       <column name="examples"></column>
@@ -1267,6 +1389,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1274,6 +1397,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1287,6 +1411,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Они не знают, что мы здесь</column>
       <column name="definition_zh_HK">他們不知道我們在這裡。</column>
       <column name="definition_pt">Eles não sabem que estamos aqui.</column>
+      <column name="definition_fi">He eivät tiedä, että olemme täällä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1297,6 +1422,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This line was cut from {Star Trek V:src}.</column>
       <column name="components">{naDev:n}, {maH:n:1h}, {'e':n}, {lu-:v}, {Sov:v}, {-be':v}</column>
       <column name="examples"></column>
@@ -1306,6 +1432,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1313,6 +1440,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1326,6 +1454,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Это зонд древнего происхождения</column>
       <column name="definition_zh_HK">（它是）一個古老的深空探測衛星。</column>
       <column name="definition_pt">(É) uma sonda de origem antiga.</column>
+      <column name="definition_fi">(Se on) antiikin alkuperää oleva koetin. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1336,6 +1465,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1345,6 +1475,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1352,6 +1483,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1365,6 +1497,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Проложить курс на Нимбус 3</column>
       <column name="definition_zh_HK">設定航線前往祥雲三星球。</column>
       <column name="definition_pt">Traçar curso para Nimbus III.</column>
+      <column name="definition_fi">Nimbus III -tapahtumakurssi. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1375,6 +1508,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The prefix should have been {wI-:v} instead of {ma-:v}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1384,6 +1518,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1391,6 +1526,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1404,6 +1540,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Звездолёт Энтерпрайз был послан на Нимбус 3</column>
       <column name="definition_zh_HK">企業號奉命前往祥雲三星球。</column>
       <column name="definition_pt">A Nave Estelar Enterprise foi despachada para Nimbus III.</column>
+      <column name="definition_fi">Starship Enterprise on lähetetty Nimbus III: een. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1414,6 +1551,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1423,6 +1561,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1430,6 +1569,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1443,6 +1583,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Максимальная скорость!</column>
       <column name="definition_zh_HK">全速前進！</column>
       <column name="definition_pt">Velocidade máxima!</column>
+      <column name="definition_fi">Suurin nopeus! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'maH vagh vatlhvI' Hong, QIt yIghoS.:sen}</column>
@@ -1453,6 +1594,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nom:adv}, {yI-:v}, {ghoS:v:2}, {-qu':v}</column>
       <column name="examples"></column>
@@ -1462,6 +1604,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1469,6 +1612,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1482,6 +1626,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Вы будете величайшим воином во вселенной</column>
       <column name="definition_zh_HK">那你就是全銀河最英勇的戰士了。</column>
       <column name="definition_pt">Você seria o maior guerreiro da galáxia.</column>
+      <column name="definition_fi">Olisit galaksin suurin soturi. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qIrq vIjeylaHchugh...:sen}</column>
@@ -1492,6 +1637,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qIb:n}, {-Daq:n}, {SuvwI':n}, {-'e':n}, {SoH:n}, {Dun:v}, {... law':sen}, {Hoch:n}, {Dun:v}, {... puS:sen}</column>
       <column name="examples"></column>
@@ -1501,6 +1647,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1508,6 +1655,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1521,6 +1669,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Трудно ли нанести удар?</column>
       <column name="definition_zh_HK">很難摧毀嗎？</column>
       <column name="definition_pt">(É) difícil de acertar?</column>
+      <column name="definition_fi">(Onko sitä vaikea lyödä? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1531,6 +1680,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The line was originally supposed to have been {wIqIpmeH Qatlh'a'?:sen@@wI-:v, qIp:v, -meH:v, Qatlh:v, -'a':v} Either way, the grammar of this sentence is strange, as it means "It is being difficult in order (for us) to hit it."</column>
       <column name="components">{qIp:v}, {-meH:v}, {Qatlh:v}, {-'a':v}</column>
       <column name="examples"></column>
@@ -1540,6 +1690,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1547,6 +1698,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1560,6 +1712,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Если бы только я мог победить Кирка...</column>
       <column name="definition_zh_HK">如果我能打敗「柯克」……</column>
       <column name="definition_pt">Se eu pudesse derrotar Kirk...</column>
+      <column name="definition_fi">Jos voisin voittaa Kirkin ... [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qIbDaq SuvwI''e' SoH Dun law' Hoch Dun puS.:sen}</column>
@@ -1570,6 +1723,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1579,6 +1733,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1586,6 +1741,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1599,6 +1755,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Куда идёт Кирк, туда идем и мы</column>
       <column name="definition_zh_HK">「柯克」去哪，我們就去哪。</column>
       <column name="definition_pt">Para onde Kirk vai, seguimos.</column>
+      <column name="definition_fi">Missä Kirk menee, seuraamme. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1609,6 +1766,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1618,6 +1776,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1625,6 +1784,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1638,6 +1798,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Я всегда хотел вступить в бой с кораблём Федерации.</column>
       <column name="definition_zh_HK">我一直想跟聯邦星艦交手。</column>
       <column name="definition_pt">Eu sempre quis envolver um navio da Federação.</column>
+      <column name="definition_fi">Olen aina halunnut osallistua federaation alukseen. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1648,6 +1809,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{reH:adv}, {DIvI':n}, {Duj:n:1}, {vI-:v}, {Suv:v}, {vI-:v}, {neH:v}</column>
       <column name="examples"></column>
@@ -1657,6 +1819,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1664,6 +1827,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1677,6 +1841,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="definition_ru">Стрельба из космического мусора не является испытанием силы воина. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">射擊太空垃圾不足以考驗戰士的勇氣。</column>
       <column name="definition_pt">Atirar no lixo espacial não é prova da coragem de um guerreiro.</column>
+      <column name="definition_fi">Avaruusjätteiden ampuminen ei ole testi soturin tahdista. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Daj:v:2}</column>
@@ -1687,6 +1852,7 @@ Watch a lesson on this joke: {YouTube video:url:http://youtu.be/HciuEJSpPq0}</co
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is a backfit for the sentence, {vaj toDDujDaj ngeHbej DIvI'.@@vaj:adv, toDDuj:n, -Daj:n, ngeH:v, -bej:v, DIvI':n} "That means the Federation will be sending a rescue ship of its own." Both sentences were spoken by Captain Klaa in {Star Trek V:src}.
 
 The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' SuvwI'.@@logh:n, veQ:n, -Daq:n, bach:v, -chugh:v, yoH:v, 'e':n, tob:v, -laH:v, -be':v, SuvwI':n}</column>
@@ -1698,6 +1864,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1705,6 +1872,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.104:src}, [2] {Star Trek V:src}, [3] {HQ 8.4, p.11-12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1718,6 +1886,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Не будет мира, пока жив Кирк.</column>
       <column name="definition_zh_HK">只要柯克生活，就不會有和平。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Não haverá paz enquanto Kirk viver.</column>
+      <column name="definition_fi">Rauhaa ei ole niin kauan kuin Kirk elää. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1728,6 +1897,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{yIn:v}, {-taH:v}, {-vIS:v}, {qIrq:n}, {DuH:v}, {-be':v}, {roj:n}</column>
       <column name="examples"></column>
@@ -1737,6 +1907,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1744,6 +1915,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V deleted scene:src}, [2] {HQ 8.4, p.12, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1758,6 +1930,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Мы получаем приоритетное сообщение от Оперативного командования. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我們正在接收來自Operations Command的優先消息。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Estamos recebendo uma mensagem prioritária do Comando de Operações.</column>
+      <column name="definition_fi">Saamme prioriteettiviestin Operations Commandilta. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1768,6 +1941,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This line was cut from {Star Trek V:src}. The sentence in which this appeared was actually written with hyphens, like this: {HoD, yo'-SeH yaH-nIv-vo' potlh De' wI-Hev-taH:sen:nolink}, with a newline between {potlh:sen:nolink} and {De':sen:nolink}.[1]</column>
       <column name="components">{yo'SeH yaHnIv:n}, {-vo':n}, {potlh De':n}, {wI-:v}, {Hev:v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -1777,6 +1951,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1784,6 +1959,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 8.4, p.11, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1797,6 +1973,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Системы защиты предприятия не работают. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">企業防禦系統癱瘓。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Os sistemas de defesa da Enterprise estão inoperantes.</column>
+      <column name="definition_fi">Yritysten puolustusjärjestelmät ovat rikki. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1807,6 +1984,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{'entepray':n:name}, {Hub:n}, {pat:n}, {-mey:n}, {lu-:v}, {chu':v:2}, {-be':v}, {-lu':v}, {-pu':v}</column>
       <column name="examples"></column>
@@ -1816,6 +1994,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1823,6 +2002,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V deleted scene:src}, [2] {HQ 8.4, p.13, Dec. 1999:src}</column>
     </table>
     <table name="mem">
@@ -1836,6 +2016,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Следуйте за предприятием. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">瞄準企業號。（跟注企業號。）</column>
       <column name="definition_pt">Siga a Enterprise.</column>
+      <column name="definition_fi">Seuraa yritystä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1846,6 +2027,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The subtitle actually says "Bear on Enterprise."</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1855,6 +2037,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1862,6 +2045,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
     <table name="mem">
@@ -1875,6 +2059,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Enterprise targeted. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">已瞄準目標：企業號。</column>
       <column name="definition_pt">O alvo é a Enterprise.</column>
+      <column name="definition_fi">Kohdennettu yritystoimintaan. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1885,6 +2070,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1894,6 +2080,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1901,6 +2088,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V:src}</column>
     </table>
 
@@ -1917,6 +2105,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Найди Чанга сейчас! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">快去找「常」！</column>
       <column name="definition_pt">Encontre Chang agora!</column>
+      <column name="definition_fi">Löydä Chang nyt! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1927,6 +2116,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{cheng:n:name}, {-'e':n}, {DaH:adv}, {Sam:v}</column>
       <column name="examples"></column>
@@ -1936,6 +2126,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1943,6 +2134,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -1956,6 +2148,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Мы возвращаемся сейчас. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我們現在回來。</column>
       <column name="definition_pt">Estamos voltando agora.</column>
+      <column name="definition_fi">Palaamme nyt. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1966,6 +2159,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru">Эта строка говорилась на клингонском языке, но не имела субтитров. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">此行在克林崗語中被使用，但沒有字幕。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta linha foi falada em klingon, mas não foi legendada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä rivi puhuttiin Klingonissa, mutta sitä ei tekstitetty. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{DaH:adv}, {ma-:v}, {chegh:v}</column>
       <column name="examples"></column>
@@ -1975,6 +2169,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1982,6 +2177,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -1995,6 +2191,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Атакуйте или будьте рабами в их мире!</column>
       <column name="definition_zh_HK">要麼進攻，要麼成為他們世界的奴隸！</column>
       <column name="definition_pt">Atacar ou ser escravos em seu mundo!</column>
+      <column name="definition_fi">Hyökkää tai ole orjia heidän maailmassa! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2005,6 +2202,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DI-:v}, {HIv:v}, {-be':v}, {-chugh:v}, {qo':n}, {-chaj:n}, {-Daq:n}, {toy'wI''a':n}, {DI-:v}, {moj:v}</column>
       <column name="examples"></column>
@@ -2014,6 +2212,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2021,6 +2220,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2034,6 +2234,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Атаковать их сейчас же, пока мы все еще можем!</column>
       <column name="definition_zh_HK">趁我們現在還行，進攻他們吧！</column>
       <column name="definition_pt">Ataque-os agora, enquanto ainda podemos!</column>
+      <column name="definition_fi">Hyökkää heihin nyt, kun voimme vielä! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2044,6 +2245,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DI-:v}, {HIv:v}, {-laH:v}, {-taH:v}, {-vIS:v}, {DaH:adv}, {DI-:v}, {HIv:v}, {-nIS:v}</column>
       <column name="examples"></column>
@@ -2053,6 +2255,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2060,6 +2263,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2073,6 +2277,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Не подцепите никаких насекомых</column>
       <column name="definition_zh_HK">可別捉蟲子。</column>
       <column name="definition_pt">Não pegue nenhum inseto.</column>
+      <column name="definition_fi">Älä löydä vikoja. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2083,6 +2288,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">According to the novelisation of {Star Trek VI:src}, this is an idiom which is smugglers' slang for wishing someone good luck in avoiding border officials.</column>
       <column name="components">{ghew:n}, {-mey:n}, {tI-:v}, {Suq:v}, {-Qo':v}</column>
       <column name="examples"></column>
@@ -2092,6 +2298,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2099,6 +2306,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKW p.207:src}, [2] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2112,6 +2320,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Похоже, что вы не понимаете нашу ситуацию</column>
       <column name="definition_zh_HK">你似乎不了解我們的情況。</column>
       <column name="definition_pt">Você parece não entender nossa situação.</column>
+      <column name="definition_fi">Et ilmeisesti ymmärrä tilannettamme. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2122,6 +2331,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghu':n}, {-maj:n}, {Da-:v}, {yaj:v}, {-be':v}, {-law':v}</column>
       <column name="examples"></column>
@@ -2131,6 +2341,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2138,6 +2349,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2151,6 +2363,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Война устарела, мы скоро будем в опасности</column>
       <column name="definition_zh_HK">戰爭已經過時了，但我們面臨著危險的處境。</column>
       <column name="definition_pt">A guerra é obsoleta, mas corremos o risco de nos tornar.</column>
+      <column name="definition_fi">Sota on vanhentunut, koska olemme vaarassa tulla. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2161,6 +2374,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The first part of this sentence, {notlh veS:sen:nolink}, appears on {KGT p.47:src}.</column>
       <column name="components">{notlh:v}, {veS:n}, {'a:conj}, {tugh:adv}, {ma-:v}, {notlh:v}, {-choH:v}, {je:adv}, {maH:n:1h}</column>
       <column name="examples"></column>
@@ -2170,6 +2384,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2177,6 +2392,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2190,6 +2406,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Они предали нас!</column>
       <column name="definition_zh_HK">他們背叛了我們！</column>
       <column name="definition_pt">Eles nos traíram!</column>
+      <column name="definition_fi">He ovat pettäneet meidät! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nutojbej!:sen}</column>
@@ -2200,6 +2417,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nu-:v}, {magh:v}</column>
       <column name="examples"></column>
@@ -2209,6 +2427,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2216,6 +2435,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2229,6 +2449,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Мы были преданы</column>
       <column name="definition_zh_HK">我們被出賣了！</column>
       <column name="definition_pt">Nós fomos traídos!</column>
+      <column name="definition_fi">Meidät on pettynyt! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{numagh!:sen}</column>
@@ -2239,6 +2460,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="notes_ru">Это означает "Они определенно обманули нас!"</column>
       <column name="notes_zh_HK">這意味著“他們肯定欺騙了我們！” [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa "Eles definitivamente nos enganaram!" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa "He ovat varmasti huijaaneet meitä!" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nu-:v}, {toj:v}, {-bej:v}</column>
       <column name="examples"></column>
@@ -2248,6 +2470,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2255,6 +2478,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2268,6 +2492,7 @@ The original line was to have been {logh veQDaq bachchugh, yoH 'e' toblaHbe' Suv
       <column name="definition_ru">Что она делает?</column>
       <column name="definition_zh_HK">她在幹什麼？（她為什麼要去那裡？）</column>
       <column name="definition_pt">O que ela está fazendo? (Por que ela está indo para lá?)</column>
+      <column name="definition_fi">Mitä hän tekee? (Miksi hän menee sinne?) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2292,6 +2517,9 @@ Undertexten var "Vad gör hon?" men en mer bokstavlig översättning är "Varfö
       <column name="notes_pt">Aqui, "ela" se refere à Empresa ({'entepray':n:name}). Chang ({cheng:n:name}) estava expressando perplexidade sobre o movimento da Enterprise.
 
 O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "Por que ela está indo lá?" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tässä "hän" tarkoittaa yritystä ({'entepray':n:name}). Chang ({cheng:n:name}) ilmaisi hämmennystä yrityksen liikkumisesta.
+
+Alaotsikko oli "Mitä hän tekee?" mutta kirjaimellisempi käännös on "Miksi hän menee sinne?" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qatlh:ques}, {pa':n:2}, {ghoS:v:1}</column>
       <column name="examples"></column>
@@ -2301,6 +2529,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2308,6 +2537,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2321,6 +2551,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Защищайте канцлера!</column>
       <column name="definition_zh_HK">保護總理！</column>
       <column name="definition_pt">Proteja o Chanceler!</column>
+      <column name="definition_fi">Suojaa liittokansleri! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2331,6 +2562,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{Qang:n}, {yI-:v}, {Qan:v}</column>
       <column name="examples"></column>
@@ -2340,6 +2572,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2347,6 +2580,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2360,6 +2594,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Восстановление вспомогательной силы тяжести. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">恢復備用重力。</column>
       <column name="definition_pt">Restaurando gravidade auxiliar</column>
+      <column name="definition_fi">Apupainovoiman palauttaminen. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlham chu'Ha'lu'!:sen}</column>
@@ -2370,6 +2605,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlham:n:1}, {chach:n}, {chu':v:2}, {-qa':v}</column>
       <column name="examples"></column>
@@ -2379,6 +2615,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2386,6 +2623,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
     <table name="mem">
@@ -2399,6 +2637,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Мы потеряли гравитацию! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我們失去了重力！</column>
       <column name="definition_pt">Nós perdemos gravidade!</column>
+      <column name="definition_fi">Olemme menettäneet painovoiman! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlham chach chu'qa'.:sen}</column>
@@ -2409,6 +2648,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlham:n:1}, {chu'Ha':v}, {-lu':v}</column>
       <column name="examples"></column>
@@ -2418,6 +2658,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2425,6 +2666,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek VI:src}</column>
     </table>
 
@@ -2441,6 +2683,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Я здесь, чтобы помочь тебе. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我是來幫你的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Estou aqui para te ajudar. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Olen täällä auttaakseni sinua. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2451,6 +2694,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "voin olla hyödyllinen. Matkustan lähetystyössä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This was a lip-match for {DevwI' ghaH 'Iv'e'?@@DevwI':n, ghaH:n, 'Iv:ques:1h, -'e':n:suff} "Who is the leader?"</column>
       <column name="components">{jI-:v}, {vuy:v}, {-laH:v}, {jI-:v}, {ve':v}</column>
       <column name="examples"></column>
@@ -2460,6 +2704,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2467,6 +2712,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -2480,6 +2726,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Есть преступник, что прячется в этих развалинах.</column>
       <column name="definition_zh_HK">這些廢墟中藏有罪犯。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Há um criminoso escondido nessas ruínas. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Näissä raunioissa on piilossa rikollinen. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2490,6 +2737,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The first half of this sentence was a lip-match for the beginning of {'ej jIHvo' nIHDI' jIbup:sen@@'ej:conj, jIH:n:1h, -vo':n, nIH:v, -DI':v, jI-:v, bup:v}.</column>
       <column name="components">{ghach:v}, {jIvvo':n}, {naH:v}, {DaH:adv}, {pIgh:n}, {-vam:n}, {-Daq:n}, {So':v:1}, {-'egh:v}, {-taH:v}</column>
       <column name="examples"></column>
@@ -2499,6 +2747,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2506,6 +2755,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek Into Darkness:src}</column>
     </table>
     <table name="mem">
@@ -2519,6 +2769,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Вы и ваши люди в опасности. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">您和您的人民處於危險之中。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você e seu povo estão em perigo.</column>
+      <column name="definition_fi">Sinä ja kansanne olette vaarassa. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2529,6 +2780,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru">Ожидаемый префикс {bam:v} - {bo-:v:pref}, поскольку субъект - множественное число и лицо второго лица. Однако иногда и при определенных обстоятельствах в предложении с составным субъектом от второго и третьего лица используется глагол без префикса. Существует мало доказательств того, что это использование становится все более распространенным в обычной речи, и, возможно, Ухура говорил неформально или идиоматически. Это предложение не следует воспринимать как учебник клингона, но может быть примером разговорного клингона.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{bam:v}上的預期前綴為{bo-:v:pref}，因為主題是複數形式且是第二人稱。但是，有時在某些情況下，在包含第二人稱和第三人稱主語的句子中，會使用非前綴動詞。很少有證據表明這種用法在隨便講話中變得越來越普遍，也許Uhura是非正式或慣用的講話。這句話不應該被當作克林崗語教科書，而應該是口語克林貢語的一個例子。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Possibly {bo-:v:pref} was mixed up with {lI-:v:pref} during filming or editing, which forced {lIb:v} to be created.</column>
       <column name="components">{Qob:n}, {lIb:v}, {bam:v}, {SoH:n}, {chuD:n}, {-lI':n}, {je:conj}</column>
       <column name="examples"></column>
@@ -2538,6 +2790,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2545,6 +2798,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek Into Darkness:src}, [2] {KLI mailing list 2020.05.22:src}</column>
     </table>
 
@@ -2561,6 +2815,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Срочное сообщение для коммандера Крюге.</column>
       <column name="definition_zh_HK">克魯格指揮官的緊急信息。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mensagem urgente para o Comandante Kruge.</column>
+      <column name="definition_fi">Kiireellinen viesti komentaja Krugelle. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2571,6 +2826,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This appears on the back of the DVD case, but not in the movie itself.</column>
       <column name="components">{Qugh:n:2,name}, {la':n}, {-vaD:n}, {QIn:n:1}, {pav:v}</column>
       <column name="examples"></column>
@@ -2580,6 +2836,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2587,6 +2844,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III - DVD case:src}</column>
     </table>
     <table name="mem">
@@ -2600,6 +2858,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Федерация контролирует Genesis Device. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聯邦控制Genesis設備。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">A Federação controla o dispositivo Gênesis.</column>
+      <column name="definition_fi">Liitto hallitsee Genesis-laitetta. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2610,6 +2869,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This appears on the back of the DVD case, but not in the movie itself.</column>
       <column name="components">{qa'vam:n}, {jan:n:1}, {SeH:v}, {DIvI':n}</column>
       <column name="examples"></column>
@@ -2619,6 +2879,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2626,6 +2887,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III - DVD case:src}</column>
     </table>
     <table name="mem">
@@ -2639,6 +2901,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">To learn the Genesis Planet's coordinates, speak to our agent. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">要了解Genesis Planet的坐標，請與我們的代理商聯繫。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Para aprender as coordenadas do Planeta Gênesis, fale com nosso agente.</column>
+      <column name="definition_fi">Jos haluat oppia Genesis-planeetan koordinaatit, puhu agenttimme kanssa. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2649,6 +2912,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This appears on the back of the DVD case, but not in the movie itself.</column>
       <column name="components">{qa'vam:n}, {yuQ:n}, {Quv:n}, {Da-:v}, {ghoj:v}, {-meH:v}, {Duy:n}, {-ma':n}, {-vaD:n}, {yI-:v}, {jatlh:v}</column>
       <column name="examples"></column>
@@ -2658,6 +2922,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2665,6 +2930,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III - DVD case:src}</column>
     </table>
     <table name="mem">
@@ -2678,6 +2944,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Приобретите устройство Genesis! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">獲得Genesis設備！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Adquira o Dispositivo Gênesis!</column>
+      <column name="definition_fi">Hanki Genesis-laite! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2688,6 +2955,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This appears on the back of the DVD case, but not in the movie itself.</column>
       <column name="components">{qa'vam:n}, {jan:n:1}, {yI-:v}, {Suq:v}</column>
       <column name="examples"></column>
@@ -2697,6 +2965,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2704,6 +2973,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III - DVD case:src}</column>
     </table>
     <table name="mem">
@@ -2717,6 +2987,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Тактика не важна. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">戰術並不重要。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Táticas não são importantes.</column>
+      <column name="definition_fi">Taktiikka ei ole tärkeää. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2727,6 +2998,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This appears on the back of the DVD case, but not in the movie itself.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2736,6 +3008,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2743,6 +3016,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek III - DVD case:src}</column>
     </table>
     <table name="mem">
@@ -2756,6 +3030,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Эта пара клингонов [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗夫婦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Aquele casal Klingon</column>
+      <column name="definition_fi">Tuo Klingon-pariskunta [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2766,6 +3041,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este foi o nome de um documentário no segundo disco do {Star Trek V Special Edition:src}, no qual Spice Williams ({vIqSIS:n:name}) e Todd Bryant ({tlha'a:n:name}) são entrevistados sobre suas experiências de trabalho no filme. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä oli nimi dokumentille {Star Trek V Special Edition:src}-toisella levyllä, jossa Spice Williamsia ({vIqSIS:n:name}) ja Todd Bryantia ({tlha'a:n:name}) haastateltiin kokemuksistaan ​​elokuvan parissa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {chang'eng:n}, {-vetlh:n}</column>
       <column name="examples"></column>
@@ -2775,6 +3051,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2782,6 +3059,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V Special Edition - That Klingon Couple:src}</column>
     </table>
     <table name="mem">
@@ -2795,6 +3073,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">О, какие замечательные мышцы! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">哦，什麼美妙的肌肉！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Oh, que músculos maravilhosos!</column>
+      <column name="definition_fi">Voi, kuinka upeita lihaksia! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2805,6 +3084,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The subtitle actually said {Somraw'Du':sen:nolink}, but this is a typo.</column>
       <column name="components">{toH:excl}, {Somraw:n}, {-Du':n}, {Dun:v}, {-qu':v}</column>
       <column name="examples"></column>
@@ -2814,6 +3094,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2821,6 +3102,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek V Special Edition - That Klingon Couple:src}</column>
     </table>
 
@@ -2837,6 +3119,7 @@ O subtítulo era "O que ela está fazendo?" mas uma tradução mais literal é "
       <column name="definition_ru">Капитан Арчер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">亞徹艦長</column>
       <column name="definition_pt">Capitão Archer</column>
+      <column name="definition_fi">Kapteeni Archer [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2849,6 +3132,9 @@ In Klingon, titles generally go after the name.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on tähtialuksen {HoD:n} nimi {'entepray':n:name}.
+
+Klingonissa otsikot ovat yleensä nimen perässä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The name {'archer:n:name,nolink} has been heard spoken in Klingon, but has not appeared in written canon.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2858,6 +3144,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2865,6 +3152,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT:src}</column>
     </table>
     <table name="mem">
@@ -2878,6 +3166,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="definition_ru">Капитан Арчер и его команда - достойные люди. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">阿切爾船長和他的船員都是光榮的人。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O capitão Archer e sua tripulação são pessoas honradas.</column>
+      <column name="definition_fi">Kapteeni Archer ja hänen miehistönsä ovat kunniallisia ihmisiä. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{lengtaH 'e' yIchaw'.:sen}</column>
@@ -2888,6 +3177,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{quv:n}, {lu-:v}, {ghaj:v}, {'archer HoD:n}, {beq:n}, {-Daj:n}, {je:conj}</column>
       <column name="examples"></column>
@@ -2897,6 +3187,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2904,6 +3195,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - The Augments:src}</column>
     </table>
     <table name="mem">
@@ -2917,6 +3209,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="definition_ru">Пусть они продолжат свой путь. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">讓他們繼續前進。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Deixe-os continuar no seu caminho.</column>
+      <column name="definition_fi">Anna heidän jatkaa matkaa. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{quv lughaj 'archer HoD beqDaj je.:sen}</column>
@@ -2927,6 +3220,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{leng:v}, {-taH:v}, {'e':n}, {yI-:v}, {chaw':v}</column>
       <column name="examples"></column>
@@ -2936,6 +3230,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2943,6 +3238,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - The Augments:src}</column>
     </table>
     <table name="mem">
@@ -2956,6 +3252,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="definition_ru">Мне нечего вам сказать, человек. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我無話同你可說，智人。</column>
       <column name="definition_pt">Não tenho nada para lhe dizer, humano.</column>
+      <column name="definition_fi">Minulla ei ole mitään sanottavaa sinulle, ihminen. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2966,6 +3263,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{SoH:n}, {-vaD:n}, {pagh:n:1h}, {vI-:v}, {jatlh:v}, {Human:n}</column>
       <column name="examples"></column>
@@ -2975,6 +3273,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2982,6 +3281,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -2995,6 +3295,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="definition_ru">I demand to see the magistrate! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我要求見到執政官！</column>
       <column name="definition_pt">Eu exijo ver o magistrado!</column>
+      <column name="definition_fi">Vaadin tapaamaan tuomarin! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3005,6 +3306,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{loHwI':n}, {vI-:v}, {Such:v}, {'e':n}, {vI-:v}, {poQ:v}</column>
       <column name="examples"></column>
@@ -3014,6 +3316,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3021,6 +3324,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -3034,6 +3338,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="definition_ru">Мой смертный приговор был заменен! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我的死刑是改判了的！</column>
       <column name="definition_pt">Minha sentença de morte foi comutada!</column>
+      <column name="definition_fi">Kuolemantuomioeni muutettiin! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3044,6 +3349,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{vI-:v}, {muH:v}, {-lu':v}, {net:n}, {wuqHa':v}</column>
       <column name="examples"></column>
@@ -3053,6 +3359,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3060,6 +3367,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -3073,6 +3381,7 @@ In Klingon, titles generally go after the name.</column>
       <column name="definition_ru">Чего ты хочешь со мной? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你們想和我做什麼？</column>
       <column name="definition_pt">O que você quer de mim?</column>
+      <column name="definition_fi">Mitä haluat minusta? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3085,6 +3394,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qatlh:ques}, {tu-:v}, {neH:v}</column>
       <column name="examples"></column>
@@ -3094,6 +3404,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3101,6 +3412,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -3114,6 +3426,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="definition_ru">Обезопасить его! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鎖住他！</column>
       <column name="definition_pt">Prenda-o!</column>
+      <column name="definition_fi">Turvaa hänet! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3124,6 +3437,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="notes_ru">Это также может означать «Защити ее!» или "Защити это!" [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這也可能意味著“保護她！”或“保護它！” [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso também pode significar "Proteja-a!" ou "Garanta!" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä voi tarkoittaa myös "Turvaa hänet!" tai "Suojaa se!" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{yI-:v}, {ngaQmoH:v:1}</column>
       <column name="examples"></column>
@@ -3133,6 +3447,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">restrain</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3140,6 +3455,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -3153,6 +3469,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="definition_ru">Целевое оружие в этом месте. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">在這個位置上射擊武器。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mire as armas neste local.</column>
+      <column name="definition_fi">Kohdista aseet tähän paikkaan. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3163,6 +3480,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="notes_ru">Это буквально означает «нацелить оружие на этот участок». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“將武器瞄準這一部分”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "apontar armas nesta seção". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "tähtäysaseita tälle osalle". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'ay':n}, {-vam:n}, {-Daq:n}, {nuH:n:1}, {-mey:n}, {tI-:v}, {Qeq:v:1}</column>
       <column name="examples"></column>
@@ -3172,6 +3490,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3179,6 +3498,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
     <table name="mem">
@@ -3192,6 +3512,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="definition_ru">Return to the transport site. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">返回傳送坐標。</column>
       <column name="definition_pt">Retorno ao local de transporte.</column>
+      <column name="definition_fi">Palaa kuljetuspaikalle. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3202,6 +3523,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jol:n}, {Quv:n}, {yI-:v}, {chegh:v}</column>
       <column name="examples"></column>
@@ -3211,6 +3533,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3218,6 +3541,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {ENT - Affliction:src}</column>
     </table>
 
@@ -3234,6 +3558,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="definition_ru">Актеры были выбраны. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">演員們已被選中了。</column>
       <column name="definition_pt">Os atores foram escolhidos.</column>
+      <column name="definition_fi">Näyttelijät on valittu. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qul yIchu'.:sen}</column>
@@ -3244,6 +3569,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{ghetwI':n}, {lu-:v}, {wIv:v}, {-lu':v}, {-ta':v}</column>
       <column name="examples"></column>
@@ -3253,6 +3579,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3260,6 +3587,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC announcement:src}</column>
     </table>
     <table name="mem">
@@ -3273,6 +3601,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="definition_ru">Зажечь огонь. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">點燃火。</column>
       <column name="definition_pt">Ascenda o fogo.</column>
+      <column name="definition_fi">Sytytä tuli. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghetwI' luwIvlu'ta'.:sen}</column>
@@ -3283,6 +3612,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{qul:n}, {yI-:v}, {chu':v:2}</column>
       <column name="examples"></column>
@@ -3292,6 +3622,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3299,6 +3630,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC announcement:src}</column>
     </table>
     <table name="mem">
@@ -3312,6 +3644,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="definition_ru">Затем Кахлесс указал на звезду в небе и сказал: «Ищите меня там, в этой точке света». [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">然後「凱勒斯」指著天空中的一顆星說：「在那個光點上尋找我。」</column>
       <column name="definition_pt">Então Kahless apontou para uma estrela no céu e disse: "Procure-me lá, naquele ponto da luz".</column>
+      <column name="definition_fi">Sitten Kahless osoitti tähteä taivaalla ja sanoi: "Etsikää minua siellä, siinä valopisteessä." [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bo'retlh:n}</column>
@@ -3322,6 +3655,7 @@ To address a single person, say {qatlh choneH?:sen@@qatlh:ques, cho-:v, neH:v}</
       <column name="notes_ru">Это часть Истории Обещания, которая рассказывает об уходе (и предсказывает возвращение) {qeylIS'e' lIjlaHbe'bogh vay':n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是“諾言故事”的一部分，該故事講述了{qeylIS'e' lIjlaHbe'bogh vay':n:name}的離開（並預言了返回）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso faz parte da história da promessa, que fala da partida (e profetiza o retorno) do {qeylIS'e' lIjlaHbe'bogh vay':n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on osa Lupauksen tarinaa, joka kertoo {qeylIS'e' lIjlaHbe'bogh vay':n:name}: n lähdöstä (ja ennustaa paluuta). [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Klingon text comes from an inscription seen on one of the {DSC:src} trailers, while the English translation is from {TNG - Rightful Heir:src}.
 
 Set photos show that this sentence is preceded by {Suto'vo'qor vIjaH 'ach 'opleS jIchegh 'e' vIlay'.:sen@@Suto'vo'qor:n, vI-:v, jaH:v, 'ach:conj, 'opleS:n, jI-:v, chegh:v, 'e':n, vI-:v, lay':v}</column>
@@ -3333,6 +3667,7 @@ Set photos show that this sentence is preceded by {Suto'vo'qor vIjaH 'ach 'opleS
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3340,6 +3675,7 @@ Set photos show that this sentence is preceded by {Suto'vo'qor vIjaH 'ach 'opleS
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC trailer:src}</column>
     </table>
     <table name="mem">
@@ -3353,6 +3689,7 @@ Set photos show that this sentence is preceded by {Suto'vo'qor vIjaH 'ach 'opleS
       <column name="definition_ru">Они идут. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">他們來了。</column>
       <column name="definition_pt">Eles estão vindo.</column>
+      <column name="definition_fi">He ovat tulossa. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3386,6 +3723,7 @@ The speech concludes with the words (in Federation Standard): "We come in peace.
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">The Klingon translation was done by {Qov:n:name}. The English comes from the subtitles, with punctuation edited for clarity.</column>
       <column name="components">{ghoS:v:1}, {-lI':v}, {chaH:n}</column>
       <column name="examples"></column>
@@ -3395,6 +3733,7 @@ The speech concludes with the words (in Federation Standard): "We come in peace.
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3402,6 +3741,7 @@ The speech concludes with the words (in Federation Standard): "We come in peace.
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - The Vulcan Hello:src}</column>
     </table>
     <table name="mem">
@@ -3415,6 +3755,7 @@ The speech concludes with the words (in Federation Standard): "We come in peace.
       <column name="definition_ru">Оставайся клингоном! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">願我們繼續是克林崗人！</column>
       <column name="definition_pt">Permaneça Klingon!</column>
+      <column name="definition_fi">Pysy Klingon! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan maH!:sen}</column>
@@ -3425,6 +3766,7 @@ The speech concludes with the words (in Federation Standard): "We come in peace.
       <column name="notes_ru">Это буквально означает «мы клингон, пусть так и будет». Английские субтитры отображают это как «Remain Klingon!» [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“我們是克林崗人，請繼續下去”。英文字幕將其表示為“保持克林崗語！” [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso literalmente significa "Somos Klingon, que continue". As legendas em inglês traduzem isso como "Permaneça Klingon!" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "Olemme Klingon, jatkaako se". Englanninkieliset tekstitykset tekevät tämän "Remain Klingon!" [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The line was deliberately translated this way as it was believed that audiences would recognise the embedded {tlhIngan maH!:sen:nolink}
 
 This can also be interpreted as {tlhIngan maHtaHjaj!:sen@@tlhIngan:n, maH:n:1h, -taH:v, -jaj:v}, "May we continue to be Klingon". This technically violates the rule that a Type 7 suffix cannot be used with {-jaj:v:nolink} (see {TKD 4.2.9:src}), but this rule has been violated in canon.</column>
@@ -3436,6 +3778,7 @@ This can also be interpreted as {tlhIngan maHtaHjaj!:sen@@tlhIngan:n, maH:n:1h, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3443,6 +3786,7 @@ This can also be interpreted as {tlhIngan maHtaHjaj!:sen@@tlhIngan:n, maH:n:1h, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - The Vulcan Hello:src}</column>
     </table>
     <table name="mem">
@@ -3456,6 +3800,7 @@ This can also be interpreted as {tlhIngan maHtaHjaj!:sen@@tlhIngan:n, maH:n:1h, 
       <column name="definition_ru">Кого мы ищем? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我們尋找誰？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Quem buscamos?</column>
+      <column name="definition_fi">Ketä etsimme? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3494,6 +3839,7 @@ The last words of {tIquvma:n:name} before he died were a version of these lines,
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">These lines were not given a name within the show, but some have referred to it online as "the Kahless prayer" or "the prayer to Kahless".
 
 Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it was still subtitled in English as "Give us light to see". This is probably a production error.</column>
@@ -3505,6 +3851,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Kahless prayer, prayer to Kahless</column>
       <column name="search_tags_de">Kahless-Gebet, Gebet</column>
       <column name="search_tags_fa"></column>
@@ -3512,6 +3859,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Battle at the Binary Stars:src}, [2] {DSC - Despite Yourself:src}, [3] {DSC - The Wolf Inside:src}</column>
     </table>
 
@@ -3528,6 +3876,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Я принимаю ваше предложение</column>
       <column name="definition_zh_HK">我接受你的提議。</column>
       <column name="definition_pt">Eu aceito sua proposta.</column>
+      <column name="definition_fi">Hyväksyn ehdotuksesi. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3538,6 +3887,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Сказано в диалоге между {qeylIS'e' lIjlaHbe'bogh vay':n:name} и {qotar:n:name} в {paq'batlh:src}.</column>
       <column name="notes_zh_HK">在{paq'batlh:src}中由{qeylIS'e' lIjlaHbe'bogh vay':n:name}說話到{qotar:n:name}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{qeylIS'e' lIjlaHbe'bogh vay':n:name} puhui {qotar:n:name}: lle {paq'batlh:src}: ssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3547,6 +3897,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3554,6 +3905,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.144-145:src}</column>
     </table>
 
@@ -3570,6 +3922,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Аккад [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">阿卡德 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Akkad</column>
+      <column name="definition_fi">Akkad [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'aqaDyan Hol:n}</column>
@@ -3580,6 +3933,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это было название древнего города на земле, столицы Аккадской империи. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上一個古老的城市的名字，阿卡德帝國的首都。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este era o nome de uma cidade antiga na Terra, a capital do Império Acadiano. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä oli nimi muinaiselle maapallon kaupungille, Akkadin valtakunnan pääkaupungille. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3589,6 +3943,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3596,6 +3951,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
         <table name="mem">
@@ -3609,6 +3965,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
           <column name="definition_ru">Аккадский язык [AUTOTRANSLATED]</column>
           <column name="definition_zh_HK">阿卡德語 [AUTOTRANSLATED]</column>
           <column name="definition_pt">Língua acadiana</column>
+          <column name="definition_fi">Akkadi kieli [AUTOTRANSLATED]</column>
           <column name="synonyms"></column>
           <column name="antonyms"></column>
           <column name="see_also">{'aqaD:n}</column>
@@ -3619,6 +3976,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
           <column name="notes_ru"></column>
           <column name="notes_zh_HK"></column>
           <column name="notes_pt"></column>
+          <column name="notes_fi"></column>
           <column name="hidden_notes">This is a borrowing from Federation Standard, so it isn't {'aqaD:n} plus {ngan:n}.</column>
           <column name="components">{'aqaD:n}, {Hol:n}</column>
           <column name="examples"></column>
@@ -3628,6 +3986,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
           <column name="examples_ru"></column>
           <column name="examples_zh_HK"></column>
           <column name="examples_pt"></column>
+          <column name="examples_fi"></column>
           <column name="search_tags"></column>
           <column name="search_tags_de"></column>
           <column name="search_tags_fa"></column>
@@ -3635,6 +3994,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
           <column name="search_tags_ru"></column>
           <column name="search_tags_zh_HK"></column>
           <column name="search_tags_pt"></column>
+          <column name="search_tags_fi"></column>
           <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
         </table>
     <table name="mem">
@@ -3648,6 +4008,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Барбара Марч</column>
       <column name="definition_zh_HK">「芭芭拉·瑪奇」</column>
       <column name="definition_pt">Barbara March</column>
+      <column name="definition_fi">Barbara maaliskuu [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3658,6 +4019,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Актриса, которая играет {lurSa':n:name}.</column>
       <column name="notes_zh_HK">她是扮演{lurSa':n:name}的女演員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ela é a atriz que interpreta {lurSa':n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on näyttelijä, joka pelaa {lurSa':n:name}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3667,6 +4029,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3674,6 +4037,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -3687,6 +4051,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Болгария [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">保加利亞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Bulgária</column>
+      <column name="definition_fi">Bulgaria [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3697,6 +4062,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3706,6 +4072,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3713,6 +4080,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3726,6 +4094,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Бирманский язык</column>
       <column name="definition_zh_HK">緬甸語</column>
       <column name="definition_pt">Idioma birmanês</column>
+      <column name="definition_fi">Burman kieli [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mIyama:n}, {Hol:n}, {'eyawaDIy:n}</column>
@@ -3736,6 +4105,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3745,6 +4115,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3752,6 +4123,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3765,6 +4137,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Банан</column>
       <column name="definition_zh_HK">香蕉</column>
       <column name="definition_pt">banana</column>
+      <column name="definition_fi">banaani [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3775,6 +4148,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3784,6 +4158,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3791,6 +4166,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -3804,6 +4180,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Индия</column>
       <column name="definition_zh_HK">印度</column>
       <column name="definition_pt">Índia</column>
+      <column name="definition_fi">Intia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3814,6 +4191,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3823,6 +4201,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3830,6 +4209,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -3843,6 +4223,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Бостон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">波斯頓 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Boston</column>
+      <column name="definition_fi">Boston [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3853,6 +4234,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это город в {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{'amerI'qa' SepjIjQa':n}的城市。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma cidade em {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kaupunki kielellä {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3862,6 +4244,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3869,6 +4252,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -3882,6 +4266,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Бельгия</column>
       <column name="definition_zh_HK">比利時</column>
       <column name="definition_pt">Bélgica</column>
+      <column name="definition_fi">Belgia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3892,6 +4277,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3901,6 +4287,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3908,6 +4295,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -3921,6 +4309,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Берлин [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">柏林 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Berlim</column>
+      <column name="definition_fi">Berliini [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3931,6 +4320,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это столица {DoyIchlan:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{DoyIchlan:n}的首都。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a capital do {DoyIchlan:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {DoyIchlan:n}: n pääkaupunki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3940,6 +4330,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3947,6 +4338,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -3960,6 +4352,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Baobab (a Terran tree) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">猢猻樹</column>
       <column name="definition_pt">Baobá (uma árvore terráquea)</column>
+      <column name="definition_fi">Baobab (Terran-puu) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Sor:n}</column>
@@ -3970,6 +4363,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это просто клингонское произношение имени определенного дерева, найденного на Земле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是地球上發現的特定樹的名稱的克林崗語發音。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é simplesmente a pronúncia klingon do nome de uma árvore específica encontrada na Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on yksinkertaisesti maasta löydetyn tietyn puun nimen klingon-ääntäminen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3979,6 +4373,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3986,6 +4381,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -3999,6 +4395,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Билл Джордж</column>
       <column name="definition_zh_HK">「比爾·喬治」</column>
       <column name="definition_pt">Bill George</column>
+      <column name="definition_fi">Bill George [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4009,6 +4406,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Один из дизайнеров плаката {BoP:src}. Смотрите {nIylo roDIS:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{BoP:src}海報的設計師之一。參見{nIylo roDIS:n:name}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um dos designers do pôster {BoP:src}. Consulte {nIylo roDIS:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksi {BoP:src}-julisteen suunnittelijoista. Katso {nIylo roDIS:n:name}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -4020,6 +4418,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
 ▶ {lu'oghta' nIylo roDIS bIl jo'rIj je:sen:nolink} "Создано: Найло Родисом &amp; Биллом Джорджем"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4027,6 +4426,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -4040,6 +4440,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Бразилия</column>
       <column name="definition_zh_HK">巴西</column>
       <column name="definition_pt">Brasil</column>
+      <column name="definition_fi">Brasilia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4050,6 +4451,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4059,6 +4461,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4066,6 +4469,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4079,6 +4483,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">британская Колумбия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不列顛哥倫比亞省</column>
       <column name="definition_pt">British Columbia</column>
+      <column name="definition_fi">Brittiläinen Kolumbia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4089,6 +4494,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это провинция {qa'naDa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{qa'naDa':n}的省。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma província do {qa'naDa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {qa'naDa':n}-maakunta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4098,6 +4504,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4105,6 +4512,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4118,6 +4526,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Боспорское [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">博斯普魯斯海峽 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Bósforo</column>
+      <column name="definition_fi">Bosporus [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4128,6 +4537,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это водный путь в {turIqya':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{turIqya':n}中的水路。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma via navegável em {turIqya':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vesiväylä kielellä {turIqya':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4137,6 +4547,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4144,6 +4555,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -4157,6 +4569,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Чехия</column>
       <column name="definition_zh_HK">捷克</column>
       <column name="definition_pt">República Checa</column>
+      <column name="definition_fi">Tšekin tasavalta [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4167,6 +4580,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Его столица - ДОНОТТРАНСЛАЙТ. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它的首都是{pIra'Ha:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Sua capital é {pIra'Ha:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen pääkaupunki on {pIra'Ha:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4176,6 +4590,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4183,6 +4598,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4196,6 +4612,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">доллар [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蚊（美元、港幣等等）</column>
       <column name="definition_pt">dólar</column>
+      <column name="definition_fi">dollari [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4206,6 +4623,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это просто название нескольких вышедших из употребления терранских валют. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是幾種廢棄的Terran貨幣的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é apenas o nome de várias moedas terrestres em desuso. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain useiden käyttämättömien Terran-valuuttojen nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4215,6 +4633,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4222,6 +4641,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4235,6 +4655,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Дания</column>
       <column name="definition_zh_HK">丹麥</column>
       <column name="definition_pt">Dinamarca</column>
+      <column name="definition_fi">Tanska [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghenlan:n}</column>
@@ -4245,6 +4666,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">В земном пересказе {Hamlet:src}, главный персонаж является принцем этой страны на Земле.</column>
       <column name="notes_zh_HK">在{Hamlet:src}的人族重述中，名義上的角色是這個國家在地球上的王子。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Na recontagem terrestre de {Hamlet:src}, o personagem titular é o príncipe deste país na Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Hamlet:src}: n Terran-uudelleenkirjoituksessa nimimerkki on tämän maan prinssi maan päällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4254,6 +4676,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4261,6 +4684,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4274,6 +4698,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Детройт [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">底特律</column>
       <column name="definition_pt">Detroit</column>
+      <column name="definition_fi">Detroit [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4284,6 +4709,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4293,6 +4719,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4300,6 +4727,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -4313,6 +4741,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Германия</column>
       <column name="definition_zh_HK">德國</column>
       <column name="definition_pt">Alemanha</column>
+      <column name="definition_fi">Saksa [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4323,6 +4752,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Его столица - {berlIn:n}. Другой большой город - {Hamburgh:n}. {qepHom'a':n} происходит в {Sarbruqen:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它的首都是{berlIn:n}。另一個大城市是{Hamburgh:n}。 {qepHom'a':n}在{Sarbruqen:n}中進行。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Sua capital é {berlIn:n}. Outra cidade grande é o {Hamburgh:n}. O {qepHom'a':n} ocorre em {Sarbruqen:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen pääkaupunki on {berlIn:n}. Toinen suuri kaupunki on {Hamburgh:n}. {qepHom'a':n} tapahtuu {Sarbruqen:n}: ssä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4332,6 +4762,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4339,6 +4770,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4352,6 +4784,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Немецкий язык</column>
       <column name="definition_zh_HK">德文、德語</column>
       <column name="definition_pt">Alemão (Língua)</column>
+      <column name="definition_fi">saksan kieli</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DoyIchlan:n}, {Hol:n}</column>
@@ -4362,6 +4795,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DoyIchlan:n}, {Hol:n}</column>
       <column name="examples"></column>
@@ -4371,6 +4805,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4378,6 +4813,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2012.04.01:src}</column>
     </table>
     <table name="mem">
@@ -4391,6 +4827,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Гренландия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">格陵蘭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Gronelândia</column>
+      <column name="definition_fi">Grönlanti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Denmargh:n}</column>
@@ -4401,6 +4838,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4410,6 +4848,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4417,6 +4856,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -4430,6 +4870,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">виноград</column>
       <column name="definition_zh_HK">提子、葡萄</column>
       <column name="definition_pt">uva</column>
+      <column name="definition_fi">rypäleen [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4440,6 +4881,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это то, что Клингоны называют земным фруктом</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4449,6 +4891,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4456,6 +4899,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4469,6 +4913,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">гиннес [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">健力士 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Guinness</column>
+      <column name="definition_fi">Guinness [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4479,6 +4924,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это всего лишь клингонское правописание для названия компании. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是公司名稱的Klingon拼寫。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é apenas a grafia Klingon para o nome da empresa. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain yrityksen nimen Klingon-kirjoitusasu. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4488,6 +4934,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4495,6 +4942,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>
     <table name="mem">
@@ -4508,6 +4956,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Гвинит Уолш</column>
       <column name="definition_zh_HK">「格瓦尼斯·沃爾什」</column>
       <column name="definition_pt">Gwynyth Walsh</column>
+      <column name="definition_fi">Gwynyth Walsh [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4518,6 +4967,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Она актриса, которая играет {be'etor:n:name}.</column>
       <column name="notes_zh_HK">她是扮演{be'etor:n:name}的女演員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ela é a atriz que interpreta {be'etor:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on näyttelijä, joka pelaa {be'etor:n:name}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4527,6 +4977,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4534,6 +4985,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -4547,6 +4999,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Гамбург [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">漢堡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Hamburgo</column>
+      <column name="definition_fi">Hampuri [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Ha'DIbaH ghIH tIr ngogh je:n}</column>
@@ -4557,6 +5010,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это название города Терран, расположенного в {DoyIchlan:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是位於{DoyIchlan:n}的Terran城市的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma cidade terrestre localizada em {DoyIchlan:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Terranin kaupungin nimi, joka sijaitsee {DoyIchlan:n}: ssä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4566,6 +5020,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4573,6 +5028,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>
     <table name="mem">
@@ -4586,6 +5042,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Джон Коликос</column>
       <column name="definition_zh_HK">約翰·科利科斯</column>
       <column name="definition_pt">John Colicos</column>
+      <column name="definition_fi">John Colicos [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qolqoS:n}</column>
@@ -4596,6 +5053,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Имя актёра, который играл Кора (смотрите {qor:n:name}).</column>
       <column name="notes_zh_HK">這是扮演Kor的演員的名字（請參閱{qor:n:name}）。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome do ator que interpretou Kor (consulte {qor:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on näyttelijän nimi, joka soitti Koria (katso {qor:n:name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4605,6 +5063,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4612,6 +5071,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -4625,6 +5085,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Джаз [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">爵士音樂</column>
       <column name="definition_pt">jazz (música)</column>
+      <column name="definition_fi">jazz-musiikki</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{QoQ:n}</column>
@@ -4635,6 +5096,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это заимствованное слово от {DIvI' Hol:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{DIvI' Hol:n}的藉詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra de empréstimo da {DIvI' Hol:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on laina sanalta {DIvI' Hol:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4644,6 +5106,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4651,6 +5114,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4664,6 +5128,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Джорджия (штат США) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">格魯吉亞（美國） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Geórgia (estado dos EUA)</column>
+      <column name="definition_fi">Georgia (Yhdysvaltain osavaltio) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4674,6 +5139,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это название штата, расположенного в {'amerI'qa' SepjIjQa':n}. Не следует путать с {SaQatvelo':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este é o nome de um estado localizado em {'amerI'qa' SepjIjQa':n}. Não deve ser confundido com {SaQatvelo':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on osavaltiossa {'amerI'qa' SepjIjQa':n} sijaitsevan osavaltion nimi. Sitä ei pidä sekoittaa {SaQatvelo':n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4683,6 +5149,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4690,6 +5157,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -4703,6 +5171,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Китай</column>
       <column name="definition_zh_HK">中國</column>
       <column name="definition_pt">China</column>
+      <column name="definition_fi">Kiina [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4713,6 +5182,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">At the {Saarbrücken qepHom'a' 2011:src}, MO said that he deliberately chose the Cantonese pronunciation for China rather than the Mandarin one, because the latter would have ended in {wo':n}, and he didn't think Klingons would like to call an Earth country by their word for "empire".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4722,6 +5192,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4729,6 +5200,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -4742,6 +5214,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Юпитер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">木星 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Júpiter</column>
+      <column name="definition_fi">Jupiter [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4752,6 +5225,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on puhekielenimi {Sol vagh:n@@Sol:n, vagh:n:1,num}-planeetalle, joka on {Sol:n}-järjestelmässä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4761,6 +5235,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4768,6 +5243,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -4781,6 +5257,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Лондон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">倫敦 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Londres</column>
+      <column name="definition_fi">Lontoo [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4791,6 +5268,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это столица {'Inglan:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{'Inglan:n}的首都。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a capital do {'Inglan:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {'Inglan:n}: n pääkaupunki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4800,6 +5278,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4807,6 +5286,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -4820,6 +5300,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Лас Вегас</column>
       <column name="definition_zh_HK">拉斯維加斯</column>
       <column name="definition_pt">Las Vegas</column>
+      <column name="definition_fi">Las Vegas [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4830,6 +5311,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это название города, расположенного в {'amerI'qa' SepjIjQa':n} на Земле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上{'amerI'qa' SepjIjQa':n}中一個城市的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma cidade localizada em {'amerI'qa' SepjIjQa':n} na Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kaupungin nimi, joka sijaitsee maan päällä {'amerI'qa' SepjIjQa':n}: ssä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Las Vegas Hilton hotel was the site of a themed attraction called Star Trek The Experience. The name of the city appeared in Klingon in the invitation to the grand opening.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4839,6 +5321,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4846,6 +5329,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek The Experience:src}</column>
     </table>
     <table name="mem">
@@ -4859,6 +5343,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Люксембург</column>
       <column name="definition_zh_HK">盧森堡</column>
       <column name="definition_pt">Luxembourg</column>
+      <column name="definition_fi">Luxemburg [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4869,6 +5354,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4878,6 +5364,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4885,6 +5372,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4898,6 +5386,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Лихтенштейн</column>
       <column name="definition_zh_HK">列支敦士登</column>
       <column name="definition_pt">Liechtenstein</column>
+      <column name="definition_fi">Liechtenstein [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4908,6 +5397,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4917,6 +5407,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4924,6 +5415,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4937,6 +5429,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Ливия</column>
       <column name="definition_zh_HK">利比亞</column>
       <column name="definition_pt">Líbia</column>
+      <column name="definition_fi">Libya [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4947,6 +5440,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4956,6 +5450,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -4963,6 +5458,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -4976,6 +5472,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Ленин [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">列寧 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Lenin</column>
+      <column name="definition_fi">Lenin [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -4986,6 +5483,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это имя человека из истории Земли. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球歷史上一個人的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma pessoa da história da Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on henkilön nimi maan historiasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -4995,6 +5493,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5002,6 +5501,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -5015,6 +5515,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Лили [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">百合 [AUTOTRANSLATED]</column>
       <column name="definition_pt">lírio</column>
+      <column name="definition_fi">lilja [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5025,6 +5526,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это просто заимствовано из Федерального стандарта. Нет родного клингонского эквивалента. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是從聯邦標準借來的。沒有本地Klingon等效項。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é apenas emprestado do Federation Standard. Não existe um equivalente Klingon nativo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain lainattu Federation Standardilta. Natiivia klingonilaista vastaavaa ei ole. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5034,6 +5536,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5041,6 +5544,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5054,6 +5558,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Венгрия</column>
       <column name="definition_zh_HK">匈牙利</column>
       <column name="definition_pt">Hungria</column>
+      <column name="definition_fi">Unkari [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5064,6 +5569,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5073,6 +5579,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5080,6 +5587,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5093,6 +5601,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Марокко</column>
       <column name="definition_zh_HK">摩洛哥</column>
       <column name="definition_pt">Marrocos</column>
+      <column name="definition_fi">Marokko [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5103,6 +5612,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5112,6 +5622,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5119,6 +5630,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5132,6 +5644,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Малайзия</column>
       <column name="definition_zh_HK">馬來西亞</column>
       <column name="definition_pt">Malásia</column>
+      <column name="definition_fi">Malesia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5142,6 +5655,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5151,6 +5665,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de">Malaysien</column>
       <column name="search_tags_fa"></column>
@@ -5158,6 +5673,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.02.06:src}</column>
     </table>
     <table name="mem">
@@ -5171,6 +5687,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Марс [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">火星 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Marte</column>
+      <column name="definition_fi">Mars [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5181,6 +5698,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on puhekielenimi {Sol loS:n@@Sol:n, loS:n:1,num}-planeetalle, joka on {Sol:n}-järjestelmässä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5190,6 +5708,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5197,6 +5716,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -5210,6 +5730,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Египет</column>
       <column name="definition_zh_HK">埃及</column>
       <column name="definition_pt">Egito</column>
+      <column name="definition_fi">Egypti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5220,6 +5741,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5229,6 +5751,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5236,6 +5759,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5249,6 +5773,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Москва [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">莫斯科 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Moscow</column>
+      <column name="definition_fi">Moskova [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5259,6 +5784,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это столица {raSya':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{raSya':n}的首都。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a capital do {raSya':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {raSya':n}: n pääkaupunki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5268,6 +5794,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5275,6 +5802,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5288,6 +5816,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Мао [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">毛澤東</column>
       <column name="definition_pt">Mao</column>
+      <column name="definition_fi">Mao [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5298,6 +5827,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это имя человека из истории Земли. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球歷史上一個人的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma pessoa da história da Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on henkilön nimi maan historiasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5307,6 +5837,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5314,6 +5845,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -5327,6 +5859,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Майкл Дорн</column>
       <column name="definition_zh_HK">「麥可·多恩」</column>
       <column name="definition_pt">Michael Dorn</column>
+      <column name="definition_fi">Michael Dorn [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5337,6 +5870,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это актёр, который играет Ворфа ({wo'rIv:n:name}).</column>
       <column name="notes_zh_HK">扮演沃爾夫（{wo'rIv:n:name}）的演員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O ator que interpreta Worf ({wo'rIv:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Näyttelijä, joka pelaa Worfia ({wo'rIv:n:name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5346,6 +5880,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5353,6 +5888,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -5366,6 +5902,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Майкл Ансара</column>
       <column name="definition_zh_HK">「麥克·安沙拉」</column>
       <column name="definition_pt">Michael Ansara</column>
+      <column name="definition_fi">Michael Ansara [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5376,6 +5913,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Актёр, который играет Канга ({qeng:n:name}).</column>
       <column name="notes_zh_HK">扮演姜（{qeng:n:name}）的演員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O ator que interpretou Kang ({qeng:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Näyttelijä, joka soitti Kangia ({qeng:n:name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5385,6 +5923,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5392,6 +5931,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -5405,6 +5945,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">манго</column>
       <column name="definition_zh_HK">芒果</column>
       <column name="definition_pt">manga</column>
+      <column name="definition_fi">mango [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5415,6 +5956,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это то, что Клингон назовет земным фруктом</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que um klingon chamaria de fruta terráquea. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingon kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5424,6 +5966,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5431,6 +5974,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5444,6 +5988,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Бирма/Мьянма</column>
       <column name="definition_zh_HK">緬甸</column>
       <column name="definition_pt">Birmânia / Mianmar</column>
+      <column name="definition_fi">Burma / Myanmar [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bama Hol:n}</column>
@@ -5454,6 +5999,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5463,6 +6009,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Myanmar</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5470,6 +6017,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru">Мьянма</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5483,6 +6031,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Монголия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蒙古</column>
       <column name="definition_pt">Mongólia</column>
+      <column name="definition_fi">Mongolia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5493,6 +6042,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это название страны на Земле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上一個國家的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um país na Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maan nimi maan päällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5502,6 +6052,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5509,6 +6060,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -5522,6 +6074,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Монако [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">摩納哥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Mônaco</column>
+      <column name="definition_fi">Monaco [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5532,6 +6085,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5541,6 +6095,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5548,6 +6103,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>
     <table name="mem">
@@ -5561,6 +6117,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Ниагара [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">尼亞加拉</column>
       <column name="definition_pt">Niágara</column>
+      <column name="definition_fi">Niagara [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5571,6 +6128,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это регион, охватывающий границу между {qa'naDa':n} и {'amerI'qa' SepjIjQa':n} со знаменитым {bIQ notron:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on alue, joka kattaa rajan {qa'naDa':n} ja {'amerI'qa' SepjIjQa':n} välillä kuuluisalla {bIQ notron:n}: lla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5580,6 +6138,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5587,6 +6146,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -5600,6 +6160,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Нигерия</column>
       <column name="definition_zh_HK">尼日利亞</column>
       <column name="definition_pt">Nigéria</column>
+      <column name="definition_fi">Nigeria [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5610,6 +6171,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5619,6 +6181,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5626,6 +6189,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5639,6 +6203,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Невада [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">內華達州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Nevada</column>
+      <column name="definition_fi">Nevada [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5649,6 +6214,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5658,6 +6224,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5665,6 +6232,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5678,6 +6246,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Нило Родис</column>
       <column name="definition_zh_HK">「尼洛·羅迪斯」</column>
       <column name="definition_pt">Nilo Rodis</column>
+      <column name="definition_fi">Nilo Rodis [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5688,6 +6257,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Один из создателей {BoP:src} постеров. Смотрите {bIl jo'rIj:n:name}.</column>
       <column name="notes_zh_HK">{BoP:src}海報的設計師之一。參見{bIl jo'rIj:n:name}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um dos designers do pôster {BoP:src}. Consulte {bIl jo'rIj:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Yksi {BoP:src}-julisteen suunnittelijoista. Katso {bIl jo'rIj:n:name}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -5699,6 +6269,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
 ▶ {lu'oghta' nIylo roDIS bIl jo'rIj je:sen:nolink} "Создано: Нило Родисом и Биллом Джорджем"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5706,6 +6277,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -5719,6 +6291,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Нью-Йорк</column>
       <column name="definition_zh_HK">紐約</column>
       <column name="definition_pt">New York</column>
+      <column name="definition_fi">New York [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5729,6 +6302,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5738,6 +6312,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5745,6 +6320,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -5758,6 +6334,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Новая Зеландия</column>
       <column name="definition_zh_HK">紐西蘭、新西蘭</column>
       <column name="definition_pt">Nova Zelândia</column>
+      <column name="definition_fi">Uusi Seelanti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{waqboch:n}</column>
@@ -5768,6 +6345,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5777,6 +6355,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5784,6 +6363,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5797,6 +6377,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Париж [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">巴黎 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Paris</column>
+      <column name="definition_fi">Pariisi [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5807,6 +6388,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это столица {vIraS:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{vIraS:n}的首都。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a capital do {vIraS:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {vIraS:n}: n pääkaupunki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5816,6 +6398,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5823,6 +6406,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -5836,6 +6420,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Парагвай [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">巴拉圭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Paraguai</column>
+      <column name="definition_fi">Paraguay [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5846,6 +6431,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5855,6 +6441,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5862,6 +6449,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5875,6 +6463,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Пенсильвания [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">賓夕法尼亞州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Pensilvânia</column>
+      <column name="definition_fi">Pennsylvania [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5885,6 +6474,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5894,6 +6484,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5901,6 +6492,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -5914,6 +6506,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">груша</column>
       <column name="definition_zh_HK">梨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pêra</column>
+      <column name="definition_fi">päärynä [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5924,6 +6517,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5933,6 +6527,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5940,6 +6535,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -5953,6 +6549,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Перу [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">秘魯 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Peru</column>
+      <column name="definition_fi">Peru [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -5963,6 +6560,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -5972,6 +6570,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -5979,6 +6578,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -5992,6 +6592,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">слива</column>
       <column name="definition_zh_HK">李子</column>
       <column name="definition_pt">ameixa</column>
+      <column name="definition_fi">luumu [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6002,6 +6603,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это то, что Клингоны зовут земным фруктом.</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6011,6 +6613,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6018,6 +6621,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6031,6 +6635,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Прага [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">布拉格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Praga</column>
+      <column name="definition_fi">Praha [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6041,6 +6646,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это столица {cheSqa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{cheSqa':n}的首都。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a capital do {cheSqa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {cheSqa':n}: n pääkaupunki. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6050,6 +6656,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6057,6 +6664,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -6070,6 +6678,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Пицца (земное блюдо)</column>
       <column name="definition_zh_HK">比薩 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pizza</column>
+      <column name="definition_fi">pizza [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chab:n:1}, {'IventoH:n}</column>
@@ -6080,6 +6689,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это то, что Клингоны зовут земной пищей. Для Клингонов пицца, определенно вид {chab:n:1}.</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族食物。對於克林貢人而言，披薩顯然是一種唐納什板岩。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de comida terráquea. Para os klingons, as pizzas são aparentemente uma espécie de {chab:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-ruokaksi. Klingonsille pizzat ovat ilmeisesti eräänlainen {chab:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6089,6 +6699,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6096,6 +6707,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6109,6 +6721,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Питтсбург</column>
       <column name="definition_zh_HK">匹茲堡</column>
       <column name="definition_pt">Pittsburgh</column>
+      <column name="definition_fi">Pittsburgh [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'a'leghen'I':n}</column>
@@ -6119,6 +6732,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Название места в {'amerI'qa' SepjIjQa':n} на Земле.</column>
       <column name="notes_zh_HK">這是地球上{'amerI'qa' SepjIjQa':n}中的地名。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um nome de lugar em {'amerI'qa' SepjIjQa':n} on Earth. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maan nimi {'amerI'qa' SepjIjQa':n}: ssä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6128,6 +6742,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6135,6 +6750,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6148,6 +6764,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Португалия</column>
       <column name="definition_zh_HK">葡萄牙</column>
       <column name="definition_pt">Portugal</column>
+      <column name="definition_fi">Portugali [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6158,6 +6775,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6167,6 +6785,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6174,6 +6793,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6187,6 +6807,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Польша</column>
       <column name="definition_zh_HK">波蘭</column>
       <column name="definition_pt">Polonia</column>
+      <column name="definition_fi">Puola [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6197,6 +6818,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6206,6 +6828,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6213,6 +6836,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6226,6 +6850,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Калифорния</column>
       <column name="definition_zh_HK">加州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">California</column>
+      <column name="definition_fi">Kaliforniassa [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6236,6 +6861,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Название штата, расположенного в {'amerI'qa' SepjIjQa':n}.</column>
       <column name="notes_zh_HK">這是位於{'amerI'qa' SepjIjQa':n}中的州的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um estado localizado em {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on osavaltiossa {'amerI'qa' SepjIjQa':n} sijaitsevan osavaltion nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6245,6 +6871,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6252,6 +6879,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -6265,6 +6893,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Камерун</column>
       <column name="definition_zh_HK">喀麥隆</column>
       <column name="definition_pt">Camarões</column>
+      <column name="definition_fi">Kamerun [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6275,6 +6904,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Название земной страны</column>
       <column name="notes_zh_HK">這是地球上的一個國家。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um país na Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maa maan päällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6284,6 +6914,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6291,6 +6922,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -6304,6 +6936,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Канада</column>
       <column name="definition_zh_HK">加拿大</column>
       <column name="definition_pt">Canadá</column>
+      <column name="definition_fi">Kanada [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6320,6 +6953,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
 ▶ {'onteryo:n}</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6329,6 +6963,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6336,6 +6971,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6349,6 +6985,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Квебек</column>
       <column name="definition_zh_HK">魁北克省</column>
       <column name="definition_pt">Quebec</column>
+      <column name="definition_fi">Quebec [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6359,6 +6996,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Является провинцией {qa'naDa':n}. Столицей является {qebeq veng:n}.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on {qa'naDa':n}-maakunta. Sen pääkaupunki on {qebeq veng:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6368,6 +7006,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6375,6 +7014,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -6388,6 +7028,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Квебек сити</column>
       <column name="definition_zh_HK">魁北克市</column>
       <column name="definition_pt">cidade de Quebec</column>
+      <column name="definition_fi">Quebecin kaupunki [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6398,6 +7039,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Является столицей провинции {qebeq:n} в {qa'naDa':n}.</column>
       <column name="notes_zh_HK">這是{qa'naDa':n}中{qebeq:n}省的省會城市。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a capital da província de {qebeq:n} em {qa'naDa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {qebeq:n}: n maakunnan pääkaupunki {qa'naDa':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6407,6 +7049,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6414,6 +7057,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -6427,6 +7071,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Канзас</column>
       <column name="definition_zh_HK">堪薩斯州</column>
       <column name="definition_pt">Kansas</column>
+      <column name="definition_fi">Kansas [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6437,6 +7082,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это название штата, расположенного в {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是位於{'amerI'qa' SepjIjQa':n}中的州的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um estado localizado em {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on osavaltiossa {'amerI'qa' SepjIjQa':n} sijaitsevan osavaltion nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6446,6 +7092,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6453,6 +7100,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -6466,6 +7114,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Кения</column>
       <column name="definition_zh_HK">肯尼亞</column>
       <column name="definition_pt">Quenia</column>
+      <column name="definition_fi">Kenia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6476,6 +7125,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6485,6 +7135,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6492,6 +7143,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6505,6 +7157,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Кока-Кола [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">可口可樂 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Coca Cola</column>
+      <column name="definition_fi">Coca Cola [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qo'la' 'awje':n}</column>
@@ -6515,6 +7168,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это всего лишь транслитерация бренда безалкогольного напитка, найденного на Земле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這只是地球上發現的軟飲料品牌的音譯。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é apenas a transliteração de uma marca de refrigerante encontrada na Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on vain translitterointi maasta löydetystä virvoitusjuomasta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6524,6 +7178,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6531,6 +7186,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.03.30:src}</column>
     </table>
     <table name="mem">
@@ -6544,6 +7200,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">кокос [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">椰子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">coco</column>
+      <column name="definition_fi">kookospähkinä [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6554,6 +7211,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это заимствование, а не родное клингонское слово. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一個借用，而不是本地的克林崗語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra emprestada e não nativa do Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on lainaa eikä ole syntyperäinen klingonilainen sana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6563,6 +7221,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6570,6 +7229,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -6583,6 +7243,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Куба</column>
       <column name="definition_zh_HK">古巴</column>
       <column name="definition_pt">Cuba</column>
+      <column name="definition_fi">Kuuba [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6593,6 +7254,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6602,6 +7264,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6609,6 +7272,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6622,6 +7286,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Роберт О'рейлли</column>
       <column name="definition_zh_HK">「羅伯特·奧雷利」</column>
       <column name="definition_pt">Robert O'Reilly</column>
+      <column name="definition_fi">Robert O'Reilly [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6632,6 +7297,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Актер, который играет Гаурона ({ghawran:n:name}).</column>
       <column name="notes_zh_HK">扮演高龍（{ghawran:n:name}）的演員。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O ator que interpreta Gowron ({ghawran:n:name}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Näyttelijä, joka pelaa Gowronia ({ghawran:n:name}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6641,6 +7307,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6648,6 +7315,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -6661,6 +7329,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Роксанн Биггс-Доусон</column>
       <column name="definition_zh_HK">羅克珊·比格斯道森</column>
       <column name="definition_pt">Roxann Biggs-Dawson</column>
+      <column name="definition_fi">Roxann Biggs-Dawson [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6671,6 +7340,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Имя актрисы, которая играет Б'Эланну Торрес.</column>
       <column name="notes_zh_HK">飾演B'Elanna Torres的女演員的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O nome da atriz que interpreta B'Elanna Torres. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Näyttelijän nimi, joka pelaa B'Elanna Torresia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6680,6 +7350,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6687,6 +7358,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {STC 104:src}</column>
     </table>
     <table name="mem">
@@ -6700,6 +7372,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">малина</column>
       <column name="definition_zh_HK">覆盆子 [AUTOTRANSLATED]</column>
       <column name="definition_pt">framboesa</column>
+      <column name="definition_fi">vadelma [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6710,6 +7383,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это то, что Клингоны называют земным фруктом</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6719,6 +7393,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6726,6 +7401,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6739,6 +7415,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Россия</column>
       <column name="definition_zh_HK">俄罗斯、俄國</column>
       <column name="definition_pt">Russia</column>
+      <column name="definition_fi">Venäjä [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6749,6 +7426,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Его столица - ДОНОТТРАНСЛАЙТ. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它的首都是{maSquwa':n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Sua capital é {maSquwa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen pääkaupunki on {maSquwa':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6758,6 +7436,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6765,6 +7444,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -6778,6 +7458,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">роза (терранский цветок) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">玫瑰花</column>
       <column name="definition_pt">rosa (uma flor terrestre)</column>
+      <column name="definition_fi">ruusu (Terran-kukka) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6788,6 +7469,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это слово заимствовано из Стандарта Федерации для обозначения определенного цветка терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是從聯邦標準借來的單詞，指代特定的人族花。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra emprestada do Federation Standard para se referir a uma flor terráquea específica. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Federal Standardilta lainattu sana viitata tiettyyn Terran-kukkaan. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6797,6 +7479,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6804,6 +7487,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -6817,6 +7501,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Сахара (Земная пустыня) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">撒哈拉沙漠</column>
       <column name="definition_pt">Saara (deserto da terra)</column>
+      <column name="definition_fi">Sahara (maan autiomaa) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Deb:n}</column>
@@ -6827,6 +7512,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это название места на Земле, поэтому оно заимствовано из стандарта Федерации. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上某個地方的名稱，因此是從“聯邦標準”中藉用的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um lugar na Terra e, portanto, é emprestado do Federation Standard. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on paikan nimi maan päällä, ja se on lainattu Federation Standardilta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6836,6 +7522,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6843,6 +7530,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2018.08.31:src}, [2] {The Little Prince:src}</column>
     </table>
     <table name="mem">
@@ -6856,6 +7544,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Грузия</column>
       <column name="definition_zh_HK">格魯吉亞</column>
       <column name="definition_pt">Geórgia</column>
+      <column name="definition_fi">Georgia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6866,6 +7555,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru">Это название страны на Земле. Не следует путать с {jorja:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上一個國家的名字。請勿將其與{jorja:n}混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um país na Terra. Não deve ser confundido com {jorja:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maan nimi maan päällä. Sitä ei pidä sekoittaa {jorja:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6875,6 +7565,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6882,6 +7573,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -6895,6 +7587,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Саарбрюккен (Германия) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">薩爾布呂肯（德國） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Saarbrücken (Alemanha)</column>
+      <column name="definition_fi">Saarbrücken (Saksa) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6905,6 +7598,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on kaupunki {DoyIchlan:n}: ssä, jossa {qepHom'a':n} tapahtuu. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6914,6 +7608,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6921,6 +7616,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -6935,6 +7631,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Сатурн</column>
       <column name="definition_zh_HK">土星</column>
       <column name="definition_pt">Saturno</column>
+      <column name="definition_fi">Saturnus [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}</column>
@@ -6945,6 +7642,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是{Sol:n}系統中的行星{Sol jav:n@@Sol:n, jav:n:1,num}的俗稱。由於它是一個外來名稱，因此未遵循正確的克林崗語音系。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome coloquial de {Sol jav:n@@Sol:n, jav:n:1,num}, um planeta no sistema {Sol:n}. Ele não segue a fonologia adequada de Klingon, pois é um nome alienígena. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on puhekielenimi {Sol jav:n@@Sol:n, jav:n:1,num}-planeetalle, joka on {Sol:n}-järjestelmässä. Se ei noudata oikeaa Klingonin fonologiaa, koska se on ulkomaalainen nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The tweet confirms that the translation was provided by MO.</column>
       <column name="components"></column>
       <column name="examples">{Saturn yIvan:sen:nolink} "Wave at Saturn"</column>
@@ -6954,6 +7652,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -6961,6 +7660,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {@CassiniSaturn tweet 2013.06.28:src}</column>
     </table>
     <table name="mem">
@@ -6974,6 +7674,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Словакия</column>
       <column name="definition_zh_HK">斯洛伐克</column>
       <column name="definition_pt">Eslováquia</column>
+      <column name="definition_fi">Slovakia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -6984,6 +7685,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -6993,6 +7695,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7000,6 +7703,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7013,6 +7717,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Скандинавия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">斯堪的那維亞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Escandinávia</column>
+      <column name="definition_fi">Skandinavia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7023,6 +7728,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7032,6 +7738,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7039,6 +7746,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>
     <table name="mem">
@@ -7052,6 +7760,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Шотландия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蘇格蘭 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Escócia</column>
+      <column name="definition_fi">Skotlanti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuqjIjQa':n}, {wo' tay':n}, {'Inglan:n}</column>
@@ -7062,6 +7771,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7071,6 +7781,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7078,6 +7789,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7091,6 +7803,7 @@ Even though the line spoken by {tIquvma:n:name} means "Give me light to go", it 
       <column name="definition_ru">Солнце (научное название Солнца Земли) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">太陽（地球太陽的科學名稱） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Sol (nome científico do sol da Terra)</column>
+      <column name="definition_fi">Aurinko (tieteellinen nimi maapallon auringolle) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7111,6 +7824,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7120,6 +7834,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7127,6 +7842,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -7140,6 +7856,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Сирия</column>
       <column name="definition_zh_HK">敘利亞</column>
       <column name="definition_pt">Síria</column>
+      <column name="definition_fi">Syyria [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7150,6 +7867,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7159,6 +7877,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7166,6 +7885,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7179,6 +7899,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">клубника [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">士多啤梨、草莓</column>
       <column name="definition_pt">morango</column>
+      <column name="definition_fi">mansikka [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7189,6 +7910,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7198,6 +7920,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7205,6 +7928,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7218,6 +7942,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Суринам [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蘇里南 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Suriname</column>
+      <column name="definition_fi">Suriname [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7228,6 +7953,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7237,6 +7963,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7244,6 +7971,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -7257,6 +7985,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Швеция</column>
       <column name="definition_zh_HK">瑞典</column>
       <column name="definition_pt">Suécia</column>
+      <column name="definition_fi">Ruotsi [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7267,6 +7996,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7276,6 +8006,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7283,6 +8014,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7296,6 +8028,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Швейцария</column>
       <column name="definition_zh_HK">瑞士</column>
       <column name="definition_pt">Suíça</column>
+      <column name="definition_fi">Sveitsi [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7306,6 +8039,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7315,6 +8049,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Swiss</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7322,6 +8057,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7335,6 +8071,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Финляндия</column>
       <column name="definition_zh_HK">芬蘭</column>
       <column name="definition_pt">Finlândia</column>
+      <column name="definition_fi">Suomi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7345,6 +8082,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7354,6 +8092,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7361,6 +8100,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7374,6 +8114,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">мандарин [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">柑橘 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tangerina</column>
+      <column name="definition_fi">tangeriini [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera' na'ran:n}</column>
@@ -7384,6 +8125,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это фрукт родом с Земли. Это не упоминается как {tera' tanje'rIn:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是最初來自地球的水果。它不被稱為{tera' tanje'rIn:n:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma fruta originária da Terra. Não é referido como {tera' tanje'rIn:n:nolink}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on alun perin maasta peräisin oleva hedelmä. Sitä ei kutsuta nimellä {tera' tanje'rIn:n:nolink}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">It is unclear why this doesn't follow the pattern of other Terran fruit names of using the borrowed word followed by {naH:n}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7393,6 +8135,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mandarin, clementine</column>
       <column name="search_tags_de">Mandarine, Clementine</column>
       <column name="search_tags_fa"></column>
@@ -7400,6 +8143,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2019:src}</column>
     </table>
     <table name="mem">
@@ -7413,6 +8157,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Техас [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">德州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Texas</column>
+      <column name="definition_fi">Texas [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7423,6 +8168,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Название штата, расположенного в {'amerI'qa' SepjIjQa':n}. Его столицей является {'oStIn:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是位於{'amerI'qa' SepjIjQa':n}中的州的名稱。它的首都是{'oStIn:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um estado localizado em {'amerI'qa' SepjIjQa':n}. Sua capital é {'oStIn:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on osavaltiossa {'amerI'qa' SepjIjQa':n} sijaitsevan osavaltion nimi. Sen pääkaupunki on {'oStIn:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7432,6 +8178,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7439,6 +8186,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Sepqep wa'DIch:src} ({KLI mailing list 2019.11.10:src})</column>
     </table>
     <table name="mem">
@@ -7452,6 +8200,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">помидор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">番茄</column>
       <column name="definition_pt">tomate</column>
+      <column name="definition_fi">tomaatti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7462,6 +8211,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7471,6 +8221,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7478,6 +8229,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7491,6 +8243,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">табак [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">煙草</column>
       <column name="definition_pt">tabaco</column>
+      <column name="definition_fi">tupakka [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{por:n}, {tlhIch:n}, {pur:v}, {mIrSam:n}</column>
@@ -7501,6 +8254,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это слово заимствовано из Стандарта Федерации в отношении земного растения [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是從聯邦標準借來的一個單詞，指的是地球植物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra emprestada do Padrão da Federação referente a uma planta da Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on federaation standardilta lainattu sana, joka viittaa maapallon kasviin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7510,6 +8264,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7517,6 +8272,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 25 (2018):src}</column>
     </table>
     <table name="mem">
@@ -7530,6 +8286,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Турция</column>
       <column name="definition_zh_HK">土耳其</column>
       <column name="definition_pt">Turqia</column>
+      <column name="definition_fi">Turkki [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boSporoS:n}</column>
@@ -7540,6 +8297,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7549,6 +8307,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7556,6 +8315,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7569,6 +8329,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Венесуэла</column>
       <column name="definition_zh_HK">委內瑞拉</column>
       <column name="definition_pt">Venezuela</column>
+      <column name="definition_fi">Venezuela [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7579,6 +8340,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7588,6 +8350,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7595,6 +8358,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7608,6 +8372,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Филадельфия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">費城 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Filadélfia</column>
+      <column name="definition_fi">Philadelphia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7618,6 +8383,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это город в {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{'amerI'qa' SepjIjQa':n}的城市。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma cidade em {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kaupunki kielellä {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7627,6 +8393,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7634,6 +8401,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -7647,6 +8415,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Франция</column>
       <column name="definition_zh_HK">法國</column>
       <column name="definition_pt">França</column>
+      <column name="definition_fi">Ranska [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7657,6 +8426,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Его столица - ДОНОТТРАНСЛАЙТ. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它的首都是{parIy:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Sua capital é {parIy:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen pääkaupunki on {parIy:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7666,6 +8436,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7673,6 +8444,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7686,6 +8458,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Вашингтон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">華盛頓特區 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Washington, DC</column>
+      <column name="definition_fi">Washington, DC [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7696,6 +8469,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это столица {'amerI'qa' SepjIjQa':n}. Он рассматривается как одно имя, и в обычном разговоре {DIySIy:sen:nolink} никогда не останавливается. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{'amerI'qa' SepjIjQa':n}的首都。它被視為單個名稱，在正常對話中，永遠不會遺忘{DIySIy:sen:nolink}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a capital do {'amerI'qa' SepjIjQa':n}. Ele é tratado como um nome único e, em conversas normais, o {DIySIy:sen:nolink} nunca é deixado de lado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {'amerI'qa' SepjIjQa':n}: n pääkaupunki. Sitä käsitellään yhtenä nimenä, ja normaalissa keskustelussa {DIySIy:sen:nolink} ei koskaan jää pois. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7705,6 +8479,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7712,6 +8487,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {'eSrIv 6, Feb. 2020:src} ({KLI mailing list 2020.01.28:src})</column>
     </table>
     <table name="mem">
@@ -7725,6 +8501,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Уэльс [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">威爾士 [AUTOTRANSLATED]</column>
       <column name="definition_pt">País de Gales</column>
+      <column name="definition_fi">Wales [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7735,6 +8512,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7744,6 +8522,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7751,6 +8530,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -7764,6 +8544,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Иерусалим</column>
       <column name="definition_zh_HK">耶路撒冷</column>
       <column name="definition_pt">Jerusalém</column>
+      <column name="definition_fi">Jerusalem [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7774,6 +8555,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7783,6 +8565,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7790,6 +8573,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7803,6 +8587,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Израиль</column>
       <column name="definition_zh_HK">以色列</column>
       <column name="definition_pt">Israel</column>
+      <column name="definition_fi">Israel [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7813,6 +8598,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7822,6 +8608,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7829,6 +8616,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7842,6 +8630,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Соединенные Штаты Америки</column>
       <column name="definition_zh_HK">美國</column>
       <column name="definition_pt">Estados Unidos da América</column>
+      <column name="definition_fi">Yhdysvallat [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuqjIjQa':n}, {yuQjIjQa':n}</column>
@@ -7852,6 +8641,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это страна на Земле. Его столица - ДОНОТТРАНСЛАЙТ. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上的一個國家。它的首都是{wa'SIngtanDIySIy:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um país na Terra. Sua capital é {wa'SIngtanDIySIy:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maa maan päällä. Sen pääkaupunki on {wa'SIngtanDIySIy:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{'amerI'qa':n:nolink}, {Sep:n}, {jIj:v}, {Qa':n:2,hyp}</column>
       <column name="examples"></column>
@@ -7861,6 +8651,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">USA, America</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7868,6 +8659,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -7881,6 +8673,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Южная Америка</column>
       <column name="definition_zh_HK">南美洲</column>
       <column name="definition_pt">América do Sul</column>
+      <column name="definition_fi">Etelä-Amerikka [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}, {yuwey:n}</column>
@@ -7891,6 +8684,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7900,6 +8694,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7907,6 +8702,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7920,6 +8716,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Северная Америка</column>
       <column name="definition_zh_HK">北美洲</column>
       <column name="definition_pt">América do Norte</column>
+      <column name="definition_fi">Pohjois-Amerikka [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}, {yuwey:n}</column>
@@ -7930,6 +8727,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7939,6 +8737,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7946,6 +8745,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7959,6 +8759,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">андорра</column>
       <column name="definition_zh_HK">安道爾</column>
       <column name="definition_pt">Andorra</column>
+      <column name="definition_fi">Andorra [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -7969,6 +8770,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это название страны на Земле. Не путать с планетой {'anDor:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上一個國家的名字。不要與{'anDor:n}星球混淆。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um país na Terra. Não deve ser confundido com o planeta {'anDor:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maan nimi maan päällä. Ei pidä sekoittaa {'anDor:n}-planeetan kanssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -7978,6 +8780,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -7985,6 +8788,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -7998,6 +8802,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Антарктида</column>
       <column name="definition_zh_HK">南極洲</column>
       <column name="definition_pt">Antártica</column>
+      <column name="definition_fi">Antarktis [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}, {yuwey:n}</column>
@@ -8008,6 +8813,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8017,6 +8823,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8024,6 +8831,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8037,6 +8845,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Аргентина</column>
       <column name="definition_zh_HK">阿根廷</column>
       <column name="definition_pt">Argentina</column>
+      <column name="definition_fi">Argentiina [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8047,6 +8856,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8056,6 +8866,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8063,6 +8874,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8076,6 +8888,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">унция [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">奧茲 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Oz</column>
+      <column name="definition_fi">Oz [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qenSaS:n}</column>
@@ -8086,6 +8899,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это имя персонажа из серии земных романов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一系列地球小說中的角色名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um personagem de uma série de romances da Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on hahmon nimi Earth-romaanisarjassa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Jack Bradley translated the story The Wizard of Oz as {'aS 'IDnar pIn'a' Dun:sen@@'aS:n, 'IDnar pIn'a':n, Dun:v}, from whence came this name and a bunch of new vocabulary.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8095,6 +8909,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8102,6 +8917,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2020.04.21:src}</column>
     </table>
     <table name="mem">
@@ -8115,6 +8931,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Австралия</column>
       <column name="definition_zh_HK">澳大利亞</column>
       <column name="definition_pt">Austrália</column>
+      <column name="definition_fi">Australia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}, {yuwey:n}</column>
@@ -8125,6 +8942,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8134,6 +8952,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8141,6 +8960,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8154,6 +8974,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Азия</column>
       <column name="definition_zh_HK">亞洲</column>
       <column name="definition_pt">Ásia</column>
+      <column name="definition_fi">Aasia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}, {yuwey:n}</column>
@@ -8164,6 +8985,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8173,6 +8995,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8180,6 +9003,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8193,6 +9017,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Атлантический океан</column>
       <column name="definition_zh_HK">大西洋</column>
       <column name="definition_pt">oceano Atlântico</column>
+      <column name="definition_fi">Atlantin valtameri [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8203,6 +9028,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8212,6 +9038,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8219,6 +9046,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Smithsonian GO FLIGHT app:src}</column>
     </table>
     <table name="mem">
@@ -8232,6 +9060,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Афганистан [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Afghanistan [AUTOTRANSLATED]</column>
       <column name="definition_pt">Afeganistão</column>
+      <column name="definition_fi">Afganistan [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8242,6 +9071,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8251,6 +9081,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8258,6 +9089,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8271,6 +9103,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Африка</column>
       <column name="definition_zh_HK">非洲</column>
       <column name="definition_pt">África</column>
+      <column name="definition_fi">Afrikka [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}, {yuwey:n}</column>
@@ -8281,6 +9114,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8290,6 +9124,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8297,6 +9132,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8310,6 +9146,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Гаити [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">海地 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Haiti</column>
+      <column name="definition_fi">Haiti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8320,6 +9157,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это название страны на Земле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上一個國家的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um país na Terra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maan nimi maan päällä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8329,6 +9167,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8336,6 +9175,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -8349,6 +9189,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Аллегейни [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">阿勒格尼 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Allegheny</column>
+      <column name="definition_fi">Allegheny [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pItlhbergh:n}</column>
@@ -8359,6 +9200,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это название места в {'amerI'qa' SepjIjQa':n} на Земле. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是地球上{'amerI'qa' SepjIjQa':n}中的地名。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um nome de lugar em {'amerI'qa' SepjIjQa':n} on Earth. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on maan nimi {'amerI'qa' SepjIjQa':n}: ssä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8368,6 +9210,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8375,6 +9218,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8388,6 +9232,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Греция</column>
       <column name="definition_zh_HK">希臘</column>
       <column name="definition_pt">Grécia</column>
+      <column name="definition_fi">Kreikka [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8398,6 +9243,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8407,6 +9253,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8414,6 +9261,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8427,6 +9275,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">яблоко [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">蘋果</column>
       <column name="definition_pt">maçã</column>
+      <column name="definition_fi">omena [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuqSIv:n}</column>
@@ -8437,6 +9286,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это то, что клингоны назвали бы фруктами терранов. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是克林崗人所說的人族水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isto é o que os klingons chamariam de fruto terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä Klingons kutsuisi Terran-hedelmäksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8446,6 +9296,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8453,6 +9304,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8466,6 +9318,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Эквадор</column>
       <column name="definition_zh_HK">厄瓜多爾</column>
       <column name="definition_pt">Equador</column>
+      <column name="definition_fi">Ecuador [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8476,6 +9329,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8485,6 +9339,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8492,6 +9347,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8505,6 +9361,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Испания</column>
       <column name="definition_zh_HK">西班牙</column>
       <column name="definition_pt">Espanha</column>
+      <column name="definition_fi">Espanja [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8515,6 +9372,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8524,6 +9382,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8531,6 +9390,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8544,6 +9404,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">spade (card suit) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鐵鍬（卡套裝） [AUTOTRANSLATED]</column>
       <column name="definition_pt">paus (naipe)</column>
+      <column name="definition_fi">lapio (korttipuku) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Degh:n:1}</column>
@@ -8554,6 +9415,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это клингонское произношение слова «лопата», означающее масть в колоде игральных карт. Для (физической) лопаты см. {ghevjur:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是單詞“鍬”的克林崗語發音，指一副撲克牌中的套裝。對於（物理）鏟，請參見{ghevjur:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a pronúncia klingon da palavra "pá", referindo-se ao naipe em um baralho de cartas. Para uma pá (física), consulte {ghevjur:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on sanan "lapio" Klingon ääntäminen viitaten pelikorttipakan pukuun. Katso (fyysinen) lapio kohdasta {ghevjur:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In MO's message, he wrote "He [Maltz] just called a spade {'eSpeD:n:nolink}." The expression "calling a spade a spade" is an idiom in English.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8563,6 +9425,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8570,6 +9433,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2014:src}</column>
     </table>
     <table name="mem">
@@ -8583,6 +9447,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Эстония</column>
       <column name="definition_zh_HK">愛沙尼亞</column>
       <column name="definition_pt">Estônia</column>
+      <column name="definition_fi">Viro [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8593,6 +9458,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8602,6 +9468,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8609,6 +9476,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8622,6 +9490,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Евро [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">歐元 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Euro</column>
+      <column name="definition_fi">Euro [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'ewrop:n}, {DeQ:n}, {Huch:n}</column>
@@ -8632,6 +9501,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это относится к единице европейской валюты. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指歐洲貨幣的單位。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Refere-se à unidade da moeda européia. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä viittaa Euroopan valuutan yksikköön. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8641,6 +9511,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8648,6 +9519,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2019.04.01:src}</column>
     </table>
     <table name="mem">
@@ -8661,6 +9533,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Европа</column>
       <column name="definition_zh_HK">歐洲</column>
       <column name="definition_pt">Europa</column>
+      <column name="definition_fi">Euroopassa [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tera':n}, {yuwey:n}, {'ewro:n}</column>
@@ -8671,6 +9544,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was accidentally left out of the continents section of the printed booklet.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8680,6 +9554,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8687,6 +9562,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8700,6 +9576,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Иравади [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">伊洛瓦底江</column>
       <column name="definition_pt">Irrawaddy</column>
+      <column name="definition_fi">Irrawaddy [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8710,6 +9587,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это название реки в {mIyama:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{mIyama:n}中的一條河的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um rio em {mIyama:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on joen nimi kielellä {mIyama:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8719,6 +9597,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8726,6 +9605,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8739,6 +9619,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Ирландия</column>
       <column name="definition_zh_HK">愛爾蘭</column>
       <column name="definition_pt">Irlanda</column>
+      <column name="definition_fi">Irlanti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8749,6 +9630,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8758,6 +9640,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8765,6 +9648,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8778,6 +9662,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">слон [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">象</column>
       <column name="definition_pt">elefante</column>
+      <column name="definition_fi">norsu [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8788,6 +9673,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это слово заимствовано из Стандарта Федерации для обозначения животного Терран. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是從Federation Standard（聯邦標準）借來的單詞，指代人族動物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma palavra emprestada da Federação Padrão para se referir ao animal terráqueo. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on Federal Standardilta lainattu sana viitata Terran-eläimeen. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8797,6 +9683,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8804,6 +9691,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 24 (2017):src}</column>
     </table>
     <table name="mem">
@@ -8817,6 +9705,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Индиана [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">印第安那州 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Indiana</column>
+      <column name="definition_fi">Indiana [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8827,6 +9716,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8836,6 +9726,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8843,6 +9734,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -8856,6 +9748,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Англия [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">英國 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Inglaterra</column>
+      <column name="definition_fi">Englanti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tuqjIjQa':n}, {wo' tay':n}, {SIqotlan:n}</column>
@@ -8866,6 +9759,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Его столица - ДОНОТТРАНСЛАЙТ. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">它的首都是{lanDan:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Sua capital é {lanDan:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Sen pääkaupunki on {lanDan:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8875,6 +9769,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8882,6 +9777,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 26 (2019):src}</column>
     </table>
     <table name="mem">
@@ -8895,6 +9791,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Исландия</column>
       <column name="definition_zh_HK">冰島</column>
       <column name="definition_pt">Islândia</column>
+      <column name="definition_fi">Islanti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8905,6 +9802,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8914,6 +9812,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8921,6 +9820,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -8934,6 +9834,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Италия</column>
       <column name="definition_zh_HK">意大利</column>
       <column name="definition_pt">Itália</column>
+      <column name="definition_fi">Italia [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8944,6 +9845,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Для описания шрифта "курсив" можно использовать {chongHa':v@@chong:v:1, -Ha':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">為了描述“斜體”字體，可以使用{chongHa':v@@chong:v:1, -Ha':v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Para descrever uma fonte "itálico", {chongHa':v@@chong:v:1, -Ha':v} pode ser usado. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Kursivoidun fontin kuvaamiseen voidaan käyttää {chongHa':v@@chong:v:1, -Ha':v}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8953,6 +9855,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8960,6 +9863,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}</column>
     </table>
     <table name="mem">
@@ -8973,6 +9877,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Ontario [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">安大略省</column>
       <column name="definition_pt">Ontario</column>
+      <column name="definition_fi">Ontario [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -8983,6 +9888,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это провинция {qa'naDa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{qa'naDa':n}的省。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma província do {qa'naDa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {qa'naDa':n}-maakunta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -8992,6 +9898,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -8999,6 +9906,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2018:src}</column>
     </table>
     <table name="mem">
@@ -9012,6 +9920,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Австрия</column>
       <column name="definition_zh_HK">奧地利</column>
       <column name="definition_pt">Áustria</column>
+      <column name="definition_fi">Itävalta [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9022,6 +9931,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9031,6 +9941,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9038,6 +9949,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -9051,6 +9963,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Остин [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Austin [AUTOTRANSLATED]</column>
       <column name="definition_pt">Austin</column>
+      <column name="definition_fi">Austin [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9061,6 +9974,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это столица штата {teqSaS:n} в {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是{'amerI'qa' SepjIjQa':n}中{teqSaS:n}州的首府城市。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é a capital do estado de {teqSaS:n} em {'amerI'qa' SepjIjQa':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on {teqSaS:n}: n osavaltion pääkaupunki {'amerI'qa' SepjIjQa':n}: ssa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9070,6 +9984,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9077,6 +9992,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Sepqep wa'DIch:src} ({KLI mailing list 2019.11.10:src})</column>
     </table>
 
@@ -9093,6 +10009,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">форма ритуальных пыток [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種儀式性的折磨 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma forma de tortura ritualística</column>
+      <column name="definition_fi">eräänlainen rituaalinen kidutus [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9103,6 +10020,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это форма ритуальных пыток, совершаемых клингонскими женщинами над военнопленными. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是克林崗婦女對戰俘實施的一種儀式折磨。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta é uma forma de tortura ritualística realizada por mulheres klingon em prisioneiros de guerra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen rituaalinen kidutus, jonka klingonilaiset suorittavat sotavangeille. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word and {norgh:n} first appeared in the novel {Sarek:src} by A. C. Crispin. Three years later, {norgh:n:nolink} appeared in {KGT:src}, but {be'joy':n:nolink} was left out, possibly to keep the book "family-friendly".[2]</column>
       <column name="components">{be':n}, {joy':v} or {joy':n:hyp,nolink}</column>
       <column name="examples"></column>
@@ -9112,6 +10030,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9119,6 +10038,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Sarek:src}, [2] {KLI mailing list 2018.07.29:src}</column>
     </table>
     <table name="mem">
@@ -9132,6 +10052,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="definition_ru">Трус</column>
       <column name="definition_zh_HK">膽小鬼、懦夫</column>
       <column name="definition_pt">covarde</column>
+      <column name="definition_fi">pelkuri [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9142,6 +10063,7 @@ The scientific name for each planet is {Sol:n:nolink} followed by a name, e.g., 
       <column name="notes_ru">Это сказано во время ритуала дискомендации ({naDHa'ghach:n}). Обычный способ сказать "трус" - это {nuch:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso é dito durante o ritual de desacompanhação ({naDHa'ghach:n}). A maneira usual de dizer "covarde" é {nuch:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sanotaan suosituksen rituaalin aikana ({naDHa'ghach:n}). Tavallinen tapa sanoa "pelkurit" on {nuch:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">According to the script for {TNG - Sins of the Father:src}, Worf says {tlhIH ghIj jIHyoj:sen@@tlhIH:n, ghIj:v, jIH:n:1, yoj:n}, which is not grammatical, but is supposed to mean "I fear your judgment". K'mpec then replies with {bIHnuch:sen:nolink}. It is reasonable to assume that these two phrases are archaic and ritualised.
 
 It's likely that these sentences were made up by a writer who consulted {TKD:src}, as they contain existing words, but did not have an understanding of Klingon grammar.</column>
@@ -9153,6 +10075,7 @@ It's likely that these sentences were made up by a writer who consulted {TKD:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9160,6 +10083,7 @@ It's likely that these sentences were made up by a writer who consulted {TKD:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNG - Sins of the Father:src}</column>
     </table>
     <table name="mem">
@@ -9173,6 +10097,7 @@ It's likely that these sentences were made up by a writer who consulted {TKD:src
       <column name="definition_ru">тип животного [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">um tipo de animal</column>
+      <column name="definition_fi">eläintyyppi [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DI'raq:n}</column>
@@ -9183,6 +10108,7 @@ It's likely that these sentences were made up by a writer who consulted {TKD:src
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">根據{Honor Bound:src}的詞彙表，這是{bo'retlh:n}的原生動物，它發出嘶啞的聲音，並傾向於繞圈跑。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o glossário do {Honor Bound:src}, este é um animal nativo do {bo'retlh:n}, que produz sons de balido e tende a circular em círculos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Honor Bound:src}: n sanaston mukaan tämä on {bo'retlh:n}: sta kotoisin oleva eläin, joka antaa bluunaa ja pyrkii juoksemaan ympyröinä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9192,6 +10118,7 @@ It's likely that these sentences were made up by a writer who consulted {TKD:src
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sheep</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9199,6 +10126,7 @@ It's likely that these sentences were made up by a writer who consulted {TKD:src
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Honor Bound:src}</column>
     </table>
     <table name="mem">
@@ -9212,6 +10140,7 @@ It's likely that these sentences were made up by a writer who consulted {TKD:src
       <column name="definition_ru">Помощник (название данной программы)</column>
       <column name="definition_zh_HK">助手（這個軟件）</column>
       <column name="definition_pt">assistente (este programa)</column>
+      <column name="definition_fi">avustaja (tämä ohjelma) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9307,6 +10236,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
 Особая благодарность Марку Окранду ({marq 'oqranD:n:name}) за создание Клингонского языка.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{boQ:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -9316,6 +10246,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">version, help, about</column>
       <column name="search_tags_de">Hilfe, Anleitung</column>
       <column name="search_tags_fa"></column>
@@ -9323,6 +10254,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9336,6 +10268,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Бокор [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">波哥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Bokor</column>
+      <column name="definition_fi">Bokor [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9346,6 +10279,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это имя девушки из курса Duolingo Klingon. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是Duolingo Klingon課程中一位女性的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma mulher no curso de Duolingo Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on naisen nimi Duolingo Klingon -kurssilla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9355,6 +10289,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9362,6 +10297,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Duolingo:src}</column>
     </table>
     <table name="mem">
@@ -9375,6 +10311,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Буран [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">暴風雪 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Buran</column>
+      <column name="definition_fi">Buran [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9385,6 +10322,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это имя предыдущего корабля капитана Лорки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這就是洛爾卡船長的上一艘船的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome do navio anterior do capitão Lorca. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on kapteeni Lorcan edellisen aluksen nimi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9394,6 +10332,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9401,6 +10340,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC:src}</column>
     </table>
     <table name="mem">
@@ -9415,6 +10355,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">сульфат меди [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">硫酸銅 [AUTOTRANSLATED]</column>
       <column name="definition_pt">sulfato de cobre</column>
+      <column name="definition_fi">kuparisulfaatti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qulSo':n:extcan}, {Sorpuq:n}, {no'negh:n}</column>
@@ -9425,6 +10366,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Этот термин не фигурирует в каноне, а был придуман для поста в блоге о науке. Это здесь, чтобы кто-то другой не придумал другого термина. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個名詞沒有出現在佳能中，而是在有關科學的博客文章中發明的。在這裡，其他人不會發明其他術語。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo não aparece no cânone, mas foi inventado para um post sobre ciência. Está aqui para que outra pessoa não invente um termo diferente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä termi ei näy kaanonissa, vaan se keksittiin pikemminkin tiedettä käsittelevälle blogikirjoitukselle. Se on täällä, jotta joku muu ei keksisi eri termiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This term was coined by Felix Malmenbeck ({loghaD:n:nolink}), and roughly means "sky-crystal gunpowder".</column>
       <column name="components">{chal:n}, {qut:n}, {ngat:n:1}</column>
       <column name="examples"></column>
@@ -9434,6 +10376,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9441,6 +10384,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9454,6 +10398,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">стиль хора [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">合唱風格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estilo de coro</column>
+      <column name="definition_fi">kuoro tyyli [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Huy'reH:n}, {QIch lut:n}</column>
@@ -9464,6 +10409,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это тип литературного стиля.</column>
       <column name="notes_zh_HK">這是一種文學風格。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de estilo literário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen kirjallisuuden tyyli. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9473,6 +10419,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9480,6 +10427,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.xxii,62,87:src}</column>
     </table>
     <table name="mem">
@@ -9493,6 +10441,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">поле? (физическая концепция) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">領域？ （物理概念） [AUTOTRANSLATED]</column>
       <column name="definition_pt">campo? (conceito de física)</column>
+      <column name="definition_fi">ala? (fysiikan käsite) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9503,6 +10452,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Элемент {chem:n:hyp,nolink}, как известно, не появляется сам по себе, но встречается в словах {ghe'chem:n}, {HoSchem:n}, {peQchem:n}, {pIvchem:n}, {Surchem:n} и {tlhamchem:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">元素{chem:n:hyp,nolink}本身不為人所知，但可以在{ghe'chem:n}，{HoSchem:n}，{peQchem:n}，{pIvchem:n}，{Surchem:n}和{tlhamchem:n}中找到。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Elementin {chem:n:hyp,nolink} ei tiedetä esiintyvän sinänsä, mutta se löytyy sanoista {ghe'chem:n}, {HoSchem:n}, {peQchem:n}, {pIvchem:n}, {Surchem:n} ja {tlhamchem:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">In {TKDA:src}, {peQ chem:n:nolink} actually appears as two words (with a space).</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9512,6 +10462,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9519,6 +10470,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9532,6 +10484,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">протокол смены вида [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">物種變態程序</column>
       <column name="definition_pt">protocolo de reatribuição de espécies</column>
+      <column name="definition_fi">lajin muuttamisprotokolla [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9542,6 +10495,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это было сделано {mo'qay tuq:n} на {voq:n}, чтобы превратить его в лейтенанта Эша Тайлера. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Isso foi realizado por {mo'qay tuq:n} em {voq:n}, para transformá-lo no tenente Ash Tyler. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän suoritti {mo'qay tuq:n} {voq:n}: lla muuttaakseen hänet luutnantiksi Ash Tyleriksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{choH:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -9551,6 +10505,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9558,6 +10513,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">{DSC - The War Without, The War Within:src}</column>
     </table>
     <table name="mem">
@@ -9571,6 +10527,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">De'vID</column>
       <column name="definition_zh_HK">De'vID</column>
       <column name="definition_pt">De'vID</column>
+      <column name="definition_fi">De'vID [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{boQwI':n:deriv}</column>
@@ -9581,6 +10538,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Имя автора этой программы и того, кто собрал этот словарь</column>
       <column name="notes_zh_HK">該程序作者及其詞典的編譯器的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">O nome do autor deste programa e o compilador de seu léxico. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän ohjelman kirjoittajan nimi ja sanaston koostaja. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{De':n}, {vID:v:is}</column>
       <column name="examples"></column>
@@ -9590,6 +10548,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9597,6 +10556,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9610,6 +10570,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">court, trial? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">庭審？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Julgamento no tribunal?</column>
+      <column name="definition_fi">oikeudenkäynti? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9620,6 +10581,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Этот элемент, как известно, не существует как слово, но появляется как компонент {bo'DIj:n} и {ghIpDIj:v}. Его гомофония к {DIj:v:1} предполагает, что он описывает две стороны, противопоставленные друг другу. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Não se sabe que esse elemento existe como uma palavra, mas aparece como um componente de {bo'DIj:n} e {ghIpDIj:v}. Sua homofonia com {DIj:v:1} sugere que ele descreve duas partes que se enfrentam. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän elementin ei tiedetä olevan sanana, mutta se esiintyy {bo'DIj:n}- ja {ghIpDIj:v}-komponentteina. Sen homofonia {DIj:v:1}: lle viittaa siihen, että se kuvaa kahta toisiaan vastustavaa osapuolta. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9629,6 +10591,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9636,6 +10599,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9649,6 +10613,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">фиолетовый, фиолетовый (не используется в клингоне) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">紫色，紫色（在克林崗州不使用） [AUTOTRANSLATED]</column>
       <column name="definition_pt">violeta, roxo (não usado em klingon)</column>
+      <column name="definition_fi">violetti, violetti (ei käytetä Klingonissa) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9659,6 +10624,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Ни {SuD:v:1}, ни {Doq:v} не включают в себя то, что называется «фиолетовым» или «фиолетовым». Это может быть связано с физиологией клингона.[2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{SuD:v:1}和{Doq:v}都不包含所謂的“紫色”或“紫色”。這可能與克林崗族生理學有關。[2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Nem {SuD:v:1} nem {Doq:v} incluem o que é chamado "violeta" ou "roxo". Isso pode estar relacionado à fisiologia de Klingon.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{SuD:v:1} ja {Doq:v} eivät sisällä sitä, mitä kutsutaan "violetiksi" tai "violetiksi". Tämä voi liittyä Klingonin fysiologiaan.[2] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Despite the statement in {KGT:src} that "violet" and "purple" are not covered by the Klingon colour words, it was nevertheless included in {TNK:src} as that software follows a fixed template which required a translation to label such a colour.</column>
       <column name="components">{Doq:v}, {'ej:conj}, {SuD:v:1}</column>
       <column name="examples"></column>
@@ -9668,6 +10634,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9675,6 +10642,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNK:src}, [2] {KGT p.82-83:src}</column>
     </table>
     <table name="mem">
@@ -9688,6 +10656,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">корабль, судно [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">船輛、車輛</column>
       <column name="definition_pt">navio, embarcação</column>
+      <column name="definition_fi">alus, alus [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9698,6 +10667,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Скорее всего, {Do':n:archaic,hyp,nolink} - устаревшее слово для современного {Duj:n:1}.[1]. Это предположение подтверждается {'ejDo':n} и {Delaq Do':excl}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">É provável que {Do':n:archaic,hyp,nolink} seja uma palavra arcaica para o moderno {Duj:n:1}.[1]. Essa conjectura é apoiada por {'ejDo':n} e {Delaq Do':excl}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9707,6 +10677,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9714,6 +10685,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.20:src}</column>
     </table>
     <table name="mem">
@@ -9727,6 +10699,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">age? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">年齡？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">age?</column>
+      <column name="definition_fi">ikä? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9737,6 +10710,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Этот элемент, как известно, не существует как слово, но появляется как компонент {nenghep:n} и {peHghep:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämän elementin ei tiedetä olevan sanana, mutta se esiintyy {nenghep:n}- ja {peHghep:n}-komponentteina. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9746,6 +10720,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9753,6 +10728,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9766,6 +10742,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Glo'meH, Гломмер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">glo'meH、glommer [AUTOTRANSLATED]</column>
       <column name="definition_pt">glo'meH, glommer</column>
+      <column name="definition_fi">glo'meH, glommer [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{yIH:n}</column>
@@ -9776,6 +10753,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это существа, выведенные клингонами специально для употребления в пищу.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這些是由克林崗人培育的生物，專門用來吃小怪獸。[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Estas são criaturas criadas por Klingons especificamente para comer tribbles.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Nämä ovat olentoja, jotka Klingons on kasvattanut nimenomaan syömään pikkujuttuja.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9785,6 +10763,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9792,6 +10771,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TAS - More Tribbles, More Troubles:src}, [2] {How to Speak Klingon, p.4:src}</column>
     </table>
     <table name="mem">
@@ -9805,6 +10785,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Гриннак (азартная игра) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">grinnak（賭博遊戲） [AUTOTRANSLATED]</column>
       <column name="definition_pt">grinnak (um jogo de azar)</column>
+      <column name="definition_fi">grinnak (uhkapeli) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{SuD:v:2}</column>
@@ -9815,6 +10796,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это описывается в глоссарии для {A Burning House:src} как игра с участием жетонов и ставок. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{A Burning House:src}的詞彙表中將其描述為涉及代幣和賭注的遊戲。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é descrito no glossário de {A Burning House:src} como um jogo envolvendo fichas e apostas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä kuvataan {A Burning House:src}-sanastossa pelinä, joka sisältää rahakkeita ja panoksia. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9824,6 +10806,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9831,6 +10814,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}</column>
     </table>
     <table name="mem">
@@ -9844,6 +10828,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">доверенный советник клингонского дома [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">克林崗之家值得信賴的顧問 [AUTOTRANSLATED]</column>
       <column name="definition_pt">conselheiro de confiança de uma casa Klingon</column>
+      <column name="definition_fi">trusted adviser of a Klingon house [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghIntaq:n:1}</column>
@@ -9854,6 +10839,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">No {TNG - Firstborn:src}, K'mtar é o gin'tak da Casa de Mogh.[1] No glossário do {A Burning House:src}, alega-se que esta palavra e {ghIntaq:n:1} são de fato a mesma palavra.[2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9863,6 +10849,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9870,6 +10857,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNG - Firstborn:src}, [2] {A Burning House:src}</column>
     </table>
     <table name="mem">
@@ -9883,6 +10871,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">гонклик, вид овоща [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">gonklik、一種蔬菜 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gonklik, uma espécie de vegetal</column>
+      <column name="definition_fi">gonklik, eräänlainen vihannes [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{naH:n}</column>
@@ -9893,6 +10882,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">В глоссарии к {A Burning House:src} это описывается как овощ, который обычно подается нарезанным кубиками. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{A Burning House:src}的詞彙表中，這被描述為通常切成丁的蔬菜。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No glossário de {A Burning House:src}, isso é descrito como um vegetal geralmente servido em cubos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{A Burning House:src}-sanastossa tämä kuvataan vihannekseksi, jota yleensä tarjotaan kuutioiksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9902,6 +10892,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9909,6 +10900,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}</column>
     </table>
     <table name="mem">
@@ -9922,6 +10914,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">drive? (mechanical system) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">駕駛？ （機械系統） [AUTOTRANSLATED]</column>
       <column name="definition_pt">dirigir? (sistema mecânico)</column>
+      <column name="definition_fi">drive? (mechanical system) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{pIvghor:n}, {Hongghor:n}</column>
@@ -9932,6 +10925,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Элемент {ghor:n:hyp,nolink}, как известно, не появляется сам по себе, но встречается в словах {pIvghor:n} и {Hongghor:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">O elemento {ghor:n:hyp,nolink} não é conhecido por aparecer por si só, mas é encontrado nas palavras {pIvghor:n} e {Hongghor:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Elementin {ghor:n:hyp,nolink} ei tiedetä esiintyvän sinänsä, mutta se löytyy sanoista {pIvghor:n} ja {Hongghor:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9941,6 +10935,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9948,6 +10943,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -9961,6 +10957,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Gurlak [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Gurlak [AUTOTRANSLATED]</column>
       <column name="definition_pt">Gurlak</column>
+      <column name="definition_fi">Gurlak [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -9971,6 +10968,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это имя используется в курсе Duolingo Klingon. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是Duolingo Klingon課程中使用的名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um nome usado no curso de Duolingo Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -9980,6 +10978,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -9987,6 +10986,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Duolingo:src}</column>
     </table>
     <table name="mem">
@@ -10000,6 +11000,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">тип камня [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">石頭的類型 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de pedra</column>
+      <column name="definition_fi">type of stone [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hew:n}</column>
@@ -10010,6 +11011,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это тип камня, присущий {Qo'noS:n}, который часто используется при строительстве скульптур. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是一種{Qo'noS:n}特有的石材，通常用於建造雕像。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de pedra nativa do {Qo'noS:n} que é frequentemente usada na construção de estátuas. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen {Qo'noS:n}: n alkuperäiskivi, jota käytetään usein patsaiden rakentamisessa. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Hab:v}, {nagh:n}</column>
       <column name="examples"></column>
@@ -10019,6 +11021,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10026,6 +11029,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Good Day to Die:src}</column>
     </table>
     <table name="mem">
@@ -10039,6 +11043,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">хуркик, вид фруктов [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">hurkik、一種水果 [AUTOTRANSLATED]</column>
       <column name="definition_pt">hurkik, uma espécie de fruta</column>
+      <column name="definition_fi">hurkik, eräänlainen hedelmä [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Du' naH:n}</column>
@@ -10049,6 +11054,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">В глоссарии {A Burning House:src} это описывается как фрукт, выращенный на клингонских фермах. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{A Burning House:src}的詞彙表中，這被描述為在克林崗農場種植的一種水果。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">No glossário de {A Burning House:src}, isso é descrito como uma fruta cultivada em fazendas de Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{A Burning House:src}-sanastossa tätä kuvaillaan hedelmänä, jota kasvatetaan Klingonin tiloilla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10058,6 +11064,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10065,6 +11072,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}</column>
     </table>
     <table name="mem">
@@ -10078,6 +11086,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">стиль арии [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">詠嘆調風格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estilo ária</column>
+      <column name="definition_fi">aaria tyyli [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'ang:n}, {QIch lut:n}</column>
@@ -10088,6 +11097,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это тип литературного стиля.</column>
       <column name="notes_zh_HK">這是一種文學風格。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de estilo literário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on eräänlainen kirjallisuuden tyyli. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10097,6 +11107,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10104,6 +11115,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.xxii:src}</column>
     </table>
     <table name="mem">
@@ -10117,6 +11129,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">mid-, middle? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">中、中？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">meio, metade?</column>
+      <column name="definition_fi">keski-, keski-? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10127,6 +11140,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это гипотетический компонент, который находится в {pemjep:n} и {ramjep:n:1}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是在{pemjep:n}和{ramjep:n:1}中找到的假設組件。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um componente hipotético encontrado em {pemjep:n} e {ramjep:n:1}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on hypoteettinen komponentti, joka löytyy kohdista {pemjep:n} ja {ramjep:n:1}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">Maltz said he'd never heard {jarjep:n:nolink}, {DISjep:n:nolink}, {Hoghjep:n:nolink}, or the like, but would get the gist of what was meant if someone said it.[1]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10136,6 +11150,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10143,6 +11158,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2015.03.22:src}</column>
     </table>
     <table name="mem">
@@ -10156,6 +11172,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">инженерия? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">工程？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Engenharia?</column>
+      <column name="definition_fi">tekniikka? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10166,6 +11183,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Não se sabe que esse elemento existe por si só, mas é encontrado em {jonpIn:n}, {jonta':n} e {jonwI':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämän elementin ei tiedetä olevan olemassa yksinään, mutta se löytyy tiedostoista {jonpIn:n}, {jonta':n} ja {jonwI':n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10175,6 +11193,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10182,6 +11201,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -10195,6 +11215,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">пенис [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">陰莖 [AUTOTRANSLATED]</column>
       <column name="definition_pt">pênis</column>
+      <column name="definition_fi">penis [AUTOTRANSLATED]</column>
       <column name="synonyms">{'InSep:n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10205,6 +11226,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was invented by author David Mack, who said it can be assumed to be in an obscure older dialect.[2]</column>
       <column name="components">{loD:n}, {mach:v}</column>
       <column name="examples"></column>
@@ -10214,6 +11236,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10221,6 +11244,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek Vanguard - Harbinger p.202:src}, [2] {KLI mailing list 2020.06.23:src}</column>
     </table>
     <table name="mem">
@@ -10234,6 +11258,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">космический кит [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">太空鯨魚</column>
       <column name="definition_pt">baleia espacial</column>
+      <column name="definition_fi">avaruusvalas [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10244,6 +11269,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Этот термин виден на табличке в продуктовом киоске, которую лейтенант Эш Тайлер перевел как «космический кит». Это относится к {ghormaghenDer:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞出現在食品攤位的標牌上，艾什·泰勒中校將其翻譯為“太空鯨魚”。它指的是{ghormaghenDer:n}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo é visto em uma placa em uma barraca de comida, que o tenente Ash Tyler traduziu como "baleia espacial". Refere-se ao {ghormaghenDer:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä termi näkyy ruokakojun kyltissä, jonka luutnantti Ash Tyler käänsi nimellä "avaruusvalas". Se viittaa {ghormaghenDer:n}: een. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{logh:n}, {ghotI':n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -10253,6 +11279,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10260,6 +11287,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DSC - Will You Take My Hand?:src}</column>
     </table>
     <table name="mem">
@@ -10273,6 +11301,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Lurveng [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Lurveng [AUTOTRANSLATED]</column>
       <column name="definition_pt">Lurveng</column>
+      <column name="definition_fi">Lurveng [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10283,6 +11312,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это имя девушки из курса Duolingo Klingon. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是Duolingo Klingon課程中一位女性的名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de uma mulher no curso de Duolingo Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10292,6 +11322,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10299,6 +11330,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Duolingo:src}</column>
     </table>
     <table name="mem">
@@ -10312,6 +11344,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Мактаг, название месяца или сезона? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Maktag、一個月或一個季節的名字？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Maktag, nome de um mês ou estação? </column>
+      <column name="definition_fi">Maktag, kuukauden tai kauden nimi? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10322,6 +11355,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Александр Роженко родился на 43-й день Мактаг. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">亞歷山大·羅任科（Alexander Rozhenko）出生於馬克塔格（Maktag）第43天。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Alexander Rozhenko nasceu no 43º dia de Maktag. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Alexander Rozhenko syntyi Maktagin 43. päivänä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The Klingon way of writing this name was never given. The script only says "Maktag".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10331,6 +11365,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10338,6 +11373,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TNG - New Ground:src}</column>
     </table>
     <table name="mem">
@@ -10351,6 +11387,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">временное перемирие [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">臨時休戰 [AUTOTRANSLATED]</column>
       <column name="definition_pt">trégua temporária</column>
+      <column name="definition_fi">väliaikainen aselepo [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rojHom:n}</column>
@@ -10361,6 +11398,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это слово появляется в трилогии {Star Trek - Prey:src} Джона Джексона Миллера. Говорят, что это «старая концепция», в которой соперники, которые какое-то время вступают в битву, отмечают временное перемирие после успешных совместных действий, прежде чем вернуться к боевым действиям. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞出現在約翰·傑克遜·米勒（John Jackson Miller）的《 {Star Trek - Prey:src}》三部曲中。據說，這是一個“古老的觀念”，在一次成功的聯合行動之後，曾經參加戰鬥的對手在暫時的休戰后慶祝暫時休戰，然後又返回敵對狀態。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra aparece na trilogia {Star Trek - Prey:src} de John Jackson Miller. Diz-se que é um "conceito antigo", no qual rivais que se aliam em batalha por um tempo celebram uma trégua temporária após uma ação conjunta bem-sucedida, antes de retornar às hostilidades. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana esiintyy John Jackson Millerin {Star Trek - Prey:src}-trilogiassa. Sen sanotaan olevan "vanha käsite", jossa kilpailijat, jotka liittoutuvat jonkin aikaa taistelussa, juhlivat väliaikaista aselepoa onnistuneen yhteisen toiminnan jälkeen ennen paluuta vihollisuuksiin. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{may':n}, {qoch:n}, {van:n}</column>
       <column name="examples"></column>
@@ -10370,6 +11408,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10377,6 +11416,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek - Prey:src}</column>
     </table>
     <table name="mem">
@@ -10390,6 +11430,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">some kind of device? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">某種設備？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">algum tipo de dispositivo?</column>
+      <column name="definition_fi">jonkinlainen laite? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10400,6 +11441,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это слово появляется в глоссарии к {Enemy Territory:src}, где оно описывается как «сексуальная помощь». Неясно, относится ли это к определенному объекту, классу объектов или даже к тому, что это вообще. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞出現在{Enemy Territory:src}的詞彙表中，在這裡被描述為“性幫助”。目前尚不清楚它是指一個特定的對象，一類對象，甚至通常指的是什麼。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra aparece no glossário de {Enemy Territory:src}, onde é descrita como "ajuda sexual". Não está claro se ele se refere a um objeto específico, a uma classe de objetos ou mesmo ao que é em geral. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sana esiintyy sanakirjassa {Enemy Territory:src}, jossa sitä kuvataan "seksiapuvälineeksi". On epäselvää, viittaako se tiettyyn esineeseen, esineiden luokkaan vai edes mihin se yleensä kuuluu. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10409,6 +11451,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">sex aid</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10416,6 +11459,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Enemy Territory:src}</column>
     </table>
     <table name="mem">
@@ -10429,6 +11473,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Кулак Мората (торпеда) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">莫拉斯的拳頭（魚雷） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Punho de Morath (torpedo)</column>
+      <column name="definition_fi">Morathin nyrkki (torpedo) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peng:n}</column>
@@ -10439,6 +11484,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{Haynes BoP Manual:src}: n mukaan tämä on eräänlainen torpedo, jota kuljetetaan alusten {bI'rel tlharghDuj:n} ja {vorcha':n} -luokilla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{moratlh:n}, {ro':n}</column>
       <column name="examples"></column>
@@ -10448,6 +11494,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10455,6 +11502,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Haynes BoP Manual p.43:src}</column>
     </table>
     <table name="mem">
@@ -10468,6 +11516,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">приятель? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">伴侶？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">parceiro?</column>
+      <column name="definition_fi">kaveri? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10478,6 +11527,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это гипотетический компонент, который находится в {loDnal:n}, {be'nal:n}, {nalqaD:n}, а также в {'e'nal:n}. Согласно {KCD:src}, {nal:n:hyp,nolink} не используется как слово само по себе. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este é um componente hipotético encontrado em {loDnal:n}, {be'nal:n}, {nalqaD:n} e também em {'e'nal:n}. De acordo com {KCD:src}, {nal:n:hyp,nolink} não é usado como uma palavra por si só. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on hypoteettinen komponentti, joka löytyy kohdista {loDnal:n}, {be'nal:n}, {nalqaD:n} ja {'e'nal:n}. {KCD:src}: n mukaan {nal:n:hyp,nolink}: ta ei käytetä yksinään sanana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10487,6 +11537,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10494,6 +11545,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -10507,6 +11559,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Eagle's Claw (torpedo or mine) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鷹爪（魚雷或我的） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Garra da águia (torpedo ou mina)</column>
+      <column name="definition_fi">Kotkan kynsi (torpedo tai minun) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peng:n}</column>
@@ -10517,6 +11570,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{Haynes BoP Manual:src}: n mukaan tämä on eräänlainen ampuma-lintu ({toQDuj:n}), jota voidaan käyttää joko lyhyen kantaman torpedona tai miinanjakelujärjestelmänä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{notqa':n}, {pach:n}</column>
       <column name="examples"></column>
@@ -10526,6 +11580,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10533,6 +11588,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Haynes BoP Manual p.44:src}</column>
     </table>
     <table name="mem">
@@ -10546,6 +11602,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Удар Когтя (торпеда) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Talon罷工（魚雷） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Ataque de Talon (torpedo)</column>
+      <column name="definition_fi">Talon's Strike (torpedo) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{peng:n}</column>
@@ -10556,6 +11613,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Согласно {Haynes BoP Manual:src}, это стандартный тип торпеды на хищной птице ({toQDuj:n}). [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據{Haynes BoP Manual:src}，這是猛禽（{toQDuj:n}）上攜帶的標準魚雷型。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o {Haynes BoP Manual:src}, este é o tipo de torpedo padrão transportado na ave de rapina ({toQDuj:n}). [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{Haynes BoP Manual:src}: n mukaan tämä on tavallinen torpedotyyppi, jota kuljetetaan petolinnulla ({toQDuj:n}). [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pach:n}, {peng:n}</column>
       <column name="examples"></column>
@@ -10565,6 +11623,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10572,6 +11631,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Haynes BoP Manual p.42:src}</column>
     </table>
     <table name="mem">
@@ -10585,6 +11645,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">жилые помещения [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">宿舍、生活區 [AUTOTRANSLATED]</column>
       <column name="definition_pt">quartos, quartos vivos</column>
+      <column name="definition_fi">quarters, living quarters [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10595,6 +11656,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">{pa'mey:n:nolink}-tyypit sisältävät {yaS pa'mey:n}, {beq pa'mey:n} ja {mebpa'mey:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{pa':n:1}, {-mey:n}</column>
       <column name="examples"></column>
@@ -10604,6 +11666,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10611,6 +11674,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -10624,6 +11688,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">triticale? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">小黑麥？</column>
       <column name="definition_pt">triticale?</column>
+      <column name="definition_fi">triticale? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tIr:n}</column>
@@ -10634,6 +11699,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Triticale é uma hibridação de trigo (gênero Triticum) e centeio (gênero Secale). {pev:n:hyp,nolink} não é uma palavra conhecida, é conhecida apenas como um elemento na palavra {loSpev:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10643,6 +11709,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">hybridisation, wheat, rye, grain</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10650,6 +11717,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -10663,6 +11731,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">сила деформации? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">扭曲力？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">energia de dobra?</column>
+      <column name="definition_fi">warp power? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hong:n}</column>
@@ -10673,6 +11742,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10682,6 +11752,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10689,6 +11760,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -10702,6 +11774,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">лития? минеральная? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">鋰？礦物？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">lítio? mineral?</column>
+      <column name="definition_fi">litium? mineraali? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10712,6 +11785,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這不是一個已知的單詞，並且作為一個元素存在於單詞{cha'puj:n}中，也可能存在於單詞{beqpuj:n}中。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä ei ole tunnettu sana, ja se esiintyy osana sanaa {cha'puj:n} ja mahdollisesti myös sanassa {beqpuj:n}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10721,6 +11795,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10728,6 +11803,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -10741,6 +11817,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Korglach [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Korglach [AUTOTRANSLATED]</column>
       <column name="definition_pt">Korglach</column>
+      <column name="definition_fi">Korglach [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10751,6 +11828,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это имя мужчины в курсе Duolingo Klingon. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是Duolingo Klingon課程中的男性名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um homem no curso de Duolingo Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on uroksen nimi Duolingo Klingon -kurssilla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10760,6 +11838,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10767,6 +11846,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Duolingo:src}</column>
     </table>
     <table name="mem">
@@ -10781,6 +11861,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">фосфористый [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">磷的 [AUTOTRANSLATED]</column>
       <column name="definition_pt">fosforoso</column>
+      <column name="definition_fi">phosphorous [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{chalqut ngat:n:extcan}</column>
@@ -10791,6 +11872,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это слово не фигурирует в каноне, а было придумано для поста в блоге о науке. Это здесь, чтобы кто-то другой не придумал другого слова. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞沒有出現在佳能中，而是在有關科學的博客文章中發明的。在這裡是為了讓其他人不要發明另一個單詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra não aparece no cânon, mas foi inventada para um post sobre ciência. Está aqui para que outra pessoa não invente uma palavra diferente. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word was coined by Felix Malmenbeck ({loghaD:n:nolink}), and roughly means "hidden fire".</column>
       <column name="components">{qul:n}, {So':v:1}</column>
       <column name="examples"></column>
@@ -10800,6 +11882,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10807,6 +11890,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -10820,6 +11904,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">животное, отмеченное за упрямство [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">頑固的動物 [AUTOTRANSLATED]</column>
       <column name="definition_pt">animal conhecido por teimosia</column>
+      <column name="definition_fi">eläin totesi itsepäisyydestään [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{mul:v}</column>
@@ -10830,6 +11915,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">It's possible that the writers intended this to be {Qu'vatlh:excl}, or based their invented word on it.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10839,6 +11925,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">mule</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10846,6 +11933,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DS9 - Sons and Daughters:src}</column>
     </table>
     <table name="mem">
@@ -10859,6 +11947,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">союз, федерация, организация, ассоциация, лига [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">聯邦、聯合會、聯盟</column>
       <column name="definition_pt">união, federação, organização, associação, liga</column>
+      <column name="definition_fi">union, federation, organization, association, league [AUTOTRANSLATED]</column>
       <column name="synonyms">{DIvI':n}</column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10869,6 +11958,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Этот элемент слова, по-видимому, является синонимом {DIvI':n}, но он не известен за пределами нескольких соединений. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該單詞元素似乎與{DIvI':n}是同義詞，但在少數化合物之外卻未知。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este elemento da palavra parece ser sinônimo de {DIvI':n}, mas não é conhecido fora de alguns compostos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -10882,6 +11972,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10889,6 +11980,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -10902,6 +11994,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Стиль повествования</column>
       <column name="definition_zh_HK">敘述者風格 [AUTOTRANSLATED]</column>
       <column name="definition_pt">estilo narrador</column>
+      <column name="definition_fi">kertojan tyyli [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cha'ang:n}, {Huy'reH:n}</column>
@@ -10912,6 +12005,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это тип литературного стиля.</column>
       <column name="notes_zh_HK">這是一種文學風格。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um tipo de estilo literário. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is written as "Qich'lut" in the book. The proper Klingon spelling is never given.</column>
       <column name="components">{QIch:n}, {lut:n}</column>
       <column name="examples"></column>
@@ -10921,6 +12015,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10928,6 +12023,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {paq'batlh p.xvii,xxii,xxxv:src}</column>
     </table>
     <table name="mem">
@@ -10941,6 +12037,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">комментарий [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">評論 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Comentar</column>
+      <column name="definition_fi">comment [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10951,6 +12048,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это относится к небольшому фрагменту текста, прикрепленному к чему-то другому, например к сообщению в социальной сети или блоку компьютерного кода.[1; 2] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指附在其他內容上的一小段文字，例如社交網絡上的帖子或計算機代碼塊。[1; 2] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um pequeno pedaço de texto anexado a outra coisa, como uma postagem em uma rede social ou um bloco de código de computador.[1; 2] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{QIn:n:1}, {-Hom:n}</column>
       <column name="examples"></column>
@@ -10960,6 +12058,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -10967,6 +12066,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Facebook:src}, [2] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <table name="mem">
@@ -10980,6 +12080,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Робин Стюарт</column>
       <column name="definition_zh_HK">羅賓·斯圖爾特</column>
       <column name="definition_pt">Robyn Stewart</column>
+      <column name="definition_fi">Robyn Stewart [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -10990,6 +12091,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Она является экспертом по Клингонскому языку для {DSC:src}.</column>
       <column name="notes_zh_HK">她是{DSC:src}中對話背後的克林崗語語言專家。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ela é a especialista em idiomas klingon por trás do diálogo em {DSC:src}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Hän on klingonin kieliasiantuntija {DSC:src}-vuoropuhelun taustalla. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -10999,6 +12101,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11006,6 +12109,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -11019,6 +12123,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Кувар</column>
       <column name="definition_zh_HK">古娃爾</column>
       <column name="definition_pt">Quvar</column>
+      <column name="definition_fi">Quvar [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{qepHom'a':n}</column>
@@ -11029,6 +12134,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это Клингонское имя Ливена Л. Литара {Клингонский учитель из Германии:url:http://www.youtube.com/user/KlingonTeacher}.</column>
       <column name="notes_zh_HK">這是{Klingon teacher from Germany:url:http://www.youtube.com/user/KlingonTeacher}的Lieven L. Litaer的克林崗名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome klingon de Lieven L. Litaer, um {Klingon teacher from Germany:url:http://www.youtube.com/user/KlingonTeacher}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11038,6 +12144,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11045,6 +12152,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -11058,6 +12166,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">тип животного, куврек [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物的類型、kuvrek [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, kuvrek</column>
+      <column name="definition_fi">type of animal, kuvrek [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11068,6 +12177,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Согласно глоссарию {Enemy Territory:src}, это животное предпочитает тень. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據{Enemy Territory:src}的詞彙表，這只動物更喜歡陰影。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o glossário de {Enemy Territory:src}, este animal prefere a sombra. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11077,6 +12187,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11084,6 +12195,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Enemy Territory:src}</column>
     </table>
     <table name="mem">
@@ -11097,6 +12209,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">транспондер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">轉發 [AUTOTRANSLATED]</column>
       <column name="definition_pt">transpônder</column>
+      <column name="definition_fi">transponder [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11107,6 +12220,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was used in the Klingon-language subtitles for {DSC:src} on Netflix for the word "transponder" in spoken English dialogue.</column>
       <column name="components">{rIS:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -11116,6 +12230,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11123,6 +12238,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2017:src}, [2] {DSC - Battle at the Binary Stars:src}</column>
     </table>
     <table name="mem">
@@ -11136,6 +12252,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">sign, indication? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">標誌、指示？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">sinal, indicação?</column>
+      <column name="definition_fi">sign, indication? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11146,6 +12263,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Не известно, что этот элемент существует за пределами {yInroH:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">未知此元素不存在於{yInroH:n}之外。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esse elemento não é conhecido por existir fora do {yInroH:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11155,6 +12273,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11162,6 +12281,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -11175,6 +12295,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">be agile, be nimble, be spry? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">敏捷、敏捷、敏捷？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser ágil, ser ligeiro?</column>
+      <column name="definition_fi">be agile, be nimble, be spry? [AUTOTRANSLATED]</column>
       <column name="synonyms">{vaD:v}</column>
       <column name="antonyms"></column>
       <column name="see_also">{pe'vIl roS:sen:idiom}, {roSHa'moH:v}</column>
@@ -11185,6 +12306,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Этот глагол, как известно, не существует, но его существование предположили, основываясь на идиоме {pe'vIl roS:sen:idiom} и глаголе {roSHa'moH:v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Não se sabe que esse verbo existe, mas sua existência é conjecturada com base no idioma {pe'vIl roS:sen:idiom} e no verbo {roSHa'moH:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11194,6 +12316,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11201,6 +12324,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {HQ 10.2, Jun. 2001:src}</column>
     </table>
     <table name="mem">
@@ -11214,6 +12338,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Ротарран [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Rotarran [AUTOTRANSLATED]</column>
       <column name="definition_pt">Rotarran</column>
+      <column name="definition_fi">Rotarran [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11224,6 +12349,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это {bI'rel tlharghDuj:n}, которым командует {martaq:n:name}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este é o {bI'rel tlharghDuj:n} comandado por {martaq:n:name}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11233,6 +12359,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11240,6 +12367,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Haynes BoP Manual:src}</column>
     </table>
     <table name="mem">
@@ -11253,6 +12381,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Рокег, тип животного? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">rokeg、動物類型？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">rokeg, tipo de animal?</column>
+      <column name="definition_fi">rokeg, type of animal? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ro'qegh'Iwchab:n}</column>
@@ -11263,6 +12392,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">В глоссарии к {Diplomatic Implausibility:src} предполагается, что это животное из или с чьей кровью изготовлено {ro'qegh'Iwchab:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在{Diplomatic Implausibility:src}的詞彙表中，假設這是從中或以血液{ro'qegh'Iwchab:n}製成的動物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11272,6 +12402,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11279,6 +12410,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -11292,6 +12424,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">контроль [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">控制 [AUTOTRANSLATED]</column>
       <column name="definition_pt">controle</column>
+      <column name="definition_fi">control [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11302,6 +12435,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was revealed after the Q &amp; A session in a document explaining the grammar of {bIQ SeHjan:n:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11311,6 +12445,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11318,6 +12453,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {qep'a' 27 (2020):src}</column>
     </table>
     <table name="mem">
@@ -11331,6 +12467,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">дождь? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">雨？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">chuva?</column>
+      <column name="definition_fi">rain? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11341,6 +12478,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Это слово, как известно, не существует за пределами соединения {SIS yoD:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">單詞{SIS yoD:n}之外不存在此單詞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Não se sabe que esta palavra exista fora do composto {SIS yoD:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">MO said at the {Saarbrücken qepHom'a' 2011:src} that the apparent noun {SIS:n:hyp,nolink} is a fossilized remnant which is probably limited to the expression {SIS yoD:n}.[1]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11350,6 +12488,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11357,6 +12496,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.11.03:src}</column>
     </table>
     <table name="mem">
@@ -11370,6 +12510,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">motherboard, core? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">主板、核心？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">placa mãe, núcleo?</column>
+      <column name="definition_fi">motherboard, core? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11380,6 +12521,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Известно только от {De'wI' SoSbor'a':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">僅從{De'wI' SoSbor'a':n}已知。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Conhecido apenas em {De'wI' SoSbor'a':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">"Mother" plus "board".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11389,6 +12531,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">computer core</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11396,6 +12539,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -11409,6 +12553,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">тип животных, такнар [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、塔克納爾 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, taknar</column>
+      <column name="definition_fi">type of animal, taknar [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{burgh:n}, {luH:n}</column>
@@ -11419,6 +12564,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru">Желудки этого животного вместе с их содержимым иногда подают в пищу. Помет этого животного особенно дурно пахнет. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這種動物的g和它們的內容物有時被當作食物。這種動物的糞便特別難聞。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">As moelas deste animal, juntamente com o seu conteúdo, às vezes são servidas como alimento. Os excrementos deste animal são particularmente fétidos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11428,6 +12574,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11435,6 +12582,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Good Day to Die:src}, [2] {A Burning House:src}</column>
     </table>
     <table name="mem">
@@ -11448,6 +12596,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">{bIt:v}</column>
       <column name="definition_zh_HK">{bIt:v}</column>
       <column name="definition_pt">{bIt:v}</column>
+      <column name="definition_fi">{bIt:v}</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11458,6 +12607,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這個詞出現在{KGT p.132:src}上，但是根據上下文，它顯然是{bIt:v}的錯字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra aparece em {KGT p.132:src}, mas com base no contexto, é claramente um erro de digitação para {bIt:v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11467,6 +12617,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11474,6 +12625,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.132:src}</column>
     </table>
     <table name="mem">
@@ -11487,6 +12639,7 @@ DSC {pIqaD:n:nolink} font: {Quvar:n:name,nolink} (Ливен Л. Литар)
       <column name="definition_ru">Сердце Добродетели [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">美德之心 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Coração de Virtude</column>
+      <column name="definition_fi">Heart of Virtue [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Degh:n:1}</column>
@@ -11499,6 +12652,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tIq:n}, {ghob:n}</column>
       <column name="examples"></column>
@@ -11508,6 +12662,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">trefoil</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11515,6 +12670,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -11528,6 +12684,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">вид животного, торгот [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">動物類型、torgot [AUTOTRANSLATED]</column>
       <column name="definition_pt">tipo de animal, torgot</column>
+      <column name="definition_fi">type of animal, torgot [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{rura' pente':n}</column>
@@ -11538,6 +12695,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Согласно глоссарию {A Burning House:src}, это крупное животное, обитающее в {rura' pente':n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">根據{A Burning House:src}的詞彙表，這是{rura' pente':n}原生的大型動物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">De acordo com o glossário do {A Burning House:src}, este é um animal de grande porte nativo do {rura' pente':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11547,6 +12705,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11554,6 +12713,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {A Burning House:src}</column>
     </table>
     <table name="mem">
@@ -11567,6 +12727,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">своего рода витаминная таблетка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">一種維生素藥丸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">uma espécie de comprimido vitamínico</column>
+      <column name="definition_fi">a kind of vitamin pill [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11577,6 +12738,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Это было взято клингонским шпионским Плюралом, который замаскировал себя как Человеческую женщину, чтобы дополнить не-клингонскую пищу, которую она должна была есть под прикрытием. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">Klingon間諜Plural偽裝成人類女性，以此來補充她臥底時必須吃的非Klingon食物。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso foi tomado pelo espião klingon Plural, que se disfarçou de uma fêmea humana, para suplementar a comida não-klingon que ela tinha que comer enquanto disfarçada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was invented by author David Mack, who said it can be assumed to be in an obscure older dialect.[2]</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11586,6 +12748,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11593,6 +12756,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek Vanguard - Harbinger p.200:src}, [2] {KLI mailing list 2020.06.23:src}</column>
     </table>
     <table name="mem">
@@ -11606,6 +12770,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">Тургал [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Turgal [AUTOTRANSLATED]</column>
       <column name="definition_pt">Turgal</column>
+      <column name="definition_fi">Turgal [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11616,6 +12781,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Это имя мужчины в курсе Duolingo Klingon. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是Duolingo Klingon課程中的男性名字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é o nome de um homem no curso de Duolingo Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11625,6 +12791,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11632,6 +12799,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Duolingo:src}</column>
     </table>
     <table name="mem">
@@ -11645,6 +12813,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">разведчик? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">偵察？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">escoteiro?</column>
+      <column name="definition_fi">scout? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11655,6 +12824,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Этот элемент известен только из {tlharghDuj:n}. Кажется, это существительное, но существование {HIvDuj:n:nolink} и {qughDuj:n:nolink} предполагает, что может существовать неизвестный глагол {tlhargh:v:hyp,nolink} «разведать». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">僅從{tlharghDuj:n}知道此元素。它似乎是一個名詞，但是{HIvDuj:n:nolink}和{qughDuj:n:nolink}的存在表明可能有一個未知的動詞{tlhargh:v:hyp,nolink}“要偵察”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11664,6 +12834,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11671,6 +12842,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -11684,6 +12856,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">Вы вошли в юрисдикцию империи клингонов. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你們已進入了克林崗帝國的管轄範圍。</column>
       <column name="definition_pt">Você entrou na jurisdição do Império Klingon.</column>
+      <column name="definition_fi">You have entered the jurisdiction of the Klingon Empire. [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11694,6 +12867,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan wo':n}, {Daq'a':n}, {bo-:v}, {'el:v}, {-pu':v}</column>
       <column name="examples"></column>
@@ -11703,6 +12877,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11710,6 +12885,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Star Trek 2009 deleted scene:src}</column>
     </table>
     <table name="mem">
@@ -11723,6 +12899,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">loop (programming) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">循環（編程） [AUTOTRANSLATED]</column>
       <column name="definition_pt">loop (programação)</column>
+      <column name="definition_fi">loop (programming) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{vIHtaH gho:sen}</column>
@@ -11733,6 +12910,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Это относится к концепции в компьютерном программировании, а именно к сегменту кода, который выполняется многократно, пока не будет выполнено какое-либо условие. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是指計算機編程中的一個概念，即重複執行直到滿足某些條件的一段代碼。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso se refere a um conceito em programação de computadores, a saber, um segmento de código que é executado repetidamente até que alguma condição seja atendida. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This was used in Klingon Blockly. Marc Okrand was shown a list of terms and their translations, and commented that Maltz said that some of them were the correct terminology used by Klingons. However, it isn't clear which ones.[2]</column>
       <column name="components">{vIH:v}, {-taH:v}, {-bogh:v}, {gho:n}</column>
       <column name="examples"></column>
@@ -11742,6 +12920,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11749,6 +12928,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KLI mailing list 2014.11.26:src}</column>
     </table>
     <!-- {yID:v} KLI slang for "to be Jewish". -->
@@ -11763,6 +12943,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">Удачи! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">祝你好運！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Boa sorte!</column>
+      <column name="definition_fi">Good luck! [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11773,6 +12954,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Поскольку это не грамматическое предложение, можно только предположить, что оно в некоторой форме {no' Hol:n}. Вместо этого рекомендуется сказать {Qapla'!:sen} или {povjaj!:excl}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">由於這不是語法語句，因此只能假定它是{no' Hol:n}的某種形式。建議改為說{Qapla'!:sen}或{povjaj!:excl}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Como essa não é uma sentença gramatical, pode-se presumir que ela esteja em alguma forma de {no' Hol:n}. Recomenda-se dizer {Qapla'!:sen} ou {povjaj!:excl}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This ungrammatical expression appears on the back cover of {How to Speak Klingon:src}, where it is translated as "Good luck".[1] Even though the sentences inside this book were provide by the Klingon Language Institute (see {tlhIngan Hol yejHaD:n}) and use proper grammar, it seems that whoever designed the cover just copied this erroneous expression from the Internet without verifying it with a competent speaker. The originator of this expression is unknown but it appeared on some fan websites in 2011, where it is claimed that it literally means "Go with fortune".</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11782,6 +12964,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11789,6 +12972,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {How to Speak Klingon:src}</column>
     </table>
     <table name="mem">
@@ -11802,6 +12986,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">аданджи, своего рода ладан [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">阿丹吉、一種香 [AUTOTRANSLATED]</column>
       <column name="definition_pt">adanji, uma espécie de incenso</column>
+      <column name="definition_fi">adanji, a kind of incense [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11812,6 +12997,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Это используется в ритуале {ma'to'vor:n}. Он должен быть реальным, а не тиражированным.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這在{ma'to'vor:n}儀式中使用。它必須是真實的並且不能複制.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado no ritual {ma'to'vor:n}. Ele deve ser real e não replicado.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11821,6 +13007,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11828,6 +13015,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DS9 - Sons of Mogh:src}, [2] {A Good Day to Die:src}</column>
     </table>
     <table name="mem">
@@ -11841,6 +13029,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">быть приземлился? быть в воздухе? (самолет) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">落地？在空中？ （飛機） [AUTOTRANSLATED]</column>
       <column name="definition_pt">ser desembarcado? estar no ar? (aeronave)</column>
+      <column name="definition_fi">be landed? be in the air? (aircraft) [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11851,6 +13040,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK">這是在{'eDSeHcha:n}中發現的未知元素。以{lolSeHcha:n}為例，這應該是與飛機著陸或起飛有關的動詞。在{'eDjen:n}中也可以找到該元素或同音字。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11860,6 +13050,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11867,6 +13058,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -11880,6 +13072,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">звезда? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">星？</column>
       <column name="definition_pt">estrela?</column>
+      <column name="definition_fi">star? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11890,6 +13083,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Este elemento é conhecido apenas em {'ejDo':n} e {'ejyo':n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11899,6 +13093,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11906,6 +13101,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD:src}</column>
     </table>
     <table name="mem">
@@ -11919,6 +13115,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">Элвис [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">埃爾維斯</column>
       <column name="definition_pt">Elvis</column>
+      <column name="definition_fi">Elvis [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -11929,6 +13126,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Это терранское имя, используемое в курсе Duolingo Klingon. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這是Duolingo Klingon課程中使用的人族名稱。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um nome terráqueo usado no curso de Duolingo Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11938,6 +13136,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11945,6 +13144,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Duolingo:src}</column>
     </table>
     <table name="mem">
@@ -11958,6 +13158,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">братство? порядок? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">兄弟會？</column>
       <column name="definition_pt">fraternidade? ordem?</column>
+      <column name="definition_fi">brotherhood? order? [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'obe':n}</column>
@@ -11968,6 +13169,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Слово {'ISletlh:n:hyp,nolink} никогда не появлялось само по себе, но встречается в {yan 'ISletlh:n}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">單詞{'ISletlh:n:hyp,nolink}從未單獨出現過，但在{yan 'ISletlh:n}中找到。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">A palavra {'ISletlh:n:hyp,nolink} nunca apareceu por si só, mas é encontrada em {yan 'ISletlh:n}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -11977,6 +13179,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -11984,6 +13187,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -11997,6 +13201,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="definition_ru">Агнешка Сольска [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Agnieszka Solska [AUTOTRANSLATED]</column>
       <column name="definition_pt">Agnieszka Solska</column>
+      <column name="definition_fi">Agnieszka Solska [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -12007,6 +13212,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="notes_ru">Она является переводчиком Дао Дэ Цзин и Искусство войны Сунци в клингон. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">她是《道德經》和《孫子的兵法》譯成克林崗語的譯者。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Ela é a tradutora do Tao Te Ching e da Art of War de Sunzi em Klingon. [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -12016,6 +13222,7 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -12023,5 +13230,6 @@ The three arms of the {tIq'ghob:n:nolink} are said to represent honor, loyalty, 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>

--- a/mem-28-examples.xml
+++ b/mem-28-examples.xml
@@ -17,6 +17,7 @@
       <column name="definition_ru">Ты голоден? Вы голодны?</column>
       <column name="definition_zh_HK">你餓嗎？</column>
       <column name="definition_pt">Você está com fome?</column>
+      <column name="definition_fi">Oletko nälkäinen?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bI'oj'a'?:sen}</column>
@@ -31,6 +32,9 @@ To answer in the negative, say {ghobe':excl} or {jISop vIneHbe'} "I don't want t
 Чтобы ответить отрицательно, скажите {ghobe':excl} "нет" or {jISop vIneHbe'} "Я не хочу есть."</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Vastaa myöntävästi sanomalla {HIja':excl} "kyllä" tai {jISop vIneH} "Haluan syödä".
+
+Jos haluat vastata kieltävästi, sano {ghobe':excl} tai {jISop vIneHbe'} "En halua syödä". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -40,6 +44,7 @@ To answer in the negative, say {ghobe':excl} or {jISop vIneHbe'} "I don't want t
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -47,6 +52,7 @@ To answer in the negative, say {ghobe':excl} or {jISop vIneHbe'} "I don't want t
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -60,6 +66,7 @@ To answer in the negative, say {ghobe':excl} or {jISop vIneHbe'} "I don't want t
       <column name="definition_ru">Хочешь пить?</column>
       <column name="definition_zh_HK">你口渴嗎？</column>
       <column name="definition_pt">Você está com sede?</column>
+      <column name="definition_fi">Oletko janoinen?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{bIghung'a'?:sen}</column>
@@ -74,6 +81,9 @@ To answer in the negative, say {ghobe':excl} or {jItlhutlh vIneHbe'} "I don't wa
 Чтобы ответить отрицательно, скажите {ghobe':excl} "нет" или {jItlhutlh vIneHbe'} "Я не хочу пить."</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Vastaa myöntävästi sanomalla {HIja':excl} "kyllä" tai {jItlhutlh vIneH} "Haluan juoda".
+
+Jos haluat vastata kieltävästi, sano {ghobe':excl} tai {jItlhutlh vIneHbe'} "En halua juoda". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -83,6 +93,7 @@ To answer in the negative, say {ghobe':excl} or {jItlhutlh vIneHbe'} "I don't wa
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -90,6 +101,7 @@ To answer in the negative, say {ghobe':excl} or {jItlhutlh vIneHbe'} "I don't wa
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -103,6 +115,7 @@ To answer in the negative, say {ghobe':excl} or {jItlhutlh vIneHbe'} "I don't wa
       <column name="definition_ru">Ты чтишь меня. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你尊敬我 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você me honra.</column>
+      <column name="definition_fi">Sinä kunnioitat minua.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -115,6 +128,9 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä ilmausta käytetään puhuttaessa yhdelle henkilölle. Kun puhut ihmisryhmälle, sano {tuquvmoH.:sen@@tu-:v, quv:v, -moH:v}
+
+Jos puhumasi henkilö on esimiehesi, harkitse {-neS:v:suff}: n lisäämistä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cho-:v}, {quv:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -124,6 +140,7 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">You honour me.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -131,6 +148,7 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -144,6 +162,7 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="definition_ru">Ты понимаешь меня? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你明白我嗎？你明白我說的嗎？</column>
       <column name="definition_pt">Você me entende?</column>
+      <column name="definition_fi">Ymmärrätkö minua?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -157,6 +176,7 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -166,6 +186,7 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -173,6 +194,7 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -186,6 +208,7 @@ If the person you're speaking to is your superior, consider adding {-neS:v:suff}
       <column name="definition_ru">Я провожу тебя до ... .</column>
       <column name="definition_zh_HK">我送你去……。</column>
       <column name="definition_pt">Eu escoltarei você para ....</column>
+      <column name="definition_fi">Saatan sinut ...:lle.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dor:v:1}</column>
@@ -198,6 +221,9 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Jos haluat vastata myöntävästi, sano {luq:excl} "ok".
+
+Jos haluat vastata kieltävästi, sano {Qo':excl} "ei, kieltäydyn". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <!-- This is needed because the analyser won't pick up {-Daq} with no attached noun. -->
       <column name="components">{-Daq:n:suff}, {qa-:v:pref}, {Dor:v:1}</column>
@@ -211,6 +237,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -218,6 +245,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -231,6 +259,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Это ... .</column>
       <column name="definition_zh_HK">這是……。</column>
       <column name="definition_pt">Isto é um ... .</column>
+      <column name="definition_fi">Tämä on ... .</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Dochvam nuq?:sen}</column>
@@ -241,6 +270,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -250,6 +280,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -257,6 +288,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -270,6 +302,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Давайте, пойдём в/на/к ... !</column>
       <column name="definition_zh_HK">來吧，我們去……！</column>
       <column name="definition_pt">vamos lá, vamos para ... !</column>
+      <column name="definition_fi">Tule, mennään ...:lle.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jaH:v}</column>
@@ -284,6 +317,9 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
 Чтобы ответить отрицательно, скажите {Qo':excl} "нет, я отказываюсь".</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Jos haluat vastata myöntävästi, sano {luq:excl} "ok".
+
+Jos haluat vastata kieltävästi, sano {Qo':excl} "ei, kieltäydyn". [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples">
@@ -302,6 +338,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
 ▶ {Ha', vaS'a' wIjaH!:sen:nolink} "Давайте, пойдём в Зал Великого совета."</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -309,6 +346,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -322,6 +360,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Какие языки ты знаешь?</column>
       <column name="definition_zh_HK">你講邊啲語言㗎？ </column>
       <column name="definition_pt">Quais idiomas você fala?</column>
+      <column name="definition_fi">Mitä kieliä puhut?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -332,6 +371,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru">В клингоне это скорее команда, чем вопрос. Это буквально означает: «Определите языки, на которых вы говорите!» [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在克林崗語中，這是命令而不是問題。它的字面意思是“確定您說的語言！” [AUTOTRANSLATED]</column>
       <column name="notes_pt">Em Klingon, isso é um comando, e não uma pergunta. Literalmente significa: "Identifique os idiomas que você fala!" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Klingonissa tämä on pikemminkin komento kuin kysymys. Se tarkoittaa kirjaimellisesti: "Tunnista kielet, joita puhut!" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -341,6 +381,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -348,6 +389,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -361,6 +403,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Тебе понравилась твоя поездка?</column>
       <column name="definition_zh_HK">你喜歡旅行嗎？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você gostou da sua viagem?</column>
+      <column name="definition_fi">Nautitko matkastasi?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -371,6 +414,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru">Возможные ответы: {HIja':excl} и {ghobe':excl}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">可能的答案是{HIja':excl}和{ghobe':excl}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Mahdollisia vastauksia ovat {HIja':excl} ja {ghobe':excl}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -380,6 +424,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -387,6 +432,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -401,6 +447,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Где ... ?</column>
       <column name="definition_zh_HK">……在哪裡？</column>
       <column name="definition_pt">Onde é o/a ...?</column>
+      <column name="definition_fi">Missä ... on?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -411,6 +458,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru">Чтобы спросить где находится человек, следует использовать {ghaH:n} вместо {'oH:n}. {nuqDaq ghaH ...'e'?:sen:nolink} "Где ...?</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Para perguntar onde uma pessoa está, {ghaH:n} deve ser usado em vez de {'oH:n}. {nuqDaq ghaH ...'e'?:sen:nolink} "Onde está ...?" [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat kysyä, missä henkilö on, {'oH:n}: n sijaan tulisi käyttää {ghaH:n}. {nuqDaq ghaH ... 'e'?: sen: nolink} "Missä on ...?"{nuqDaq ghaH ...'e'?:sen:nolink} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {'oH:n:pro}, {-'e':n:suff}</column>
       <column name="examples">
@@ -428,6 +476,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
 ▶ {nuqDaq 'oH Qe' QaQ'e'?:sen} "Где хороший ресторан?"</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -435,6 +484,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -448,6 +498,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Where do you live? Where is your home? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你住在哪裡？你家在哪裡？</column>
       <column name="definition_pt">Onde você mora? Onde fica sua casa?</column>
+      <column name="definition_fi">Missä asut? Missä kotisi on?</column>
       <column name="synonyms">
 ▶ {Daq DaDabbogh yIngu'!:sen}</column>
       <column name="antonyms"></column>
@@ -459,6 +510,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {'oH:n:pro}, {juH:n}, {-lIj:n}, {-'e':n:suff}</column>
       <column name="examples"></column>
@@ -468,6 +520,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -475,6 +528,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -488,6 +542,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Как тебя зовут?</column>
       <column name="definition_zh_HK">你叫什麼名字？</column>
       <column name="definition_pt">Qual é seu nome?</column>
+      <column name="definition_fi">Mikä sinun nimesi on?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{... 'oH pongwIj'e'.:sen}, {SoH 'Iv?:sen}</column>
@@ -498,6 +553,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuq:ques}, {'oH:n}, {pong:n}, {-lIj:n}, {-'e':n}</column>
       <column name="examples"></column>
@@ -507,6 +563,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -514,6 +571,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -527,6 +585,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Я почтен встретиться с тобой.</column>
       <column name="definition_zh_HK">很榮幸同您見面。</column>
       <column name="definition_pt">Sinto-me honrado em conhecê-lo.</column>
+      <column name="definition_fi">On kunnia tavata sinut.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -537,6 +596,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Some sources claim that {qaqIHneS} means "I am honored to meet you", but that actually means "I meet you, your honor" and is only spoken to a social superior. Other sources further compound this error by misspelling the phrase as {qaqItlhneS:sen:nolink}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -546,6 +606,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">qaqItlhneS</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -553,6 +614,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru">Очень приято познакомиться.</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -566,6 +628,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Что происходит?</column>
       <column name="definition_zh_HK">發生了什麼事？</column>
       <column name="definition_pt">O que está acontecendo? O que está acontecendo?</column>
+      <column name="definition_fi">Mitä tapahtuu? Miten menee?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -576,6 +639,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence doesn't appear exactly in canon, but {qaStaH nuq jay'?:sen:nolink} "What the #$*@ is happening?" appears on {TKD p.177:src}.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -585,6 +649,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -592,6 +657,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -605,6 +671,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Я приветствую тебя!</column>
       <column name="definition_zh_HK">我向你致敬！</column>
       <column name="definition_pt">Eu te saúdo!</column>
+      <column name="definition_fi">Tervehdin sinua!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -615,6 +682,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru">Используется для обращения к одному лицу. Чтобы приветствовать множество лиц, скажите {Savan!:sen}</column>
       <column name="notes_zh_HK">稱呼一個人時使用。 {Savan!:sen}說要向多個人致敬 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado ao endereçar uma única pessoa. Para saudar várias pessoas, diga {Savan!:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään puhuttaessa yksittäiseen henkilöön. Tervehdi useita ihmisiä sanomalla {Savan!:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{qa-:v:pref}, {van:v:1}</column>
       <column name="examples"></column>
@@ -624,6 +692,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -631,6 +700,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -644,6 +714,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Говори(те) медленно!</column>
       <column name="definition_zh_HK">慢慢地說！</column>
       <column name="definition_pt">Falar devagar!</column>
+      <column name="definition_fi">Puhu hitaasti!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{jIyajbe'.:sen}</column>
@@ -654,6 +725,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -663,6 +735,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -670,6 +743,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -683,6 +757,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Я приветствую вас, я приветствую вас всех! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我向你們致敬！</column>
       <column name="definition_pt">Eu vos saúdo, eu vos saúdo a todos!</column>
+      <column name="definition_fi">Tervehdin teitä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -693,6 +768,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="notes_ru">Это используется при обращении к нескольким людям. Чтобы приветствовать одного человека, скажите {qavan!:sen} [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">在與多個人聯繫時使用。要向一個人致敬，請說{qavan!:sen} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado ao endereçar várias pessoas. Para saudar uma pessoa, diga {qavan!:sen} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään puhuttaessa useille ihmisille. Tervehdi yhtä henkilöä sanomalla {qavan!:sen} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Sa-:v:pref}, {van:v:1}</column>
       <column name="examples"></column>
@@ -702,6 +778,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -709,6 +786,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -722,6 +800,7 @@ To answer in the negative, say {Qo':excl} "no, I refuse".</column>
       <column name="definition_ru">Вы уважаете меня, вы все уважаете меня. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">你尊重我，你們都尊重我。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você me honra, todos vocês me honram.</column>
+      <column name="definition_fi">Te kunnioitatte minua.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -734,6 +813,9 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tätä ilmausta käytetään puhuttaessa useille ihmisille. Kun puhut yhdelle henkilölle, sano {choquvmoH.:sen}
+
+Jos puhut ihmiset ovat esimiehiäsi, harkitse {-neS:v:suff}: n lisäämistä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -743,6 +825,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">You honour me, you all honour me.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -750,6 +833,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -763,6 +847,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Я учу клингонский язык.</column>
       <column name="definition_zh_HK">我學克林崗語。</column>
       <column name="definition_pt">Eu aprendo Klingon.</column>
+      <column name="definition_fi">Opin klingonia.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{tlhIngan Hol Dajatlh'a'?:sen}</column>
@@ -775,6 +860,9 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Harkitse tyypin 7 verbiliitteen, kuten {-taH:v:suff} tai {-lI':v:suff}, käyttöä:
+▶ {tlhIngan Hol vIghojtaH.:sen:nolink} "Oppin klingonia (jatkuu)."
+▶ {tlhIngan Hol vIghojlI'.:sen:nolink} "Oppin klingonia (etenen kohti tunnettua tavoitetta)." [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{tlhIngan:n}, {Hol:n}, {vI-:v}, {ghoj:v}</column>
       <column name="examples"></column>
@@ -784,6 +872,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -791,6 +880,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -804,6 +894,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Запиши(те) это.</column>
       <column name="definition_zh_HK">寫下來。</column>
       <column name="definition_pt">Escreva, anote</column>
+      <column name="definition_fi">Kirjoita se ylös.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -814,6 +905,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -823,6 +915,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -830,6 +923,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
 
@@ -849,6 +943,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">расплющить, раздавить</column>
       <column name="definition_zh_HK">鏟平、弄平</column>
       <column name="definition_pt">aplainar</column>
+      <column name="definition_fi">tasoittaa, litistää</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{gho':v}, {tap:v}</column>
@@ -859,6 +954,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{beQ:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -868,6 +964,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -875,6 +972,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -888,6 +986,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Охлаждать(что-либо)</column>
       <column name="definition_zh_HK">很酷（某事） [AUTOTRANSLATED]</column>
       <column name="definition_pt">esfriar (algo)</column>
+      <column name="definition_fi">viilentää, jäähdyttää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tujmoH:v}</column>
       <column name="see_also"></column>
@@ -898,6 +997,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{bIr:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -907,6 +1007,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -914,6 +1015,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -927,6 +1029,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">укреплять [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">加強</column>
       <column name="definition_pt">fortalecer</column>
+      <column name="definition_fi">vahvistaa, voimistaa</column>
       <column name="synonyms">{rach:v}</column>
       <column name="antonyms">{pujmoH:v}</column>
       <column name="see_also"></column>
@@ -937,6 +1040,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{HoS:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -946,6 +1050,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -953,6 +1058,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -966,6 +1072,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">уменьшать что-то в размерах</column>
       <column name="definition_zh_HK">縮小、縮細</column>
       <column name="definition_pt">encolher (algo)</column>
+      <column name="definition_fi">kutistaa, pienentää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tInmoH:v}</column>
       <column name="see_also"></column>
@@ -976,6 +1083,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{mach:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -985,6 +1093,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -992,6 +1101,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1005,6 +1115,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">уволить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">解僱、默默無聞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">demitir</column>
+      <column name="definition_fi">lähettää pois</column>
       <column name="synonyms"></column>
       <column name="antonyms">{rIt:v}</column>
       <column name="see_also">{ghomHa':v}</column>
@@ -1015,6 +1126,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{rIt:v}, {-Ha':v}</column>
       <column name="examples"></column>
@@ -1024,6 +1136,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1031,6 +1144,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1044,6 +1158,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">поставить в известность [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">通知</column>
       <column name="definition_pt">informar</column>
+      <column name="definition_fi">antaa tietoa, tiedottaa, ilmoittaa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ja':v}</column>
@@ -1054,6 +1169,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru">Посмотрите {qawmoH:v} для примера того, как использовать глагол как этот. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">有關如何使用此類動詞的示例，請參見{qawmoH:v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Veja {qawmoH:v} para um exemplo de como usar um verbo como este. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Katso {qawmoH:v} esimerkki siitä, miten tämän kaltaista verbiä käytetään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{Sov:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -1063,6 +1179,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">tell</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1070,6 +1187,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1083,6 +1201,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">увеличить [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">放大 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aumentar, ampliar</column>
+      <column name="definition_fi">suurentaa</column>
       <column name="synonyms"></column>
       <column name="antonyms">{machmoH:v}</column>
       <column name="see_also">{Sach:v:1}</column>
@@ -1093,6 +1212,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{tIn:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -1102,6 +1222,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">embiggen</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1109,6 +1230,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1122,6 +1244,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">нагреть [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">熱（某事）起來 [AUTOTRANSLATED]</column>
       <column name="definition_pt">aquecer (algo)</column>
+      <column name="definition_fi">lämmittää</column>
       <column name="synonyms"></column>
       <column name="antonyms">{bIrmoH:v}</column>
       <column name="see_also"></column>
@@ -1132,6 +1255,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{tuj:v}, {-moH:v}</column>
       <column name="examples"></column>
@@ -1141,6 +1265,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1148,6 +1273,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
 
@@ -1168,6 +1294,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Обряд наследования [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">繼承儀式 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Rito de Sucessão</column>
+      <column name="definition_fi">Perintöriitti [AUTOTRANSLATED]</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{cho':n}, {tay:n:2}, {SonchIy:n}, {ja'chuq:n}</column>
@@ -1178,6 +1305,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru">Это слово не появляется в каноне. Тем не менее, он следует шаблону других слов {tay:n:2} и включен сюда для справки. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這個詞沒有出現在佳能中。但是，它遵循其他{tay:n:2}單詞的模式，在此包含以供參考。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Esta palavra não aparece no cânon. No entanto, segue o padrão das outras palavras {tay:n:2} e é incluído aqui para referência. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä sanaa ei näy kaanonissa. Se noudattaa kuitenkin muiden {tay:n:2}-sanojen mallia ja sisältyy tähän viitteeksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{cho':n}, {tay:n:2}</column>
       <column name="examples"></column>
@@ -1187,6 +1315,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1194,6 +1323,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1207,6 +1337,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">сегодня ночью [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">今晚</column>
       <column name="definition_pt">esta noite</column>
+      <column name="definition_fi">tänä yönä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaHjaj:n}</column>
@@ -1217,6 +1348,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DaHjaj:n}, {ram:n}</column>
       <column name="examples"></column>
@@ -1226,6 +1358,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">evening</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1233,6 +1366,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1246,6 +1380,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">спидометр</column>
       <column name="definition_zh_HK">速度計</column>
       <column name="definition_pt">velocímetro</column>
+      <column name="definition_fi">nopeusmittari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{'Iv juvwI':n}</column>
@@ -1256,6 +1391,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This term does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{Do:n}, {juv:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1265,6 +1401,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1272,6 +1409,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1285,6 +1423,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">мгновенное сообщение [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">即時消息 [AUTOTRANSLATED]</column>
       <column name="definition_pt">mensagem instantânea</column>
+      <column name="definition_fi">pikaviesti</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1295,6 +1434,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is not canonical but is apparently widely known, after the model of {Do Qe':n}.</column>
       <column name="components">{Do:n}, {QIn:n:1}</column>
       <column name="examples"></column>
@@ -1304,6 +1444,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1311,6 +1452,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1324,6 +1466,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">минимальная классификация безопасности [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">最低安全等級 [AUTOTRANSLATED]</column>
       <column name="definition_pt">classificação mínima de segurança [AUTOTRANSLATED]</column>
+      <column name="definition_fi">vähimmäisturvaluokitus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1334,6 +1477,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is not explicitly defined, but its meaning is clear from the example.</column>
       <column name="components">{Hung:n}, {buv:n}, {rav:n:2}</column>
       <column name="examples">
@@ -1345,6 +1489,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
 ▶ {Hung buv rav:sen:nolink}: {patlh Hut:sen:nolink} "Объявленный уровень от 9 и выше"[1]</column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1352,6 +1497,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {BoP:src}</column>
     </table>
     <table name="mem">
@@ -1365,6 +1511,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">страхование от отмены рейса [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">航程取消保險 [AUTOTRANSLATED]</column>
       <column name="definition_pt">seguro de cancelamento de viagem</column>
+      <column name="definition_fi">matkanperuutusvakuutus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1375,6 +1522,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru">«Страхование от отмены рейса» было странным понятием для Мальца, а не термина или фразы, которые он слышал раньше, но он сказал, что {leng chach mab:n:nolink} «контракт на экстренную поездку» будет пониматься клингонами как означающее соглашение о том, кто за что отвечает, если что-то идет не так во время путешествия. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">“航程取消保險”對於馬爾茨來說是一個奇怪的概念，不是他以前聽過的術語或短語，但是他說，克林崗斯將{leng chach mab:n:nolink}的“航程緊急合同”理解為是關於誰對什麼負責的協議，如果在旅途中出了點問題。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">"Seguro de cancelamento de viagem" era um conceito estranho para Maltz, e não um termo ou frase que ele já ouvira antes, mas ele disse que Klingons "{leng chach mab:n:nolink}" contrato de emergência de viagem "seria entendido por Klingons como um acordo sobre quem é responsável por quê, se algo dá errado durante uma jornada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">"Matkan peruutusvakuutus" oli outo käsite Maltzille, eikä termi tai lause, jonka hän oli aiemmin kuullut, mutta hän sanoi, että {leng chach mab:n:nolink} "matkan hätäsopimus" ymmärretään Klingonsin mukaan sopimuksena siitä, kuka on vastuussa mistä, jos jokin menee pieleen matkan aikana. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{leng:n}, {chach:n}, {mab:n:1}</column>
       <column name="examples"></column>
@@ -1384,6 +1532,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1391,6 +1540,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2016:src}</column>
     </table>
     <table name="mem">
@@ -1404,6 +1554,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">десяток, десятилетие</column>
       <column name="definition_zh_HK">年代</column>
       <column name="definition_pt">década</column>
+      <column name="definition_fi">vuosikymmen</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1414,6 +1565,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru">Этот термин не использовался в каноне, но его значение выведено по аналогии с {vatlh DIS poH:n} и т. Д. Эта запись приведена здесь только для удобства. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">該術語未在佳能中使用，但其含義是通過與{vatlh DIS poH:n}等類似推論得出的。此條目僅出於便於參考的目的。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este termo não foi usado no cânone, mas seu significado é inferido por analogia com {vatlh DIS poH:n}, etc. Esta entrada está aqui apenas para facilitar a referência. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä termiä ei ole käytetty kaanonissa, mutta sen merkitys päätetään analogisesti {vatlh DIS poH:n}: n jne. Kanssa. Tämä merkintä on tarkoitettu vain viitteeksi. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{maH:n:2,num}, {DIS:n:2}, {poH:n}</column>
       <column name="examples"></column>
@@ -1423,6 +1575,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1430,6 +1583,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1443,6 +1597,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">коронавирус [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">新冠病毒 [AUTOTRANSLATED]</column>
       <column name="definition_pt">coronavírus [AUTOTRANSLATED]</column>
+      <column name="definition_fi">koronavirus</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1453,6 +1608,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is not canonical, but came into general use in the Terran year 2020 and is widely understood.</column>
       <column name="components">{mIv'a':n}, {javtIm:n}</column>
       <column name="examples"></column>
@@ -1462,6 +1618,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">covid-19</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1469,6 +1626,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1482,6 +1640,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">палач</column>
       <column name="definition_zh_HK">劊子手</column>
       <column name="definition_pt">carrasco</column>
+      <column name="definition_fi">pyöveli, teloittaja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1492,6 +1651,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{muH:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1501,6 +1661,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1508,6 +1669,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1521,6 +1683,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">минимальный возраст [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">最低年齡 [AUTOTRANSLATED]</column>
       <column name="definition_pt">idade minima [AUTOTRANSLATED]</column>
+      <column name="definition_fi">vähimmäisikä</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1531,6 +1694,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is not explicitly defined, but its meaning is clear from the example.</column>
       <column name="components">{nen:n}, {rav:n:2}</column>
       <column name="examples">
@@ -1541,6 +1705,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1548,6 +1713,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Klingon Monopoly:src}</column>
     </table>
     <table name="mem">
@@ -1561,6 +1727,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Следующее поколение</column>
       <column name="definition_zh_HK">下一代</column>
       <column name="definition_pt">A próxima geração</column>
+      <column name="definition_fi">Uusi sukupolvi (TNG)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Hov leng:n}</column>
@@ -1571,6 +1738,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This phrase does not appear in canon, but it is an obvious derivation from canonical terms.</column>
       <column name="components">{puq poH:n}, {veb:v}</column>
       <column name="examples"></column>
@@ -1580,6 +1748,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1587,6 +1756,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1600,6 +1770,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Сверхновая звезда</column>
       <column name="definition_zh_HK">超新星 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Super Nova</column>
+      <column name="definition_fi">supernova</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1610,6 +1781,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">Non-canonical but obviously based on {puyjaq:n}.</column>
       <column name="components">{puyjaq:n}, {-'a':n}</column>
       <column name="examples"></column>
@@ -1619,6 +1791,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1626,6 +1799,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1639,6 +1813,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">затычка для ушей</column>
       <column name="definition_zh_HK">耳塞 [AUTOTRANSLATED]</column>
       <column name="definition_pt">tampão para os ouvidos</column>
+      <column name="definition_fi">korvatulppa</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -1649,6 +1824,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This construction doesn't appear in canon, but during a discussion of {qorghwI':n} at {Saarbrücken qepHom'a' 2013:src}, everyone immediately knew what it meant.</column>
       <column name="components">{qogh:n:2}, {qorghwI':n}</column>
       <column name="examples"></column>
@@ -1658,6 +1834,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1665,6 +1842,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1678,6 +1856,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">андроид [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">安卓 [AUTOTRANSLATED]</column>
       <column name="definition_pt">andróide</column>
+      <column name="definition_fi">androidi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghogh HablI':n}</column>
@@ -1688,6 +1867,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru">{yoqqoq:n@@yoq:n, -qoq:n}, конечно, будет «так называемым гуманоидом». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">{yoqqoq:n@@yoq:n, -qoq:n}當然將是“所謂的類人動物”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Um {yoqqoq:n@@yoq:n, -qoq:n} seria, obviamente, um "chamado humanóide". [AUTOTRANSLATED]</column>
+      <column name="notes_fi">{yoqqoq:n@@yoq:n, -qoq:n} olisi tietysti "niin kutsuttu humanoidi". [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{qoq:n}, {yoq:n}</column>
       <column name="examples"></column>
@@ -1697,6 +1877,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1704,6 +1885,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1717,6 +1899,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">щетка [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">刷子</column>
       <column name="definition_pt">escova</column>
+      <column name="definition_fi">harja</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{teywI':n}</column>
@@ -1727,6 +1910,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon by itself, but can be inferred from {jIb yachwI':n}.</column>
       <column name="components">{yach:v:1}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1736,6 +1920,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1743,6 +1928,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1756,6 +1942,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">ноготь на пальце ноги [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">腳指甲</column>
       <column name="definition_pt">unha do dedo do pé</column>
+      <column name="definition_fi">varpaankynsi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{nItlhpach:n:1}</column>
@@ -1766,6 +1953,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not seem to have appeared in canon, but it is obvious by analogy with {nItlhpach:n:1}.</column>
       <column name="components">{yaD:n:1}, {pach:n}</column>
       <column name="examples"></column>
@@ -1775,6 +1963,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nail</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1782,6 +1971,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1795,6 +1985,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">высотомер [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">高度表</column>
       <column name="definition_pt">altímetro</column>
+      <column name="definition_fi">korkeusmittari</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{Do juvwI':n}</column>
@@ -1805,6 +1996,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This term does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components">{'Iv:n:2h}, {juv:v}, {-wI':v}</column>
       <column name="examples"></column>
@@ -1814,6 +2006,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1821,6 +2014,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
 
@@ -1838,6 +2032,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">значительно, много? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">相當多、很多？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">consideravelmente, muito?</column>
+      <column name="definition_fi">huomattavasti, paljon?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{loQ:adv}</column>
       <column name="see_also">{tlhoy:adv}, {tlhoS:adv}, {-law':v:suff}, {-Ha':v:suff}</column>
@@ -1848,6 +2043,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru">Подумайте об использовании суффикса {-qu':v:suff}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">考慮使用後綴{-qu':v:suff}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Considere usar o sufixo {-qu':v:suff}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Harkitse loppuliitteen {-qu':v:suff} käyttöä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1857,6 +2053,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1864,6 +2061,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1877,6 +2075,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">необычно, нетипично, не так, как ожидалось [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">出奇、異常、非典型、不如預期</column>
       <column name="definition_pt">invulgarmente, atipicamente, não como o esperado</column>
+      <column name="definition_fi">epätavallisesti, epätyypillisesti, ei odotetulla tavalla</column>
       <column name="synonyms"></column>
       <column name="antonyms">{motlh:adv}</column>
       <column name="see_also">{-Ha':v:suff}</column>
@@ -1887,6 +2086,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1896,6 +2096,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1903,6 +2104,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1916,6 +2118,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">постепенно, понемногу, исподволь, мало-помалу</column>
       <column name="definition_zh_HK">逐漸 [AUTOTRANSLATED]</column>
       <column name="definition_pt">gradualmente</column>
+      <column name="definition_fi">vähitellen</column>
       <column name="synonyms"></column>
       <column name="antonyms">{pay':adv}</column>
       <column name="see_also">{-Ha':v:suff}</column>
@@ -1926,6 +2129,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1935,6 +2139,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1942,6 +2147,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1955,6 +2161,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">давным-давно, давным-давно? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">前一段時間、很久以前？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">há algum tempo atrás, há muito tempo?</column>
+      <column name="definition_fi">jonkin aikaa sitten, kauan sitten?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{qen:adv}</column>
       <column name="see_also">{-Ha':v:suff}</column>
@@ -1965,6 +2172,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru">Подумайте об использовании {ben law':sen@@ben:n:1, law':v}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">考慮使用{ben law':sen@@ben:n:1, law':v}。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Considere usar {ben law':sen@@ben:n:1, law':v}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Harkitse {ben law':sen@@ben:n:1, law':v}: n käyttöä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -1974,6 +2182,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -1981,6 +2190,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -1994,6 +2204,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">earlier than expected, initially, at first? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">最初比起預期更早、最初？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">mais cedo do que o esperado, inicialmente, a princípio?</column>
+      <column name="definition_fi">odotettua aikaisemmin, aluksi, ensin?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tagha':adv}</column>
       <column name="see_also">{-Ha':v:suff}, {wejHa':adv:hyp}</column>
@@ -2004,6 +2215,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2013,6 +2225,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2020,6 +2233,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2033,6 +2247,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">точно, правда, совсем? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">確切地、真的、相當？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">exatamente, sério?</column>
+      <column name="definition_fi">tarkalleen, aivan</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhoS:adv}</column>
       <column name="see_also">{-Ha':v:suff}</column>
@@ -2043,6 +2258,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2052,6 +2268,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2059,6 +2276,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2072,6 +2290,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">неадекватно, недостаточно, слишком мало? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">不充分、不充分、太少？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">insuficientemente, inadequadamente, muito pouco?</column>
+      <column name="definition_fi">puutteellisesti, riittämättömästi, liian vähän?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{tlhoy:adv}</column>
       <column name="see_also">{-Ha':v:suff}</column>
@@ -2082,6 +2301,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2091,6 +2311,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2098,6 +2319,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2111,6 +2333,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">already, yet? [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">已經、但是？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">já ainda?</column>
+      <column name="definition_fi">jo, vielä?</column>
       <column name="synonyms"></column>
       <column name="antonyms">{wej:adv}</column>
       <column name="see_also">{-Ha':v:suff}, {tagha'Ha':adv:hyp}</column>
@@ -2121,6 +2344,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This word does not appear in canon. This entry is here for ease of reference only.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2130,6 +2354,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2137,6 +2362,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
 
@@ -2152,6 +2378,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Я требую кровь врага. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我要求敵人的鮮血。</column>
       <column name="definition_pt">Eu exijo o sangue do inimigo</column>
+      <column name="definition_fi">Vaadin vihollisen verta.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2162,6 +2389,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence does not appear in canon. It is included here because it is used in some fan ceremonies.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2171,6 +2399,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2178,6 +2407,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2191,6 +2421,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Эта битва моя битва. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">這場戰鬥是我的戰鬥。</column>
       <column name="definition_pt">Esta batalha é minha batalha.</column>
+      <column name="definition_fi">Tämä taistelu on minun taisteluni.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2201,6 +2432,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence does not appear in canon. It is included here because it is used in some fan ceremonies.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2210,6 +2442,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2217,6 +2450,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2230,6 +2464,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Тело мёртвого врага лежит перед моими ногами</column>
       <column name="definition_zh_HK">死敵的屍體就在我的腳前。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">O corpo do inimigo morto está na frente dos meus pés.</column>
+      <column name="definition_fi">Kuolleen vihollisen ruumis on jalkojeni edessä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2240,6 +2475,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence does not appear in canon. It is included here because it is used in some fan ceremonies.</column>
       <column name="components">{qam:n}, {-Du':n}, {-wIj:n}, {-Daq:n}, {Hegh:v}, {-pu':v}, {-bogh:v}, {jagh:n}, {tu'lu':v}</column>
       <column name="examples"></column>
@@ -2249,6 +2485,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">nentay</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2256,6 +2493,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
 
@@ -2271,6 +2509,7 @@ If the people you're speaking to are your superiors, consider adding {-neS:v:suf
       <column name="definition_ru">Укуси меня! (Песня) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">咬我！ （歌曲） [AUTOTRANSLATED]</column>
       <column name="definition_pt">Morde-me! (canção)</column>
+      <column name="definition_fi">Suutele minua! (laulu)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2321,6 +2560,44 @@ Buy the full "Warrior Woman" album: {Google Play store:url:https://play.google.c
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on klingonilainen karaokeklassikko.
+
+▶ {HIchop:sen@@HI-:v, chop:v}
+   {rol ghajbogh tIrvo' HIghoS:sen@@rol:n, ghaj:v, -bogh:v, tIr:n, -vo':n, HI-:v, ghoS:v:1}
+   {Hoch ram SuDbogh tI SuD retlhDaq:sen@@Hoch:n, ram:n, SuD:v:1, -bogh:v, tI:n, SuD:v:1, retlh:n, -Daq:n}
+   {DIng, DIng, qammaj tIDIngmoH:sen@@DIng:v, DIng:v, qam:n, -maj:n, tI-:v, DIng:v, -moH:v}
+   {waqvetlh tItuQ 'ej paHvam vItuQ jIH:sen@@waq:n, -vetlh:n, tI-:v, tuQ:v, 'ej:conj, paH:n, -vam:n, vI-:v, tuQ:v, jIH:n:1}   
+   {HIchop:sen:nolink}
+   {'ej choS chIS bIngDaq HIchop:sen@@'ej:conj, choS:n, chIS:v, bIng:n, -Daq:n, HI-:v, chop:v}
+   {HIDev:sen@@HI-:v, Dev:v}
+   {ravDaq Hov Huv bIngDaq:sen@@rav:n:1, -Daq:n, Hov:n, Huv:v:1, bIng:n, -Daq:n}
+   {jIHvaD ghIt yIpep:sen@@jIH:n:1, -vaD:n, ghIt:n:1, yI-:v, pep:v}
+   {DaH QoQ yIchu':sen@@DaH:adv, QoQ:n, yI-:v, chu':v:3}
+   {'ej mI'jaj wewbogh ghew:sen@@'ej:conj, mI':v, -jaj:v, wew:v, -bogh:v, ghew:n}
+   {bochtaHmo' maS chIS:sen@@boch:v, -taH:v, -mo':v, maS:n, chIS:v}
+   {DaH HIchop:sen@@DaH:adv, HI-:v, chop:v}   
+   {HIchop:sen:nolink}
+   {Duj puylu'pu'bogh retlhDaq:sen@@Duj:n:1, puy:v, -lu':v, -pu':v, -bogh:v, retlh:n, -Daq:n}
+   {bang bom tIbom:sen@@bang bom:n, tI-:v, bom:v}
+   {jagh Hom tIjaD:sen@@jagh:n, Hom:n:1, tI-:v, jaD:v}
+   {HIchuH:sen@@HI-:v, chuH:v:1}
+   {tIqwIj'e' qa'ang:sen@@tIq:n, -wIj:n, -'e':n, qa-:v, 'ang:v}
+   {He 'angbogh vavlI' pu'jIn tIQ wItlha'}   
+   {HIchop:sen:nolink}
+   {'ej choS chIS bIngDaq HIchop:sen:nolink}
+   {HIDev:sen:nolink}
+   {ravDaq Hov Huv bIngDaq:sen:nolink}
+   {jIHvaD ghIt yIpep:sen:nolink}
+   {DaH QoQ yIchu':sen:nolink}
+   {'ej mI'jaj wewbogh ghew:sen:nolink}
+   {bochtaHmo' maS chIS:sen:nolink}
+   {DaH HIchop:sen:nolink}
+
+Sanat käänsivät Robyn Stewart, Chris Lipscombe, Christopher Kidder-Mostrom, Jeremy Cowan, and Ali Kidder-Mostrom Klingonien Saiturin joulusta.
+
+Katso se Jen Usellisin esittämänä, tuottajana Improvised Star Trek: {YouTube video:url:http://youtu.be/v2bjc6U0tjI}
+
+Osta koko Warrior Woman -albumi: {Google Play Kauppa: url: https: //play.google.com/store/music/album/The_Klingon_Pop_Warrior_Warrior_Woman? Id = Bwiodbf4hmegoplslpyfcjb7woq}</column>
       <column name="hidden_notes">This song is a translation of "Kiss Me" by the band Sixpence None the Richer.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2330,6 +2607,7 @@ Buy the full "Warrior Woman" album: {Google Play store:url:https://play.google.c
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2337,6 +2615,7 @@ Buy the full "Warrior Woman" album: {Google Play store:url:https://play.google.c
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2350,6 +2629,7 @@ Buy the full "Warrior Woman" album: {Google Play store:url:https://play.google.c
       <column name="definition_ru">Имперский Гимн [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">帝國國歌 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Um Hino Imperial</column>
+      <column name="definition_fi">Eläköön keisarikunta (Keisarillinen hymni)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{van bom:n}, {Qoy qeylIS puqloD:sen:lyr}</column>
@@ -2383,6 +2663,30 @@ The lyrics are as follows:
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on {tlhIngan Hol yejHaD:n}:in (epävirallinen) hymni, joka on laulettu jokaisella {qep'a':n:nolink}:lla.
+
+Sanat ovat:
+▶ {taHjaj wo', 'ej taHjaj voDleHma'!:sen:nolink}
+   {wItoy'mo', vaj nuquvmoHjaj ta'!:sen:nolink}
+   {Dun wo'maj, 'ej Qochchugh vay':sen:nolink}
+   {vaj DaSmeymaj bIngDaq chaH DIbeQmoHchu' jay'!:sen:nolink}
+
+   {taHjaj wo', 'ej taHjaj maH!:sen:nolink}
+   {bechjaj jaghma', Heghjaj chaH!:sen:nolink}
+   {wItoy'bej net Sov net Sov!:sen:nolink}
+   {val 'ej may voDleHma' pov!:sen:nolink}
+   {Dun wo'vam, juHmaj, not Dej.:sen:nolink}
+   {Qochchugh vay' vaj Doghqu'bej!:sen:nolink}
+   {DaSmeymaj bIngDaq chaH DIbeQmoHchu' jay'!:sen:nolink}
+
+   {maSopnISbe', matlhutlhnISbe', 'ej maDo'chugh, matlhuHnISbe'.:sen:nolink}
+   {Doch neH wIta'nISbogh 'oH tlhIngan wo''a' HoSghaj toy'ghach'e'.:sen:nolink}
+   {may''a'meyDaq, veS'a'meyDaq, 'ej reH 'ej reH yay'a'meyDaq:sen:nolink}
+   {Qapla' wIchav, 'ej batlh wISuq, 'ej tlhIngan wo' nIvghach wImaq.:sen:nolink}
+   {matoy'rupchu', maSuvlaHchu', maHeghqangchu', 'utchugh 'utmo'.:sen:nolink}
+   {'ach Heghmaj yIpIHQo', ghaytan wa'DIch jagh'e' wIHeghmoHmo'.:sen:nolink}
+   {vaj taHjaj wo', vaj taHjaj wo', 'u' HeHDaq tlhIngan juHqo'vo':sen:nolink}
+   {vaj taHjaj taHjaj taHjaj taHjaj taHjaj tlhIngan wo'!:sen:nolink}</column>
       <column name="hidden_notes">This song was composed by Rich Yampell, a.k.a. {HoD Qanqor:n:name,nolink}. Note that ordinarily, a rank such as {HoD:n} follows the name in Klingon, but {HoD Qanqor:n:name,nolink} comes from a region where one's rank precedes one's name.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2392,6 +2696,7 @@ The lyrics are as follows:
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2399,6 +2704,7 @@ The lyrics are as follows:
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2412,6 +2718,7 @@ The lyrics are as follows:
       <column name="definition_ru">Сезоны любви (песня) [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">愛的季節（歌）</column>
       <column name="definition_pt">Estações do amor (canção)</column>
+      <column name="definition_fi">Seasons of Love (laulu)</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2439,6 +2746,24 @@ Watch this song performed by Rachel Bloom: {YouTube video:url:http://youtu.be/Y3
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi">Tämä on kappale maapallolaisesta "Rent"-musikaalista. Klingoninkielinen otsikko tarkoittaa kirjaimellisesti "525 600 minuuttia".
+
+▶ {vaghbIp cha'netlh vaghSaD javvatlh tup,:sen@@vagh:n:1, bIp:n, cha':n, netlh:n, vagh:n:1, SaD:n, jav:n:1, vatlh:n}
+   {lo'laHbogh vaghbIp cha'netlh vaghSaD poHmey,:sen@@lo'laH:v, -bogh:v, vagh:n:1, bIp:n, cha':n, netlh:n, vagh:n:1, SaD:n, poH:n, -mey:n}
+   {vaghbIp cha'netlh vaghSaD javvatlh tup.:sen:nolink}
+   {chay' DIS DajuvlaH?:sen@@chay':ques, DIS:n:2, Da-:v, juv:v, -laH:v}
+
+   {bIjuvmeH pemmey, povmey, ramjepmey, qa'vIn HIvje'mey,:sen@@bI-:v, juv:v, -meH:v, pem:n, -mey:n, pov:n, -mey:n, ramjep:n:1, -mey:n, qa'vIn:n, HIvje':n, -mey:n}
+   {'ujmey, qelI'qammey, naD, QeH ghap Dalo'laH.:sen@@'uj:n, -mey:n, qelI'qam:n, -mey:n, naD:n, QeH:n, ghap:conj, Da-:v, lo':v, -laH:v}
+   {vaghbIp cha'netlh vaghSaD javvatlh tup Dalo'laH.:sen@@vagh:n:1, bIp:n, cha':n, netlh:n, vagh:n:1, SaD:n, jav:n:1, vatlh:n, Da-:v, lo':v, -laH:v}
+   {chay' wa' yIn DIS DajuvlaH?:sen@@chay':ques, wa':n, yIn:n, DIS:n:2, Da-:v, juv:v, -laH:v}
+
+   {parmaq Dalo'laH'a'?:sen@@parmaq:n, Da-:v, lo':v, -laH:v, -'a':v}
+   {parmaq Dalo'laH'a'?:sen:nolink}
+   {parmaq Dalo'laH'a'?:sen:nolink}
+   {bIjuvmeH parmaq yIlo'.:sen@@bI-:v, juv:v, -meH:v, parmaq:n, yI-:v, lo':v}
+
+Katso tämä kappale Rachel Bloomin esittämänä: {YouTube video:url:http://youtu.be/Y3Q2HXXRlBM}</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2448,6 +2773,7 @@ Watch this song performed by Rachel Bloom: {YouTube video:url:http://youtu.be/Y3
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2455,6 +2781,7 @@ Watch this song performed by Rachel Bloom: {YouTube video:url:http://youtu.be/Y3
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2468,6 +2795,7 @@ Watch this song performed by Rachel Bloom: {YouTube video:url:http://youtu.be/Y3
       <column name="definition_ru">Песня Tribble [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">Tribble Song [AUTOTRANSLATED]</column>
       <column name="definition_pt">A música Tribble</column>
+      <column name="definition_fi">Tribble-laulu</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2510,6 +2838,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2519,6 +2848,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2526,6 +2856,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
 
@@ -2541,6 +2872,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Ты моя любовь(возлюбленный(ая)).</column>
       <column name="definition_zh_HK">你是我的愛。</column>
       <column name="definition_pt">Você é meu amado (ente pessoas que se amam).</column>
+      <column name="definition_fi">Olet kultani.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -2553,6 +2885,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2562,6 +2895,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">I love you.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2569,6 +2903,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru">Я тебя люблю.</column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2582,6 +2917,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Я принял запись экипажа о битве.</column>
       <column name="definition_zh_HK">我已經接受了船員的戰鬥記錄。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Aceitei o registro de batalha da tripulação. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Olen hyväksynyt miehistön taistelutiedot.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DaH yaS wa'DIch vIgheS.:sen}</column>
@@ -2592,6 +2928,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2601,6 +2938,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2608,6 +2946,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.184:src}</column>
     </table>
     <table name="mem">
@@ -2621,6 +2960,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Ничего не значащая фраза</column>
       <column name="definition_zh_HK">無意義的口頭短語 [AUTOTRANSLATED]</column>
       <column name="definition_pt">frase verbal sem sentido</column>
+      <column name="definition_fi">merkityksetön taivutettu verbi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{wot:n}, {mojaq:n}, {QaghHommeyHeylIjmo':n}</column>
@@ -2631,6 +2971,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru">Это глагол с каждым из типов суффиксов. Он ничего не означает.</column>
       <column name="notes_zh_HK">這是一個帶每種後綴類型的動詞。這真的沒有任何意義。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Este é um verbo com um de cada tipo de sufixo. Realmente não significa nada. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä on verbi, jolla on yksi kustakin päätteestä. Se ei oikeastaan ​​tarkoita mitään. [AUTOTRANSLATED]</column>
       <column name="hidden_notes">The invention of this verbal phrase is attributed to Mark Shoulson.</column>
       <column name="components">{bI-:v}, {Qong:v}, {-'egh:v}, {-qang:v}, {-choH:v}, {-moH:v}, {-laH:v}, {-chu':v}, {-pu':v}, {-neS:v}, {-chugh:v}</column>
       <column name="examples"></column>
@@ -2640,6 +2981,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2647,6 +2989,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2660,6 +3003,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Ты очень красивый(ая).</column>
       <column name="definition_zh_HK">你真漂亮。</column>
       <column name="definition_pt">Você é muito bonita.</column>
+      <column name="definition_fi">Olet hyvin kaunis.</column>
       <column name="synonyms">Du bist wunderschön.</column>
       <column name="antonyms"></column>
       <column name="see_also">{bImoHqu'.:sen}</column>
@@ -2670,6 +3014,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This sentence doesn't appear in canon. It is here for symmetry with {bImoHqu'.:sen}</column>
       <column name="components">{bI-:v}, {'IH:v}, {-qu':v}</column>
       <column name="examples"></column>
@@ -2679,6 +3024,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2686,6 +3032,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2699,6 +3046,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Теперь я занимаю свое место первого офицера. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我現在擔任副駕駛。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu agora tomo meu lugar como primeiro oficial. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Otan nyt paikkani yliperämiehenä.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{beq may' ta vIlajpu'.:sen}</column>
@@ -2709,6 +3057,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru">Это буквально означает «Теперь я беру на себя обязанности первого помощника». [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“現在我承擔副駕駛的職責”。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "Agora eu assumo as responsabilidades de primeiro oficial". [AUTOTRANSLATED]</column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{DaH:adv}, {yaS:n}, {wa'DIch:n}, {vI-:v}, {gheS:v}</column>
       <column name="examples"></column>
@@ -2718,6 +3067,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2725,6 +3075,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.182:src}</column>
     </table>
     <table name="mem">
@@ -2738,6 +3089,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Уволен! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">解散！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Demitido! [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Poistukaa!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{ghomHa':v}</column>
@@ -2748,6 +3100,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">In {DS9 - Sons and Daughters:src}, Worf dismisses a group of crewmen with {yIghomHa'!:sen:nolink} Since he was addressing multiple people, it should have been {peghomHa'!:sen:nolink} Furthermore, since he was addressing subordinates, he should probably have used clipped Klingon, i.e., {ghomHa'!:sen:nolink}</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2757,6 +3110,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2764,6 +3118,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {DS9 - Sons and Daughters:src}</column>
     </table>
     <table name="mem">
@@ -2777,6 +3132,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Я прнимаю ваши жизни в свои руки.</column>
       <column name="definition_zh_HK">我接受你的生命。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eu aceito suas vidas em minhas mãos. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Hyväksyn elämänne minun käsiini.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2787,6 +3143,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru">Об этом говорится в ответе на {juDev 'ej Dujvam ra'wI' DagheS 'e' vItlhob.:sen}. За ним следует фраза {no' Hol:n} {Delaq Do':sen}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">據說這是對{juDev 'ej Dujvam ra'wI' DagheS 'e' vItlhob.:sen}的響應，其後是{no' Hol:n}短語{Delaq Do':sen}.[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é dito em resposta a {juDev 'ej Dujvam ra'wI' DagheS 'e' vItlhob.:sen}. É seguido pela frase {no' Hol:n} {Delaq Do':sen}.[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä sanotaan vastauksena {juDev 'ej Dujvam ra'wI' DagheS 'e' vItlhob.:sen}: een. Sitä seuraa {no' Hol:n}-lause {Delaq Do':sen}.[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2796,6 +3153,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2803,6 +3161,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.184:src}</column>
     </table>
     <table name="mem">
@@ -2816,6 +3175,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Какой твой любимый месяц?</column>
       <column name="definition_zh_HK">您最喜歡哪個月份？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Qual é o seu mês favorito? [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Mikä on suosikkikuukautesi?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2826,6 +3186,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{jar:n}, {Da-:v}, {maS:v}, {-qu':v}, {-bogh:v}, {yI-:v}, {ngu':v}</column>
       <column name="examples"></column>
@@ -2835,6 +3196,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2842,6 +3204,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {msn 1996.12.12:src}</column>
     </table>
     <table name="mem">
@@ -2855,6 +3218,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Я прошу вас повести нас, как командир этого корабля.</column>
       <column name="definition_zh_HK">我請你帶領我們擔任這艘船的指揮官。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Peço-lhe para nos liderar como comandante deste navio. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Pyydän sinua johtamaan meitä tämän aluksen komentajana.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2865,6 +3229,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru">Это буквально означает: "Я прошу, чтобы вы повели нас и чтобы вы приняли обязанности командира этого корабля." Ответ: {ghopDu'wIjDaq yInmeyraj vIlaj.:sen}[1]. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">字面意思是“我要求您領導我們，並承擔這艘船的指揮官的職責。”響應為{ghopDu'wIjDaq yInmeyraj vIlaj.:sen}[1] [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "Solicito que nos lidere e assuma as funções de comandante deste navio". A resposta é {ghopDu'wIjDaq yInmeyraj vIlaj.:sen}[1] [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "Pyydän sinua johtamaan meitä ja suorittamaan tämän aluksen komentajan tehtävät". Vastaus on {ghopDu'wIjDaq yInmeyraj vIlaj.:sen}[1] [AUTOTRANSLATED]</column>
       <column name="hidden_notes">{ju-:v}, {Dev:v}, {'ej:conj}, {Duj:n:1}, {ra'wI':n}, {Da-:v}, {gheS:v}, {'e':n}, {vI-:v}, {tlhob:v}</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2874,6 +3239,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2881,6 +3247,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.184:src}</column>
     </table>
     <table name="mem">
@@ -2894,6 +3261,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Я чувствую удачу. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我感覺我是幸運的。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Estou me sentindo com sorte.</column>
+      <column name="definition_fi">Olen valmis ottamaan riskin.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2904,6 +3272,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru">Это буквально означает «я готов рискнуть». Эта фраза связана с популярной поисковой системой {Google:url:http://www.google.com/}. [AUTOTRANSLATED]</column>
       <column name="notes_zh_HK">這字面意思是“我準備好機會了”。該短語與流行的搜索引擎{Google:url:http://www.google.com/}相關。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso literalmente significa "Estou pronto para arriscar". Esta frase está associada ao popular mecanismo de pesquisa {Google:url:http://www.google.com/}. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "olen valmis ottamaan riskin". Tämä lause liittyy suosittuun hakukoneeseen {Google:url:http://www.google.com/}. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{jI-:v}, {SuD:v:2}, {-rup:v}</column>
       <column name="examples"></column>
@@ -2913,6 +3282,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2920,6 +3290,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -2934,6 +3305,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Мне 40 лет.</column>
       <column name="definition_zh_HK">我今年40歲。</column>
       <column name="definition_pt">Tenho 40 anos de idade. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Olen 40-vuotias.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2944,6 +3316,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{loS:n:1}, {maH:n:2}, {ben:n:1}, {jI-:v}, {bogh:v}, {-pu':v}</column>
       <column name="examples"></column>
@@ -2953,6 +3326,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2960,6 +3334,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {msn 1996.12.12:src}</column>
     </table>
     <table name="mem">
@@ -2973,6 +3348,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Мое судно на воздушной подушке полно угрей. [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我的氣墊船上到處都是鰻魚。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Meu hovercraft está cheio de enguias.</column>
+      <column name="definition_fi">Sukkulani on täynnä matoja.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -2983,6 +3359,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -2992,6 +3369,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -2999,6 +3377,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -3012,6 +3391,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Какое оружие тебе нужно?</column>
       <column name="definition_zh_HK">您要哪種武器？ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Qual arma você quer? [AUTOTRANSLATED]</column>
+      <column name="definition_fi">Minkä aseen haluat?</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3022,6 +3402,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nuH:n:1}, {Da-:v}, {neH:v}, {-bogh:v}, {yI-:v}, {ngu':v}</column>
       <column name="examples"></column>
@@ -3031,6 +3412,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3038,6 +3420,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {KGT p.105:src}</column>
     </table>
     <table name="mem">
@@ -3051,6 +3434,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Они не прикончили нас.</column>
       <column name="definition_zh_HK">他們還沒有結束我們。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Eles não acabaram conosco. [AUTOTRANSLATED]</column>
+      <column name="definition_fi">He eivät ole tuhonneet meitä kokonaan.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3061,6 +3445,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{nu-:v}, {Qaw':v}, {-qu':v}, {-be':v}</column>
       <column name="examples"></column>
@@ -3070,6 +3455,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3077,6 +3463,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.48:src}</column>
     </table>
     <table name="mem">
@@ -3129,6 +3516,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Ты моя любовь, ты мой возлюленный</column>
       <column name="definition_zh_HK">你是我的愛（浪漫伴侶）。 [AUTOTRANSLATED]</column>
       <column name="definition_pt">Você é meu amor (companheiro romântico).</column>
+      <column name="definition_fi">Olet rakkaani.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -3141,6 +3529,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3150,6 +3539,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">I love you.</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3157,6 +3547,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -3170,6 +3561,7 @@ The lyrics are by Lawrence Schoen, and the accompanying music is by Rich Yampell
       <column name="definition_ru">Я люблю тебя</column>
       <column name="definition_zh_HK">我愛你。</column>
       <column name="definition_pt">Eu te amo.</column>
+      <column name="definition_fi">Rakastan sinua.</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">
@@ -3186,6 +3578,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
 Вопреки к некоторым ненадежным источникам, фраза "Urkuk lu Stalga" не означает "Я люблю тебя малышка" на Клингонском. Фактически, это совсем не Клингонский. Называя кого-то малышкой (смотрите {ghu:n}) это не считается признаком любви.</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3195,6 +3588,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags">Urkuk lu Stalga</column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3202,6 +3596,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -3215,6 +3610,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="definition_ru">С днём рождения</column>
       <column name="definition_zh_HK">生日快樂！</column>
       <column name="definition_pt">Feliz Aniversário!</column>
+      <column name="definition_fi">Hyvää syntymäpäivää!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3225,6 +3621,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="notes_ru">Дословно это значит "Пусть ты насладишься твоим днём рождения!". Чтобы пожелать счастья множеству людей, скажитеsay {qoSraj botIvjaj!}</column>
       <column name="notes_zh_HK">這字面意思是“祝您生日快樂！”祝多人生日快樂，請說{qoSraj botIvjaj!} [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso significa literalmente "você pode aproveitar seu aniversário!" Para desejar um feliz aniversário para várias pessoas, diga {qoSraj botIvjaj!} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tämä tarkoittaa kirjaimellisesti "saatatko nauttia syntymäpäivästäsi!" Jos haluat toivottaa hyvää syntymäpäivää useille ihmisille, sano {qoSraj botIvjaj!} [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3234,6 +3631,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3241,6 +3639,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>
     <table name="mem">
@@ -3254,6 +3653,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="definition_ru">из-за твоих очевидных незначительных ошибок</column>
       <column name="definition_zh_HK">由於你明顯的小錯誤 [AUTOTRANSLATED]</column>
       <column name="definition_pt">devido a seus aparentes erros menores</column>
+      <column name="definition_fi">ilmeisten pienten virheidesi vuoksi</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also">{DIp:n}, {mojaq:n}, {bIQong'eghqangchoHmoHlaHchu'pu'neSchugh:v}</column>
@@ -3264,6 +3664,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="notes_ru">В {TKD:src} используется, как пример существительного со всеми пятью суффиксами.</column>
       <column name="notes_zh_HK">在{TKD:src}中使用它作為帶有所有五種後綴類型的名詞的示例。 [AUTOTRANSLATED]</column>
       <column name="notes_pt">Isso é usado no {TKD:src} como um exemplo de um substantivo com todos os cinco tipos de sufixos. [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Tätä käytetään {TKD:src}: ssä esimerkkinä substantiivista, jolla on kaikki viisi päätetyyppiä. [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{Qagh:n}, {-Hom:n}, {-mey:n}, {-Hey:n}, {-lIj:n}, {-mo':n}</column>
       <column name="examples"></column>
@@ -3273,6 +3674,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3280,6 +3682,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {TKD p.29:src}</column>
     </table>
     <table name="mem">
@@ -3293,6 +3696,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="definition_ru">мой 10-летний брат [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">我十歲的哥哥 [AUTOTRANSLATED]</column>
       <column name="definition_pt">meu irmão de 10 anos [AUTOTRANSLATED]</column>
+      <column name="definition_fi">10-vuotias veljeni</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3303,6 +3707,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes"></column>
       <column name="components">{wa':n}, {maH:n:2}, {ben:n:2}, {loDnI':n}, {-wI':n}</column>
       <column name="examples"></column>
@@ -3312,6 +3717,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3319,6 +3725,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source">[1] {Saarbrücken qepHom'a' 2015:src}</column>
     </table>
     <table name="mem">
@@ -3332,6 +3739,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="definition_ru">Не будь глупой! [AUTOTRANSLATED]</column>
       <column name="definition_zh_HK">別傻了！ [AUTOTRANSLATED]</column>
       <column name="definition_pt">Não seja bobo!</column>
+      <column name="definition_fi">Älä ole typerä!</column>
       <column name="synonyms"></column>
       <column name="antonyms"></column>
       <column name="see_also"></column>
@@ -3342,6 +3750,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="notes_ru"></column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt"></column>
+      <column name="notes_fi"></column>
       <column name="hidden_notes">This is one of the example Klingon phrases on the KLI web site.</column>
       <column name="components"></column>
       <column name="examples"></column>
@@ -3351,6 +3760,7 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="examples_ru"></column>
       <column name="examples_zh_HK"></column>
       <column name="examples_pt"></column>
+      <column name="examples_fi"></column>
       <column name="search_tags"></column>
       <column name="search_tags_de"></column>
       <column name="search_tags_fa"></column>
@@ -3358,5 +3768,6 @@ Contrary to some unreliable sources, the phrase "Urkuk lu Stalga" does not mean 
       <column name="search_tags_ru"></column>
       <column name="search_tags_zh_HK"></column>
       <column name="search_tags_pt"></column>
+      <column name="search_tags_fi"></column>
       <column name="source"></column>
     </table>

--- a/mem-28-examples.xml
+++ b/mem-28-examples.xml
@@ -458,7 +458,7 @@ Jos haluat vastata kieltävästi, sano {Qo':excl} "ei, kieltäydyn". [AUTOTRANSL
       <column name="notes_ru">Чтобы спросить где находится человек, следует использовать {ghaH:n} вместо {'oH:n}. {nuqDaq ghaH ...'e'?:sen:nolink} "Где ...?</column>
       <column name="notes_zh_HK"></column>
       <column name="notes_pt">Para perguntar onde uma pessoa está, {ghaH:n} deve ser usado em vez de {'oH:n}. {nuqDaq ghaH ...'e'?:sen:nolink} "Onde está ...?" [AUTOTRANSLATED]</column>
-      <column name="notes_fi">Jos haluat kysyä, missä henkilö on, {'oH:n}: n sijaan tulisi käyttää {ghaH:n}. {nuqDaq ghaH ... 'e'?: sen: nolink} "Missä on ...?"{nuqDaq ghaH ...'e'?:sen:nolink} [AUTOTRANSLATED]</column>
+      <column name="notes_fi">Jos haluat kysyä, missä henkilö on, {'oH:n}: n sijaan tulisi käyttää {ghaH:n}. {nuqDaq ghaH ...'e'?:sen:nolink} "Missä on ...?" [AUTOTRANSLATED]</column>
       <column name="hidden_notes"></column>
       <column name="components">{nuqDaq:ques}, {'oH:n:pro}, {-'e':n:suff}</column>
       <column name="examples">
@@ -2597,7 +2597,7 @@ Sanat käänsivät Robyn Stewart, Chris Lipscombe, Christopher Kidder-Mostrom, J
 
 Katso se Jen Usellisin esittämänä, tuottajana Improvised Star Trek: {YouTube video:url:http://youtu.be/v2bjc6U0tjI}
 
-Osta koko Warrior Woman -albumi: {Google Play Kauppa: url: https: //play.google.com/store/music/album/The_Klingon_Pop_Warrior_Warrior_Woman? Id = Bwiodbf4hmegoplslpyfcjb7woq}</column>
+Osta koko Warrior Woman -albumi: {Google Play -Kauppa:url:https://play.google.com/store/music/album/The_Klingon_Pop_Warrior_Warrior_Woman?Id=Bwiodbf4hmegoplslpyfcjb7woq}</column>
       <column name="hidden_notes">This song is a translation of "Kiss Me" by the band Sixpence None the Richer.</column>
       <column name="components"></column>
       <column name="examples"></column>

--- a/stats.sh
+++ b/stats.sh
@@ -10,6 +10,7 @@ RU_COUNT=$(get_count "ru")
 SV_COUNT=$(get_count "sv")
 ZH_HK_COUNT=$(get_count "zh_HK")
 PT_COUNT=$(get_count "pt")
+FI_COUNT=$(get_count "fi")
 
 # Note: These are sorted in order of completeness.
 echo "Remaining entries:"
@@ -19,3 +20,4 @@ echo "sv: $SV_COUNT"
 echo "ru: $RU_COUNT"
 echo "zh-HK: $ZH_HK_COUNT"
 echo "fa: $FA_COUNT"
+echo "fi: $FI_COUNT"

--- a/xml2json.py
+++ b/xml2json.py
@@ -266,6 +266,7 @@ ret['locales']['ru'] = 'Русский язык'
 ret['locales']['sv'] = 'Svenska'
 ret['locales']['zh_HK'] = '中文 (香港)'
 ret['locales']['pt'] = 'Português'
+ret['locales']['fi'] = 'Finnish'
 
 ret['supported_locales'] = [
   'de',

--- a/xml2sql.pl
+++ b/xml2sql.pl
@@ -36,7 +36,7 @@ print "PRAGMA foreign_keys=OFF;\n".
       "BEGIN TRANSACTION;\n".
       "CREATE TABLE IF NOT EXISTS \"android_metadata\" (\"locale\" TEXT DEFAULT 'en_US');\n".
       "INSERT INTO android_metadata VALUES('en_US');\n".
-      "CREATE TABLE IF NOT EXISTS \"mem\" (\"_id\" INTEGER PRIMARY KEY,\"entry_name\" TEXT,\"part_of_speech\" TEXT,\"definition\" TEXT,\"synonyms\" TEXT,\"antonyms\" TEXT,\"see_also\" TEXT,\"notes\" TEXT,\"hidden_notes\" TEXT,\"components\" TEXT,\"examples\" TEXT,\"search_tags\" TEXT,\"source\" TEXT,\"definition_de\" TEXT,\"notes_de\" TEXT,\"examples_de\" TEXT,\"search_tags_de\" TEXT,\"definition_fa\" TEXT,\"notes_fa\" TEXT,\"examples_fa\" TEXT,\"search_tags_fa\" TEXT,\"definition_sv\" TEXT,\"notes_sv\" TEXT,\"examples_sv\" TEXT,\"search_tags_sv\" TEXT,\"definition_ru\" TEXT,\"notes_ru\" TEXT,\"examples_ru\" TEXT,\"search_tags_ru\" TEXT,\"definition_zh_HK\" TEXT,\"notes_zh_HK\" TEXT,\"examples_zh_HK\" TEXT,\"search_tags_zh_HK\" TEXT,\"definition_pt\" TEXT,\"notes_pt\" TEXT,\"examples_pt\" TEXT,\"search_tags_pt\" TEXT DEFAULT \"\");\n";
+      "CREATE TABLE IF NOT EXISTS \"mem\" (\"_id\" INTEGER PRIMARY KEY,\"entry_name\" TEXT,\"part_of_speech\" TEXT,\"definition\" TEXT,\"synonyms\" TEXT,\"antonyms\" TEXT,\"see_also\" TEXT,\"notes\" TEXT,\"hidden_notes\" TEXT,\"components\" TEXT,\"examples\" TEXT,\"search_tags\" TEXT,\"source\" TEXT,\"definition_de\" TEXT,\"notes_de\" TEXT,\"examples_de\" TEXT,\"search_tags_de\" TEXT,\"definition_fa\" TEXT,\"notes_fa\" TEXT,\"examples_fa\" TEXT,\"search_tags_fa\" TEXT,\"definition_sv\" TEXT,\"notes_sv\" TEXT,\"examples_sv\" TEXT,\"search_tags_sv\" TEXT,\"definition_ru\" TEXT,\"notes_ru\" TEXT,\"examples_ru\" TEXT,\"search_tags_ru\" TEXT,\"definition_zh_HK\" TEXT,\"notes_zh_HK\" TEXT,\"examples_zh_HK\" TEXT,\"search_tags_zh_HK\" TEXT,\"definition_pt\" TEXT,\"notes_pt\" TEXT,\"examples_pt\" TEXT,\"search_tags_pt\" TEXT DEFAULT \"\",\"definition_fi\" TEXT,\"notes_fi\" TEXT,\"examples_fi\" TEXT,\"search_tags_fi\" TEXT DEFAULT \"\");\n";
 
 # Regex to check "en" language fields.
 $valid_en = qr/^[A-Za-z0-9 '":;,.\-?!_\/\()@=%&*{}\[\]<>▶\nàéü+×÷#神舟]*$/;
@@ -108,7 +108,11 @@ foreach $e (@{$data->{database}->{mem}})
     print $e->{definition_pt}, "','";
     print $e->{notes_pt}, "','";
     print $e->{examples_pt}, "','";
-    print $e->{search_tags_pt}, "');\n";
+    print $e->{search_tags_pt}, "','";
+    print $e->{definition_fi}, "','";
+    print $e->{notes_fi}, "','";
+    print $e->{examples_fi}, "','";
+    print $e->{search_tags_fi}, "');\n";
 }
 
 # print sql file footer

--- a/xml2sql.pl
+++ b/xml2sql.pl
@@ -42,7 +42,7 @@ print "PRAGMA foreign_keys=OFF;\n".
 $valid_en = qr/^[A-Za-z0-9 '":;,.\-?!_\/\()@=%&*{}\[\]<>▶\nàéü+×÷#神舟]*$/;
 
 # Language tags.
-@langs = qw(de fa ru sv zh-HK pt);
+@langs = qw(de fa ru sv zh-HK pt fi);
 
 # cycle through and print the entries
 foreach $e (@{$data->{database}->{mem}})


### PR DESCRIPTION
Translated dictionary to Finnish

Much of this is still kind of "first draft" and not finished. Many translations have question marks indicating that I'm not sure that they are correctly translated.

Some notes:
* In Finnish, much like in Klingon, most verbs are either transitive or intransitive. I have usually taken the "best guess of transitivity" when translating. For example, `bar` (v:i) is translated as intrasitive verbs "vilkkua, välähtää" instead of transitive "väläyttää".
* Finnish has noun cases and postpositions in place of prepositions. I have marked the case of direct object with the word jokin (something) without parentheses. So for example `parHa'` is translated "pitää jostakin" which means that the object of the word should take the elative (-sta) case. If there is "jokin" in parentheses, it is just a note and not the case of the object.
* Finnish has a rich inflectional morphology, so many Klingon suffixes have been given Finnish equivalents or approximates. (Though not all Klingon suffixes have these). For example, `-vIs` can be translated with the Finnish verb infinitive endings "-en, -essa", so they are given in addition to a Finnish conjunction "kun" ("while").
* Many Klingon words seem to have an English bias. For example `num` means both increase someone's rank (ylentää in Finnish) and advocate for a cause (tukea in Finnish). There are awkwardly many of these and they become obvious when comparing to a non-germanic language. This has lead me to wonder if Klingon is actually a germanic language in diaguise.
* The Finnish translations of Star Trek series currently available in Netflix are horrible. I have no idea how to translate fictional things correctly (or even if there is any correct way). These things include technologies (deflectors, disruptors etc.), peoples and places (eg. Vulcan is currently translated as Vulkanus which is the form that Finnish Wikipedia uses although I'm not completely sure where it comes from).